### PR TITLE
docs: Add API docs and testing docs

### DIFF
--- a/.goreleaser-ci.yml
+++ b/.goreleaser-ci.yml
@@ -22,6 +22,8 @@ dockers:
     use_buildx: true
     build_flag_templates:
       - "--platform=linux/amd64"
+    extra_files:
+      - conf.default.yaml
 
   - image_templates:
       - "ghcr.io/cerbos/cerbos:{{ .Version }}-arm64"
@@ -30,6 +32,8 @@ dockers:
     use_buildx: true
     build_flag_templates:
       - "--platform=linux/arm64"
+    extra_files:
+      - conf.default.yaml
 docker_manifests:
   - name_template: "ghcr.io/cerbos/cerbos:{{ .Version }}"
     image_templates:

--- a/.goreleaser-dev.yml
+++ b/.goreleaser-dev.yml
@@ -17,6 +17,8 @@ dockers:
   - image_templates:
       - "ghcr.io/cerbos/cerbos:latest"
       - "ghcr.io/cerbos/cerbos:{{ .Version }}"
+    extra_files:
+      - conf.default.yaml
 checksum:
   disable: true
 changelog:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM gcr.io/distroless/base
+EXPOSE 3592 3593
+VOLUME ["/policies"]
 ENTRYPOINT ["/cerbos"]
+CMD ["server", "--config=/conf.default.yaml"]
 COPY cerbos /cerbos
+COPY conf.default.yaml /conf.default.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,6 @@ pre-commit: lint-helm build generate-notice
 build: $(GORELEASER) generate lint test
 	@ $(GORELEASER) --config=.goreleaser-dev.yml --snapshot --skip-publish --rm-dist
 
-.PHONY: run
-run:
-	@ go run main.go server --config=conf.default.yaml
-
 .PHONY: docs
 docs:
 	@ docs/build.sh

--- a/conf.default.yaml
+++ b/conf.default.yaml
@@ -1,6 +1,6 @@
 ---
 server:
-  httpListenAddr: ":9999"
+  httpListenAddr: ":3592"
   grpcListenAddr: ":3593"
 
 engine:
@@ -9,11 +9,5 @@ engine:
 storage:
   driver: "disk"
   disk:
-    directory: internal/test/testdata/store
-  git:
-    protocol: file
-    url: file://${HOME}/tmp/ava/source
-    branch: policies
-    subDir: policies
-    checkoutDir: ${HOME}/tmp/ava/work
-    updatePollInterval: 60s
+    directory: /policies
+    watchForChanges: true

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -4,6 +4,7 @@ title: Cerbos
 version: master
 nav:
   - modules/ROOT/nav.adoc
+  - modules/api/nav.adoc
   - modules/policies/nav.adoc
   - modules/configuration/nav.adoc
   - modules/deployment/nav.adoc

--- a/docs/modules/ROOT/pages/installation/container.adoc
+++ b/docs/modules/ROOT/pages/installation/container.adoc
@@ -7,5 +7,35 @@ Login to the container registry using the provided username and API key.
 [source,sh,subs="attributes"]
 ----
 echo YOUR_API_KEY | docker login {app-container-registry} -u YOUR_USERNAME --password-stdin
-docker pull {app-docker-img}
+docker run --rm --name cerbos -p 3592:3592 {app-docker-img} 
 ----
+
+By default, the container is configured to listen on ports 3592 (HTTP) and 3593 (gRPC) and watch for policy files on the volume mounted at `/policies`. You can override these by creating a new xref:configuration:index.adoc[configuration file]. 
+
+.Create a directory to hold the config file and policies.
+[source,sh,subs="attributes"]
+----
+mkdir -p cerbos-quickstart/policies
+----
+
+.Create a config file.
+[source,sh,subs="attributes,+macros"]
+----
+cat $$>$$ cerbos-quickstart/conf.yaml $$<<$$EOF
+server:
+  httpListenAddr: ":3592"
+
+storage:
+  driver: "disk"
+  disk:
+    directory: /quickstart/policies
+    watchForChanges: true
+EOF
+----
+
+.Launch the container with the new config file.
+[source,sh,subs="attributes"]
+----
+docker run --rm --name cerbos -d -v $(pwd)/cerbos-quickstart:/quickstart -p 3592:3592 {app-docker-img} server --config=/quickstart/conf.yaml
+----
+

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -3,27 +3,11 @@ include::partial$attributes.adoc[]
 = Quickstart
 
 
