### PR TITLE
enhancement: Switch from Distroless to scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM alpine:3.15 AS base
-RUN apk add -U --no-cache ca-certificates
-RUN update-ca-certificates
+RUN apk add -U --no-cache ca-certificates && update-ca-certificates
 
 FROM scratch
 EXPOSE 3592 3593

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM gcr.io/distroless/base
+FROM alpine:3.15 AS base
+RUN apk add -U --no-cache ca-certificates
+RUN update-ca-certificates
+
+FROM scratch
 EXPOSE 3592 3593
 VOLUME ["/policies"]
 ENTRYPOINT ["/cerbos"]
 CMD ["server", "--config=/conf.default.yaml"]
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY cerbos /cerbos
 COPY conf.default.yaml /conf.default.yaml
 


### PR DESCRIPTION
The Distroless base image uses some packages from Debian that have
vulnerabilities: https://github.com/GoogleContainerTools/distroless/issues/886

Even though we don't use the affected library in any way (CGO is disabled),
container image scans would still report the problem.

The fix is only available in [Debian Sid and Bookworm](https://security-tracker.debian.org/tracker/CVE-2021-33574)
but Distroless still has not migrated to those versions of Debian.

Since both upstream projects are moving very slowly, we'll just have to
address the issue ourselves. This PR switches the base image to
`scratch` and uses the CA certificates from Alpine. I have tested the
new image with GitHub and GCS and there were no issues establishing the
TLS connections.

Security scan reveals no issues either:

```
trivy i ghcr.io/cerbos/cerbos:0.12.0-prerelease-amd64
2021-12-30T09:45:49.723Z	INFO	Number of language-specific files: 1
2021-12-30T09:45:49.723Z	INFO	Detecting gobinary vulnerabilities...

cerbos (gobinary)
=================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

trivy i ghcr.io/cerbos/cerbos:0.12.0-prerelease-arm64
2021-12-30T09:46:14.269Z	INFO	Number of language-specific files: 1
2021-12-30T09:46:14.269Z	INFO	Detecting gobinary vulnerabilities...

cerbos (gobinary)
=================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
