### PR TITLE
feature: Add playground support to SDK

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -38,17 +38,18 @@ type Client interface {
 }
 
 type config struct {
-	address        string
-	plaintext      bool
-	tlsAuthority   string
-	tlsInsecure    bool
-	tlsCACert      string
-	tlsClientCert  string
-	tlsClientKey   string
-	connectTimeout time.Duration
-	maxRetries     uint
-	retryTimeout   time.Duration
-	userAgent      string
+	address            string
+	plaintext          bool
+	tlsAuthority       string
+	tlsInsecure        bool
+	tlsCACert          string
+	tlsClientCert      string
+	tlsClientKey       string
+	connectTimeout     time.Duration
+	maxRetries         uint
+	retryTimeout       time.Duration
+	userAgent          string
+	playgroundInstance string
 }
 
 type Opt func(*config)
@@ -114,6 +115,15 @@ func WithRetryTimeout(timeout time.Duration) Opt {
 func WithUserAgent(ua string) Opt {
 	return func(c *config) {
 		c.userAgent = ua
+	}
+}
+
+// WithPlaygroundInstance sets the Cerbos playground instance to use as the source of policies.
+// Note that Playground instances are for demonstration purposes only and do not provide any
+// performance or availability guarantees.
+func WithPlaygroundInstance(instance string) Opt {
+	return func(c *config) {
+		c.playgroundInstance = instance
 	}
 }
 
@@ -189,6 +199,10 @@ func mkDialOpts(conf *config) ([]grpc.DialOption, error) {
 		if conf.tlsAuthority != "" {
 			dialOpts = append(dialOpts, grpc.WithAuthority(conf.tlsAuthority))
 		}
+	}
+
+	if conf.playgroundInstance != "" {
+		dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(newPlaygroundInstanceCredentials(conf.playgroundInstance)))
 	}
 
 	return dialOpts, nil

--- a/client/credentials.go
+++ b/client/credentials.go
@@ -17,14 +17,15 @@ import (
 )
 
 const (
-	authorizationHeader = "authorization"
-	usernameEnvVar      = "CERBOS_USERNAME"
-	passwordEnvVar      = "CERBOS_PASSWORD"
-	serverEnvVar        = "CERBOS_SERVER"
-	netrcFile           = ".netrc"
-	netrcEnvVar         = "NETRC"
-	netrcUserKey        = "login"
-	netrcPassKey        = "password"
+	authorizationHeader      = "authorization"
+	playgroundInstanceHeader = "playground-instance"
+	usernameEnvVar           = "CERBOS_USERNAME"
+	passwordEnvVar           = "CERBOS_PASSWORD"
+	serverEnvVar             = "CERBOS_SERVER"
+	netrcFile                = ".netrc"
+	netrcEnvVar              = "NETRC"
+	netrcUserKey             = "login"
+	netrcPassKey             = "password"
 )
 
 var (
@@ -179,4 +180,20 @@ func (ba basicAuthCredentials) GetRequestMetadata(ctx context.Context, uri ...st
 
 func (ba basicAuthCredentials) RequireTransportSecurity() bool {
 	return ba.requireTLS
+}
+
+type playgroundInstanceCredentials struct {
+	instance string
+}
+
+func newPlaygroundInstanceCredentials(instance string) playgroundInstanceCredentials {
+	return playgroundInstanceCredentials{instance: instance}
+}
+
+func (pic playgroundInstanceCredentials) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
+	return map[string]string{playgroundInstanceHeader: pic.instance}, nil
+}
+
+func (playgroundInstanceCredentials) RequireTransportSecurity() bool {
+	return false
 }

--- a/client/testutil/server.go
+++ b/client/testutil/server.go
@@ -117,6 +117,13 @@ func WithDefaultPolicyVersion(version string) ServerOpt {
 	}
 }
 
+// WithPlaygroundAPI enables the Playground API. Defaults to disabled.
+func WithPlaygroundAPI() ServerOpt {
+	return func(so *serverOpt) {
+		so.serverConf.PlaygroundEnabled = true
+	}
+}
+
 type serverOpt struct {
 	serverConf           *server.Conf
 	defaultPolicyVersion string


### PR DESCRIPTION
Add support for using the Cerbos playground as a policy source

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
