### PR TITLE
chore(ci): Disable patch version updates for AWS SDK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       - "chore"
       - "ci"
       - "bots"
+    ignore:
+      - dependency-name: github.com/aws/aws-sdk-go
+        update-types: 
+          - version-update:semver-patch
 
   - package-ecosystem: "gomod"
     directory: "/tools"


### PR DESCRIPTION
AWS SDK gets updated very frequently and most of the updates are not relevant to us

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
