### PR TITLE
enhancement: Compound expressions without parentheses

### DIFF
--- a/internal/codegen/cel.go
+++ b/internal/codegen/cel.go
@@ -79,7 +79,9 @@ type celGen struct {
 func (cg *celGen) addMatch(m *policyv1.Match) error {
 	switch t := m.Op.(type) {
 	case *policyv1.Match_Expr:
+		cg.WriteString("(")
 		cg.WriteString(t.Expr)
+		cg.WriteString(")")
 	case *policyv1.Match_All:
 		cg.WriteString("(")
 		if err := cg.join("&&", t.All.Of); err != nil {

--- a/internal/codegen/cel_test.go
+++ b/internal/codegen/cel_test.go
@@ -24,7 +24,7 @@ func TestCELGen(t *testing.T) {
 					Expr: "a || b && c",
 				},
 			},
-			want: "a || b && c",
+			want: "(a || b && c)",
 		},
 		{
 			name: "all_single_expr",
@@ -37,7 +37,7 @@ func TestCELGen(t *testing.T) {
 					},
 				},
 			},
-			want: "(a)",
+			want: "((a))",
 		},
 		{
 			name: "all_multiple_expr",
@@ -52,7 +52,7 @@ func TestCELGen(t *testing.T) {
 					},
 				},
 			},
-			want: "(a && b && c)",
+			want: "((a) && (b) && (c))",
 		},
 		{
 			name: "any_single_expr",
@@ -65,7 +65,7 @@ func TestCELGen(t *testing.T) {
 					},
 				},
 			},
-			want: "(a)",
+			want: "((a))",
 		},
 		{
 			name: "any_multiple_expr",
@@ -80,7 +80,7 @@ func TestCELGen(t *testing.T) {
 					},
 				},
 			},
-			want: "(a || b || c)",
+			want: "((a) || (b) || (c))",
 		},
 		{
 			name: "none_single_expr",
@@ -93,7 +93,7 @@ func TestCELGen(t *testing.T) {
 					},
 				},
 			},
-			want: "!(a)",
+			want: "!((a))",
 		},
 		{
 			name: "none_multiple_expr",
@@ -108,7 +108,7 @@ func TestCELGen(t *testing.T) {
 					},
 				},
 			},
-			want: "!(a || b || c)",
+			want: "!((a) || (b) || (c))",
 		},
 		{
 			name: "nested",
@@ -143,7 +143,7 @@ func TestCELGen(t *testing.T) {
 					},
 				},
 			},
-			want: "((x || y) && !(p || q || r) && a && b)",
+			want: "(((x) || (y)) && !((p) || (q) || (r)) && (a) && (b))",
 		},
 	}
 

