### PR TITLE
feature: Condition ergonomics

### DIFF
--- a/deploy/charts/cerbos/Chart.yaml
+++ b/deploy/charts/cerbos/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 maintainers:
   - name: Cerbos authors
     email: help+helm@cerbos.dev
-version: "0.0.0-alpha8"
-appVersion: "0.0.0-alpha8"
+version: "0.0.0-alpha9"
+appVersion: "0.0.0-alpha9"

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -14,7 +14,7 @@ content:
 asciidoc:
   attributes:
     app-name: "cerbos"
-    app-version: "0.0.0-alpha8"
+    app-version: "0.0.0-alpha9"
     experimental: true
     page-pagination: true
 ui:

--- a/docs/modules/policies/pages/conditions.adoc
+++ b/docs/modules/policies/pages/conditions.adoc
@@ -2,10 +2,7 @@ include::ROOT:partial$attributes.adoc[]
 
 = Conditions
 
-A powerful feature of Cerbos policies is the ability to define conditions that are evaluated against the data provided in the request. Conditions can be written in the link:https://github.com/google/cel-spec/blob/master/doc/intro.md[Common Expression Language (CEL)] or link:https://www.openpolicyagent.org/docs/latest/policy-language/[Rego].
-
-Conditions are defined in policies using the `condition` field. CEL conditions are defined under the `match` key and Rego conditions are defined under the `script` key. Only one kind of condition is allowed. You cannot mix both in a single `condition` block.
-
+A powerful feature of Cerbos policies is the ability to define conditions that are evaluated against the data provided in the request. Conditions are written using the link:https://github.com/google/cel-spec/blob/master/doc/intro.md[Common Expression Language (CEL)].
 
 .CEL condition
 [source,yaml,linenums]
@@ -18,26 +15,20 @@ condition:
         - expr: "GB" in request.resource.attr.geographies
 ----
 
+Within a condition block you have access to three special variables:
 
-.Rego condition
-[source,yaml,linenums]
-----
-condition:
-  script: input.resource.attr.owner == input.principal.id
-----
+`request`:: The entire request object containing data provided about the resource and the principal. Use dots to access nested fields. For example, the expression to get the principal's department attribute is `request.principal.attr.department`.
+`P`:: An alias for `request.principal` for accessing the principal object.
+`R`:: An alias for `request.resource` for accessing the resource object.
 
-
-== CEL conditions
-
-* You can access the request object using the special `request` variable. Use dots to access different fields of the request. For example, the expression to get the current principal ID is `request.principal.id`.
-* You can write complex expressions using the helpers provided by the `match` block. Ensure that the final result of evaluating the set of expression always produces a boolean true/false value. 
+Every condition expression must evaluate to a boolean true/false value. You can combine complex expressions together in a single condition block by using the `all`, `any`, or `none` operators.
 
 .Single boolean expression
 [source,yaml,linenums]
 ----
 condition:
   match:
-    expr: matches(request.principal.id, "^dev_.*")
+    expr: matches(P.id, "^dev_.*")
 ----
 
 .``all`` operator: all expressions must evaluate to true (logical AND)
@@ -47,9 +38,9 @@ condition:
   match:
     all:
       of:
-        - expr: request.resource.attr.status == "PENDING_APPROVAL"
-        - expr: "GB" in request.resource.attr.geographies
-        - expr: request.principal.attr.geography == "GB"
+        - expr: R.attr.status == "PENDING_APPROVAL"
+        - expr: "GB" in R.attr.geographies
+        - expr: P.attr.geography == "GB"
 ----
 
 .``any`` operator: only one of the expressions has to evaluate to true (logical OR)
@@ -59,9 +50,9 @@ condition:
   match:
     any:
       of:
-        - expr: request.resource.attr.status == "PENDING_APPROVAL"
-        - expr: "GB" in request.resource.attr.geographies
-        - expr: request.principal.attr.geography == "GB"
+        - expr: R.attr.status == "PENDING_APPROVAL"
+        - expr: "GB" in R.attr.geographies
+        - expr: P.attr.geography == "GB"
 ----
 
 
@@ -72,9 +63,9 @@ condition:
   match:
     none:
       of:
-        - expr: request.resource.attr.status == "PENDING_APPROVAL"
-        - expr: "GB" in request.resource.attr.geographies
-        - expr: request.principal.attr.geography == "GB"
+        - expr: R.attr.status == "PENDING_APPROVAL"
+        - expr: "GB" in R.attr.geographies
+        - expr: P.attr.geography == "GB"
 ----
 
 
