### PR TITLE
chore(ci): Configure semantic commit prefixes

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,1 +1,10 @@
 titleOnly: true
+types:
+  - enhancement
+  - feat
+  - fix
+  - docs
+  - test
+  - ci
+  - chore
+  - revert


### PR DESCRIPTION
The default prefixes don't include "enhancement" which is an important
distinction to make when producing release notes.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
