### PR TITLE
fix: Updates URL to download Cerbos binaries

### DIFF
--- a/docs/modules/ROOT/partials/attributes.adoc
+++ b/docs/modules/ROOT/partials/attributes.adoc
@@ -2,6 +2,6 @@
 :app-container-registry: ghcr.io
 :app-docker-img: {app-container-registry}/cerbos/cerbos:{app-version}
 :app-github-url: https://github.com/cerbos/cerbos
-:app-github-download-page: {app-github-url}/releases/tag/v{app-version}
+:app-github-download-page: {app-github-url}/releases/download/v{app-version}
 :app-helm-chart-repo: https://download.cerbos.dev/helm-charts
 :cerbos-openapi-schema: /schema/swagger.json 

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -155,7 +155,7 @@ func readFileContents(tb testing.TB, filePath string) []byte {
 	if _, err := os.Stat(filePath); err == nil {
 		b, err := os.ReadFile(filePath)
 		if err != nil {
-			tb.Errorf("Failed to read %s: %w", filePath, err)
+			tb.Errorf("Failed to read %s: %s", filePath, err)
 			return nil
 		}
 


### PR DESCRIPTION
Signed-off-by: Dennis Buduev <dennis@cerbos.dev>

#### Description

Updates documentation to specify correct URL to download Cerbos binaries.

Fixes #421

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