@@ -85,15 +76,15 @@ condition:
   match:
     all:
       of:
-        - expr: request.resource.attr.status == "DRAFT"
+        - expr: R.attr.status == "DRAFT"
         - any:
             of: 
-              - expr: request.resource.attr.dev == true
-              - expr: matches(request.resource.attr.id, "^[98][0-9]+")
+              - expr: R.attr.dev == true
+              - expr: matches(R.attr.id, "^[98][0-9]+")
         - none:
             of:
-              - expr: request.resource.attr.qa == true
-              - expr: request.resource.attr.canary == true
+              - expr: R.attr.qa == true
+              - expr: R.attr.canary == true
 ----
 
 The above nested block is equivalent to the following:
@@ -103,14 +94,14 @@ The above nested block is equivalent to the following:
 condition:
   match:
     expr: |-
-      (request.resource.attr.status == "DRAFT" && 
-        (request.resource.attr.dev == true || matches(request.resource.attr.id, "^[98][0-9]+")) &&
-        !(request.resource.attr.qa == true || request.resource.attr.canary == true))
+      (R.attr.status == "DRAFT" && 
+        (R.attr.dev == true || matches(R.attr.id, "^[98][0-9]+")) &&
+        !(R.attr.qa == true || R.attr.canary == true))
 ----
 
 
 
-=== Operators
+== Operators
 
 NOTE: CEL has many builtin functions and operators. The fully up-to-date list can be found at https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions. 
 
@@ -136,18 +127,85 @@ NOTE: CEL has many builtin functions and operators. The fully up-to-date list ca
 |===
 
 
-=== Lists and maps
+== Durations
 
-The code examples in the following table all evaluate to `true` given a principal with the following attributes:
+.Test data
+[source,json,linenums]
+----
+...
+"resource": {
+  "name": "leave_request",
+  "attr": {
+    "cooldownPeriod": "3750s",
+    "lastUpdateTime": "2021-05-01T13:34:12.024Z",
+    "lastAccessed": "2021-05-02T14:24:22.034Z"
+  }
+}
+...
+----
 
