### PR TITLE
chore(ci): Remove GoReleaser mod stanza

### DIFF
--- a/.goreleaser-ci.yml
+++ b/.goreleaser-ci.yml
@@ -1,6 +1,3 @@
-gomod:
-  proxy: true
-
 snapshot:
   name_template: '{{ incminor .Version }}-prerelease'
 


### PR DESCRIPTION
Go releaser seems unable to handle 1.17 go.mod yet. See https://github.com/cerbos/cerbos/runs/3993815003?check_suite_focus=true
