### PR TITLE
enhancement: Hierarchy function improvements

### DIFF
--- a/docs/modules/policies/pages/conditions.adoc
+++ b/docs/modules/policies/pages/conditions.adoc
@@ -220,12 +220,14 @@ NOTE: The hierarchy functions are Cerbos-specific extensions to CEL.
 [%header,cols=".^1m,.^2,4m",grid=rows]
 |===
 | Function | Description | Example 
-| hierarchy | Convert a dotted string representation to a hierarchy | hierarchy("a.b.c").size() == 3
+| hierarchy | Convert a dotted string or a string list to a hierarchy | hierarchy("a.b.c") == hierarchy(["a","b","c"])
+| hierarchy | Convert a delimited string representation to a hierarchy | hierarchy("a:b:c", ":").size() == 3
 | ancestorOf | Returns true if the first hierarchy shares a common prefix with the second hierarchy | hierarchy("a.b").ancestorOf(hierarchy("a.b.c.d")) == true
 | commonAncestors | Returns the common ancestor hierarchy | hierarchy(R.attr.scope).commonAncestors(hierarchy(P.attr.scope)) == hierarchy("foo.bar")
 | descendentOf | Mirror function of `ancestorOf` | hierarchy("a.b.c.d").descendentOf(hierarchy("a.b")) == true 
 | immediateChildOf | Returns true if the first hierarchy is a first-level child of the second hierarchy | hierarchy("a.b.c").immediateChildOf(hierarchy("a.b")) == true && hierarchy("a.b.c.d").immediateChildOf(hierarchy("a.b")) == false
 | immediateParentOf | Mirror function of `immediateChildOf` | hierarchy("a.b").immediateParentOf(hierarchy("a.b.c")) == true && hierarchy("a.b").immediateParentOf(hierarchy("a.b.c.d")) == false
+| overlaps | Returns true if one of the hierarchies is a prefix of the other | hierarchy("a.b.c").overlaps(hierarchy("a.b.c.d.e")) == true && hierarchy("a.b.x").overlaps(hierarchy("a.b.c.d.e")) == false
 | siblingOf | Returns true if both hierarchies share the same parent | hierarchy("a.b.c").siblingOf(hierarchy("a.b.d")) == true
 | size | Returns the number of levels in the hierarchy | hierarchy("a.b.c").size() == 3
 | []   | Access a level in the hierarchy | hierarchy("a.b.c.d")[1] == "b"

--- a/internal/conditions/cerbos_lib_test.go
+++ b/internal/conditions/cerbos_lib_test.go
@@ -51,6 +51,9 @@ func TestCerbosLib(t *testing.T) {
 		{expr: `[1,2,3] + [3,5] == [1,2,3,3,5]`},
 		{expr: `hierarchy("a.b.c.d") == hierarchy("a.b.c.d")`},
 		{expr: `hierarchy("a.b.c.d") != hierarchy("a.b.c.d.e")`},
+		{expr: `hierarchy("a:b:c:d", ":") == hierarchy("a.b.c.d")`},
+		{expr: `hierarchy("aFOObFOOcFOOd", "FOO") == hierarchy("a.b.c.d")`},
+		{expr: `hierarchy(["a","b","c","d"]) == hierarchy("a.b.c.d")`},
 		{expr: `hierarchy("a.b.c.d").size() == 4`},
 		{expr: `hierarchy("a.b.c.d")[2] == "c"`},
 		{expr: `hierarchy("a.b").ancestorOf(hierarchy("a.b.c.d.e"))`},
@@ -70,6 +73,10 @@ func TestCerbosLib(t *testing.T) {
 		{expr: `hierarchy("a.b.c").siblingOf(hierarchy("a.b.d"))`},
 		{expr: `hierarchy("a.b.c").siblingOf(hierarchy("x.b.d")) == false`},
 		{expr: `hierarchy("a.b.c.d").siblingOf(hierarchy("a.b.d")) == false`},
+		{expr: `hierarchy("a.b.c.d").overlaps(hierarchy("a.b.c.d")) == true`},
+		{expr: `hierarchy("a.b.c.d").overlaps(hierarchy("a.b.c")) == true`},
+		{expr: `hierarchy("a.b").overlaps(hierarchy("a.b.c.d")) == true`},
+		{expr: `hierarchy("a.b.x").overlaps(hierarchy("a.b.c.d")) == false`},
 	}
 	env, err := cel.NewEnv(conditions.CerbosCELLib())
 	require.NoError(t, err)

--- a/internal/test/testdata/cel_eval/hierarchy_funcs.yaml
+++ b/internal/test/testdata/cel_eval/hierarchy_funcs.yaml
@@ -3,7 +3,9 @@ condition:
   all:
     of:
       - expr: |-
-          hierarchy("a.b.c").size() == 3
+          hierarchy("a.b.c") == hierarchy(["a","b","c"])
+      - expr: |-
+          hierarchy("a:b:c", ":").size() == 3
       - expr: |-
           hierarchy("a.b").ancestorOf(hierarchy("a.b.c.d")) == true
       - expr: |-
@@ -14,6 +16,8 @@ condition:
           hierarchy("a.b.c").immediateChildOf(hierarchy("a.b")) == true && hierarchy("a.b.c.d").immediateChildOf(hierarchy("a.b")) == false
       - expr: |-
           hierarchy("a.b").immediateParentOf(hierarchy("a.b.c")) == true && hierarchy("a.b").immediateParentOf(hierarchy("a.b.c.d")) == false
+      - expr: |-
+          hierarchy("a.b.c").overlaps(hierarchy("a.b.c.d.e")) == true && hierarchy("a.b.x").overlaps(hierarchy("a.b.c.d.e")) == false
       - expr: |-
           hierarchy("a.b.c").siblingOf(hierarchy("a.b.d")) == true
       - expr: |-


### PR DESCRIPTION
- Allow specifying an optional delimiter when converting a string to a
  hierarchy.
- Allow converting string arrays to a hierarchy
- Add `overlaps` method to check whether one hierarchy is a prefix of
  the other

Fixes #328

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
