### PR TITLE
chore(ci): Enable server tests in CI

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func TestServer(t *testing.T) {
-	test.SkipIfGHActions(t) // TODO (cell) Servers don't work inside GH Actions for some reason.
-
 	dir := test.PathToDir(t, "store")
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
@@ -150,8 +148,6 @@ func TestServer(t *testing.T) {
 }
 
 func TestAdminService(t *testing.T) {
-	test.SkipIfGHActions(t) // TODO (cell) Servers don't work inside GH Actions for some reason.
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 


### PR DESCRIPTION
Server tests didn't work inside GH Actions before. Checking to see whether that's still the case.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>

