### PR TITLE
enhancement: Allow intermingling of tests with policies

### DIFF
--- a/internal/storage/disk/index/builder.go
+++ b/internal/storage/disk/index/builder.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cerbos/cerbos/internal/namer"
 	"github.com/cerbos/cerbos/internal/policy"
 	"github.com/cerbos/cerbos/internal/util"
-	"github.com/cerbos/cerbos/internal/verify"
 )
 
 // BuildError is an error type that contains details about the failures encountered during the index build.
@@ -129,7 +128,7 @@ func Build(ctx context.Context, fsys fs.FS, opts ...BuildOpt) (Index, error) {
 		}
 
 		if d.IsDir() {
-			if d.Name() == verify.TestDataDirectory {
+			if d.Name() == util.TestDataDirectory {
 				return fs.SkipDir
 			}
 

--- a/internal/storage/disk/index/builder.go
+++ b/internal/storage/disk/index/builder.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cerbos/cerbos/internal/namer"
 	"github.com/cerbos/cerbos/internal/policy"
 	"github.com/cerbos/cerbos/internal/util"
+	"github.com/cerbos/cerbos/internal/verify"
 )
 
 // BuildError is an error type that contains details about the failures encountered during the index build.
@@ -128,10 +129,18 @@ func Build(ctx context.Context, fsys fs.FS, opts ...BuildOpt) (Index, error) {
 		}
 
 		if d.IsDir() {
+			if d.Name() == verify.TestDataDirectory {
+				return fs.SkipDir
+			}
+
 			return nil
 		}
 
 		if !util.IsSupportedFileType(d.Name()) {
+			return nil
+		}
+
+		if util.IsSupportedTestFile(d.Name()) {
 			return nil
 		}
 

--- a/internal/test/testdata/index/intermingled_test_files.yaml
+++ b/internal/test/testdata/index/intermingled_test_files.yaml
@@ -1,0 +1,70 @@
+---
+files:
+  "test.txt": |-
+    this is some text
+
+  "principal.yaml": |-
+    ---
+    apiVersion: "api.cerbos.dev/v1"
+    principalPolicy:
+      principal: donald_duck
+      version: "20210210"
+      rules:
+        - resource: leave_request
+          actions:
+            - action: "*"
+              condition:
+                match:
+                  expr: "request.resource.attr.dev_record == true"
+              effect: EFFECT_ALLOW
+
+        - resource: salary_record
+          actions:
+            - action: "*"
+              effect: EFFECT_DENY
+
+  "resource_test.yaml": |-
+    ---
+    name: TestSuite
+    description: Tests for verifying something
+    tests:
+      - name: John and his leave request
+        input:
+          requestId: "test"
+          actions:
+            - "view:public"
+            - "approve"
+          resource: "john_leave_request"
+        expected:
+          -
+            principal: john
+            actions:
+              "view:public": "EFFECT_ALLOW"
+              "approve": "EFFECT_DENY"
+
+  "testdata/principals.yaml": |-
+    ---
+    principals:
+      john:
+        id: john
+        policyVersion: '20210210'
+        roles:
+          - employee
+        attr:
+          department: marketing
+          geography: GB
+          team: design
+
+  "testdata/resources.yaml": |-
+    ---
+    resources:
+      john_leave_request:
+        kind: leave_request
+        policyVersion: '20210210'
+        id: XX125
+        attr:
+          department: marketing
+          geography: GB
+          id: XX125
+          owner: john
+          team: design

--- a/internal/util/filesystem.go
+++ b/internal/util/filesystem.go
@@ -14,6 +14,9 @@ import (
 
 var supportedFileTypes = map[string]struct{}{".yaml": {}, ".yml": {}, ".json": {}}
 
+// TestDataDirectory is the name of the special directory containing test fixtures. It is defined here to avoid an import loop.
+const TestDataDirectory = "testdata"
+
 // IsSupportedTestFile return true if the given file is a supported test file name, i.e. "*_test.{yaml,yml,json}".
 func IsSupportedTestFile(fileName string) bool {
 	if ext, ok := IsSupportedFileTypeExt(fileName); ok {

--- a/internal/verify/test_fixture.go
+++ b/internal/verify/test_fixture.go
@@ -27,7 +27,6 @@ type testFixture struct {
 const (
 	PrincipalsFileName = "principals"
 	ResourcesFileName  = "resources"
-	TestDataDirectory  = "testdata" // contains test fixture files like principals.yaml and resources.yaml
 )
 
 func loadTestFixture(fsys fs.FS, path string) (tf *testFixture, err error) {

--- a/internal/verify/test_fixture_test.go
+++ b/internal/verify/test_fixture_test.go
@@ -15,6 +15,7 @@ import (
 	effectv1 "github.com/cerbos/cerbos/api/genpb/cerbos/effect/v1"
 	v1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
+	"github.com/cerbos/cerbos/internal/util"
 )
 
 func Test_loadPrincipals(t *testing.T) {
@@ -30,7 +31,7 @@ principals:
       team: design
 `
 	fsys := make(fstest.MapFS)
-	fsys["a/"+TestDataDirectory+"/principals.yaml"] = newMapFile(principals)
+	fsys["a/"+util.TestDataDirectory+"/principals.yaml"] = newMapFile(principals)
 
 	tests := []struct {
 		name    string
@@ -38,7 +39,7 @@ principals:
 		wantErr bool
 	}{
 		{
-			name: "a/" + TestDataDirectory,
+			name: "a/" + util.TestDataDirectory,
 			want: map[string]*v1.Principal{
 				"harry": {
 					Id:    "harry",

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -85,7 +85,7 @@ func doVerify(ctx context.Context, fsys fs.FS, eng *engine.Engine, conf Config) 
 		}
 
 		if d.IsDir() {
-			if d.Name() == TestDataDirectory {
+			if d.Name() == util.TestDataDirectory {
 				fixtureDefs[path] = struct{}{}
 				return fs.SkipDir
 			}
@@ -134,7 +134,7 @@ func doVerify(ctx context.Context, fsys fs.FS, eng *engine.Engine, conf Config) 
 			continue
 		}
 
-		fixtureDir := filepath.Join(filepath.Dir(sd), TestDataDirectory)
+		fixtureDir := filepath.Join(filepath.Dir(sd), util.TestDataDirectory)
 		fixture, err := getFixture(fixtureDir)
 		if err != nil {
 			result.Results = append(result.Results, SuiteResult{

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cerbos/cerbos/internal/engine"
 	"github.com/cerbos/cerbos/internal/storage/disk"
 	"github.com/cerbos/cerbos/internal/test"
+	"github.com/cerbos/cerbos/internal/util"
 )
 
 func TestVerify(t *testing.T) {
@@ -239,14 +240,14 @@ func Test_doVerify(t *testing.T) {
 			t.Run(fmt.Sprintf("principals = %v, resources = %v", optionTitles[optionPrincipals], optionTitles[optionResources]), func(t *testing.T) {
 				fsys := make(fstest.MapFS)
 				if optionResources == external {
-					fsys[filepath.Join(TestDataDirectory, ResourcesFileName)+".yaml"] = newMapFile(resources)
+					fsys[filepath.Join(util.TestDataDirectory, ResourcesFileName)+".yaml"] = newMapFile(resources)
 				} else if optionResources == mixed {
-					fsys[filepath.Join(TestDataDirectory, ResourcesFileName)+".json"] = newMapFile(fauxResources)
+					fsys[filepath.Join(util.TestDataDirectory, ResourcesFileName)+".json"] = newMapFile(fauxResources)
 				}
 				if optionPrincipals == external {
-					fsys[filepath.Join(TestDataDirectory, PrincipalsFileName)+".yaml"] = newMapFile(principals)
+					fsys[filepath.Join(util.TestDataDirectory, PrincipalsFileName)+".yaml"] = newMapFile(principals)
 				} else if optionPrincipals == mixed {
-					fsys[filepath.Join(TestDataDirectory, PrincipalsFileName)+".json"] = newMapFile(fauxPrincipals)
+					fsys[filepath.Join(util.TestDataDirectory, PrincipalsFileName)+".json"] = newMapFile(fauxPrincipals)
 				}
 				table := genTable(t, optionResources != external, optionPrincipals != external)
 				fsys["leave_request_test.yaml"] = newMapFile(table)
@@ -261,8 +262,8 @@ func Test_doVerify(t *testing.T) {
 	}
 	t.Run("Should fail for faux principals", func(t *testing.T) {
 		fsys := make(fstest.MapFS)
-		fsys[filepath.Join(TestDataDirectory, ResourcesFileName)+".yaml"] = newMapFile(resources)
-		fsys[filepath.Join(TestDataDirectory, PrincipalsFileName)+".json"] = newMapFile(fauxPrincipals)
+		fsys[filepath.Join(util.TestDataDirectory, ResourcesFileName)+".yaml"] = newMapFile(resources)
+		fsys[filepath.Join(util.TestDataDirectory, PrincipalsFileName)+".json"] = newMapFile(fauxPrincipals)
 
 		table := genTable(t, false, false)
 		fsys["leave_request_test.yaml"] = newMapFile(table)
@@ -275,8 +276,8 @@ func Test_doVerify(t *testing.T) {
 	})
 	t.Run("Should fail for faux resources", func(t *testing.T) {
 		fsys := make(fstest.MapFS)
-		fsys[filepath.Join(TestDataDirectory, ResourcesFileName)+".json"] = newMapFile(fauxResources)
-		fsys[filepath.Join(TestDataDirectory, PrincipalsFileName)+".yaml"] = newMapFile(principals)
+		fsys[filepath.Join(util.TestDataDirectory, ResourcesFileName)+".json"] = newMapFile(fauxResources)
+		fsys[filepath.Join(util.TestDataDirectory, PrincipalsFileName)+".yaml"] = newMapFile(principals)
 
 		table := genTable(t, false, false)
 		fsys["leave_request_test.yaml"] = newMapFile(table)
@@ -291,7 +292,7 @@ func Test_doVerify(t *testing.T) {
 		fsys := make(fstest.MapFS)
 		ts := genTable(t, false, false)
 		for _, dir := range []string{"a", "b", "c"} {
-			d := filepath.Join(dir, TestDataDirectory)
+			d := filepath.Join(dir, util.TestDataDirectory)
 			fsys[d+"/principals.yaml"] = newMapFile(principals)
 			fsys[d+"/resources.yaml"] = newMapFile(resources)
 			fsys[dir+"/leave_request_test.yaml"] = newMapFile(ts)


### PR DESCRIPTION
Ignore test files and testdata when looking for policies

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