-Create a directory to store the server config and policies.
+Create a directory to store the policies.
 
 [source,sh]
 ----
 mkdir -p cerbos-quickstart/policies
-----
-
-Create the config file for the server.
-
-[source,sh,subs="attributes,+macros"]
-----
-cat $$>$$ cerbos-quickstart/conf.yaml $$<<$$EOF
-server:
-  httpListenAddr: ":3592"
-
-storage:
-  driver: "disk"
-  disk:
-    directory: /quickstart/policies
-    watchForChanges: true
-EOF
 ----
 
 Now start the Cerbos server. We are using the container image in this guide but you can follow along using the binary as well. See xref:installation/binary.adoc[installation instructions] for more information.
@@ -42,7 +26,7 @@ echo YOUR_API_KEY | docker login {app-container-registry} -u YOUR_USERNAME --pas
 
 [source,shell,subs="attributes"]
 ----
-docker run --rm --name cerbos -d -v $(pwd)/cerbos-quickstart:/quickstart -p 3592:3592 {app-docker-img} server --config=/quickstart/conf.yaml
+docker run --rm --name cerbos -d -v $(pwd)/cerbos-quickstart/policies:/policies -p 3592:3592 {app-docker-img} 
 ----
 
 Launch a browser and navigate to http://localhost:3592/. You will be presented with a webpage with documentation about the Cerbos API.

--- a/docs/modules/api/nav.adoc
+++ b/docs/modules/api/nav.adoc
@@ -1,0 +1,2 @@
+.Cerbos API
+* xref:index.adoc[Using the API]

