### PR TITLE
chore(ci): Add contents write permission to Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,6 +1,8 @@
 name: Dependabot
 on:
   pull_request
+permissions:
+  contents: write
 
 jobs:
   dependabot:


### PR DESCRIPTION
#### Description

Adds `contents: write` permission to get rid of HTTP 403 error.

#### Checklist 

- [x] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
