### PR TITLE
chore: Move Helm lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ clean-tools:
 .PHONY: lint
 lint: $(GOLANGCI_LINT)
 	@ $(GOLANGCI_LINT) run --config=.golangci.yaml 
+
+.PHONY: lint-helm
+lint-helm:
 	@ deploy/charts/validate.sh
 
 .PHONY: generate


### PR DESCRIPTION
Move the Helm lint script to its own target because kubeconform does not work on ARM architectures
