### PR TITLE
chore: Change docs redirect

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -12,6 +12,8 @@ content:
       branches: [HEAD]
       edit_url: 'https://github.com/cerbos/cerbos/tree/{refname}/{path}'
       start_path: docs
+urls:
+  redirect_facility: netlify
 asciidoc:
   attributes:
     app-name: "cerbos"


### PR DESCRIPTION
Antora's default redirect page adds a `no-index` directive to the source
which makes the Googlebot ignore it. This patch changes the redirect
strategy to use Netlify redirects -- which are pure 301s.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