+[caption=]
+[%header,cols=".^1m,.^2,4m",grid=rows]
+|===
+| Function | Description | Example 
+| duration | Convert a string to a duration. The string must contain a valid duration suffixed by one of `ns`, `us`, `ms`, `s`, `m` or `h`. E.g. `3750s` | duration(R.attr.cooldownPeriod).getSeconds == 3750
+| getHours | Get hours from a timestamp | timestamp(R.attr.cooldownPeriod).getHours() == 1
+| getMilliseconds | Get milliseconds from a timestamp | timestamp(R.attr.lastAccessed).getMilliseconds() == 3750000
+| getMinutes | Get minutes from a timestamp | timestamp(R.attr.lastAccessed).getMinutes() == 62
+| getSeconds | Get seconds from a timestamp | timestamp(R.attr.lastAccessed).getSeconds() == 3750
+|===
+
+
+.Example: Assert that no more than 36 hours has elapsed between last access time and last update time 
+[source,yaml,linenums]
+----
+timestamp(R.attr.lastAccessed) - timestamp(R.attr.lastUpdateTime) < duration("36h")
+----
+
+.Example: Add a duration to a timestamp
+[source,yaml,linenums]
+----
+timestamp(R.attr.lastAccessed) + duration("24h") == timestamp("2021-05-03T14:24:22.034Z")
+----
+
+== IP Addresses
+
+NOTE: The IP address functions are Cerbos-specific extensions to CEL.
+
+.Test data
 [source,json,linenums]
 ----
 ...
 "principal": {
-  "name": "elmer_fudd",
+  "id": "elmer_fudd",
+  "attr": {
+    "ipv4Address": "192.168.0.10",
+    "ipv6Address": "2001:0db8:0000:0000:0000:0000:1000:0000"
+  }
+}
+...
+----
+
+[caption=]
+[%header,cols=".^1m,.^2,4m",grid=rows]
+|===
+| Function | Description | Example 
+| inIPAddrRange | Check whether the IP address is in the range defined by the CIDR | P.attr.ipv4Address.inIPAddrRange("192.168.0.0/24") && P.attr.ipv6Address.inIPAddrRange("2001:db8::/48")
+|===
+
+
+
+== Lists and maps
+
+.Test data
+[source,json,linenums]
+----
+...
+"principal": {
+  "id": "elmer_fudd",
   "attr": {
     "id": "125",
-    "teams": ["design", "product_marketing", "communications"],
+    "teams": ["design", "product_marketing", "communications", "commercial"],
     "clients": {
       "acme": {"active": true},
       "bb inc": {"active": true}
@@ -161,16 +219,20 @@ The code examples in the following table all evaluate to `true` given a principa
 [%header,cols=".^1m,.^2,4m",grid=rows]
 |===
 | Operator/Function | Description | Example 
-| in       | Check whether the given element is contained in the list or map | ("design" in request.principal.attr.teams) && ("acme" in request.principal.attr.clients)
-| []       | Index into a list or a map | request.principal.attr.teams[0] == "design" && request.principal.attr.clients["acme"]["active"] == true
-| size     | Number of elements in a list or map | size(request.principal.attr.teams) == 3 && size(request.principal.attr.clients) == 2 
+| []       | Index into a list or a map | P.attr.teams[0] == "design" && P.attr.clients["acme"]["active"] == true
+| all      | Check whether all elements in a list match the predicate | P.attr.teams.all(t, size(t) > 3)
+| exists   | Check whether at least one element matching the predicate exists | P.attr.teams.exists(t, t.startsWith("comm"))
+| exists_one | Check that only one element matching the predicate exists | P.attr.teams.exists_one(t, t.startsWith("comm")) == false
+| filter   | Filter a list using the predicate | size(P.attr.teams.filter(t, t.matches("^comm"))) == 2
+| in       | Check whether the given element is contained in the list or map | ("design" in P.attr.teams) && ("acme" in P.attr.clients)
+| map      | Transform each element in a list | "DESIGN" in P.attr.teams.map(t, t.upperAscii())
+| size     | Number of elements in a list or map | size(P.attr.teams) == 4 && size(P.attr.clients) == 2 
 |===
 
 
-=== Strings 
+== Strings 
 
-The code examples in the table all evaluate to `true` given a resource with the following attributes:
-
+.Test data
 [source,json,linenums]
 ----
 ...
@@ -188,45 +250,30 @@ The code examples in the table all evaluate to `true` given a resource with the 
 [%header,cols=".^1m,.^2,4m",grid=rows]
 |===
 | Function | Description | Example 
-| contains | Check whether a string contains the given substring | request.resource.attr.department.contains("arket")
-| endsWith | Check whether a string has the given suffix | request.resource.attr.department.endsWith("ing")
-| matches  | Check whether a string matches a link:https://github.com/google/re2/wiki/Syntax[RE2] regular expression | request.resource.attr.department.matches("^[mM].*g$")
-| size     | Get the length of the string | size(request.resource.attr.department) == 9  
-| startsWith | Check whether a string has the given prefix | request.resource.attr.department.startsWith("mark")
+| base64.encode | Encode as base64 | base64.encode(bytes("hello")) == "aGVsbG8="
+| base64.decode | Decode base64    | base64.decode("aGVsbG8=") == bytes("hello")
+| charAt   | Get the character at given index | R.attr.department.chartAt(1) == 'a'
+| contains | Check whether a string contains the given substring | R.attr.department.contains("arket")
+| endsWith | Check whether a string has the given suffix | R.attr.department.endsWith("ing")
+| indexOf  | Index of the first occurrence of the given character | R.attr.department.indexOf('a') == 1
+| lastIndexOf | Index of the last occurrence of the given character | R.attr.department.lastIndexOf('g') == 8
+| lowerAscii  | Convert ASCII characters to lowercase | "MARKETING".lowerAscii() == R.attr.department
+| matches  | Check whether a string matches a link:https://github.com/google/re2/wiki/Syntax[RE2] regular expression | R.attr.department.matches("^[mM].*g$")
+| replace  | Replace all occurrences of a substring | R.attr.department.replace("market", "engineer") == "engineering"
+| replace  | Replace with limits. Limit 0 replaces nothing, -1 replaces all. | "engineering".replace("e", "a", 1) == "angineering" && "engineering".replace("e", "a", -1) == "anginaaring"
+| size     | Get the length of the string | size(R.attr.department) == 9  
+| split    | Split a string using a delimiter | "a,b,c,d".split(",")[1] == "b"
+| split    | Split a string with limits. Limit 0 returns an empty list, 1 returns a list containing the original string. | "a,b,c,d".split(",", 2)[1] == "b,c,d"
+| startsWith | Check whether a string has the given prefix | R.attr.department.startsWith("mark")
+| substring | Selects a substring from the string | R.attr.department.substring(4) == "eting" && R.attr.department.substring(4, 6) == "et"
+| trim     | Remove whitespace from beginning and end | "  marketing  ".trim() == "marketing"
+| upperAscii | Convert ASCII characters to uppercase | R.attr.department.upperAscii() == "MARKETING"
 |===
 
 
-=== Durations
+== Timestamps
 
-The code examples in the table all evaluate to `true` given a resource with the following attributes:
-
-[source,json,linenums]
-----
-...
-"resource": {
-  "name": "leave_request",
-  "attr": {
-    "cooldownPeriod": "3750s"
-  }
-}
-...
-----
-
-[caption=]
-[%header,cols=".^1m,.^2,4m",grid=rows]
-|===
-| Function | Description | Example 
-| duration | Convert a string to a duration. The string must contain a valid duration in seconds suffixed by `s`. E.g. `3750s` | duration(request.resource.attr.cooldownPeriod).getSeconds == 3750
-| getHours | Get hours from a timestamp | timestamp(request.resource.attr.cooldownPeriod).getHours() == 1
-| getMilliseconds | Get milliseconds from a timestamp | timestamp(request.resource.attr.lastAccessed).getMilliseconds() == 3750000
-| getMinutes | Get minutes from a timestamp | timestamp(request.resource.attr.lastAccessed).getMinutes() == 62
-| getSeconds | Get seconds from a timestamp | timestamp(request.resource.attr.lastAccessed).getSeconds() == 3750
-|===
-
-=== Timestamps
-
-The code examples in the table all evaluate to `true` given a resource with the following attributes:
-
+.Test data
 [source,json,linenums]
 ----
 ...
@@ -243,30 +290,17 @@ The code examples in the table all evaluate to `true` given a resource with the 
 [%header,cols=".^1m,.^2,4m",grid=rows]
 |===
 | Function | Description | Example 
-| timestamp | Convert an RFC3339 formatted string to a timestamp | timestamp(request.resource.attr.lastAccessed).getFullYear() == 2021
-| getDate  | Get day of month from a timestamp | timestamp(request.resource.attr.lastAccessed).getDate() == 20
-| getDayOfMonth | Get day of month from a timestamp. Returns a zero-based value | timestamp(request.resource.attr.lastAccessed).getDayOfMonth() == 19
-| getDayOfWeek | Get day of week from a timestamp. Returns a zero-based value where Sunday is 0 | timestamp(request.resource.attr.lastAccessed).getDayOfWeek() == 2
-| getDayOfYear | Get day of year from a timestamp. Returns a zero-based value | timestamp(request.resource.attr.lastAccessed).getDayOfYear() == 109
-| getFullYear | Get full year from a timestamp | timestamp(request.resource.attr.lastAccessed).getFullYear() == 2021 
-| getHours | Get hours from a timestamp | timestamp(request.resource.attr.lastAccessed).getHours() == 10
-| getMilliseconds | Get milliseconds from a timestamp | timestamp(request.resource.attr.lastAccessed).getMilliseconds() == 21
-| getMinutes | Get minutes from a timestamp | timestamp(request.resource.attr.lastAccessed).getMinutes() == 5
-| getMonth | Get month from a timestamp. Returns a zero-based value where January is 0 | timestamp(request.resource.attr.lastAccessed).getMonth() == 3
-| getSeconds | Get seconds from a timestamp | timestamp(request.resource.attr.lastAccessed).getSeconds() == 20
+| timestamp | Convert an RFC3339 formatted string to a timestamp | timestamp(R.attr.lastAccessed).getFullYear() == 2021
+| getDate  | Get day of month from a timestamp | timestamp(R.attr.lastAccessed).getDate() == 20
+| getDayOfMonth | Get day of month from a timestamp. Returns a zero-based value | timestamp(R.attr.lastAccessed).getDayOfMonth() == 19
+| getDayOfWeek | Get day of week from a timestamp. Returns a zero-based value where Sunday is 0 | timestamp(R.attr.lastAccessed).getDayOfWeek() == 2
+| getDayOfYear | Get day of year from a timestamp. Returns a zero-based value | timestamp(R.attr.lastAccessed).getDayOfYear() == 109
+| getFullYear | Get full year from a timestamp | timestamp(R.attr.lastAccessed).getFullYear() == 2021 
+| getHours | Get hours from a timestamp | timestamp(R.attr.lastAccessed).getHours() == 10
+| getMilliseconds | Get milliseconds from a timestamp | timestamp(R.attr.lastAccessed).getMilliseconds() == 21
+| getMinutes | Get minutes from a timestamp | timestamp(R.attr.lastAccessed).getMinutes() == 5
+| getMonth | Get month from a timestamp. Returns a zero-based value where January is 0 | timestamp(R.attr.lastAccessed).getMonth() == 3
+| getSeconds | Get seconds from a timestamp | timestamp(R.attr.lastAccessed).getSeconds() == 20
+| timeSince | Time elapsed since the given timestamp to current time on the server. This is a Cerbos extension to CEL | timestamp(R.attr.lastAccessed).timeSince() > duration("1h")
 |===
 
-
-== Rego conditions
-
-* You can access the request object using the special `input` variable. Use dots to access different fields of the request. For example, the expression to get the current principal ID is `input.principal.id`.
-* Ensure that the final result of evaluating the Rego script always produces a single boolean true/false value. 
-
-
-[source,yaml,linenums]
-----
-condition:
-  script: |-
-    input.resource.attr.owner == input.principal.id;
-    regex.match("^dev_.*", input.principal.id);
-----

--- a/docs/modules/policies/pages/index.adoc
+++ b/docs/modules/policies/pages/index.adoc
@@ -11,7 +11,7 @@ xref:principal_policies.adoc[Principal policies]:: Defines overrides for a speci
 
 Policies are evaluated based on the metadata passed in the request to the Cerbos PDP. 
 
-NOTE: The OpenAPI (Swagger) schema for the request can be obtained from a running Cerbos instance by accessing `{cerbos-openapi-schema}`. 
+NOTE: View the latest documentation and example requests by accessing a running Cerbos instance using a browser (e.g. http://localhost:3592/). The OpenAPI (Swagger) schema can be obtained by accessing `{cerbos-openapi-schema}` as well. 
 
 [source,json,linenums]
 ----

--- a/internal/codegen/cel.go
+++ b/internal/codegen/cel.go
@@ -7,17 +7,26 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/ext"
-	"github.com/google/cel-go/parser"
 
 	policyv1 "github.com/cerbos/cerbos/internal/genpb/policy/v1"
 )
 
+const (
+	CELRequestIdent    = "request"
+	CELResourceAbbrev  = "R"
+	CELPrincipalAbbrev = "P"
+)
+
 func GenerateCELProgram(parent string, m *policyv1.Match) (cel.Program, error) {
 	env, err := cel.NewEnv(
-		cel.Declarations(decls.NewVar("request", decls.NewMapType(decls.String, decls.Dyn))),
-		cel.Macros(parser.AllMacros...),
+		cel.Declarations(
+			decls.NewVar(CELRequestIdent, decls.NewMapType(decls.String, decls.Dyn)),
+			decls.NewVar(CELResourceAbbrev, decls.NewMapType(decls.String, decls.Dyn)),
+			decls.NewVar(CELPrincipalAbbrev, decls.NewMapType(decls.String, decls.Dyn)),
+		),
 		ext.Strings(),
 		ext.Encoders(),
+		CerbosCELLib(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CEL environment: %w", err)

--- a/internal/codegen/cel_lib.go
+++ b/internal/codegen/cel_lib.go
@@ -1,0 +1,119 @@
+package codegen
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/interpreter/functions"
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+const (
+	inIPAddrRangeFn = "inIPAddrRange"
+	timeSinceFn     = "timeSince"
+)
+
+// CerbosCELLib returns the custom CEL functions provided by Cerbos.
+func CerbosCELLib() cel.EnvOption {
+	return cel.Lib(cerbosLib{})
+}
+
+type cerbosLib struct{}
+
+func (clib cerbosLib) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Declarations(
+			decls.NewFunction(inIPAddrRangeFn,
+				decls.NewInstanceOverload(
+					fmt.Sprintf("%s_string", inIPAddrRangeFn),
+					[]*exprpb.Type{decls.String, decls.String},
+					decls.Bool,
+				),
+			),
+
+			decls.NewFunction(timeSinceFn,
+				decls.NewInstanceOverload(
+					fmt.Sprintf("%s_timestamp", timeSinceFn),
+					[]*exprpb.Type{decls.Timestamp},
+					decls.Duration,
+				),
+			),
+		),
+	}
+}
+
+func (clib cerbosLib) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{
+		cel.Functions(
+			&functions.Overload{
+				Operator: inIPAddrRangeFn,
+				Binary:   callInStringStringOutBool(clib.inIPAddrRangeFunc),
+			},
+
+			&functions.Overload{
+				Operator: timeSinceFn,
+				Unary:    callInTimestampOutDuration(clib.timeSinceFunc),
+			},
+
+			&functions.Overload{
+				Operator: fmt.Sprintf("%s_timestamp", timeSinceFn),
+				Unary:    callInTimestampOutDuration(clib.timeSinceFunc),
+			},
+		),
+	}
+}
+
+func (clib cerbosLib) inIPAddrRangeFunc(ipAddrVal, cidrVal string) (bool, error) {
+	ipAddr := net.ParseIP(ipAddrVal)
+	if ipAddr == nil {
+		return false, fmt.Errorf("invalid IP address: %s", ipAddrVal)
+	}
+
+	_, cidr, err := net.ParseCIDR(cidrVal)
+	if err != nil {
+		return false, err
+	}
+
+	return cidr.Contains(ipAddr), nil
+}
+
+func (clib cerbosLib) timeSinceFunc(ts time.Time) time.Duration {
+	return time.Since(ts)
+}
+
+func callInStringStringOutBool(fn func(string, string) (bool, error)) functions.BinaryOp {
+	return func(lhsVal, rhsVal ref.Val) ref.Val {
+		lhs, ok := lhsVal.(types.String)
+		if !ok {
+			return types.MaybeNoSuchOverloadErr(lhsVal)
+		}
+
+		rhs, ok := rhsVal.(types.String)
+		if !ok {
+			return types.MaybeNoSuchOverloadErr(rhsVal)
+		}
+
+		retVal, err := fn(string(lhs), string(rhs))
+		if err != nil {
+			return types.NewErr(err.Error())
+		}
+
+		return types.DefaultTypeAdapter.NativeToValue(retVal)
+	}
+}
+
+func callInTimestampOutDuration(fn func(time.Time) time.Duration) functions.UnaryOp {
+	return func(val ref.Val) ref.Val {
+		ts, ok := val.(types.Timestamp)
+		if !ok {
+			return types.MaybeNoSuchOverloadErr(val)
+		}
+
+		return types.DefaultTypeAdapter.NativeToValue(fn(ts.Time))
+	}
+}

--- a/internal/codegen/cel_lib_test.go
+++ b/internal/codegen/cel_lib_test.go
@@ -1,0 +1,45 @@
+package codegen_test
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cerbos/cerbos/internal/codegen"
+)
+
+func TestCerbosLib(t *testing.T) {
+	testCases := []struct {
+		expr    string
+		wantErr bool
+	}{
+		{expr: `"192.168.0.5".inIPAddrRange("192.168.0.0/24") == true`},
+		{expr: `"192.169.1.5".inIPAddrRange("192.168.0.0/24") == false`},
+		{expr: `"test".inIPAddrRange("192.168.0.0/24") == false`, wantErr: true},
+		{expr: `"2001:0db8:0000:0000:0000:0000:1000:0000".inIPAddrRange("2001:db8::/48") == true`},
+		{expr: `"3001:0fff:0000:0000:0000:0000:0000:0000".inIPAddrRange("2001:db8::/48") == false`},
+		{expr: `timestamp("2021-05-01T00:00:00.000Z").timeSince() > duration("1h")`},
+	}
+
+	env, err := cel.NewEnv(codegen.CerbosCELLib())
+	require.NoError(t, err)
+
+	for _, tc := range testCases {
+		t.Run(tc.expr, func(t *testing.T) {
+			ast, issues := env.Compile(tc.expr)
+			require.NoError(t, issues.Err())
+
+			prg, err := env.Program(ast)
+			require.NoError(t, err)
+
+			have, _, err := prg.Eval(cel.NoVars())
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, true, have.Value())
+			}
+		})
+	}
+}

