### PR TITLE
docs: Add Algolia DocSearch

### DIFF
--- a/docs/supplemental-ui/css/site-extra.css
+++ b/docs/supplemental-ui/css/site-extra.css
@@ -12,4 +12,20 @@
     justify-content: center;
 }
 
+#search-input {
+  color: #333;
+  font-family: inherit;
+  font-size: 0.95rem;
+  width: 150px;
+  border: 1px solid #dbdbdb;
+  border-radius: 0.1em;
+  line-height: 1.5;
+  padding: 0 0.25em;
+}
+
+@media screen and (min-width: 769px) {
+  #search-input {
+    width: 200px;
+  }
+}
 

--- a/docs/supplemental-ui/partials/footer-content.hbs
+++ b/docs/supplemental-ui/partials/footer-content.hbs
@@ -4,3 +4,14 @@
     </a>
     <span>&nbsp;&nbsp;Copyright (C) 2020-{{year}} <a href="https://cerbos.dev">Zenauth Ltd.</a></span>
 </footer>
+
+<!-- Algolia DocSearch -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+apiKey: 'a95a2992f9a9d3adf7ee3380e5503fb3',
+indexName: 'cerbos',
+inputSelector: '#search-input',
+debug: false // Set debug to true if you want to inspect the dropdown
+});
+</script>
+<!-- End Algolia DocSearch -->

--- a/docs/supplemental-ui/partials/head-meta.hbs
+++ b/docs/supplemental-ui/partials/head-meta.hbs
@@ -1,9 +1,14 @@
 <link rel="stylesheet" href="{{uiRootPath}}/css/site-extra.css">
 
-  <!-- Google Tag Manager -->
+<!-- Algolia DocSearch -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+<!-- End Algolia DocSearch -->
+
+<!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-59KSJHV');</script>
 <!-- End Google Tag Manager -->
+

--- a/docs/supplemental-ui/partials/header-content.hbs
+++ b/docs/supplemental-ui/partials/header-content.hbs
@@ -6,6 +6,8 @@
             <img src="{{uiRootPath}}/cerbos.svg" alt="Cerbos" width="134" height="50"/>
         </a>
       </div>
+
+
       <button class="navbar-burger" data-target="topbar-nav">
         <span></span>
         <span></span>
@@ -14,6 +16,10 @@
     </div>
     <div id="topbar-nav" class="navbar-menu">
       <div class="navbar-end">
+        <div class="navbar-item hide-for-print">
+            <input id="search-input" type="text" placeholder="Search docs">
+        </div>
+
         <div class="navbar-item has-dropdown is-hoverable">
           <div class="navbar-link">Projects</div>
           <div class="navbar-dropdown">


### PR DESCRIPTION
Add [Algolia DocSearch](https://docsearch.algolia.com) to the header of
the docs site.

Site configuration is available here:
https://github.com/algolia/docsearch-configs/blob/master/configs/cerbos.json

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
