### PR TITLE
chore(ci): Add DCO config

### DIFF
--- a/.github/dco.yaml
+++ b/.github/dco.yaml
@@ -1,0 +1,3 @@
+---
+require:
+  members: false


### PR DESCRIPTION
Add config to not require the DCO from members of the Cerbos org.

See https://github.com/probot/dco#skipping-sign-off-for-organization-members
