### PR TITLE
docs: Remove CERBOS_KEY from install instructions

### DIFF
--- a/docs/modules/ROOT/pages/installation/binary.adoc
+++ b/docs/modules/ROOT/pages/installation/binary.adoc
@@ -18,7 +18,7 @@ You can download the binaries by running the following command. Substitute `<BUN
 
 [source,sh,subs="attributes,macros"]
 ----
-curl -H "X-JFrog-Art-Api:$$<$$CERBOS_KEY$$>$$" -L -o {app-name}.tar.gz "{app-binaries-url}/$$<$$BUNDLE$$>$$"
+curl -L -o {app-name}.tar.gz "{app-github-download-page}/$$<$$BUNDLE$$>$$"
 tar xvf {app-name}.tar.gz
 chmod +x {app-name}
 ----

--- a/docs/modules/ROOT/pages/installation/container.adoc
+++ b/docs/modules/ROOT/pages/installation/container.adoc
@@ -2,11 +2,8 @@ include::partial$attributes.adoc[]
 
 = Run from container
 
-Login to the container registry using the Cerbos key.
-
 [source,sh,subs="attributes"]
 ----
-echo CERBOS_KEY | docker login {app-container-registry} -u cerbos-ea --password-stdin
 docker run --rm --name cerbos -p 3592:3592 {app-docker-img} 
 ----
 

--- a/docs/modules/ROOT/pages/installation/helm.adoc
+++ b/docs/modules/ROOT/pages/installation/helm.adoc
@@ -2,11 +2,11 @@ include::partial$attributes.adoc[]
 
 = Install from Helm chart
 
-Add the Cerbos Helm repository using the Cerbos key provided to you:
+Add the Cerbos Helm repository:
 
 [source,sh,subs="attributes,macros"]
 ----
-helm repo add cerbos https://cerbos.jfrog.io/artifactory/charts --username cerbos-ea --password $$<$$CERBOS_KEY$$>$$
+helm repo add cerbos {app-helm-chart-repo}
 helm repo update
 ----
 
@@ -16,26 +16,6 @@ You can view all the available configuration values for the chart by running the
 ----
 helm show values cerbos/cerbos --version={app-version}
 ----
-
-[NOTE]
-====
-During the private alpha period, the Cerbos container registry requires authentication to pull the container images referenced in the Helm chart. You need to create a Kubernetes secret containing the credentials and reference them during installation as follows:
-
-Create a Kubernetes secret containing the credentials provided to you.
-
-[source,sh,subs="attributes,macros"]
-----
-kubectl create secret docker-registry cerbos-registry --docker-server={app-container-registry} --docker-username=cerbos-ea --docker-password=$$<$$CERBOS_KEY$$>$$
-----
-
-When installing Cerbos using the Helm chart, append `--set='imagePullSecrets[0].name=cerbos-registry'` to the argument list. For example:
-
-[source,sh,subs="attributes,macros"]
-----
-helm install cerbos cerbos/cerbos --version={app-version} --set='imagePullSecrets[0].name=cerbos-registry'
-----
-
-====
 
 .Securing Cerbos with TLS
 ****
@@ -107,7 +87,7 @@ cerbos:
 +
 [source,sh,subs="attributes"]
 ----
-helm install cerbos cerbos/cerbos --version={app-version} --values=git-values.yaml --set='imagePullSecrets[0].name=cerbos-registry'
+helm install cerbos cerbos/cerbos --version={app-version} --values=git-values.yaml 
 ----
 
 
@@ -147,5 +127,5 @@ cerbos:
 +
 [source,sh,subs="attributes"]
 ----
-helm install cerbos cerbos/cerbos --version={app-version} --values=pv-values.yaml --set='imagePullSecrets[0].name=cerbos-registry'
+helm install cerbos cerbos/cerbos --version={app-version} --values=pv-values.yaml 
 ----

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -12,18 +12,6 @@ mkdir -p cerbos-quickstart/policies
 
 Now start the Cerbos server. We are using the container image in this guide but you can follow along using the binary as well. See xref:installation/binary.adoc[installation instructions] for more information.
 
-.Downloading the container image
-****
-
-During the early access period you will need to login to the container registry using the provided Cerbos key.
-
-[source,sh,subs="attributes"]
-----
-echo CERBOS_KEY | docker login {app-container-registry} -u cerbos-ea --password-stdin
-----
-
-****
-
 [source,shell,subs="attributes"]
 ----
 docker run --rm --name cerbos -d -v $(pwd)/cerbos-quickstart/policies:/policies -p 3592:3592 {app-docker-img} 

--- a/docs/modules/ROOT/partials/attributes.adoc
+++ b/docs/modules/ROOT/partials/attributes.adoc
@@ -1,6 +1,6 @@
-:app-container-registry: pkg.cerbos.dev
-:app-docker-img: {app-container-registry}/containers/cerbos:{app-version}
+:app-container-registry: ghcr.io
+:app-docker-img: {app-container-registry}/cerbos/cerbos:{app-version}
 :app-github-url: https://github.com/cerbos/cerbos
 :app-github-download-page: {app-github-url}/releases/tag/v{app-version}
-:app-binaries-url: https://cerbos.jfrog.io/artifactory/binaries
+:app-helm-chart-repo: https://cerbos.jfrog.io/artifactory/charts
 :cerbos-openapi-schema: /schema/swagger.json 

--- a/docs/modules/configuration/pages/storage.adoc
+++ b/docs/modules/configuration/pages/storage.adoc
@@ -2,7 +2,7 @@ include::ROOT:partial$attributes.adoc[]
 
 = Storage block
 
-Cerbos policies can be read from a directory on disk or a git repository. Which storage driver to use is defined by the `driver` setting.
+Cerbos supports multiple backends for storing policies. Which storage driver to use is defined by the `driver` setting.
 
 == Disk driver
 

--- a/docs/supplemental-ui/partials/header-content.hbs
+++ b/docs/supplemental-ui/partials/header-content.hbs
@@ -18,8 +18,9 @@
           <div class="navbar-link">Projects</div>
           <div class="navbar-dropdown">
             <div class="navbar-item"><strong>Cerbos</strong></div>
-            <a class="navbar-item" href="https://github.com/cerbos/cerbos">Repository</a>
+            <a class="navbar-item" href="https://github.com/cerbos/cerbos">Code</a>
             <a class="navbar-item" href="https://github.com/cerbos/cerbos/issues">Issue Tracker</a>
+            <a class="navbar-item" href="https://github.com/cerbos/cerbos/discussions">Discussion Forum</a>
           </div>
         </div>
 
@@ -27,6 +28,7 @@
           <div class="navbar-link">Support</div>
           <div class="navbar-dropdown is-right">
             <a class="navbar-item" href="http://go.cerbos.io/slack">Community Slack</a>
+            <a class="navbar-item" href="https://github.com/cerbos/cerbos/discussions">Discussion Forum</a>
             <a class="navbar-item" href="mailto:help@cerbos.dev">Email (help@cerbos.dev)</a>
           </div>
         </div>


### PR DESCRIPTION
Removes the CERBOS_KEY requirement from the installation instructions in
preparation for opening up the repo.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
