### PR TITLE
chore(perf): Fix struct field alignment

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,6 +28,11 @@ linters-settings:
       Copyright {{ YEAR-RANGE }} {{ COMPANY }}
       SPDX-License-Identifier: Apache-2.0
 
+  govet:
+    enable-all: true 
+    disable:
+      - shadow
+
   nolintlint:
     allow-unused: false
     allow-leading-space: false
@@ -62,6 +67,7 @@ linters:
     - goheader
     - gomnd
     - gosec
+    - govet
     - ifshort
     - importas
     - makezero
@@ -121,3 +127,4 @@ issues:
       linters:
         - goconst
         - gomnd
+        - govet

--- a/client/client.go
+++ b/client/client.go
@@ -41,17 +41,17 @@ type Client interface {
 
 type config struct {
 	address            string
-	plaintext          bool
 	tlsAuthority       string
-	tlsInsecure        bool
 	tlsCACert          string
 	tlsClientCert      string
 	tlsClientKey       string
-	connectTimeout     time.Duration
-	maxRetries         uint
-	retryTimeout       time.Duration
 	userAgent          string
 	playgroundInstance string
+	connectTimeout     time.Duration
+	retryTimeout       time.Duration
+	maxRetries         uint
+	plaintext          bool
+	tlsInsecure        bool
 }
 
 type Opt func(*config)

--- a/client/model.go
+++ b/client/model.go
@@ -270,8 +270,8 @@ func (crsr *CheckResourceSetResponse) MarshalJSON() ([]byte, error) {
 
 // ResourceBatch is a container for a batch of heterogeneous resources.
 type ResourceBatch struct {
-	batch []*requestv1.CheckResourceBatchRequest_BatchEntry
 	err   error
+	batch []*requestv1.CheckResourceBatchRequest_BatchEntry
 }
 
 // NewResourceBatch creates a new resource batch.
@@ -327,8 +327,8 @@ func (rb *ResourceBatch) Validate() error {
 // CheckResourceBatchResponse is the response from the CheckResourceBatch API call.
 type CheckResourceBatchResponse struct {
 	*responsev1.CheckResourceBatchResponse
-	once sync.Once
 	idx  map[string][]int
+	once sync.Once
 }
 
 func (crbr *CheckResourceBatchResponse) buildIdx() {
@@ -388,8 +388,8 @@ func (crbr *CheckResourceBatchResponse) MarshalJSON() ([]byte, error) {
 
 // PolicySet is a container for a set of policies.
 type PolicySet struct {
-	policies []*policyv1.Policy
 	err      error
+	policies []*policyv1.Policy
 }
 
 // NewPolicySet creates a new policy set.
@@ -835,8 +835,8 @@ func (me matchExpr) build() *policyv1.Match {
 }
 
 type matchList struct {
-	list []match
 	cons func([]*policyv1.Match) *policyv1.Match
+	list []match
 }
 
 func (ml matchList) build() *policyv1.Match {
@@ -869,11 +869,11 @@ const (
 
 // AuditLogOptions is used to filter audit logs.
 type AuditLogOptions struct {
-	Type      AuditLogType
-	Tail      uint32
 	StartTime time.Time
 	EndTime   time.Time
 	Lookup    string
+	Tail      uint32
+	Type      AuditLogType
 }
 
 type AuditLogEntry struct {
@@ -903,8 +903,8 @@ type sortingOptions struct {
 }
 
 type policyListOptions struct {
-	filters        []*requestv1.ListPoliciesRequest_Filter
 	sortingOptions *sortingOptions
+	filters        []*requestv1.ListPoliciesRequest_Filter
 }
 
 // ListOpt is used to specify options for ListPolicies method.

--- a/cmd/cerbos/server/server.go
+++ b/cmd/cerbos/server/server.go
@@ -24,9 +24,9 @@ import (
 
 type serverArgs struct {
 	configFile      string
-	configOverrides []string
 	debugListenAddr string
 	logLevel        string
+	configOverrides []string
 	zpagesEnabled   bool
 }
 

--- a/cmd/cerbosctl/internal/flags.go
+++ b/cmd/cerbosctl/internal/flags.go
@@ -20,10 +20,10 @@ import (
 var errMoreThanOneFilter = errors.New("more than one filter specified: choose from either `tail`, `between`, `since` or `lookup`")
 
 type AuditLogFilterDef struct {
-	tail    uint16
+	lookup  string
 	between timerangeFlag
 	since   time.Duration
-	lookup  string
+	tail    uint16
 }
 
 func NewAuditLogFilterDef() *AuditLogFilterDef {
@@ -167,11 +167,11 @@ func GenAuditLogOptions(filter *AuditLogFilterDef) client.AuditLogOptions {
 }
 
 type ListPoliciesFilterDef struct {
+	sort       string
+	format     string
 	fieldEq    []string
 	fieldMatch []string
-	sort       string
 	sortDesc   bool
-	format     string
 }
 
 func NewListPoliciesFilterDef() *ListPoliciesFilterDef {

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -86,7 +86,7 @@ storage:
       maxIdleTime: 45s
       maxOpen: 4
       maxIdle: 1 
-    dsn: "user:password@tcp(localhost:3306)/db?interpolateParams=true" # Required. Data source name
+    dsn: "user:password@tcp(localhost:3306)/db?interpolateParams=true" # Required. DSN is the data source connection string.
     serverPubKey: 
       mykey: testdata/server_public_key.pem 
     tls: 

--- a/internal/audit/conf.go
+++ b/internal/audit/conf.go
@@ -19,10 +19,10 @@ type Conf struct {
 }
 
 type confHolder struct {
-	// Enabled defines whether audit logging is enabled.
-	Enabled bool `yaml:"enabled" conf:",example=false"`
 	// Backend states which backend to use for Audits.
 	Backend string `yaml:"backend" conf:",example=local"`
+	// Enabled defines whether audit logging is enabled.
+	Enabled bool `yaml:"enabled" conf:",example=false"`
 	// AccessLogsEnabled defines whether access logging is enabled.
 	AccessLogsEnabled bool `yaml:"accessLogsEnabled" conf:",example=true"`
 	// DecisionLogsEnabled defines whether logging of policy decisions is enabled.

--- a/internal/audit/id.go
+++ b/internal/audit/id.go
@@ -125,8 +125,8 @@ func nearestPowerOfTwo(v uint64) uint64 {
 
 // lockedRand is a rand protected by a mutex because random sources are not thread-safe.
 type lockedRand struct {
-	mu  sync.Mutex
 	rnd *rand.Rand
+	mu  sync.Mutex
 }
 
 func newLockedRand(seed int64) *lockedRand {

--- a/internal/audit/local/badgerdb.go
+++ b/internal/audit/local/badgerdb.go
@@ -54,10 +54,10 @@ type Log struct {
 	logger   *zap.Logger
 	db       *badgerv3.DB
 	buffer   chan *badgerv3.Entry
-	wg       sync.WaitGroup
-	stopOnce sync.Once
 	stopChan chan struct{}
 	ttl      time.Duration
+	wg       sync.WaitGroup
+	stopOnce sync.Once
 }
 
 func NewLog(conf *Conf) (*Log, error) {

--- a/internal/audit/local/collector.go
+++ b/internal/audit/local/collector.go
@@ -16,10 +16,10 @@ type collector interface {
 }
 
 type accessLogEntryCollector struct {
-	buffer   chan *auditv1.AccessLogEntry
-	doneOnce sync.Once
-	mu       sync.RWMutex
 	err      error
+	buffer   chan *auditv1.AccessLogEntry
+	mu       sync.RWMutex
+	doneOnce sync.Once
 }
 
 func newAccessLogEntryCollector() *accessLogEntryCollector {
@@ -65,10 +65,10 @@ func (a *accessLogEntryCollector) Next() (*auditv1.AccessLogEntry, error) {
 }
 
 type decisionLogEntryCollector struct {
-	buffer   chan *auditv1.DecisionLogEntry
-	doneOnce sync.Once
-	mu       sync.RWMutex
 	err      error
+	buffer   chan *auditv1.DecisionLogEntry
+	mu       sync.RWMutex
+	doneOnce sync.Once
 }
 
 func newDecisionLogEntryCollector() *decisionLogEntryCollector {

--- a/internal/auxdata/conf.go
+++ b/internal/auxdata/conf.go
@@ -26,12 +26,12 @@ type JWTConf struct {
 }
 
 type JWTKeySet struct {
-	// ID is the unique reference to this keyset.
-	ID string `yaml:"id" conf:"required,example=ks1"`
 	// Remote defines a remote keyset. Mutually exclusive with Local.
 	Remote *RemoteSource `yaml:"remote"`
 	// Local defines a local keyset. Mutually exclusive with Remote.
 	Local *LocalSource `yaml:"local"`
+	// ID is the unique reference to this keyset.
+	ID string `yaml:"id" conf:"required,example=ks1"`
 }
 
 type RemoteSource struct {

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -94,9 +94,9 @@ func compileResourcePolicy(modCtx *moduleCtx, rp *policyv1.ResourcePolicy, schem
 
 func compileImportedDerivedRoles(modCtx *moduleCtx, rp *policyv1.ResourcePolicy) (map[string]*runtimev1.RunnableDerivedRole, error) {
 	type derivedRoleInfo struct {
+		compiledRoles *runtimev1.RunnableDerivedRolesSet
 		importName    string
 		sourceFile    string
-		compiledRoles *runtimev1.RunnableDerivedRolesSet
 	}
 
 	roleImports := make(map[string][]derivedRoleInfo)

--- a/internal/compile/errors.go
+++ b/internal/compile/errors.go
@@ -110,8 +110,8 @@ func newError(file, desc string, err error) *Error {
 
 // CELCompileError holds CEL compilation errors.
 type CELCompileError struct {
-	expr   string
 	issues *cel.Issues
+	expr   string
 }
 
 func newCELCompileError(expr string, issues *cel.Issues) *CELCompileError {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,8 +143,8 @@ func GetSection(section Section) error {
 }
 
 type configHolder struct {
-	mu       sync.RWMutex
 	provider config.Provider
+	mu       sync.RWMutex
 }
 
 func (ch *configHolder) Get(key string, out interface{}) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,9 +19,9 @@ import (
 var errTestValidate = errors.New("validation error")
 
 type Server struct {
+	TLS        *TLS   `yaml:"tls"`
 	DataDir    string `yaml:"dataDir"`
 	ListenAddr string `yaml:"listenAddr"`
-	TLS        *TLS   `yaml:"tls"`
 }
 
 func (s *Server) Key() string {
@@ -153,8 +153,8 @@ func TestCerbosConfig(t *testing.T) {
 
 func TestStrictParsing(t *testing.T) {
 	testCases := []struct {
-		name    string
 		conf    map[string]interface{}
+		name    string
 		wantErr bool
 	}{
 		{

--- a/internal/engine/ast.go
+++ b/internal/engine/ast.go
@@ -393,8 +393,9 @@ func buildExpr(expr *exprpb.Expr, acc *responsev1.ResourcesQueryPlanResponse_Exp
 		var operands []*ExprOp
 
 		for _, r := range []struct {
-			n, v string
-			x    *exprpb.Expr
+			x *exprpb.Expr
+			n string
+			v string
 		}{
 			{n: LoopStep, x: x.LoopStep},
 			{n: LoopCondition, x: x.LoopCondition},

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -82,12 +82,12 @@ func WithWriterTraceSink(w io.Writer) CheckOpt {
 }
 
 type Engine struct {
-	conf        *Conf
-	workerIndex uint64
-	workerPool  []chan<- workIn
-	compileMgr  *compile.Manager
 	schemaMgr   schema.Manager
 	auditLog    audit.Log
+	conf        *Conf
+	compileMgr  *compile.Manager
+	workerPool  []chan<- workIn
+	workerIndex uint64
 }
 
 type Components struct {
@@ -451,8 +451,8 @@ func (engine *Engine) policyAttr(name, version string) (pName, pVersion string) 
 }
 
 type evaluationCtx struct {
-	numChecks int
 	checks    [2]Evaluator
+	numChecks int
 }
 
 func (ec *evaluationCtx) addCheck(eval Evaluator) {
@@ -540,15 +540,15 @@ func (er *evaluationResult) merge(res *PolicyEvalResult) bool {
 }
 
 type workOut struct {
-	index  int
-	result *enginev1.CheckOutput
 	err    error
+	result *enginev1.CheckOutput
+	index  int
 }
 
 type workIn struct {
-	index     int
 	ctx       context.Context
 	input     *enginev1.CheckInput
 	checkOpts *checkOptions
 	out       chan<- workOut
+	index     int
 }

--- a/internal/engine/planner.go
+++ b/internal/engine/planner.go
@@ -23,9 +23,9 @@ type (
 	qpNLO = enginev1.ResourcesQueryPlanOutput_Node_LogicalOperation
 	qpNE  = enginev1.ResourcesQueryPlanOutput_Node_Expression
 	rN    = struct {
-		role string
 		f    func() (*qpN, error)
 		node *qpN
+		role string
 	}
 )
 

--- a/internal/engine/trace.go
+++ b/internal/engine/trace.go
@@ -111,8 +111,8 @@ func (zts *ZapTraceSink) WriteEvent(component []string, data ...KV) {
 
 // WriterTraceSink implements TraceSink using an io.Writer.
 type WriterTraceSink struct {
-	mu sync.Mutex
 	w  io.Writer
+	mu sync.Mutex
 }
 
 func NewWriterTraceSink(w io.Writer) *WriterTraceSink {
@@ -138,8 +138,8 @@ func (wts *WriterTraceSink) WriteEvent(component []string, data ...KV) {
 }
 
 type tracer struct {
-	enabled bool
 	sink    TraceSink
+	enabled bool
 }
 
 func newTracer(sink TraceSink) *tracer {
@@ -155,9 +155,9 @@ func (t *tracer) beginTrace(nameFormat string, params ...interface{}) *traceCont
 }
 
 type traceContext struct {
-	enabled   bool
-	component []string
 	sink      TraceSink
+	component []string
+	enabled   bool
 }
 
 var noopTraceCtx = &traceContext{enabled: false}

--- a/internal/observability/tracing/conf.go
+++ b/internal/observability/tracing/conf.go
@@ -22,14 +22,14 @@ var (
 
 // Conf is optional configuration for tracing.
 type Conf struct {
-	// SampleProbability is the probability of sampling expressed as a number between 0 and 1.
-	SampleProbability float64 `yaml:"sampleProbability" conf:",example=0.1"`
+	// Jaeger configures the Jaeger exporter.
+	Jaeger *JaegerConf `yaml:"jaeger"`
 	// PropagationFormat is the trace propagation format to use. Valid values are w3c-tracecontext or b3.
 	PropagationFormat string `yaml:"propagationFormat" conf:",ignore"`
 	// Exporter is the type of trace exporter to use.
 	Exporter string `yaml:"exporter" conf:",example=jaeger"`
-	// Jaeger configures the Jaeger exporter.
-	Jaeger *JaegerConf `yaml:"jaeger"`
+	// SampleProbability is the probability of sampling expressed as a number between 0 and 1.
+	SampleProbability float64 `yaml:"sampleProbability" conf:",example=0.1"`
 }
 
 type JaegerConf struct {

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -124,13 +124,13 @@ func GetSourceFile(p *policyv1.Policy) string {
 
 // Wrapper is a convenience layer over the policy definition.
 type Wrapper struct {
-	ID           namer.ModuleID
+	*policyv1.Policy
 	FQN          string
 	Kind         string
 	Name         string
 	Version      string
 	Dependencies []namer.ModuleID
-	*policyv1.Policy
+	ID           namer.ModuleID
 }
 
 func Wrap(p *policyv1.Policy) Wrapper {
@@ -176,8 +176,8 @@ func Wrap(p *policyv1.Policy) Wrapper {
 // For example, if a resource policy named R imports derived roles named D, the compilation unit will contain
 // both R and D with the ModID field pointing to R because it is the main policy.
 type CompilationUnit struct {
-	ModID       namer.ModuleID
 	Definitions map[namer.ModuleID]*policyv1.Policy
+	ModID       namer.ModuleID
 }
 
 func (cu *CompilationUnit) AddDefinition(id namer.ModuleID, p *policyv1.Policy) {

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -38,8 +38,8 @@ const (
 var alwaysValidResult = &ValidationResult{Reject: false}
 
 type ValidationResult struct {
-	Reject bool
 	Errors ValidationErrorList
+	Reject bool
 }
 
 func (vr *ValidationResult) add(errs ...ValidationError) {

--- a/internal/server/conf.go
+++ b/internal/server/conf.go
@@ -29,12 +29,14 @@ var (
 
 // Conf is required configuration for the server.
 type Conf struct {
+	// AdminAPI defines the admin API configuration.
+	AdminAPI AdminAPIConf `yaml:"adminAPI"`
+	// TLS defines the TLS configuration for the server.
+	TLS *TLSConf `yaml:"tls"`
 	// HTTPListenAddr is the dedicated HTTP address.
 	HTTPListenAddr string `yaml:"httpListenAddr" conf:"required,example=\":3592\""`
 	// GRPCListenAddr is the dedicated GRPC address.
 	GRPCListenAddr string `yaml:"grpcListenAddr" conf:"required,example=\":3593\""`
-	// TLS defines the TLS configuration for the server.
-	TLS *TLSConf `yaml:"tls"`
 	// CORS defines the CORS configuration for the server.
 	CORS CORSConf `yaml:"cors"`
 	// MetricsEnabled defines whether the metrics endpoint is enabled.
@@ -43,8 +45,6 @@ type Conf struct {
 	LogRequestPayloads bool `yaml:"logRequestPayloads" conf:",example=false"`
 	// PlaygroundEnabled defines whether the playground API is enabled.
 	PlaygroundEnabled bool `yaml:"playgroundEnabled" conf:",example=false"`
-	// AdminAPI defines the admin API configuration.
-	AdminAPI AdminAPIConf `yaml:"adminAPI"`
 }
 
 // TLSConf holds TLS configuration.
@@ -58,21 +58,21 @@ type TLSConf struct {
 }
 
 type CORSConf struct {
-	// Disabled sets whether CORS is disabled.
-	Disabled bool `yaml:"disabled" conf:",example=false"`
 	// AllowedOrigins is the contents of the allowed-origins header.
 	AllowedOrigins []string `yaml:"allowedOrigins" conf:",example=['*']"`
 	// AllowedHeaders is the contents of the allowed-headers header.
 	AllowedHeaders []string `yaml:"allowedHeaders" conf:",example=['content-type']"`
+	// Disabled sets whether CORS is disabled.
+	Disabled bool `yaml:"disabled" conf:",example=false"`
 	// MaxAge is the max age of the CORS preflight check.
 	MaxAge time.Duration `yaml:"maxAge" conf:",example=10s"`
 }
 
 type AdminAPIConf struct {
-	// Enabled defines whether the admin API is enabled.
-	Enabled bool `yaml:"enabled" conf:",example=true"`
 	// AdminCredentials defines the admin user credentials.
 	AdminCredentials *AdminCredentialsConf `yaml:"adminCredentials"`
+	// Enabled defines whether the admin API is enabled.
+	Enabled bool `yaml:"enabled" conf:",example=true"`
 }
 
 type AdminCredentialsConf struct {

--- a/internal/storage/blob/conf.go
+++ b/internal/storage/blob/conf.go
@@ -26,6 +26,10 @@ const (
 // Conf is required (if driver is set to 'blob') configuration for cloud storage driver.
 //+desc=This section is required only if storage.driver is blob.
 type Conf struct {
+	// DownloadTimeout specifies the timeout for downloading from cloud storage.
+	DownloadTimeout *time.Duration `yaml:"downloadTimeout,omitempty" conf:",example=30s"`
+	// RequestTimeout specifies the timeout for an HTTP request.
+	RequestTimeout *time.Duration `yaml:"requestTimeout,omitempty" conf:",example=10s"`
 	// Bucket URL (Examples: s3://my-bucket?region=us-west-1 gs://my-bucket azblob://my-container).
 	Bucket string `yaml:"bucket" conf:"required,example=\"s3://my-bucket-name?region=us-east-2\""`
 	// Prefix specifies a subdirectory to download.
@@ -34,10 +38,6 @@ type Conf struct {
 	WorkDir string `yaml:"workDir" conf:",example=${HOME}/tmp/cerbos/work"`
 	// UpdatePollInterval specifies the interval to poll the cloud storage. Set to 0 to disable.
 	UpdatePollInterval time.Duration `yaml:"updatePollInterval" conf:",example=15s"`
-	// DownloadTimeout specifies the timeout for downloading from cloud storage.
-	DownloadTimeout *time.Duration `yaml:"downloadTimeout,omitempty" conf:",example=30s"`
-	// RequestTimeout specifies the timeout for an HTTP request.
-	RequestTimeout *time.Duration `yaml:"requestTimeout,omitempty" conf:",example=10s"`
 }
 
 func (conf *Conf) Key() string {

--- a/internal/storage/db/internal/db.go
+++ b/internal/storage/db/internal/db.go
@@ -260,9 +260,9 @@ func (s *dbStorage) GetCompilationUnits(ctx context.Context, ids ...namer.Module
 	units := make(map[namer.ModuleID]*policy.CompilationUnit)
 	for results.Next() {
 		var row struct {
+			Definition PolicyDefWrapper
 			Parent     namer.ModuleID
 			ID         namer.ModuleID
-			Definition PolicyDefWrapper
 		}
 
 		if err := results.ScanStruct(&row); err != nil {

--- a/internal/storage/db/internal/model.go
+++ b/internal/storage/db/internal/model.go
@@ -30,18 +30,18 @@ const (
 )
 
 type Schema struct {
-	ID         string
 	Definition *pgtype.JSON
+	ID         string
 }
 
 type Policy struct {
-	ID          namer.ModuleID
+	Definition  PolicyDefWrapper
 	Kind        string
 	Name        string
 	Version     string
 	Description string
+	ID          namer.ModuleID
 	Disabled    bool
-	Definition  PolicyDefWrapper
 }
 
 type PolicyDependency struct {
@@ -79,14 +79,14 @@ func (pdw *PolicyDefWrapper) Scan(src interface{}) error {
 }
 
 type PolicyRevision struct {
-	RevisionID  int64 `db:"revision_id"`
-	ID          namer.ModuleID
-	Kind        string
-	Name        string
+	Timestamp   time.Time `db:"update_timestamp"`
+	Definition  PolicyDefWrapper
+	Action      string
 	Version     string
 	Description string
-	Action      string
+	Kind        string
+	Name        string
+	ID          namer.ModuleID
+	RevisionID  int64 `db:"revision_id"`
 	Disabled    bool
-	Definition  PolicyDefWrapper
-	Timestamp   time.Time `db:"update_timestamp"`
 }

--- a/internal/storage/db/mysql/conf.go
+++ b/internal/storage/db/mysql/conf.go
@@ -13,11 +13,11 @@ const confKey = storage.ConfKey + ".mysql"
 // Conf is required (if driver is set to 'mysql') configuration for mysql driver.
 //+desc=This section is required only if storage.driver is mysql.
 type Conf struct {
-	// Data source name
-	DSN          string                 `yaml:"dsn" conf:"required,example=\"user:password@tcp(localhost:3306)/db?interpolateParams=true\""`
 	ConnPool     *internal.ConnPoolConf `yaml:"connPool" conf:",example=\n  maxLifeTime: 60m\n  maxIdleTime: 45s\n  maxOpen: 4\n  maxIdle: 1"`
 	TLS          map[string]TLSConf     `yaml:"tls" conf:",example=\n  mytls:\n    cert: /path/to/certificate\n    key: /path/to/private_key\n    caCert: /path/to/CA_certificate"`
 	ServerPubKey map[string]string      `yaml:"serverPubKey" conf:",example=\n  mykey: testdata/server_public_key.pem"`
+	// DSN is the data source connection string.
+	DSN string `yaml:"dsn" conf:"required,example=\"user:password@tcp(localhost:3306)/db?interpolateParams=true\""`
 }
 
 type TLSConf struct {

--- a/internal/storage/db/postgres/conf.go
+++ b/internal/storage/db/postgres/conf.go
@@ -13,9 +13,9 @@ const confKey = storage.ConfKey + ".postgres"
 // Conf is required (if driver is set to 'postres') configuration for postres driver.
 //+desc=This section is required only if storage.driver is postgres.
 type Conf struct {
-	// URL is the Postgres connection URL. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-	URL      string                 `yaml:"url" conf:"required,example=\"postgres://user:password@localhost:port/db\""`
 	ConnPool *internal.ConnPoolConf `yaml:"connPool" conf:",example=\n  maxLifeTime: 60m\n  maxIdleTime: 45s\n  maxOpen: 4\n  maxIdle: 1"`
+	// URL is the Postgres connection URL. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+	URL string `yaml:"url" conf:"required,example=\"postgres://user:password@localhost:port/db\""`
 }
 
 func (c *Conf) Key() string {

--- a/internal/storage/disk/conf.go
+++ b/internal/storage/disk/conf.go
@@ -14,10 +14,10 @@ const confKey = storage.ConfKey + ".disk"
 type Conf struct {
 	// Directory is the path on disk where policies are stored.
 	Directory string `yaml:"directory" conf:"required,example=pkg/test/testdata/store"`
-	// WatchForChanges enables watching the directory for changes.
-	WatchForChanges bool `yaml:"watchForChanges" conf:"required,example=false"`
 	// [DEPRECATED] ScratchDir is the directory to use for holding temporary data.
 	ScratchDir string `yaml:"scratchDir" conf:",ignore"`
+	// WatchForChanges enables watching the directory for changes.
+	WatchForChanges bool `yaml:"watchForChanges" conf:"required,example=false"`
 }
 
 func (conf *Conf) Key() string {

--- a/internal/storage/disk/dirwatch.go
+++ b/internal/storage/disk/dirwatch.go
@@ -56,15 +56,15 @@ func watchDir(ctx context.Context, dir string, idx index.Index, sub *storage.Sub
 }
 
 type dirWatch struct {
-	dir       string
-	log       *zap.SugaredLogger
-	watchChan chan notify.EventInfo
-	idx       index.Index
+	lastEventTime time.Time
+	idx           index.Index
+	log           *zap.SugaredLogger
+	watchChan     chan notify.EventInfo
+	eventBatch    map[string]struct{}
 	*storage.SubscriptionManager
+	dir            string
 	cooldownPeriod time.Duration
 	mu             sync.RWMutex
-	eventBatch     map[string]struct{}
-	lastEventTime  time.Time
 }
 
 func (dw *dirWatch) handleEvents(ctx context.Context) {

--- a/internal/storage/git/conf.go
+++ b/internal/storage/git/conf.go
@@ -28,6 +28,12 @@ const (
 // Conf is required (if driver is set to 'git') configuration for Git storage driver.
 //+desc=This section is required only if storage.driver is git.
 type Conf struct {
+	// SSH holds auth details for the SSH protocol.
+	SSH *SSHAuth `yaml:"ssh,omitempty"`
+	// HTTPS holds auth details for the HTTPS protocol.
+	HTTPS *HTTPSAuth `yaml:"https,omitempty"`
+	// OperationTimeout specifies the timeout for git operations.
+	OperationTimeout *time.Duration `yaml:"operationTimeout,omitempty" conf:",example=60s"`
 	// Protocol is the Git protocol to use. Valid values are https, ssh, and file.
 	Protocol string `yaml:"protocol" conf:"required,example=file"`
 	// URL is the URL to the Git repo.
@@ -40,12 +46,6 @@ type Conf struct {
 	CheckoutDir string `yaml:"checkoutDir" conf:",example=${HOME}/tmp/cerbos/work"`
 	// [DEPRECATED] ScratchDir is the directory to use for holding temporary data.
 	ScratchDir string `yaml:"scratchDir" conf:",ignore"`
-	// SSH holds auth details for the SSH protocol.
-	SSH *SSHAuth `yaml:"ssh,omitempty"`
-	// HTTPS holds auth details for the HTTPS protocol.
-	HTTPS *HTTPSAuth `yaml:"https,omitempty"`
-	// OperationTimeout specifies the timeout for git operations.
-	OperationTimeout *time.Duration `yaml:"operationTimeout,omitempty" conf:",example=60s"`
 	// UpdatePollInterval specifies the interval to poll the Git repository for changes. Set to 0 to disable.
 	UpdatePollInterval time.Duration `yaml:"updatePollInterval" conf:",example=60s"`
 }

--- a/internal/storage/index/builder.go
+++ b/internal/storage/index/builder.go
@@ -45,8 +45,8 @@ type DuplicateDef struct {
 
 // LoadFailure describes a failure to load a policy.
 type LoadFailure struct {
-	File string
 	Err  error
+	File string
 }
 
 func (lf LoadFailure) MarshalJSON() ([]byte, error) {

--- a/internal/storage/index/index.go
+++ b/internal/storage/index/index.go
@@ -45,14 +45,14 @@ type Index interface {
 }
 
 type index struct {
-	fsys         fs.FS
-	mu           sync.RWMutex
 	executables  map[namer.ModuleID]struct{}
 	modIDToFile  map[namer.ModuleID]string
 	fileToModID  map[string]namer.ModuleID
 	dependents   map[namer.ModuleID]map[namer.ModuleID]struct{}
 	dependencies map[namer.ModuleID]map[namer.ModuleID]struct{}
 	schemaLoader *SchemaLoader
+	fsys         fs.FS
+	mu           sync.RWMutex
 }
 
 func (idx *index) GetFiles() []string {

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -22,8 +22,8 @@ var (
 
 // InvalidPolicyError is a custom error to signal that a policy is invalid.
 type InvalidPolicyError struct {
-	Message string
 	Err     error
+	Message string
 }
 
 func (ipe InvalidPolicyError) Error() string {
@@ -120,9 +120,9 @@ const (
 
 // Event is an event detected by the storage layer.
 type Event struct {
+	SchemaFile string
 	Kind       EventKind
 	PolicyID   namer.ModuleID
-	SchemaFile string
 }
 
 func (evt Event) String() string {

--- a/internal/storage/subscriptionmgr.go
+++ b/internal/storage/subscriptionmgr.go
@@ -15,10 +15,10 @@ import (
 const eventBufferSize = 16
 
 type SubscriptionManager struct {
-	once        sync.Once
 	eventChan   chan Event
-	mu          sync.RWMutex
 	subscribers map[string]Subscriber
+	mu          sync.RWMutex
+	once        sync.Once
 }
 
 func NewSubscriptionManager(ctx context.Context) *SubscriptionManager {
@@ -128,8 +128,8 @@ func TestSubscription(s Subscribable) func(*testing.T, time.Duration, ...Event) 
 
 type subscriber struct {
 	stream chan Event
-	mu     sync.RWMutex
 	events []Event
+	mu     sync.RWMutex
 }
 
 func (s *subscriber) SubscriberID() string {

--- a/internal/svc/admin_svc.go
+++ b/internal/svc/admin_svc.go
@@ -39,11 +39,11 @@ var (
 
 // CerbosAdminService implements the Cerbos administration service.
 type CerbosAdminService struct {
-	store           storage.Store
-	auditLog        audit.Log
+	store    storage.Store
+	auditLog audit.Log
+	*svcv1.UnimplementedCerbosAdminServiceServer
 	adminUser       string
 	adminPasswdHash []byte
-	*svcv1.UnimplementedCerbosAdminServiceServer
 }
 
 func NewCerbosAdminService(store storage.Store, auditLog audit.Log, adminUser string, adminPasswdHash []byte) *CerbosAdminService {

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -129,9 +129,9 @@ func DataFS() fs.FS {
 }
 
 type Case struct {
+	Want  map[string][]byte
 	Name  string
 	Input []byte
-	Want  map[string][]byte
 }
 
 // LoadTestCases loads groups of test files from the given path.

--- a/internal/verify/test_fixture_test.go
+++ b/internal/verify/test_fixture_test.go
@@ -34,8 +34,8 @@ principals:
 	fsys["a/"+util.TestDataDirectory+"/principals.yaml"] = newMapFile(principals)
 
 	tests := []struct {
-		name    string
 		want    map[string]*v1.Principal
+		name    string
 		wantErr bool
 	}{
 		{

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -53,8 +53,8 @@ func cleanup(r *http.Request) {
 }
 
 type swaggerMod struct {
-	schema []byte
 	err    error
+	schema []byte
 }
 
 func newSwaggerMod() *swaggerMod {


### PR DESCRIPTION
- Re-arrange struct fields to optimize memory layout.
- Enable govet which had been accidentally disabled.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
