### PR TITLE
chore(lint): Enable more linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,6 +66,7 @@ linters:
     - goimports
     - goheader
     - gomnd
+    - gomoddirectives
     - gosec
     - govet
     - ifshort
@@ -89,6 +90,7 @@ linters:
     - tparallel
     - unconvert
     - unparam
+    - wastedassign
     - whitespace
   disable:
     - cyclop
@@ -113,7 +115,6 @@ linters:
     - paralleltest
     - stylecheck
     - testpackage
-    - wastedassign
     - wrapcheck
     - wsl
 

--- a/client/credentials.go
+++ b/client/credentials.go
@@ -72,7 +72,7 @@ func loadCredsFromNetrc(env environment, server string) (username, password stri
 		return "", "", fmt.Errorf("failed to parse server target '%s': %w", server, err)
 	}
 
-	netrcPath := ""
+	var netrcPath string
 	if np, ok := env.LookupEnv(netrcEnvVar); ok {
 		netrcPath = np
 	} else {

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -126,7 +126,7 @@ type Event struct {
 }
 
 func (evt Event) String() string {
-	kind := ""
+	var kind string
 	id := evt.PolicyID.String()
 	switch evt.Kind {
 	case EventAddOrUpdatePolicy:


### PR DESCRIPTION
- Enable `gomoddirectives` to catch accidental `replace` directives
- Enable `wastedassign` to catch wasted assignments

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