--- a/internal/storage/disk/index/builder_test.go
+++ b/internal/storage/disk/index/builder_test.go
@@ -39,13 +39,15 @@ func TestBuildIndexWithDisk(t *testing.T) {
 
 	t.Run("check_contents", func(t *testing.T) {
 		data := idxImpl.Inspect()
-		require.Len(t, data, 5)
+		require.Len(t, data, 7)
 
 		rp1 := filepath.Join("resource_policies", "policy_01.yaml")
 		rp2 := filepath.Join("resource_policies", "policy_02.yaml")
+		rp3 := filepath.Join("resource_policies", "policy_03.yaml")
 		pp := filepath.Join("principal_policies", "policy_01.yaml")
 		dr1 := filepath.Join("derived_roles", "derived_roles_01.yaml")
 		dr2 := filepath.Join("derived_roles", "derived_roles_02.yaml")
+		dr3 := filepath.Join("derived_roles", "derived_roles_03.yaml")
 
 		require.Contains(t, data, rp1)
 		require.Len(t, data[rp1].Dependencies, 2)
@@ -54,6 +56,11 @@ func TestBuildIndexWithDisk(t *testing.T) {
 
 		require.Contains(t, data, rp2)
 		require.Len(t, data[rp2].Dependencies, 0)
+
+		require.Contains(t, data, rp3)
+		require.Len(t, data[rp3].Dependencies, 1)
+		require.Contains(t, data[rp3].Dependencies, dr3)
+		require.Empty(t, data[rp3].References)
 
 		require.Contains(t, data, pp)
 		require.Empty(t, data[pp].Dependencies)
@@ -68,6 +75,11 @@ func TestBuildIndexWithDisk(t *testing.T) {
 		require.Empty(t, data[dr2].Dependencies)
 		require.Len(t, data[dr2].References, 1)
 		require.Contains(t, data[dr2].References, rp1)
+
+		require.Contains(t, data, dr3)
+		require.Empty(t, data[dr3].Dependencies)
+		require.Len(t, data[dr3].References, 1)
+		require.Contains(t, data[dr3].References, rp3)
 	})
 
 	t.Run("add_empty", func(t *testing.T) {

--- a/internal/test/testdata/compile/bad_cel_expr.yaml
+++ b/internal/test/testdata/compile/bad_cel_expr.yaml
@@ -2,7 +2,7 @@
 wantErrors:
   - "principal_policies/donald_duck_20210210.yaml: [invalid match expression] Invalid match expression in 'leave_request-rule-001': Syntax error: token recognition error at: '^'"
   - "principal_policies/donald_duck_20210210.yaml: [invalid match expression] Invalid match expression in 'leave_request-rule-001': Syntax error: token recognition error at: '^'"
-  - "principal_policies/donald_duck_20210210.yaml: [invalid match expression] Invalid match expression in 'leave_request-rule-001': Syntax error: extraneous input 'true' expecting <EOF>"
+  - "principal_policies/donald_duck_20210210.yaml: [invalid match expression] Invalid match expression in 'leave_request-rule-001': Syntax error: extraneous input 'true' expecting ')'"
 mainDef: "principal_policies/donald_duck_20210210.yaml"
 inputDefs:
   "principal_policies/donald_duck_20210210.yaml":

--- a/internal/test/testdata/engine/case_09.yaml
+++ b/internal/test/testdata/engine/case_09.yaml
@@ -1,0 +1,101 @@
+---
+description: "CEL expression combination using parentheses"
+inputs: [
+  {
+    "requestId": "test1",
+    "actions": [
+      "view",
+      "delete"
+    ],
+    "principal": {
+      "id": "123",
+      "roles": ["user"],
+      "attr": {
+        "orgId": "foo",
+        "jobRoles": ["buyer"],
+        "tags": {
+          "brands": ["brand"],
+          "classes": ["*"],
+          "regions": ["*"]
+        }
+      }
+    },
+    "resource": {
+      "kind": "purchase_order",
+      "id": "X111",
+      "attr": {
+        "ownerOrgId": "foo",
+        "tags": {
+          "brand": "brand",
+          "class": "Footwear",
+          "region": "EMEA"
+        }
+      }
+    }
+  },
+  {
+    "requestId": "test2",
+    "actions": [
+      "view",
+      "delete"
+    ],
+    "principal": {
+      "id": "123",
+      "roles": ["user"],
+      "attr": {
+        "orgId": "foo",
+        "jobRoles": ["buyer"],
+        "tags": {
+          "brands": ["brand"],
+          "classes": ["*"],
+          "regions": ["*"]
+        }
+      }
+    },
+    "resource": {
+      "kind": "purchase_order",
+      "id": "X222",
+      "attr": {
+        "ownerOrgId": "foo",
+        "tags": {
+          "brand": "wibblewobble",
+          "class": "Footwear",
+          "region": "EMEA"
+        }
+      }
+    }
+  }
+]
+wantOutputs: [
+  {
+    "requestId": "test1",
+    "resourceId": "X111",
+    "actions": {
+      "view": {
+        "effect": "EFFECT_ALLOW",
+        "policy": "resource.purchase_order.vdefault"
+      },
+      "delete": {
+        "effect": "EFFECT_ALLOW",
+        "policy": "resource.purchase_order.vdefault"
+      }
+    },
+    "effectiveDerivedRoles": [
+      "buyer"
+    ]
+  },
+  {
+    "requestId": "test2",
+    "resourceId": "X222",
+    "actions": {
+      "view": {
+        "effect": "EFFECT_DENY",
+        "policy": "resource.purchase_order.vdefault"
+      },
+      "delete": {
+        "effect": "EFFECT_DENY",
+        "policy": "resource.purchase_order.vdefault"
+      }
+    }
+  }
+]

--- a/internal/test/testdata/store/derived_roles/derived_roles_03.yaml
+++ b/internal/test/testdata/store/derived_roles/derived_roles_03.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: "api.cerbos.dev/v1"
+derivedRoles:
+  name: buyer_derived_roles
+  definitions:
+    - name: buyer
+      parentRoles: ["user"]
+      condition:
+        match:
+          all:
+            of:
+              - expr: R.attr.ownerOrgId == P.attr.orgId
+              - expr: ("buyer" in P.attr.jobRoles)
+              - expr: (R.attr.tags.brand in P.attr.tags.brands) || ("*" in P.attr.tags.brands)
+              - expr: (R.attr.tags.class in P.attr.tags.classes) || ("*" in P.attr.tags.classes)
+              - expr: (R.attr.tags.region in P.attr.tags.regions) || ("*" in P.attr.tags.regions)

--- a/internal/test/testdata/store/resource_policies/policy_03.yaml
+++ b/internal/test/testdata/store/resource_policies/policy_03.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: "api.cerbos.dev/v1"
+resourcePolicy:
+  version: "default"
+  importDerivedRoles:
+    - buyer_derived_roles
+  resource: purchase_order
+  rules:
+    - actions: ["*"]
+      effect: EFFECT_ALLOW
+      roles:
+        - support
+        - admin
+
+    - actions:
+        - create
+        - view
+        - update
+        - delete
+      effect: EFFECT_ALLOW
+      derivedRoles:
+        - buyer


### PR DESCRIPTION
[CEL does not short-circuit when evaluating logical
expressions](https://github.com/google/cel-spec/blob/master/doc/langdef.md#logical-operators).
Because of this, if a condition contains a compound logical expression,
it should be parenthesised to obtain the desired result.

For example:

```
match:
  all:
    of:
      - expr: a
      - expr: b || c
```

should be written in one of the following ways to be correct:

```
match:
  all:
    of:
      - expr: a
      - expr: (b || c)
```

```
match:
  all:
    of:
      - expr: a
      - any:
         of:
           - expr: b
           - expr: c
```

This PR automatically parenthesises expressions so that users do not
have to remember to do it themselves.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
