### PR TITLE
chore(ci): Run E2E tests on schedule

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,6 +2,8 @@
 name: E2E Tests
 on:
   workflow_dispatch:
+  schedule:
+    - cron: 0 1 * * 1-5
 jobs:
   runE2ETests:
     name: Run E2E Tests
@@ -54,3 +56,13 @@ jobs:
         env:
           E2E_SKIP_CLUSTER: "true"
           E2E_NO_CLEANUP: "true"
+
+      - name: Notify Slack
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: C02TMGNNL4V
+          status: FAILED
+          color: danger

--- a/e2e/blob/blob_test.go
+++ b/e2e/blob/blob_test.go
@@ -3,7 +3,7 @@
 
 //go:build e2e
 
-package postgres_test
+package blob_test
 
 import (
 	"fmt"
@@ -36,5 +36,5 @@ func TestBlob(t *testing.T) {
 		time.Sleep(150 * time.Millisecond)
 	}
 
-	e2e.RunSuites(t, e2e.WithContextID("blob"), e2e.WithSuites(e2e.ChecksSuite), e2e.WithPostSetup(postSetup))
+	e2e.RunSuites(t, e2e.WithContextID("blob"), e2e.WithImmutableStoreSuites(), e2e.WithPostSetup(postSetup))
 }

--- a/e2e/git/git_test.go
+++ b/e2e/git/git_test.go
@@ -12,5 +12,5 @@ import (
 )
 
 func TestGit(t *testing.T) {
-	e2e.RunSuites(t, e2e.WithContextID("git"), e2e.WithSuites(e2e.ChecksSuite))
+	e2e.RunSuites(t, e2e.WithContextID("git"), e2e.WithImmutableStoreSuites())
 }

--- a/e2e/mysql/mysql_test.go
+++ b/e2e/mysql/mysql_test.go
@@ -12,5 +12,5 @@ import (
 )
 
 func TestMySQL(t *testing.T) {
-	e2e.RunSuites(t, e2e.WithContextID("mysql"), e2e.WithSuites(e2e.AdminSuite, e2e.ChecksSuite))
+	e2e.RunSuites(t, e2e.WithContextID("mysql"), e2e.WithMutableStoreSuites())
 }

--- a/e2e/postgres/postgres_test.go
+++ b/e2e/postgres/postgres_test.go
@@ -12,5 +12,5 @@ import (
 )
 
 func TestPostgres(t *testing.T) {
-	e2e.RunSuites(t, e2e.WithContextID("postgres"), e2e.WithSuites(e2e.AdminSuite, e2e.ChecksSuite))
+	e2e.RunSuites(t, e2e.WithContextID("postgres"), e2e.WithMutableStoreSuites())
 }

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -29,7 +29,7 @@ stop_kind() {
 run_tests() {
     (
         cd "$SCRIPT_DIR"
-        telepresence connect --no-report -- go test -v --tags="tests e2e" "$@"
+        telepresence connect --no-report -- go test -v -failfast -p=2 --tags="tests e2e" "$@"
     )
 }
 

--- a/e2e/sqlite/sqlite_test.go
+++ b/e2e/sqlite/sqlite_test.go
@@ -12,5 +12,5 @@ import (
 )
 
 func TestSQLite(t *testing.T) {
-	e2e.RunSuites(t, e2e.WithContextID("sqlite"), e2e.WithSuites(e2e.AdminSuite, e2e.ChecksSuite))
+	e2e.RunSuites(t, e2e.WithContextID("sqlite"), e2e.WithMutableStoreSuites())
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -59,7 +59,7 @@ func TestServer(t *testing.T) {
 
 	param := Param{AuditLog: auditLog, AuxData: auxData, Store: store, Engine: eng}
 
-	testCases := LoadTestCases(t, "checks", "playground", "plan_resources")
+	tr := LoadTestCases(t, "checks", "playground", "plan_resources")
 
 	t.Run("with_tls", func(t *testing.T) {
 		testdataDir := test.PathToDir(t, "server")
@@ -82,9 +82,9 @@ func TestServer(t *testing.T) {
 
 			tlsConf := &tls.Config{InsecureSkipVerify: true} //nolint:gosec
 
-			t.Run("grpc", RunGRPCTests(testCases, conf.GRPCListenAddr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConf))))
-			t.Run("grpc_over_http", RunGRPCTests(testCases, conf.HTTPListenAddr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConf))))
-			t.Run("http", RunHTTPTests(testCases, fmt.Sprintf("https://%s", conf.HTTPListenAddr), nil))
+			t.Run("grpc", tr.RunGRPCTests(conf.GRPCListenAddr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConf))))
+			t.Run("grpc_over_http", tr.RunGRPCTests(conf.HTTPListenAddr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConf))))
+			t.Run("http", tr.RunHTTPTests(fmt.Sprintf("https://%s", conf.HTTPListenAddr), nil))
 		})
 
 		t.Run("uds", func(t *testing.T) {
@@ -107,8 +107,8 @@ func TestServer(t *testing.T) {
 
 			tlsConf := &tls.Config{InsecureSkipVerify: true} //nolint:gosec
 
-			t.Run("grpc", RunGRPCTests(testCases, conf.GRPCListenAddr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConf))))
-			t.Run("grpc_over_http", RunGRPCTests(testCases, conf.HTTPListenAddr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConf))))
+			t.Run("grpc", tr.RunGRPCTests(conf.GRPCListenAddr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConf))))
+			t.Run("grpc_over_http", tr.RunGRPCTests(conf.HTTPListenAddr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConf))))
 		})
 	})
 