--- a/internal/test/testdata/cel_eval/cerbos_lib.yaml
+++ b/internal/test/testdata/cel_eval/cerbos_lib.yaml
@@ -1,0 +1,29 @@
+---
+condition:
+  all:
+    of:
+      - expr: |-
+          P.attr.ipv4Address.inIPAddrRange("192.168.0.0/24")
+      - expr: |-
+          P.attr.ipv6Address.inIPAddrRange("2001:db8::/48")
+      - expr: |-
+          timestamp(P.attr.lastLogin).timeSince() > duration("24h")
+input: {
+  "requestId": "test",
+  "actions": ["*"],
+  "principal": {
+    "id": "john",
+    "roles": ["employee"],
+    "attr": {
+      "department": "marketing",
+      "ipv4Address": "192.168.0.5",
+      "ipv6Address": "2001:0db8:0000:0000:0000:0000:1000:0000",
+      "lastLogin": "2021-04-20T10:05:20.021-05:00"
+    }
+  },
+  "resource": {
+    "name": "leave_request",
+    "attr": {}
+  }
+}
+want: true

--- a/internal/test/testdata/cel_eval/duration_funcs.yaml
+++ b/internal/test/testdata/cel_eval/duration_funcs.yaml
@@ -2,10 +2,11 @@
 condition:
   all:
     of:
