### PR TITLE
chore(bug): Handle case when query plan filter is nil

### DIFF
--- a/internal/engine/ast.go
+++ b/internal/engine/ast.go
@@ -215,6 +215,10 @@ func convert(expr *enginev1.ResourcesQueryPlanOutput_Node, acc *responsev1.Resou
 		ExprOpVar   = responsev1.ResourcesQueryPlanResponse_Expression_Operand_Variable
 	)
 
+	if expr == nil || expr.Node == nil {
+		return nil
+	}
+
 	switch node := expr.Node.(type) {
 	case *enginev1.ResourcesQueryPlanOutput_Node_Expression:
 		err := buildExpr(node.Expression.Expr, acc)

--- a/internal/test/testdata/query_planner/policies/resource_policy.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policy.yaml
@@ -8,6 +8,9 @@ resourcePolicy:
   importDerivedRoles:
     - beta
   rules:
+    - actions: ["*"]
+      roles: ["admin"]
+      effect: EFFECT_ALLOW
     - actions: ["view:refer-derived-role"]
       derivedRoles:
         - owner

--- a/internal/test/testdata/query_planner/suite/adam.yaml
+++ b/internal/test/testdata/query_planner/suite/adam.yaml
@@ -1,0 +1,13 @@
+---
+description: Adam tests
+principal:
+    id: adam
+    policyVersion: default
+    roles:
+        - admin
+tests:
+    - action: "approve:refer-derived-role"
+      resource:
+        kind: leave_request
+        policyVersion: default
+      want: {}


### PR DESCRIPTION
Handle the case when the query plan produces a nil filter because
there's nothing to filter on.

Not a "proper bug" because this feature is not yet released.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
