### PR TITLE
bug: Preserve all imported derived roles during execution

### DIFF
--- a/internal/codegen/rego.go
+++ b/internal/codegen/rego.go
@@ -69,11 +69,19 @@ func NewRegoGen(packageName string, imports ...string) *RegoGen {
 	}
 
 	rg.line("package ", packageName)
-	for _, imp := range imports {
-		rg.line("import ", imp)
+	if len(imports) > 0 {
+		rg.line(derivedRolesMap, "=", mergeDerivedRoles(imports))
 	}
 
 	return rg
+}
+
+func mergeDerivedRoles(imports []string) string {
+	if len(imports) == 1 {
+		return imports[0]
+	}
+
+	return fmt.Sprintf("object.union(%s, %s)", imports[0], mergeDerivedRoles(imports[1:]))
 }
 
 func (rg *RegoGen) line(ss ...string) {

--- a/internal/storage/disk/index/builder_test.go
+++ b/internal/storage/disk/index/builder_test.go
@@ -39,16 +39,17 @@ func TestBuildIndexWithDisk(t *testing.T) {
 
 	t.Run("check_contents", func(t *testing.T) {
 		data := idxImpl.Inspect()
-		require.Len(t, data, 4)
+		require.Len(t, data, 5)
 
 		rp1 := filepath.Join("resource_policies", "policy_01.yaml")
 		rp2 := filepath.Join("resource_policies", "policy_02.yaml")
 		pp := filepath.Join("principal_policies", "policy_01.yaml")
-		dr := filepath.Join("derived_roles", "derived_roles_01.yaml")
+		dr1 := filepath.Join("derived_roles", "derived_roles_01.yaml")
+		dr2 := filepath.Join("derived_roles", "derived_roles_02.yaml")
 
 		require.Contains(t, data, rp1)
-		require.Len(t, data[rp1].Dependencies, 1)
-		require.Contains(t, data[rp1].Dependencies, dr)
+		require.Len(t, data[rp1].Dependencies, 2)
+		require.Contains(t, data[rp1].Dependencies, dr1)
 		require.Empty(t, data[rp1].References)
 
 		require.Contains(t, data, rp2)
@@ -58,10 +59,15 @@ func TestBuildIndexWithDisk(t *testing.T) {
 		require.Empty(t, data[pp].Dependencies)
 		require.Empty(t, data[pp].References)
 
-		require.Contains(t, data, dr)
-		require.Empty(t, data[dr].Dependencies)
-		require.Len(t, data[dr].References, 1)
-		require.Contains(t, data[dr].References, rp1)
+		require.Contains(t, data, dr1)
+		require.Empty(t, data[dr1].Dependencies)
+		require.Len(t, data[dr1].References, 1)
+		require.Contains(t, data[dr1].References, rp1)
+
+		require.Contains(t, data, dr2)
+		require.Empty(t, data[dr2].Dependencies)
+		require.Len(t, data[dr2].References, 1)
+		require.Contains(t, data[dr2].References, rp1)
 	})
 
 	t.Run("add_empty", func(t *testing.T) {

--- a/internal/test/testdata/codegen/valid_resource_policy_03.yaml
+++ b/internal/test/testdata/codegen/valid_resource_policy_03.yaml
@@ -4,7 +4,9 @@ inputPolicy:
   resourcePolicy:
     version: "20210210"
     importDerivedRoles:
-      - my_derived_roles
+      - alpha
+      - beta
+      - gamma
     resource: "hr:leave_request"
     rules:
       - actions: ['*']
@@ -49,7 +51,7 @@ inputPolicy:
 wantRego: |-
   package cerbos.resource.hr_leave_request.v20210210
 
-  cerbos_derived_roles = data.cerbos.derived_roles.my_derived_roles.cerbos_derived_roles
+  cerbos_derived_roles = object.union(data.cerbos.derived_roles.alpha.cerbos_derived_roles, object.union(data.cerbos.derived_roles.beta.cerbos_derived_roles, data.cerbos.derived_roles.gamma.cerbos_derived_roles))
 
   cerbos_effect_for(cerbos_action) = "allow" {
       glob.match("*", [], cerbos_action)

--- a/internal/test/testdata/store/derived_roles/derived_roles_01.yaml
+++ b/internal/test/testdata/store/derived_roles/derived_roles_01.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: "api.cerbos.dev/v1"
 derivedRoles:
-  name: my_derived_roles
+  name: alpha
   definitions:
     - name: admin
       parentRoles: ["admin"]
@@ -14,15 +14,3 @@ derivedRoles:
       condition:
         script: |-
           input.resource.attr.owner == input.principal.id
-
-    - name: any_employee
-      parentRoles: ["employee"]
-
-    - name: direct_manager
-      parentRoles: ["manager"]
-      condition:
-        match:
-          all:
-            of:
-              - expr: "request.resource.attr.geography == request.principal.attr.geography"
-              - expr: "request.resource.attr.geography == request.principal.attr.managed_geographies"

--- a/internal/test/testdata/store/derived_roles/derived_roles_02.yaml
+++ b/internal/test/testdata/store/derived_roles/derived_roles_02.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: "api.cerbos.dev/v1"
+derivedRoles:
+  name: beta
+  definitions:
+    - name: any_employee
+      parentRoles: ["employee"]
+
+    - name: direct_manager
+      parentRoles: ["manager"]
+      condition:
+        match:
+          all:
+            of:
+              - expr: "request.resource.attr.geography == request.principal.attr.geography"
+              - expr: "request.resource.attr.geography == request.principal.attr.managed_geographies"

--- a/internal/test/testdata/store/resource_policies/policy_01.yaml
+++ b/internal/test/testdata/store/resource_policies/policy_01.yaml
@@ -2,7 +2,8 @@
 apiVersion: api.cerbos.dev/v1
 resourcePolicy:
   importDerivedRoles:
-  - my_derived_roles
+  - alpha
+  - beta
   resource: leave_request
   rules:
   - actions: ['*']


### PR DESCRIPTION
When multiple derived roles are imported, only the last set is "active"
within the policy execution environment. This is because the Rego import
statements override each other.

This PR fixes the above problem by merging all imports together
explicitly.

Also fixes an issue with the DB driver where multiple imports were not
getting stored correctly in the table.

Fixes #329

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
