### PR TITLE
fix: Create blob store work dir when it does not exist

### DIFF
--- a/internal/storage/blob/cloner.go
+++ b/internal/storage/blob/cloner.go
@@ -61,6 +61,18 @@ type CloneResult struct {
 	failuresCount int
 }
 
+func (cr *CloneResult) isEmpty() bool {
+	return cr == nil || (len(cr.updateOrAdd) == 0 && len(cr.delete) == 0)
+}
+
+func (cr *CloneResult) failures() int {
+	if cr == nil {
+		return 0
+	}
+
+	return cr.failuresCount
+}
+
 func (c *Cloner) Clone(ctx context.Context) (*CloneResult, error) {
 	iter := c.bucket.List(nil)
 	info := make(infoType, len(c.info))

--- a/internal/storage/blob/store.go
+++ b/internal/storage/blob/store.go
@@ -213,15 +213,17 @@ func (s *Store) updateIndex(ctx context.Context) error {
 		return err
 	}
 
-	if changes == nil {
+	if failures := changes.failures(); failures > 0 {
+		s.log.Warnf("Failed to download (%d) files", failures)
+	}
+
+	if changes.isEmpty() {
 		s.log.Debug("No changes")
 		return nil
 	}
-	if changes.failuresCount > 0 {
-		s.log.Warnf("Failed to download (%d) files from the bucket %q", changes.failuresCount, s.conf.Bucket)
-	}
 
 	s.log.Infof("Detected changes: added or updated (%d), deleted (%d)", len(changes.updateOrAdd), len(changes.delete))
+
 	var p *policyv1.Policy
 	var event storage.Event
 	for _, f := range changes.updateOrAdd {


### PR DESCRIPTION
Creates the work dir if it does not exist.
This was previously handled by `Store.init` but the `cloner` gets
instantiated before the store and tries to read the work directory.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