--- a/docs/modules/api/pages/index.adoc
+++ b/docs/modules/api/pages/index.adoc
@@ -1,0 +1,153 @@
+include::ROOT:partial$attributes.adoc[]
+
+= The Cerbos API
+
+The main API endpoint for making policy decisions is the `/api/check` REST endpoint (`svc.v1.CheckResourceSet` RPC in the gRPC API). You can view the latest API documentation from a running Cerbos instance by accessing the root directory of the HTTP endpoint using a browser.
+
+[source,sh,subs="attributes"]
+----
+echo YOUR_API_KEY | docker login {app-container-registry} -u YOUR_USERNAME --password-stdin
+docker run --rm --name cerbos -p 3592:3592 {app-docker-img} 
+----
+
+Navigate to link:http://localhost:3592/[] using your browser to explore the Cerbos API documentation.
+
+== Request and response formats
+
+.Request
+[source,json,linenums]
+----
+{
+  "requestId":  "test01", <1>
+  "actions":  ["view"], <2>
+  "resource":  {
+    "policyVersion": "dev", <3>
+    "kind":  "album:object", <4>
+    "instances": { <5>
+      "XX125": { <6>
+        "attr":  { <7>
+          "owner":  "alicia",
+          "id":  "XX125",
+          "public": false,
+          "tags": ["x", "y"],
+          "flagged": false
+        }
+      }
+    }
+  },
+  "principal":  {
+    "id":  "alicia", <8>
+    "policyVersion": "dev", <9>
+    "roles":  ["user"], <10>
+    "attr": { <11>
+      "geography": "GB"
+    }
+  },
+  "includeMeta": true <12>
+}
+----
+<1> Request ID can be anything that uniquely identifies a request.
+<2> Actions being performed on the resource instances. Required.
+<3> Resource policy version. Optional. The server falls back to the xref:configuration:engine.adoc[configured default version] if this is not specified.
+<4> Resource kind. Required. This value is used to determine the resource policy to evaluate. 
+<5> Container for the set of resource instances to check. You can check access to multiple resource instances in a single request by adding them under this field. 
+<6> A unique identifier for a resource instance. This identifier will be used in the response to indicate the result of the policy evaluation.
+<7> Free-form context data about this resource instance. Policy rule conditions are evaluated based on these values.
+<8> ID of the principal performing the actions. Required.
+<9> Principal policy version. Optional. The server falls back to the xref:configuration:engine.adoc[configured default version] if this is not specified.
+<10> Static roles that are assigned to this principal by your identity management system. Required.
+<11> Free-form context data about this principal. Policy rule conditions are evaluated based on these values.
+<12> An optional flag to signal that the response should include metadata about policy evaluation. Useful for debugging.
+
+
+.Response
+[source,json,linenums]
+----
+{
+  "requestId": "test01", <1>
+  "resourceInstances": {
+    "XX125": { <2>
+      "actions": {
+        "view": "EFFECT_ALLOW" <3>
+      }
+    }
+  },
+  "meta": { <4>
+    "resourceInstances": {
+      "XX125": {
+        "actions": {
+          "view": {
+            "matchedPolicy": "album:object:default" <5>
+          }
+        },
+        "effectiveDerivedRoles": [ <6>
+          "owner"
+        ]
+      }
+    }
+  }
+}
+----
+<1> The request ID received from the request. Helpful for correlating logs.
+<2> Unique ID of the resource.
+<3> Policy decision for each action on the resource.
+<4> Optional metadata about request evaluation.
+<5> The policy that matched to make the decision for the given action.
+<6> Derived roles that were activated.
+
+
+
+.Using curl to access the API
+[source,sh,linenums]
+----
+cat <<EOF | curl --silent "localhost:3592/api/check" -d @-
+{
+  "requestId":  "test01",
+  "includeMeta": true,
+  "actions":  ["view"],
+  "resource":  {
+    "policyVersion": "default",
+    "kind":  "album:object",
+    "instances": {
+      "XX125": {
+        "attr":  {
+          "owner":  "alicia",
+          "id":  "XX125",
+          "public": false,
+          "flagged": false
+        }
+      }
+    }
+  },
+  "principal":  {
+    "id":  "alicia",
+    "policyVersion": "default",
+    "roles":  ["user"]
+  }
+}
+EOF
+----
+
+
+== Generating API clients
+
+The Cerbos OpenAPI specification can be obtained from a running Cerbos instance by accessing link:http://localhost:3592{cerbos-openapi-schema}[].
+
+There are many tools available to generate clients from an OpenAPI specification. https://openapi.tools/#sdk is a good resource for finding a tool suitable for your preferred language. link:https://openapi-generator.tech[OpenAPI Generator] has link:https://openapi-generator.tech/docs/generators#client-generators[support for many popular programming languages and frameworks].
+
+=== Example: Generating a Java client using OpenAPI Generator
+
+This is an example of using the popular link:https://openapi-generator.tech[OpenAPI Generator] service to generate a Java client API.
+
+.Download the Cerbos OpenAPI specification
+[source,sh,subs="attributes"]
+----
+curl -Lo swagger.json http://localhost:3592{cerbos-openapi-schema}
+----
+
+.Run the OpenAPI Generator
+[source,sh,subs="attributes"]
+----
+docker run --rm -v $(pwd):/oas openapitools/openapi-generator-cli generate -i /oas/swagger.json -g java -o /oas/java
+----
+

--- a/docs/modules/policies/nav.adoc
+++ b/docs/modules/policies/nav.adoc
@@ -3,4 +3,4 @@
 * xref:resource_policies.adoc[Resource Policies]
 * xref:principal_policies.adoc[Principal Policies]
 * xref:conditions.adoc[Conditions]
-* Writing tests
+* xref:compile.adoc[Compiling and testing]

