### PR TITLE
WIP: add creation date to policy metadata

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -730,6 +730,38 @@ Contents of probable licence file $GOMODCACHE/github.com/dgraph-io/badger/v3@v3.
 
 
 --------------------------------------------------------------------------------
+Module  : github.com/djherbis/times
+Version : v1.5.0
+Time    : 2021-04-27T23:32:16Z
+Licence : MIT
+
+Contents of probable licence file $GOMODCACHE/github.com/djherbis/times@v1.5.0/LICENSE:
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Dustin H
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+--------------------------------------------------------------------------------
 Module  : github.com/doug-martin/goqu/v9
 Version : v9.16.0
 Time    : 2021-08-28T05:41:15Z

--- a/cmd/cerbosctl/list/list.go
+++ b/cmd/cerbosctl/list/list.go
@@ -73,7 +73,7 @@ func printPolicies(w io.Writer, policies []*policy.Policy, format string) error 
 	default:
 		headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
 
-		tbl := table.New("NAME", "KIND", "DEPENDENCIES", "VERSION")
+		tbl := table.New("NAME", "KIND", "DEPENDENCIES", "VERSION", "CREATED")
 		tbl.WithWriter(w)
 		tbl.WithHeaderFormatter(headerFmt)
 
@@ -88,15 +88,20 @@ func printPolicies(w io.Writer, policies []*policy.Policy, format string) error 
 	return nil
 }
 
-// policyPrintables creates values according to {"NAME", "KIND", "DEPENDENCIES"}.
+// policyPrintables creates values according to {"NAME", "KIND", "DEPENDENCIES", "VERSION", "CREATED"}.
 func policyPrintables(p *policy.Policy) []interface{} {
+	creation := "-"
+	if d, ok := p.Metadata.Annotations["created_at"]; ok {
+		creation = d
+	}
+
 	switch pt := p.PolicyType.(type) {
 	case *policy.Policy_ResourcePolicy:
-		return []interface{}{getPolicyName(p), "RESOURCE", strings.Join(pt.ResourcePolicy.ImportDerivedRoles, ", "), pt.ResourcePolicy.Version}
+		return []interface{}{getPolicyName(p), "RESOURCE", strings.Join(pt.ResourcePolicy.ImportDerivedRoles, ", "), pt.ResourcePolicy.Version, creation}
 	case *policy.Policy_PrincipalPolicy:
-		return []interface{}{getPolicyName(p), "PRINCIPAL", "-", pt.PrincipalPolicy.Version}
+		return []interface{}{getPolicyName(p), "PRINCIPAL", "-", pt.PrincipalPolicy.Version, creation}
 	case *policy.Policy_DerivedRoles:
-		return []interface{}{getPolicyName(p), "DERIVED_ROLES", "-", "-"}
+		return []interface{}{getPolicyName(p), "DERIVED_ROLES", "-", "-", creation}
 	default:
 		return []interface{}{"-"}
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/cespare/xxhash v1.1.0
 	github.com/dgraph-io/badger/v3 v3.2103.1
+	github.com/djherbis/times v1.5.0
 	github.com/doug-martin/goqu/v9 v9.16.0
 	github.com/envoyproxy/protoc-gen-validate v0.6.1
 	github.com/fatih/color v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -346,6 +346,8 @@ github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 h1:fAjc9m62+UWV/WA
 github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/distribution/distribution/v3 v3.0.0-20210804104954-38ab4c606ee3/go.mod h1:gt38b7cvVKazi5XkHvINNytZXgTEntyhtyM3HQz46Nk=
+github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
+github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=

--- a/internal/storage/db/internal/tests.go
+++ b/internal/storage/db/internal/tests.go
@@ -9,6 +9,7 @@ package internal
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -132,6 +133,10 @@ func TestSuite(store DBStorage) func(*testing.T) {
 				policies, err := store.GetPolicies(ctx)
 				require.NoError(t, err)
 				require.NotEmpty(t, policies)
+
+				require.NotNil(t, policies[0].Policy.Metadata)
+				_, err = time.Parse(time.RFC3339, policies[0].Policy.Metadata.Annotations["created_at"])
+				require.NoError(t, err)
 			})
 		})
 


### PR DESCRIPTION
Signed-off-by: serdar <serdar@cerbos.dev>

#### Description

Adds creation date to policy metadata. This is a graceful attempt to include creation date, this time handled in upper layer to avoid breaking abstraction in index for `disk` and `git` store types.

I'd like to get early feedback if this would be the right direction to go. We can later decide on time formatting etc.

Fixes #299 

#### Checklist 

- [x] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
