### PR TITLE
enhancement: Add option to log request payloads

### DIFF
--- a/cmd/server/conf.go
+++ b/cmd/server/conf.go
@@ -20,6 +20,8 @@ type Conf struct {
 	TLS *TLSConf `yaml:"tls"`
 	// MetricsEnabled defines whether the metrics endpoint is enabled.
 	MetricsEnabled bool `yaml:"metricsEnabled"`
+	// LogRequestPayloads defines whether the request payloads should be logged.
+	LogRequestPayloads bool `yaml:"logRequestPayloads"`
 }
 
 // TLSConf holds TLS configuration.

--- a/cmd/server/middleware.go
+++ b/cmd/server/middleware.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"strings"
 
+	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/logging"
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -27,4 +29,11 @@ func XForwardedHostUnaryServerInterceptor(ctx context.Context, req interface{}, 
 // loggingDecider prevents healthcheck requests from being logged.
 func loggingDecider(fullMethodName string, _ error) bool {
 	return fullMethodName != "/grpc.health.v1.Health/Check"
+}
+
+// payloadLoggingDecider decides whether to log request payloads.
+func payloadLoggingDecider(conf *Conf) grpc_logging.ServerPayloadLoggingDecider {
+	return func(ctx context.Context, fullMethodName string, servingObject interface{}) bool {
+		return conf.LogRequestPayloads && strings.HasPrefix(fullMethodName, "/svc.v1")
+	}
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -346,6 +346,8 @@ func defaultTLSConfig() *tls.Config {
 
 func (s *server) startGRPCServer(cerbosSvc *svc.CerbosService, l net.Listener) *grpc.Server {
 	log := zap.L().Named("grpc")
+	payloadLog := log.Named("payload")
+
 	// grpc_zap.ReplaceGrpcLoggerV2(log)
 	// TODO (cell) log payload
 
@@ -356,6 +358,7 @@ func (s *server) startGRPCServer(cerbosSvc *svc.CerbosService, l net.Listener) *
 			grpc_ctxtags.StreamServerInterceptor(),
 			grpc_zap.StreamServerInterceptor(log, grpc_zap.WithDecider(loggingDecider)),
 			grpc_validator.StreamServerInterceptor(),
+			grpc_zap.PayloadStreamServerInterceptor(payloadLog, payloadLoggingDecider(s.conf)),
 		),
 		grpc.ChainUnaryInterceptor(
 			grpc_recovery.UnaryServerInterceptor(),
@@ -363,6 +366,7 @@ func (s *server) startGRPCServer(cerbosSvc *svc.CerbosService, l net.Listener) *
 			XForwardedHostUnaryServerInterceptor,
 			grpc_zap.UnaryServerInterceptor(log, grpc_zap.WithDecider(loggingDecider)),
 			grpc_validator.UnaryServerInterceptor(),
+			grpc_zap.PayloadUnaryServerInterceptor(payloadLog, payloadLoggingDecider(s.conf)),
 		),
 		grpc.StatsHandler(&ocgrpc.ServerHandler{}),
 	}

--- a/docs/modules/configuration/pages/index.adoc
+++ b/docs/modules/configuration/pages/index.adoc
@@ -16,6 +16,7 @@ server:
   httpListenAddr: ":3592" 
   grpcListenAddr: ":3593"
   metricsEnabled: true # Set to false to disable the /_cerbos/metrics endpoint
+  logRequestPayloads: false # Set to true to log full request and response payloads. Affects performance.
   tls: # Optional
     cert: /path/to/certificate
     key: /path/to/private_key

--- a/docs/modules/configuration/pages/server.adoc
+++ b/docs/modules/configuration/pages/server.adoc
@@ -40,6 +40,18 @@ server:
   metricsEnabled: false
 ----
 
+== Payload logging
+
+For debugging or auditing purposes, you can enable request and response payload logging for each request. i
+
+CAUTION: Enabling this setting affects server performance and could expose potentially sensitive data contained in the requests to anyone with access to the server logs.
+
+[source,yaml,linenums]
+----
+server:
+  logRequestPayloads: true
+----
+
 == Transport layer security (TLS)
 
 You can enable transport layer security (TLS) by defining the paths to the certificate and key file in the `TLS` section.

--- a/hack/dev/conf.insecure.yaml
+++ b/hack/dev/conf.insecure.yaml
@@ -2,6 +2,7 @@
 server:
   httpListenAddr: ":3592"
   grpcListenAddr: ":3593"
+  logRequestPayloads: false
 
 storage:
   driver: "disk"

--- a/hack/dev/conf.secure.yaml
+++ b/hack/dev/conf.secure.yaml
@@ -2,6 +2,7 @@
 server:
   httpListenAddr: ":3592"
   grpcListenAddr: ":3593"
+  logRequestPayloads: false
   tls:
     cert: hack/dev/tls.crt
     key: hack/dev/tls.key


### PR DESCRIPTION
Allows users to log request and response payloads in full by setting the
`server.logRequestPayloads` key to true.

Related to #5
