### PR TITLE
docs: Fix passwordHash in full configuration doc

### DIFF
--- a/docs/modules/configuration/pages/index.adoc
+++ b/docs/modules/configuration/pages/index.adoc
@@ -63,7 +63,7 @@ server:
     enabled: true # Defines whether the admin API is enabled.
     adminCredentials: # Defines the admin user credentials.
       username: cerbos # The hardcoded username to use for authentication.
-      passwordHash: $2y$10$6v.PIn0zJ1xFdIDPlX3yheDZHM2iXI8CSKT5a3d35djtOxnOATxFi # The bcrypt hash of the password to use for authentication.
+      passwordHash: JDJ5JDEwJEdEOVFzZDE2VVhoVkR0N2VkUFBVM09nalc0QnNZaC9xc2E4bS9mcUJJcEZXenp5OUpjMi91Cgo= # BCrypt hashed and base64 encoded password to use for authentication.
 
 auxData: # Optional
   jwt:


### PR DESCRIPTION
#### Description
Fixes `passwordHash` parameter not being base64 encoded in the full configuration section of the configuration docs.

Fixes #431 

#### Checklist 

- [ ] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