-      - expr: duration(request.resource.attr.cooldownPeriod).getSeconds() == 3750
-      - expr: duration(request.resource.attr.cooldownPeriod).getHours() == 1
-      - expr: duration(request.resource.attr.cooldownPeriod).getMilliseconds() == 3750000
-      - expr: duration(request.resource.attr.cooldownPeriod).getMinutes() == 62
+      - expr: duration(R.attr.cooldownPeriod).getSeconds() == 3750
+      - expr: duration(R.attr.cooldownPeriod).getHours() == 1
+      - expr: duration(R.attr.cooldownPeriod).getMilliseconds() == 3750000
+      - expr: duration(R.attr.cooldownPeriod).getMinutes() == 62
+      - expr: timestamp(R.attr.lastAccessTime) - timestamp(R.attr.lastUpdateTime) < duration("36h") 
 input: {
   "requestId": "test",
   "actions": ["*"],
@@ -19,7 +20,9 @@ input: {
   "resource": {
     "name": "leave_request",
     "attr": {
-      "cooldownPeriod": "3750s"
+      "cooldownPeriod": "3750s",
+      "lastUpdateTime": "2021-05-01T13:34:12.024Z",
+      "lastAccessTime": "2021-05-02T14:24:22.034Z"
     }
   }
 }

--- a/internal/test/testdata/cel_eval/maps_and_lists.yaml
+++ b/internal/test/testdata/cel_eval/maps_and_lists.yaml
@@ -3,18 +3,29 @@ condition:
   all:
     of:
       - expr: |-
-          "design" in request.principal.attr.teams
+          "design" in P.attr.teams
       - expr: |-
-          "acme" in request.principal.attr.clients
+          "acme" in P.attr.clients
       - expr: |-
-          request.principal.attr.teams[0] == "design"
+          P.attr.teams[0] == "design"
       - expr: |-
-          request.principal.attr.clients["acme"]["active"] == true
+          P.attr.clients["acme"]["active"] == true
       - expr: |-
-          size(request.principal.attr.teams) == 3
+          size(P.attr.teams) == 4
       - expr: |-
-          size(request.principal.attr.clients) == 2
-
+          size(P.attr.clients) == 2
+      - expr: |-
+          has(P.attr.department)
+      - expr: |-
+          P.attr.teams.all(t, size(t) > 3)
+      - expr: |-
+          P.attr.teams.exists(t, t.startsWith("comm"))
+      - expr: |-
+          P.attr.teams.exists_one(t, t.startsWith("comm")) == false
+      - expr: |-
+          "DESIGN" in P.attr.teams.map(t, t.upperAscii())
+      - expr: |-
+          size(P.attr.teams.filter(t, t.matches("^comm"))) == 2
 input: {
   "requestId": "test",
   "actions": ["*"],
@@ -23,7 +34,7 @@ input: {
     "roles": ["employee"],
     "attr": {
       "department": "marketing",
-      "teams": ["design", "communications", "product"],
+      "teams": ["design", "communications", "product", "commercial"],
       "clients": {
         "acme": {"active": true},
         "bb inc": {"active": true}

--- a/internal/test/testdata/cel_eval/string_funcs.yaml
+++ b/internal/test/testdata/cel_eval/string_funcs.yaml
@@ -4,12 +4,35 @@ condition:
     of:
       - expr: '"mark"+"eting" == "marketing"'
       - expr: '"mark" > "eting"'
-      - expr: request.principal.attr.department.contains("arket")
-      - expr: request.resource.attr.department.endsWith("ing")
+      - expr: P.attr.department.contains("arket")
+      - expr: R.attr.department.endsWith("ing")
       - expr: int("42") == 42
-      - expr: request.principal.attr.department.matches("^[mM].*g$")
-      - expr: size(request.principal.attr.department) == 9
-      - expr: request.resource.attr.department.startsWith("mark")
+      - expr: P.attr.department.matches("^[mM].*g$")
+      - expr: size(P.attr.department) == 9
+      - expr: R.attr.department.startsWith("mark")
+      - expr: R.attr.department.charAt(1) == 'a'
+      - expr: R.attr.department.indexOf('a') == 1
+      - expr: R.attr.department.lastIndexOf('g') == 8
+      - expr: |-
+          "MARKETING".lowerAscii() == R.attr.department
+      - expr: |-
+          R.attr.department.replace("market", "engineer") == "engineering"
+      - expr: |-
+          "engineering".replace("e", "a", 1) == "angineering" && "engineering".replace("e", "a", -1) == "anginaaring"
+      - expr: |-
+          "a,b,c,d".split(",")[1] == "b"
+      - expr: |-
+          "a,b,c,d".split(",", 2)[1] == "b,c,d"
+      - expr: |-
+          R.attr.department.substring(4) == "eting" && R.attr.department.substring(4, 6) == "et"
+      - expr: |-
+          "  marketing  ".trim() == "marketing"
+      - expr: |-
+          R.attr.department.upperAscii() == "MARKETING"
+      - expr: |-
+          base64.decode("aGVsbG8=") == bytes("hello")
+      - expr: |-
+          base64.encode(bytes("hello")) == "aGVsbG8="
 input: {
   "requestId": "test",
   "actions": ["*"],

--- a/internal/test/testdata/cel_eval/timestamp_funcs.yaml
+++ b/internal/test/testdata/cel_eval/timestamp_funcs.yaml
@@ -2,16 +2,18 @@
 condition:
   all:
     of:
-      - expr: timestamp(request.resource.attr.lastAccessed).getDate() == 20
-      - expr: timestamp(request.resource.attr.lastAccessed).getDayOfMonth() == 19
-      - expr: timestamp(request.resource.attr.lastAccessed).getDayOfWeek() == 2
-      - expr: timestamp(request.resource.attr.lastAccessed).getDayOfYear() == 109
-      - expr: timestamp(request.resource.attr.lastAccessed).getFullYear() == 2021
-      - expr: timestamp(request.resource.attr.lastAccessed).getHours() == 10
-      - expr: timestamp(request.resource.attr.lastAccessed).getMilliseconds() == 21
-      - expr: timestamp(request.resource.attr.lastAccessed).getMinutes() == 5
-      - expr: timestamp(request.resource.attr.lastAccessed).getMonth() == 3
-      - expr: timestamp(request.resource.attr.lastAccessed).getSeconds() == 20
+      - expr: timestamp(R.attr.lastAccessed).getDate() == 20
+      - expr: timestamp(R.attr.lastAccessed).getDayOfMonth() == 19
+      - expr: timestamp(R.attr.lastAccessed).getDayOfWeek() == 2
+      - expr: timestamp(R.attr.lastAccessed).getDayOfYear() == 109
+      - expr: timestamp(R.attr.lastAccessed).getFullYear() == 2021
+      - expr: timestamp(R.attr.lastAccessed).getHours() == 10
+      - expr: timestamp(R.attr.lastAccessed).getMilliseconds() == 21
+      - expr: timestamp(R.attr.lastAccessed).getMinutes() == 5
+      - expr: timestamp(R.attr.lastAccessed).getMonth() == 3
+      - expr: timestamp(R.attr.lastAccessed).getSeconds() == 20
+      - expr: |-
+          timestamp(R.attr.lastAccessed) + duration("24h") == timestamp("2021-04-21T10:05:20.021-05:00")
 input: {
   "requestId": "test",
   "actions": ["*"],


### PR DESCRIPTION
- Introduce utility functions `inIPAddrRange` and `timeSince` that can
  be used to write conditions targeting IP address ranges and times.
- Introduce the `R` alias to refer to `request.resource`.
- Introduce the `P` alias to refer to `request.principal`.
- Document all available CEL functions with examples.
- Remove documentation about Rego conditions to avoid tying the policies
  too deeply with OPA.
- Add tests to cover CEL functions.

Fixes #15