--- a/docs/modules/policies/pages/compile.adoc
+++ b/docs/modules/policies/pages/compile.adoc
@@ -1,0 +1,73 @@
+include::ROOT:partial$attributes.adoc[]
+
+= Compiling policies
+
+You can use the Cerbos compiler to make sure that your policies are valid before pushing them to a production Cerbos instance. We recommend setting up a git hook or a CI step to run the Cerbos compiler before you push any policy changes to production.
+
+[source,sh,subs="attributes"]
+----
+docker run -i -t -v /path/to/policy/dir:/policies {app-docker-img} compile /policies
+----
+
+
+== Testing policies
+
+You can write optional tests for policies and run them as part of the compilation stage to make sure that the policies do exactly what you expect.
+
+Tests are defined using the familiar YAML format as well. Make sure that your tests are in separate directory from the policies to avoid confusion. We recommend storing them in a top-level directory named `tests`.
+
+.Test suite definition
+[source,yaml]
+----
+---
+name: AlbumObjectTestSuite <1>
+description: Tests for verifying the album:object resource policy <2>
+tests: <3>
+  - name: Alicia tries to view her own private album <4>
+    input: { <5>
+      "requestId": "test",
+      "actions": ["view"],
+      "principal": {
+        "id": "alicia",
+        "roles": ["user"]
+      },
+      "resource": {
+        "kind": "album:object",
+        "attr": {
+          "owner": "alicia",
+          "id": "XX125",
+          "public": false,
+          "flagged": false
+        }
+      }
+    }
+    expected: <6>
+      view: EFFECT_ALLOW
+----
+<1> Name of the test suite
+<2> Description of the test suite
+<3> List of tests in this suite
+<4> Name of the test
+<5> Input to the policy engine
+<6> Expected outcome for each of the actions defined in the input
+
+
+To run the tests, provide the path to the tests directory using the `--tests` flag.
+
+[source,sh,subs="attributes"]
+----
+docker run -i -t \
+    -v /path/to/policy/dir:/policies \
+    -v /path/to/test/dir:/tests \
+    {app-docker-img} compile --tests=/tests /policies
+----
+
+----
+Test results
+= AlbumObjectTestSuite (album_object_tests.yaml)
+== Alicia tries to view her own private album [OK]
+== Bradley tries to view Alicia's private album [OK]
+== Bradley tries to view Alicia's public album [OK]
+== Moderator tries to delete a flagged album [OK]
+== Moderator tries to delete an unflagged album [OK]
+----

--- a/docs/modules/policies/pages/index.adoc
+++ b/docs/modules/policies/pages/index.adoc
@@ -9,53 +9,11 @@ xref:resource_policies.adoc[Resource policies]:: Defines rules for actions that 
 xref:principal_policies.adoc[Principal policies]:: Defines overrides for a specific user. 
 
 
-Policies are evaluated based on the metadata passed in the request to the Cerbos PDP. 
+
+Policies are evaluated based on the metadata passed in the request to the Cerbos PDP. See xref:api:index.adoc[Cerbos API] for more information.
 
 NOTE: View the latest documentation and example requests by accessing a running Cerbos instance using a browser (e.g. http://localhost:3592/). The OpenAPI (Swagger) schema can be obtained by accessing `{cerbos-openapi-schema}` as well. 
 
-[source,json,linenums]
-----
-{
-  "requestId":  "test01", <1>
-  "actions":  ["view"], <2>
-  "resource":  {
-    "policyVersion": "dev", <3>
-    "kind":  "album:object", <4>
-    "instances": { <5>
-      "XX125": { <6>
-        "attr":  { <7>
-          "owner":  "alicia",
-          "id":  "XX125",
-          "public": false,
-          "tags": ["x", "y"],
-          "flagged": false
-        }
-      }
-    }
-  },
-  "principal":  {
-    "id":  "alicia", <8>
-    "policyVersion": "dev", <9>
-    "roles":  ["user"], <10>
-    "attr": { <11>
-      "geography": "GB"
-    }
-  },
-  "includeMeta": true <12>
-}
-----
-<1> Request ID can be anything that uniquely identifies a request.
-<2> Actions being performed on the resource instances. Required.
-<3> Resource policy version. Optional. The server falls back to the xref:configuration:engine.adoc[configured default version] if this is not specified.
-<4> Resource kind. Required. This value is used to determine the resource policy to evaluate. 
-<5> Container for the set of resource instances to check. You can check access to multiple resource instances in a single request by adding them under this field. 
-<6> A unique identifier for a resource instance. This identifier will be used in the response to indicate the result of the policy evaluation.
-<7> Free-form context data about this resource instance. Policy rule conditions are evaluated based on these values.
-<8> ID of the principal performing the actions. Required.
-<9> Principal policy version. Optional. The server falls back to the xref:configuration:engine.adoc[configured default version] if this is not specified.
-<10> Static roles that are assigned to this principal by your identity management system. Required.
-<11> Free-form context data about this principal. Policy rule conditions are evaluated based on these values.
-<12> An optional flag to signal that the response should include metadata about policy evaluation. Useful for debugging.
 
 == Policy authoring tips
 


### PR DESCRIPTION
- Add a new section describing the API and how to generate API clients
- Simplify container usage by shipping a default config file
- Cosmetic and editorial fixes to some docs
