### PR TITLE
chore: Fix schema cache and blob store timeout

### DIFF
--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -6,8 +6,6 @@ package policy
 import (
 	"fmt"
 
-	jsonschema "github.com/santhosh-tekuri/jsonschema/v5"
-
 	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
 	"github.com/cerbos/cerbos/internal/namer"
 )
@@ -180,7 +178,6 @@ func Wrap(p *policyv1.Policy) Wrapper {
 type CompilationUnit struct {
 	ModID       namer.ModuleID
 	Definitions map[namer.ModuleID]*policyv1.Policy
-	Schemas     map[string]*jsonschema.Schema
 }
 
 func (cu *CompilationUnit) AddDefinition(id namer.ModuleID, p *policyv1.Policy) {
@@ -189,20 +186,6 @@ func (cu *CompilationUnit) AddDefinition(id namer.ModuleID, p *policyv1.Policy) 
 	}
 
 	cu.Definitions[id] = p
-}
-
-func (cu *CompilationUnit) AddSchemas(schemas map[string]*jsonschema.Schema) {
-	if len(schemas) == 0 {
-		return
-	}
-
-	if cu.Schemas == nil {
-		cu.Schemas = make(map[string]*jsonschema.Schema, len(schemas))
-	}
-
-	for id, def := range schemas {
-		cu.Schemas[id] = def
-	}
 }
 
 func (cu *CompilationUnit) MainSourceFile() string {

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -223,11 +223,11 @@ func (m *manager) OnStorageEvent(events ...storage.Event) {
 		//nolint:exhaustive
 		switch event.Kind {
 		case storage.EventAddOrUpdateSchema:
-			cacheKey := fmt.Sprintf("%s/%s", URLScheme, event.SchemaFile)
+			cacheKey := fmt.Sprintf("%s:///%s", URLScheme, event.SchemaFile)
 			_ = m.cache.Remove(cacheKey)
 			m.log.Debug("Handled schema add/update event", zap.String("schema", cacheKey))
 		case storage.EventDeleteSchema:
-			cacheKey := fmt.Sprintf("%s/%s", URLScheme, event.SchemaFile)
+			cacheKey := fmt.Sprintf("%s:///%s", URLScheme, event.SchemaFile)
 			_ = m.cache.Remove(cacheKey)
 			m.log.Warn("Handled schema delete event", zap.String("schema", cacheKey))
 		}

--- a/internal/storage/blob/cloner.go
+++ b/internal/storage/blob/cloner.go
@@ -135,7 +135,8 @@ func (c *Cloner) downloadToFile(ctx context.Context, key, file string) (err erro
 	if err != nil {
 		return fmt.Errorf("failed to create a reader for the object %q: %w", key, err)
 	}
-	defer multierr.AppendInvoke(&err, multierr.Close(r))
+	// defer multierr.AppendInvoke(&err, multierr.Close(r))
+	defer r.Close()
 
 	if _, err = io.Copy(fd, r); err != nil {
 		return fmt.Errorf("failed to read the object %q: %w", key, err)

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -132,6 +132,7 @@ type Event struct {
 
 func (evt Event) String() string {
 	kind := ""
+	id := evt.PolicyID.String()
 	switch evt.Kind {
 	case EventAddOrUpdatePolicy:
 		kind = "ADD/UPDATE"
@@ -139,15 +140,17 @@ func (evt Event) String() string {
 		kind = "DELETE"
 	case EventAddOrUpdateSchema:
 		kind = "ADD/UPDATE SCHEMA"
+		id = evt.SchemaFile
 	case EventDeleteSchema:
 		kind = "DELETE SCHEMA"
+		id = evt.SchemaFile
 	case EventNop:
 		kind = "NOP"
 	default:
 		kind = "UNKNOWN"
 	}
 
-	return fmt.Sprintf("%s [%s]", kind, evt.PolicyID.String())
+	return fmt.Sprintf("%s [%s]", kind, id)
 }
 
 // NewPolicyEvent creates a new storage event for a policy.


### PR DESCRIPTION
- Blob store clone was always failing due to a potential issue with the
  upstream library
- Schema cache was using the wrong key and not updating itself correctly
  while processing storage events

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
