### PR TITLE
docs: Add logo and update CSS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 **/*.png filter=lfs diff=lfs merge=lfs -text
 assets/ filter=lfs diff=lfs merge=lfs -text
+**/*.svg filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Example
 ```yaml
 ---
 apiVersion: "api.cerbos.dev/v1"
-derived_roles:
+derivedRoles:
   name: common_roles
   definitions:
     - name: owner

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -48,7 +48,7 @@ Let's create a xref:policies:derived_roles.adoc[derived roles] definition that a
 cat > cerbos-quickstart/policies/derived_roles_common.yaml <<EOF
 ---
 apiVersion: "api.cerbos.dev/v1"
-derived_roles:
+derivedRoles:
   name: common_roles
   definitions:
     - name: owner

--- a/docs/modules/policies/pages/derived_roles.adoc
+++ b/docs/modules/policies/pages/derived_roles.adoc
@@ -8,7 +8,7 @@ include::ROOT:partial$attributes.adoc[]
 apiVersion: "api.cerbos.dev/v1"
 description: |-
   Common dynamic roles used within the Apatr app
-derived_roles:
+derivedRoles:
   name: apatr_common_roles <1>
   definitions:
     - name: owner <2>

--- a/docs/modules/tutorials/examples/photo-share/policies/01_apatr_common_roles.yaml
+++ b/docs/modules/tutorials/examples/photo-share/policies/01_apatr_common_roles.yaml
@@ -2,7 +2,7 @@
 apiVersion: "api.cerbos.dev/v1"
 description: |-
   Common dynamic roles used within the Apatr app
-derived_roles:
+derivedRoles:
   name: apatr_common_roles
   definitions:
     - name: owner

--- a/docs/modules/tutorials/pages/photo-share/index.adoc
+++ b/docs/modules/tutorials/pages/photo-share/index.adoc
@@ -116,7 +116,7 @@ These capabilities are determined based on contextual information. Let's codify 
 apiVersion: "api.cerbos.dev/v1"
 description: |-
   Common dynamic roles used within the Apatr app
-derived_roles:
+derivedRoles:
   name: apatr_common_roles <1>
   definitions:
     - name: owner <2>

--- a/docs/supplemental-ui/cerbie.svg
+++ b/docs/supplemental-ui/cerbie.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e839fbd624abf1daf186a97353080416393e927620ec5ce69d9cb8950687445
+size 2166

--- a/docs/supplemental-ui/cerbos.svg
+++ b/docs/supplemental-ui/cerbos.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4042d1e021750176a302be03a651fd44095c1842942777c68e9631f72b7078bb
+size 21703

--- a/docs/supplemental-ui/css/site-extra.css
+++ b/docs/supplemental-ui/css/site-extra.css
@@ -1,0 +1,7 @@
+.navbar {
+    background-color: #ffb901 !important;
+}
+
+.footer {
+    background-color: #ffb901 !important;
+}

--- a/docs/supplemental-ui/partials/footer-content.hbs
+++ b/docs/supplemental-ui/partials/footer-content.hbs
@@ -1,3 +1,6 @@
 <footer class="footer">
-  <p>Copyright (C) 2020-{{year}} <a href="https://cerbos.dev">Zenauth Ltd.</a></p>
+    <a style="vertical-align: middle;" href="https://cerbos.dev">
+        <img src="{{uiRootPath}}/cerbie.svg" alt="Cerbos" height="50"/>
+    </a>
+    <span>&nbsp;&nbsp;Copyright (C) 2020-{{year}} <a href="https://cerbos.dev">Zenauth Ltd.</a></span>
 </footer>

--- a/docs/supplemental-ui/partials/head-meta.hbs
+++ b/docs/supplemental-ui/partials/head-meta.hbs
@@ -1,0 +1,9 @@
+<link rel="stylesheet" href="{{uiRootPath}}/css/site-extra.css">
+
+  <!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-59KSJHV');</script>
+<!-- End Google Tag Manager -->

--- a/docs/supplemental-ui/partials/header-content.hbs
+++ b/docs/supplemental-ui/partials/header-content.hbs
@@ -2,9 +2,9 @@
   <nav class="navbar">
     <div class="navbar-brand">
       <div class="navbar-item">
-        <a href="https://cerbos.dev">Cerbos</a>
-        <span class="separator">//</span>
-        <a href="{{or site.url (or siteRootUrl siteRootPath)}}">Docs</a>
+        <a href="{{or site.url (or siteRootUrl siteRootPath)}}" style="vertical-align: middle;">
+            <img src="{{uiRootPath}}/cerbos.svg" alt="Cerbos" width="134" height="50"/>
+        </a>
       </div>
       <button class="navbar-burger" data-target="topbar-nav">
         <span></span>
@@ -25,11 +25,4 @@
       </div>
     </div>
   </nav>
-  <!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-59KSJHV');</script>
-<!-- End Google Tag Manager -->
 </header>

--- a/hack/dev/requests/admin_add_or_update_policy/req01.json
+++ b/hack/dev/requests/admin_add_or_update_policy/req01.json
@@ -2,7 +2,7 @@
   "policies": [
     {
       "apiVersion": "api.cerbos.dev/v1",
-      "derived_roles": {
+      "derivedRoles": {
         "name": "my_derived_roles",
         "definitions": [
           {

--- a/internal/test/testdata/codegen/invalid_CEL_condition_in_derived_roles.yaml
+++ b/internal/test/testdata/codegen/invalid_CEL_condition_in_derived_roles.yaml
@@ -1,7 +1,7 @@
 ---
 inputPolicy:
   apiVersion: "api.cerbos.dev/v1"
-  derived_roles:
+  derivedRoles:
     name: my_derived_roles
     definitions:
       - name: direct_manager

--- a/internal/test/testdata/codegen/valid_derived_roles_01.yaml
+++ b/internal/test/testdata/codegen/valid_derived_roles_01.yaml
@@ -1,7 +1,7 @@
 ---
 inputPolicy:
   apiVersion: "api.cerbos.dev/v1"
-  derived_roles:
+  derivedRoles:
     name: my_derived_roles
     definitions:
       - name: admin

--- a/internal/test/testdata/compile/ambiguous_derived_roles.yaml
+++ b/internal/test/testdata/compile/ambiguous_derived_roles.yaml
@@ -40,7 +40,7 @@ inputDefs:
 
   "derived_roles/alpha.yaml":
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: alpha
       definitions:
         - name: tester
@@ -54,7 +54,7 @@ inputDefs:
 
   "derived_roles/beta.yaml":
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: beta
       definitions:
         - name: tester
@@ -65,7 +65,7 @@ inputDefs:
 
   "derived_roles/gamma.yaml":
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: gamma
       definitions:
         - name: any_employee

--- a/internal/test/testdata/compile/bad_rego_script.yaml
+++ b/internal/test/testdata/compile/bad_rego_script.yaml
@@ -38,7 +38,7 @@ inputDefs:
 
   "derived_roles/my_derived_roles.yaml":
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: my_derived_roles
       definitions:
         - name: tester

--- a/internal/test/testdata/compile/multiple_imports.yaml
+++ b/internal/test/testdata/compile/multiple_imports.yaml
@@ -38,7 +38,7 @@ inputDefs:
 
   "derived_roles/alpha.yaml":
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: alpha
       definitions:
         - name: tester
@@ -52,7 +52,7 @@ inputDefs:
 
   "derived_roles/beta.yaml":
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: beta
       definitions:
         - name: any_employee
@@ -60,7 +60,7 @@ inputDefs:
 
   "derived_roles/gamma.yaml":
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: gamma
       definitions:
         - name: direct_manager

--- a/internal/test/testdata/compile/only_derived_roles.yaml
+++ b/internal/test/testdata/compile/only_derived_roles.yaml
@@ -3,7 +3,7 @@ mainDef: "derived_roles/my_derived_roles.yaml"
 inputDefs:
   "derived_roles/my_derived_roles.yaml":
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: my_derived_roles
       definitions:
         - name: tester

--- a/internal/test/testdata/compile/simple_valid_policy_set.yaml
+++ b/internal/test/testdata/compile/simple_valid_policy_set.yaml
@@ -36,7 +36,7 @@ inputDefs:
 
   "derived_roles/my_derived_roles.yaml":
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: my_derived_roles
       definitions:
         - name: tester

--- a/internal/test/testdata/compile/unknown_derived_role.yaml
+++ b/internal/test/testdata/compile/unknown_derived_role.yaml
@@ -40,7 +40,7 @@ inputDefs:
 
   "derived_roles/alpha.yaml":
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: alpha
       definitions:
         - name: tester
@@ -54,7 +54,7 @@ inputDefs:
 
   "derived_roles/beta.yaml":
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: beta
       definitions:
         - name: any_employee
@@ -62,7 +62,7 @@ inputDefs:
 
   "derived_roles/gamma.yaml":
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: gamma
       definitions:
         - name: direct_manager

--- a/internal/test/testdata/index/duplicate_definitions.yaml
+++ b/internal/test/testdata/index/duplicate_definitions.yaml
@@ -16,7 +16,7 @@ files:
   "derived1.yaml": |-
     ---
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: my_derived_roles
       definitions:
         - name: admin
@@ -46,7 +46,7 @@ files:
   "derived2.yaml": |-
     ---
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: my_derived_roles
       definitions:
         - name: admin

--- a/internal/test/testdata/index/incomplete_files.yaml
+++ b/internal/test/testdata/index/incomplete_files.yaml
@@ -24,5 +24,5 @@ files:
   "derived.yaml": |-
     ---
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: my_derived_roles

--- a/internal/test/testdata/index/valid_files.yaml
+++ b/internal/test/testdata/index/valid_files.yaml
@@ -39,7 +39,7 @@ files:
   "derived.yaml": |-
     ---
     apiVersion: "api.cerbos.dev/v1"
-    derived_roles:
+    derivedRoles:
       name: my_derived_roles
       definitions:
         - name: admin

--- a/internal/test/testdata/policy_formats/derived_roles_01.json
+++ b/internal/test/testdata/policy_formats/derived_roles_01.json
@@ -1,6 +1,6 @@
 {
   "apiVersion": "api.cerbos.dev/v1",
-  "derived_roles": {
+  "derivedRoles": {
     "name": "my_derived_roles",
     "definitions": [
       {

--- a/internal/test/testdata/policy_formats/derived_roles_01.yaml
+++ b/internal/test/testdata/policy_formats/derived_roles_01.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: "api.cerbos.dev/v1"
-derived_roles:
+derivedRoles:
   name: my_derived_roles
   definitions:
     - name: admin

--- a/internal/test/testdata/server/admin/add_or_update_policy/case_00.yaml
+++ b/internal/test/testdata/server/admin/add_or_update_policy/case_00.yaml
@@ -8,7 +8,7 @@ adminAddOrUpdatePolicy:
     "policies": [
       {
         "apiVersion": "api.cerbos.dev/v1",
-        "derived_roles": {
+        "derivedRoles": {
           "name": "my_derived_roles",
           "definitions": [
             {

--- a/internal/test/testdata/server/admin/add_or_update_policy/invalid_case_01.yaml
+++ b/internal/test/testdata/server/admin/add_or_update_policy/invalid_case_01.yaml
@@ -9,7 +9,7 @@ adminAddOrUpdatePolicy:
     "policies": [
       {
         "apiVersion": "api.cerbos.dev/v1",
-        "derived_roles": {
+        "derivedRoles": {
           "name": "my_derived_roles",
           "definitions": [
             {

--- a/internal/test/testdata/store/derived_roles/derived_roles_01.yaml
+++ b/internal/test/testdata/store/derived_roles/derived_roles_01.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: "api.cerbos.dev/v1"
-derived_roles:
+derivedRoles:
   name: my_derived_roles
   definitions:
     - name: admin


### PR DESCRIPTION
Adds the Cerbos logo and changes the CSS to use orange for header and
footer.

Also fixes occurrences of `derived_roles` with `derivedRoles`.
