### PR TITLE
chore(ci): Add workflow to run E2E tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,56 @@
+---
+name: E2E Tests
+on:
+  workflow_dispatch:
+jobs:
+  runE2ETests:
+    name: Run E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/.cache/cerbos/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+
+      - name: Install Helmfile and Telepresence
+        run: |
+          mkdir bin
+          curl -fL https://github.com/roboll/helmfile/releases/download/v0.143.0/helmfile_linux_amd64 -o bin/helmfile
+          chmod +x bin/helmfile
+          curl -fL https://app.getambassador.io/download/tel2/linux/amd64/latest/telepresence -o bin/telepresence
+          chmod +x bin/telepresence
+          echo "$(pwd)/bin" >> $GITHUB_PATH
+          mkdir -p ~/.config/telepresence
+          cat >~/.config/telepresence/config.yml <<EOF
+          timeouts:
+            helm: 60s
+          EOF
+
+      - name: Install KinD
+        uses: helm/kind-action@v1.2.0
+        with:
+          cluster_name: cerbos-e2e
+          config: e2e/kind.yaml
+          wait: 180s
+
+      - name: Run E2E Tests
+        run: e2e/run.sh
+        env:
+          E2E_SKIP_CLUSTER: "true"
+          E2E_NO_CLEANUP: "true"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -23,6 +23,18 @@ This is still a WIP.
 ./run.sh ./... -args -run-id=mytest
 ```
 
+### Common Problems
+
+#### Telepresence timeout
+
+If telepresence exits with `telepresence: error: connector.Connect: failed to start traffic manager: the helm operation timed out`, try increasing the timeout in `~/.config/telepresence/config.yml`.
+
+```sh
+$ cat ~/.config/telepresence/config.yml 
+timeouts:
+  helm: 60s
+```
+
 ### How do I
 
 #### Use an existing K8s cluster

--- a/e2e/kind.yaml
+++ b/e2e/kind.yaml
@@ -1,0 +1,6 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -16,13 +16,13 @@ check_prerequisites() {
 
 start_kind() {
     if [[ "$E2E_SKIP_CLUSTER" == "false" ]]; then
-        kind create cluster --name "$E2E_CLUSTER" 
+        kind create cluster --name="$E2E_CLUSTER" --config="${SCRIPT_DIR}/kind.yaml"
     fi
 }
 
 stop_kind() {
     if [[ "$E2E_SKIP_CLUSTER" == "false" && "$E2E_NO_CLEANUP" == "false" ]]; then
-        kind delete cluster --name "$E2E_CLUSTER"
+        kind delete cluster --name="$E2E_CLUSTER"
     fi
 }
 


### PR DESCRIPTION
Add a GitHub workflow to run E2E tests. This is still experimental
because Telepresence doesn't seem to play nice inside a container.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
