### PR TITLE
chore: Add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ hack/dev/tls.key
 
 # Editor files
 .vscode
+.idea
 
 # macOS files
 .DS_Store


### PR DESCRIPTION
#### Description

Adds the .idea folder (used by JetBrains IDEs) to .gitignore.

#### Checklist 

- [x] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
