### PR TITLE
chore(ci): Update Buf push action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   - package-ecosystem: "gomod"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,11 +30,19 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to GHCR
-        run:  echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Log in to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Artifactory
-        run:  echo "${{ secrets.ARTIFACTORY_PROD_SECRET }}" | docker login cerbos.jfrog.io -u ${{ secrets.ARTIFACTORY_PROD_USERNAME }} --password-stdin
+      - name: Log in to JFrog
+        uses: docker/login-action@v1
+        with:
+          registry: cerbos.jfrog.io
+          username: ${{ secrets.ARTIFACTORY_PROD_USERNAME }}
+          password: ${{ secrets.ARTIFACTORY_PROD_SECRET }}
 
       - uses: actions/cache@v2
         with:
@@ -64,10 +72,10 @@ jobs:
         uses: bufbuild/buf-setup-action@v0.3.1
 
       - name: Push to BSR 
-        uses: bufbuild/buf-push-action@v0.2.0
+        uses: bufbuild/buf-push-action@v0.3.0
         with:
-          branch: releases
           buf_token: ${{ secrets.BUF_TOKEN }}
+          input: api/public
 
 
   releaseDocs:

--- a/.github/workflows/snaphot.yaml
+++ b/.github/workflows/snaphot.yaml
@@ -28,8 +28,12 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to GHCR
-        run:  echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Log in to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/cache@v2
         with:
@@ -69,6 +73,7 @@ jobs:
         uses: bufbuild/buf-setup-action@v0.3.1
 
       - name: Push to BSR 
-        uses: bufbuild/buf-push-action@v0.2.0
+        uses: bufbuild/buf-push-action@v0.3.0
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}
+          input: api/public


### PR DESCRIPTION
- Update the buf-push-action to use latest bugfix. (See
https://github.com/bufbuild/buf-push-action/issues/4)
- Configure buf-push-action to publish the public API only.
- Update jobs to use the official Docker login action.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
