### PR TITLE
enhancement: Add change detection to disk driver

### DIFF
--- a/cmd/compile/compile.go
+++ b/cmd/compile/compile.go
@@ -58,7 +58,7 @@ func doRun(cmd *cobra.Command, args []string) error {
 	ctx, stopFunc := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stopFunc()
 
-	store, err := disk.NewReadOnlyStore(ctx, args[0])
+	store, err := disk.NewReadOnlyStore(ctx, &disk.Conf{Directory: args[0]})
 	if err != nil {
 		idxErr := new(disk.IndexBuildError)
 		if errors.As(err, &idxErr) {

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -122,7 +122,7 @@ func mkEngine(t *testing.T) *engine.Engine {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 
-	store, err := disk.NewReadOnlyStore(ctx, dir)
+	store, err := disk.NewReadOnlyStore(ctx, &disk.Conf{Directory: dir})
 	require.NoError(t, err)
 
 	eng, err := engine.New(ctx, store)

--- a/docs/modules/configuration/pages/storage.adoc
+++ b/docs/modules/configuration/pages/storage.adoc
@@ -8,9 +8,9 @@ Cerbos policies can be read from a directory on disk or a git repository. Which 
 
 The disk driver is a way to serve the policies from a directory on the filesystem. Any `.yaml`, `.yml` or `.json` files in the directory tree rooted at the given path will be read and parsed as policies.
 
-NOTE: The `disk` driver does not support detecting updates to the policy files. The server must be restarted to pick up any new changes made to policies after they were loaded.
 
 
+.Static fileset with no change detection
 [source,yaml,linenums]
 ----
 storage:
@@ -19,6 +19,17 @@ storage:
     directory: /etc/cerbos/policies
 ----
 
+.Dynamic fileset with change detection
+[source,yaml,linenums]
+----
+storage:
+  driver: disk
+  disk: 
+    directory: /etc/cerbos/policies
+    watchForChanges: true
+----
+
+CAUTION: On some platforms the automatic change detection feature can be inefficient and resource-intensive if the watched directory contains many files or gets updated frequently.
 
 == Git driver
 
@@ -30,6 +41,8 @@ Git is the preferred method of storing Cerbos policies. The server is smart enou
 * The `checkoutDir` is the working directory of the server and must be writable by the server process.
 * If `updatePollInterval` is set to 0, the source repository will not be polled to pick up any new commits.
 * If `operationTimeout` is not specified, the default timeout for git operations is 60 seconds.
+
+CAUTION: If the git repository is remote, setting the `updatePollInterval` to a low value could increase resource consumption in both the client and the server systems. Some managed service providers may even impose rate limits or temporary suspensions on your account if the number of requests is too high. 
 
 
 .Local git repository

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/prometheus/common v0.20.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/rjeczalik/notify v0.9.3-0.20201210012515-e2a77dcc14cf
 	github.com/rs/zerolog v1.20.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/afero v1.5.1 // indirect
@@ -51,7 +52,7 @@ require (
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20210412220455-f1c623a9e750 // indirect
+	golang.org/x/sys v0.0.0-20210415045647-66c3f260301c // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	google.golang.org/genproto v0.0.0-20210325224202-eed09b1b5210
 	google.golang.org/grpc v1.37.0-dev.0.20210309003715-fce74a94bdff

--- a/go.sum
+++ b/go.sum
@@ -899,6 +899,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqn
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rjeczalik/notify v0.9.3-0.20201210012515-e2a77dcc14cf h1:MY2fqXPSLfjld10N04fNcSFdR9K/Y57iXxZRFAivHzI=
+github.com/rjeczalik/notify v0.9.3-0.20201210012515-e2a77dcc14cf/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
@@ -1249,6 +1251,7 @@ golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1313,8 +1316,8 @@ golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210412220455-f1c623a9e750 h1:ZBu6861dZq7xBnG1bn5SRU0vA8nx42at4+kP07FMTog=
-golang.org/x/sys v0.0.0-20210412220455-f1c623a9e750/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210415045647-66c3f260301c h1:6L+uOeS3OQt/f4eFHXZcTxeZrGCuz+CLElgEBjbcTA4=
+golang.org/x/sys v0.0.0-20210415045647-66c3f260301c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=

--- a/hack/dev/conf.insecure.yaml
+++ b/hack/dev/conf.insecure.yaml
@@ -7,3 +7,4 @@ storage:
   driver: "disk"
   disk:
     directory: internal/test/testdata/store
+    watchForChanges: true

--- a/hack/dev/conf.secure.yaml
+++ b/hack/dev/conf.secure.yaml
@@ -17,3 +17,4 @@ storage:
   driver: "disk"
   disk:
     directory: internal/test/testdata/store
+    watchForChanges: true

--- a/hack/dev/dev.mk
+++ b/hack/dev/dev.mk
@@ -39,16 +39,18 @@ check-grpc-insecure: protoset $(GRPCURL)
 check-http:
 	@ $(foreach REQ_FILE,\
 		$(wildcard $(DEV_DIR)/requests/*),\
+		echo "";\
 		echo $(REQ_FILE); \
-		curl -i -k https://localhost:$(HTTP_PORT)/api/check -d @$(REQ_FILE);\
+		curl -k https://localhost:$(HTTP_PORT)/api/check -d @$(REQ_FILE);\
 		echo "";)
 
 .PHONY: check-http-insecure
 check-http-insecure:
 	@ $(foreach REQ_FILE,\
 		$(wildcard $(DEV_DIR)/requests/*),\
+		echo "";\
 		echo $(REQ_FILE); \
-		curl -i http://localhost:$(HTTP_PORT)/api/check -d @$(REQ_FILE);\
+		curl http://localhost:$(HTTP_PORT)/api/check -d @$(REQ_FILE);\
 		echo "";)
 
 .PHONY: perf

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -17,6 +17,11 @@ import (
 	"github.com/cerbos/cerbos/internal/observability/metrics"
 )
 
+type Notification struct {
+	FullRecompile bool
+	Payload       *Incremental
+}
+
 type Unit struct {
 	ModID       namer.ModuleID
 	Definitions map[string]*policyv1.Policy

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -21,7 +21,7 @@ func TestEngineCheck(t *testing.T) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 
-	store, err := disk.NewReadOnlyStore(ctx, dir)
+	store, err := disk.NewReadOnlyStore(ctx, &disk.Conf{Directory: dir})
 	require.NoError(t, err)
 
 	eng, err := New(ctx, store)
@@ -159,7 +159,7 @@ func BenchmarkCheck(b *testing.B) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 
-	store, err := disk.NewReadOnlyStore(ctx, dir)
+	store, err := disk.NewReadOnlyStore(ctx, &disk.Conf{Directory: dir})
 	require.NoError(b, err)
 
 	eng, err := New(ctx, store)

--- a/internal/observability/metrics/metrics.go
+++ b/internal/observability/metrics/metrics.go
@@ -10,6 +10,8 @@ var (
 	KeyCompileStatus        = tag.MustNewKey("status")
 	KeyEngineDecisionEffect = tag.MustNewKey("effect")
 	KeyEngineDecisionStatus = tag.MustNewKey("status")
+	KeyEngineUpdateType     = tag.MustNewKey("update_type")
+	KeyEngineUpdateStatus   = tag.MustNewKey("update_status")
 )
 
 var (
@@ -36,11 +38,24 @@ var (
 		TagKeys:     []tag.Key{KeyEngineDecisionEffect, KeyEngineDecisionStatus},
 		Aggregation: defaultLatencyDistribution(),
 	}
+
+	EngineUpdateLatency = stats.Float64(
+		"cerbos.dev/engine/update_latency",
+		"Time to apply an update to the engine",
+		stats.UnitMilliseconds,
+	)
+
+	EngineUpdateLatencyView = &view.View{
+		Measure:     EngineUpdateLatency,
+		TagKeys:     []tag.Key{KeyEngineUpdateType, KeyEngineUpdateStatus},
+		Aggregation: defaultLatencyDistribution(),
+	}
 )
 
 var DefaultCerbosViews = []*view.View{
 	CompileDurationView,
 	EngineDecisionLatencyView,
+	EngineUpdateLatencyView,
 }
 
 func defaultLatencyDistribution() *view.Aggregation {

--- a/internal/storage/common/notifier.go
+++ b/internal/storage/common/notifier.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/cerbos/cerbos/internal/compile"
+)
+
+type Notifier struct {
+	mu         sync.RWMutex
+	notifyChan chan<- compile.Notification
+}
+
+func NewNotifier() *Notifier {
+	return new(Notifier)
+}
+
+func (n *Notifier) SetNotificationChannel(ch chan<- compile.Notification) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	n.notifyChan = ch
+}
+
+func (n *Notifier) NotifyIncrementalUpdate(ctx context.Context, change *compile.Incremental) error {
+	return n.notify(ctx, compile.Notification{FullRecompile: false, Payload: change})
+}
+
+func (n *Notifier) NotifyFullUpdate(ctx context.Context) error {
+	return n.notify(ctx, compile.Notification{FullRecompile: true})
+}
+
+func (n *Notifier) notify(ctx context.Context, notification compile.Notification) error {
+	n.mu.RLock()
+	notifyChan := n.notifyChan //nolint:ifshort
+	n.mu.RUnlock()
+
+	if notifyChan != nil {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("failed to send notification: %w", ctx.Err())
+		case notifyChan <- notification:
+		}
+	}
+
+	return nil
+}

--- a/internal/storage/disk/conf.go
+++ b/internal/storage/disk/conf.go
@@ -8,4 +8,6 @@ type Conf struct {
 	Directory string `yaml:"directory"`
 	// ReadOnly defines that the server cannot write or update policies on disk.
 	ReadOnly bool `yaml:"readOnly"`
+	// WatchForChanges enables watching the directory for changes.
+	WatchForChanges bool `yaml:"watchForChanges"`
 }

--- a/internal/storage/disk/dirwatch.go
+++ b/internal/storage/disk/dirwatch.go
@@ -1,0 +1,126 @@
+package disk
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/rjeczalik/notify"
+	"go.uber.org/zap"
+
+	"github.com/cerbos/cerbos/internal/storage/common"
+	"github.com/cerbos/cerbos/internal/util"
+)
+
+const (
+	// cooldownPeriod is the amount of time to wait before triggering a notification to update.
+	// This is necessary because many file update events can fire even for a seemingly simple operation on a file.
+	// We want the system to settle down before performing an expensive update operation.
+	cooldownPeriod = 3 * time.Second
+	notifyTimeout  = 2 * time.Second
+	reloadTimeout  = 60 * time.Second
+)
+
+func newDirWatch(ctx context.Context, dir string, index Index, notifier *common.Notifier) (*dirWatch, error) {
+	dw := &dirWatch{
+		log:       zap.S().Named("dir.watch").With("dir", dir),
+		index:     index,
+		watchChan: make(chan notify.EventInfo, 8), //nolint:gomnd
+		Notifier:  notifier,
+	}
+
+	if err := notify.Watch(filepath.Join(dir, "..."), dw.watchChan, notify.All); err != nil {
+		return nil, fmt.Errorf("failed to watch directory %s: %w", dir, err)
+	}
+
+	go dw.handleEvents(ctx)
+
+	return dw, nil
+}
+
+type dirWatch struct {
+	log       *zap.SugaredLogger
+	watchChan chan notify.EventInfo
+	index     Index
+	*common.Notifier
+	mu            sync.RWMutex
+	eventsSeen    bool
+	lastEventTime time.Time
+}
+
+func (dw *dirWatch) handleEvents(ctx context.Context) {
+	ticker := time.NewTicker(cooldownPeriod)
+
+	defer func() {
+		ticker.Stop()
+		notify.Stop(dw.watchChan)
+	}()
+
+	dw.log.Info("Watching directory for changes")
+
+	for {
+		select {
+		case <-ctx.Done():
+			dw.log.Info("Stopped watching directory for changes")
+			return
+		case evtInfo := <-dw.watchChan:
+			dw.processEvent(evtInfo)
+		case <-ticker.C:
+			dw.triggerUpdate()
+		}
+	}
+}
+
+func (dw *dirWatch) processEvent(evtInfo notify.EventInfo) {
+	if util.IsSupportedFileType(evtInfo.Path()) {
+		dw.mu.Lock()
+		dw.eventsSeen = true
+		dw.lastEventTime = time.Now()
+		dw.mu.Unlock()
+	}
+}
+
+func (dw *dirWatch) triggerUpdate() {
+	dw.mu.RLock()
+	shouldUpdate := dw.eventsSeen && (time.Since(dw.lastEventTime) > cooldownPeriod)
+	dw.mu.RUnlock()
+
+	if shouldUpdate {
+		dw.mu.Lock()
+		proceed := dw.eventsSeen && (time.Since(dw.lastEventTime) > cooldownPeriod)
+		if !proceed {
+			dw.mu.Unlock()
+			return
+		}
+
+		dw.eventsSeen = false
+		dw.mu.Unlock()
+
+		if err := dw.reloadIndex(); err != nil {
+			dw.log.Errorw("Failed to reload index", "error", err)
+			return
+		}
+
+		ctx, cancelFunc := context.WithTimeout(context.Background(), notifyTimeout)
+		defer cancelFunc()
+
+		if err := dw.NotifyFullUpdate(ctx); err != nil {
+			dw.log.Warnw("Failed to send update notification: %w", err)
+		}
+	}
+}
+
+func (dw *dirWatch) reloadIndex() error {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), reloadTimeout)
+	defer cancelFunc()
+
+	dw.log.Debug("Reloading index")
+	if err := dw.index.Reload(ctx); err != nil {
+		return err
+	}
+
+	dw.log.Info("Index reloaded")
+	return nil
+}

--- a/internal/storage/disk/readonly.go
+++ b/internal/storage/disk/readonly.go
@@ -7,20 +7,34 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/cerbos/cerbos/internal/compile"
+	"github.com/cerbos/cerbos/internal/storage/common"
 )
 
 type ReadOnlyStore struct {
+	*common.Notifier
 	index Index
+	dw    *dirWatch
 }
 
-func NewReadOnlyStore(ctx context.Context, policyDir string) (*ReadOnlyStore, error) {
-	zap.S().Named("disk.store").Infow("Creating read-only disk store", "root", policyDir)
-	idx, err := BuildIndex(ctx, os.DirFS(policyDir), ".")
+func NewReadOnlyStore(ctx context.Context, conf *Conf) (*ReadOnlyStore, error) {
+	zap.S().Named("disk.store").Infow("Creating read-only disk store", "root", conf.Directory)
+	idx, err := BuildIndex(ctx, os.DirFS(conf.Directory), ".")
 	if err != nil {
 		return nil, err
 	}
 
-	return &ReadOnlyStore{index: idx}, nil
+	ros := &ReadOnlyStore{index: idx, Notifier: common.NewNotifier()}
+
+	if conf.WatchForChanges {
+		dw, err := newDirWatch(ctx, conf.Directory, idx, ros.Notifier)
+		if err != nil {
+			return nil, err
+		}
+
+		ros.dw = dw
+	}
+
+	return ros, nil
 }
 
 func (s *ReadOnlyStore) Driver() string {
@@ -29,8 +43,4 @@ func (s *ReadOnlyStore) Driver() string {
 
 func (s *ReadOnlyStore) GetAllPolicies(ctx context.Context) <-chan *compile.Unit {
 	return s.index.GetAllPolicies(ctx)
-}
-
-func (s *ReadOnlyStore) SetNotificationChannel(chan<- *compile.Incremental) {
-	// nothing to do because this is a read-only store
 }

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -15,7 +15,7 @@ import (
 type Store interface {
 	Driver() string
 	GetAllPolicies(context.Context) <-chan *compile.Unit
-	SetNotificationChannel(chan<- *compile.Incremental)
+	SetNotificationChannel(chan<- compile.Notification)
 }
 
 // WritableStore is a store that supports modifications.
@@ -39,10 +39,10 @@ func New(ctx context.Context) (Store, error) {
 		}
 
 		if conf.Disk.ReadOnly {
-			return disk.NewReadOnlyStore(ctx, conf.Disk.Directory)
+			return disk.NewReadOnlyStore(ctx, conf.Disk)
 		}
 
-		return disk.NewReadWriteStore(ctx, conf.Disk.Directory)
+		return disk.NewReadWriteStore(ctx, conf.Disk)
 	case git.DriverName:
 		if conf.Git == nil {
 			return nil, errors.New("git storage configuration not provided")


### PR DESCRIPTION
Enables change detection with the disk driver. This feature is disabled
by default and can be enabled by setting `storage.disk.watchForChanges`
to `true`.

Unfortunately, due to differences between operating systems, it is
extremely tricky to perform incremental compilation using filesystem
events. Therefore, the current implementation performs a full reload of
the policies after a short cooldown period.

Fixes #48
