### PR TITLE
chore(ci): Run PR workflow for backports

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'v*'
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Configures the PR workflow to run for backport PRs raised against v* branches

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
