### PR TITLE
chore: Run make commands to generate NOTICE after dependabot PRs

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    #if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
 
@@ -17,9 +17,10 @@ jobs:
         run: "make deps generate-notice"
 
       - name: Commit NOTICE
-        run: |
-          git config --global user.name 'Cerbos Actions'
-          git config --global user.email 'info@cerbos.dev'
-          git commit -am "Generate NOTICE"
-          git push
+        uses: EndBug/add-and-commit@v7
+        with:
+          message: Generate NOTICE
+          committer_name: Cerbos Actions
+          committer_email: info@cerbos.dev
+          signoff: true
 


### PR DESCRIPTION
#### Description

Run `make deps` and `make generate-notice` to ensure that the NOTICE file is up-to-date.

Fixes #361

#### Checklist 

- [x] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
