### PR TITLE
chore: Configure redirect for latest docs

### DIFF
--- a/hack/scripts/prep-release.sh
+++ b/hack/scripts/prep-release.sh
@@ -35,6 +35,7 @@ update_version() {
 
 # Set release version and tag
 update_version $VERSION
+sed -i -E "s#to = \"/cerbos/[0-9]+\.[0-9]+\.[0-9]+.*/:splat\"#to = \"/cerbos/${VERSION}/:splat\"#g" "${PROJECT_DIR}/netlify.toml"
 git -C "$PROJECT_DIR" commit -s -a -m "chore(release): Prepare release $VERSION"
 git tag "v${VERSION}" -m "v${VERSION}"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,9 @@
 [build]
   base = "docs"
   publish = "build"
+
+[[redirects]]
+from = "/cerbos/latest/*"
+to = "/cerbos/0.6.0/:splat"
+status = 302
+force = true


### PR DESCRIPTION
Adds a redirect from `latest` to current version. E.g. https://docs.cerbos.dev/cerbos/latest/index.html -> https://docs.cerbos.dev/cerbos/0.6.0/index.html

This is a temporary solution until [Antora's LFS support lands](https://gitlab.com/antora/antora/-/issues/185) (see #273). 

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