@@ -125,9 +125,9 @@ func TestServer(t *testing.T) {
 
 			startServer(ctx, conf, param)
 
-			t.Run("grpc", RunGRPCTests(testCases, conf.GRPCListenAddr, grpc.WithTransportCredentials(local.NewCredentials())))
-			t.Run("h2c", RunGRPCTests(testCases, conf.HTTPListenAddr, grpc.WithTransportCredentials(local.NewCredentials())))
-			t.Run("http", RunHTTPTests(testCases, fmt.Sprintf("http://%s", conf.HTTPListenAddr), nil))
+			t.Run("grpc", tr.RunGRPCTests(conf.GRPCListenAddr, grpc.WithTransportCredentials(local.NewCredentials())))
+			t.Run("h2c", tr.RunGRPCTests(conf.HTTPListenAddr, grpc.WithTransportCredentials(local.NewCredentials())))
+			t.Run("http", tr.RunHTTPTests(fmt.Sprintf("http://%s", conf.HTTPListenAddr), nil))
 		})
 
 		t.Run("uds", func(t *testing.T) {
@@ -144,7 +144,7 @@ func TestServer(t *testing.T) {
 
 			startServer(ctx, conf, param)
 
-			t.Run("grpc", RunGRPCTests(testCases, conf.GRPCListenAddr, grpc.WithTransportCredentials(local.NewCredentials())))
+			t.Run("grpc", tr.RunGRPCTests(conf.GRPCListenAddr, grpc.WithTransportCredentials(local.NewCredentials())))
 		})
 	})
 }
@@ -196,12 +196,12 @@ func TestAdminService(t *testing.T) {
 
 	startServer(ctx, conf, Param{Store: store, Engine: eng, AuditLog: auditLog, AuxData: auxData})
 
-	testCases := LoadTestCases(t, "admin", "checks")
+	tr := LoadTestCases(t, "admin", "checks")
 	creds := &AuthCreds{Username: "cerbos", Password: "cerbosAdmin"}
 
 	tlsConf := &tls.Config{InsecureSkipVerify: true} //nolint:gosec
-	t.Run("grpc", RunGRPCTests(testCases, conf.GRPCListenAddr, grpc.WithPerRPCCredentials(creds), grpc.WithTransportCredentials(credentials.NewTLS(tlsConf))))
-	t.Run("http", RunHTTPTests(testCases, fmt.Sprintf("https://%s", conf.HTTPListenAddr), creds))
+	t.Run("grpc", tr.RunGRPCTests(conf.GRPCListenAddr, grpc.WithPerRPCCredentials(creds), grpc.WithTransportCredentials(credentials.NewTLS(tlsConf))))
+	t.Run("http", tr.RunHTTPTests(fmt.Sprintf("https://%s", conf.HTTPListenAddr), creds))
 }
 
 func getFreeListenAddr(t *testing.T) string {


### PR DESCRIPTION
- Run E2E tests every weekday at 1 am
- Increase timeout for tests because Kind on GH Actions is slow
- Add query planner suite to the suites list
- Make tests fail fast to avoid wasting time on subsequent tests
- Reduce parallelism to 2

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
