### PR TITLE
docs: Upgrade to DocSearch v3

### DIFF
--- a/docs/supplemental-ui/partials/footer-content.hbs
+++ b/docs/supplemental-ui/partials/footer-content.hbs
@@ -6,12 +6,13 @@
 </footer>
 
 <!-- Algolia DocSearch -->
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-<script type="text/javascript"> docsearch({
-apiKey: 'a95a2992f9a9d3adf7ee3380e5503fb3',
-indexName: 'cerbos',
-inputSelector: '#search-input',
-debug: false // Set debug to true if you want to inspect the dropdown
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@alpha"></script>
+<script type="text/javascript">
+docsearch({
+  container: '#docsearch',
+  appId: '8URDSOZBS0',
+  indexName: 'cerbos',
+  apiKey: 'dee65155682fdeb12ea7dc2e30fa6de7'
 });
 </script>
 <!-- End Algolia DocSearch -->

--- a/docs/supplemental-ui/partials/head-meta.hbs
+++ b/docs/supplemental-ui/partials/head-meta.hbs
@@ -9,7 +9,11 @@
 <meta name="theme-color" content="#ffffff">
 
 <!-- Algolia DocSearch -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+<link rel="preconnect" href="https://8URDSOZBS0-dsn.algolia.net" crossorigin />
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/@docsearch/css@alpha"
+/>
 <!-- End Algolia DocSearch -->
 
 <!-- Google Tag Manager -->

--- a/docs/supplemental-ui/partials/header-content.hbs
+++ b/docs/supplemental-ui/partials/header-content.hbs
@@ -17,7 +17,7 @@
     <div id="topbar-nav" class="navbar-menu">
       <div class="navbar-end">
         <div class="navbar-item hide-for-print">
-            <input id="search-input" type="text" placeholder="Search docs">
+            <div id="docsearch"></div>
         </div>
 
         <div class="navbar-item has-dropdown is-hoverable">


### PR DESCRIPTION
Algolia is deprecating DocSearch v2. 

https://docsearch.algolia.com/docs/DocSearch-v3

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
