### PR TITLE
chore(refactor): Fix list policies endpoint returning error message

### DIFF
--- a/internal/svc/admin_svc.go
+++ b/internal/svc/admin_svc.go
@@ -225,7 +225,8 @@ func (cas *CerbosAdminService) ListPolicies(ctx context.Context, req *requestv1.
 
 	units, err := cas.store.GetPolicies(context.Background())
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("could not get policies: %s", err.Error()))
+		ctxzap.Extract(ctx).Error("Could not get policies", zap.Error(err))
+		return nil, status.Error(codes.Internal, "could not get policies")
 	}
 
 	policies, err := filterPolicies(req.Filters, units)


### PR DESCRIPTION
#### Description

List policies were returning the error message in case some error happens internally. This PR makes list policies not return the error message but only log it.

Fixes #480 

#### Checklist 

- [x] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
