### PR TITLE
chore(ci): Fix dependabot workflow committing issue

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -8,6 +8,8 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - uses: actions/setup-go@v2
         with:
@@ -23,4 +25,4 @@ jobs:
           committer_name: Cerbos Actions
           committer_email: info@cerbos.dev
           signoff: true
-
+          push: origin


### PR DESCRIPTION
#### Description

Dependatbot workflow had a problem where it couldn't push to the PR branch.

#### Checklist 

- [ ] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
