### PR TITLE
bug: Rename cors.enabled config key to cors.disabled

### DIFF
--- a/internal/server/conf.go
+++ b/internal/server/conf.go
@@ -50,7 +50,7 @@ type TLSConf struct {
 
 type CORSConf struct {
 	// Disabled sets whether CORS is disabled.
-	Disabled bool `yaml:"enabled"`
+	Disabled bool `yaml:"disabled"`
 	// AllowedOrigins is the contents of the allowed-origins header.
 	AllowedOrigins []string `yaml:"allowedOrigins"`
 	// AllowedHeaders is the contents of the allowed-headers header.


### PR DESCRIPTION
By mistake, the config key to _disable_ CORS is actually called
`cors.enabled`. This change renames the config key to the correct usage
of `cors.disabled`.

Fixes #333

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
