### PR TITLE
feat: Add SQL Server support

### DIFF
--- a/docs/modules/configuration/examples/sqlserver_schema.sql
+++ b/docs/modules/configuration/examples/sqlserver_schema.sql
@@ -1,0 +1,1 @@
+../../../../internal/storage/db/sqlserver/schema.sql

--- a/docs/modules/configuration/pages/storage.adoc
+++ b/docs/modules/configuration/pages/storage.adoc
@@ -300,3 +300,53 @@ You can customise the script below to suit your environment. Make sure to specif
 ----
 include::example$mysql_schema.sql[]
 ----
+
+[#sqlserver]
+== Microsoft SQL Server Driver
+
+The SQL Server storage backend is one of the dynamic stores that supports adding or updating policies at runtime through the xref:server.adoc#admin-api[Admin API].
+
+NOTE: Unlike the SQLite3 driver, the tables and other database objects are not created automatically by the Cerbos SQL Server driver. This is to minimize the privileges the Cerbos instance has on the SQL Server installation. You must create the required tables using the provided script before configuring Cerbos to connect to the database.
+
+The driver configuration expects the connection details to be provided as connection URL. See link:https://github.com/denisenkom/go-mssqldb#connection-parameters-and-dsn[SQL Server connstring documentation] for more information. Use the `database` parameter to point to the database containing the Cerbos tables.
+
+You can use environment variable references in the URL to avoid storing credentials as part of the Cerbos configuration file.
+
+.Using SQL Server as a storage backend for Cerbos
+[source,yaml,linenums]
+----
+storage:
+  driver: "sqlserver"
+  sqlserver:
+    url: "sqlserver://${SQL_SERVER_USERNAME}:${SQL_SERVER_PASSWORD}@host/instance?database=cerbos&param1=value&param2=value"
+----
+
+=== Connection pool
+
+include::partial$connpool.adoc[]
+
+[source,yaml,linenums]
+----
+storage:
+  driver: "sqlserver"
+  sqlserver:
+    url: "sqlserver://${SQL_SERVER_USERNAME}:${SQL_SERVER_PASSWORD}@host/instance?database=cerbos&param1=value&param2=value"
+    connPool:
+      maxLifeTime: 5m
+      maxIdleTime: 3m
+      maxOpen: 10
+      maxIdle: 5
+----
+
+
+
+=== Database object definitions
+
+You can customise the script below to suit your environment. Make sure to specify a strong password for the `cerbos_user` user.
+
+[source,sql,linenums]
+----
+include::example$sqlserver_schema.sql[]
+----
+
+

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -112,7 +112,7 @@ storage:
       maxIdleTime: 45s
       maxOpen: 4
       maxIdle: 1 
-    url: "sqlserver://username:password@host/instance?param1=value&param2=value" # Required. URL is the Postgres connection URL. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+    url: "sqlserver://username:password@host/instance?param1=value&param2=value" # Required. URL is the SQL Server connection URL. See https://github.com/denisenkom/go-mssqldb#connection-parameters-and-dsn
 tracing:
   exporter: jaeger # Exporter is the type of trace exporter to use.
   jaeger: # Jaeger configures the Jaeger exporter.

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -105,6 +105,14 @@ storage:
   sqlite3:
     # This section is required only if storage.driver is sqlite3.
     dsn: ":memory:?_fk=true" # Required. Data source name
+  sqlserver:
+    # This section is required only if storage.driver is sqlserver.
+    connPool: 
+      maxLifeTime: 60m
+      maxIdleTime: 45s
+      maxOpen: 4
+      maxIdle: 1 
+    url: "sqlserver://username:password@host/instance?param1=value&param2=value" # Required. URL is the Postgres connection URL. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
 tracing:
   exporter: jaeger # Exporter is the type of trace exporter to use.
   jaeger: # Jaeger configures the Jaeger exporter.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go v1.42.23
 	github.com/bluele/gcache v0.0.2
 	github.com/cespare/xxhash v1.1.0
+	github.com/denisenkom/go-mssqldb v0.11.0
 	github.com/dgraph-io/badger/v3 v3.2103.2
 	github.com/doug-martin/goqu/v9 v9.18.0
 	github.com/envoyproxy/protoc-gen-validate v0.6.3
@@ -127,6 +128,7 @@ require (
 	github.com/go-logr/stdr v1.2.0 // indirect
 	github.com/goccy/go-json v0.9.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -414,6 +414,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d h1:
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d/go.mod h1:tmAIfUFEirG/Y8jhZ9M+h36obRZAk/1fcSpXwAVlfqE=
 github.com/denisenkom/go-mssqldb v0.9.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
+github.com/denisenkom/go-mssqldb v0.11.0 h1:9rHa233rhdOyrz2GcP9NM+gi2psgJZ4GWDpL/7ND8HI=
+github.com/denisenkom/go-mssqldb v0.11.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
 github.com/dgraph-io/badger/v3 v3.2103.2 h1:dpyM5eCJAtQCBcMCZcT4UBZchuTJgCywerHHgmxfxM8=
@@ -600,6 +602,7 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -72,6 +72,9 @@ import (
 	// Import sqlite3 to register the storage driver.
 	_ "github.com/cerbos/cerbos/internal/storage/db/sqlite3"
 
+	// Import sqlserver to register the storage driver.
+	_ "github.com/cerbos/cerbos/internal/storage/db/sqlserver"
+
 	// Import disk to register the storage driver.
 	_ "github.com/cerbos/cerbos/internal/storage/disk"
 

--- a/internal/storage/db/internal/db.go
+++ b/internal/storage/db/internal/db.go
@@ -48,7 +48,6 @@ func NewDBStorage(ctx context.Context, db *goqu.Database) (DBStorage, error) {
 			return nil, err
 		}
 
-		log.Println("YAHOO!")
 		db.Logger(log)
 	}
 

--- a/internal/storage/db/internal/db.go
+++ b/internal/storage/db/internal/db.go
@@ -28,7 +28,6 @@ const policyKeySep = "."
 
 type DBStorage interface {
 	storage.Subscribable
-	NotifySubscribers(events ...storage.Event)
 	AddOrUpdate(ctx context.Context, policies ...policy.Wrapper) error
 	GetCompilationUnits(ctx context.Context, ids ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error)
 	GetDependents(ctx context.Context, ids ...namer.ModuleID) (map[namer.ModuleID][]namer.ModuleID, error)
@@ -41,7 +40,11 @@ type DBStorage interface {
 	LoadPolicy(ctx context.Context, policyKey ...string) ([]*policy.Wrapper, error)
 }
 
-func NewDBStorage(ctx context.Context, db *goqu.Database) (DBStorage, error) {
+func NewDBStorage(ctx context.Context, db *goqu.Database, dbOpts ...DBOpt) (DBStorage, error) {
+	opts := &dbOpt{}
+	for _, opt := range dbOpts {
+		opt(opts)
+	}
 	if _, ok := os.LookupEnv("CERBOS_DEBUG_DB"); ok {
 		log, err := zap.NewStdLogAt(zap.L().Named("db"), zap.DebugLevel)
 		if err != nil {
@@ -52,13 +55,15 @@ func NewDBStorage(ctx context.Context, db *goqu.Database) (DBStorage, error) {
 	}
 
 	return &dbStorage{
+		opts:                opts,
 		db:                  db,
 		SubscriptionManager: storage.NewSubscriptionManager(ctx),
 	}, nil
 }
 
 type dbStorage struct {
-	db *goqu.Database
+	opts *dbOpt
+	db   *goqu.Database
 	*storage.SubscriptionManager
 }
 
@@ -80,12 +85,18 @@ func (s *dbStorage) AddOrUpdateSchema(ctx context.Context, schemas ...*schemav1.
 				ID:         sch.Id,
 				Definition: &defJSON,
 			}
+			var err error
 
-			if _, err := tx.Insert(SchemaTbl).
-				Rows(row).
-				OnConflict(goqu.DoUpdate(SchemaTblIDCol, row)).
-				Executor().
-				ExecContext(ctx); err != nil {
+			if s.opts.upsertSchema != nil {
+				err = s.opts.upsertSchema(ctx, tx, row)
+			} else {
+				_, err = tx.Insert(SchemaTbl).
+					Rows(row).
+					OnConflict(goqu.DoUpdate(SchemaTblIDCol, row)).
+					Executor().
+					ExecContext(ctx)
+			}
+			if err != nil {
 				return fmt.Errorf("failed to upsert the schema with id %s: %w", sch.Id, err)
 			}
 
@@ -202,12 +213,18 @@ func (s *dbStorage) AddOrUpdate(ctx context.Context, policies ...policy.Wrapper)
 				Definition:  PolicyDefWrapper{Policy: p.Policy},
 			}
 
+			var err error
 			// try to upsert this policy record
-			if _, err := tx.Insert(PolicyTbl).
-				Prepared(true).
-				Rows(policyRecord).
-				OnConflict(goqu.DoUpdate(PolicyTblIDCol, policyRecord)).
-				Executor().ExecContext(ctx); err != nil {
+			if s.opts.upsertPolicy != nil {
+				err = s.opts.upsertPolicy(ctx, tx, p)
+			} else {
+				_, err = tx.Insert(PolicyTbl).
+					Prepared(true).
+					Rows(policyRecord).
+					OnConflict(goqu.DoUpdate(PolicyTblIDCol, policyRecord)).
+					Executor().ExecContext(ctx)
+			}
+			if err != nil {
 				return fmt.Errorf("failed to upsert %s: %w", p.FQN, err)
 			}
 

--- a/internal/storage/db/internal/db.go
+++ b/internal/storage/db/internal/db.go
@@ -264,7 +264,7 @@ func (s *dbStorage) GetCompilationUnits(ctx context.Context, ids ...namer.Module
 		Where(
 			goqu.And(
 				goqu.C(PolicyDepTblPolicyIDCol).Table("pd").In(ids),
-				goqu.C(PolicyTblDisabledCol).Table("p").Eq(DialectFalseValue(s.db.Dialect())),
+				goqu.C(PolicyTblDisabledCol).Table("p").Eq(goqu.V(false)),
 			),
 		)
 
@@ -280,7 +280,7 @@ func (s *dbStorage) GetCompilationUnits(ctx context.Context, ids ...namer.Module
 		Where(
 			goqu.And(
 				goqu.I(PolicyTblIDCol).In(ids),
-				goqu.I(PolicyTblDisabledCol).Eq(DialectFalseValue(s.db.Dialect())),
+				goqu.I(PolicyTblDisabledCol).Eq(goqu.V(false)),
 			),
 		).
 		UnionAll(depsQuery).

--- a/internal/storage/db/internal/db_opts.go
+++ b/internal/storage/db/internal/db_opts.go
@@ -1,0 +1,39 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"context"
+
+	"github.com/doug-martin/goqu/v9"
+
+	"github.com/cerbos/cerbos/internal/policy"
+)
+
+// DBOpt defines database driver options.
+type DBOpt func(*dbOpt)
+
+type (
+	upsertPolicyFunc func(ctx context.Context, tx *goqu.TxDatabase, p policy.Wrapper) error
+	upsertSchemaFunc func(ctx context.Context, tx *goqu.TxDatabase, schema Schema) error
+)
+
+type dbOpt struct {
+	upsertPolicy upsertPolicyFunc
+	upsertSchema upsertSchemaFunc
+}
+
+// WithUpsertSchema sets custom upsert schema function.
+func WithUpsertSchema(f upsertSchemaFunc) DBOpt {
+	return func(opt *dbOpt) {
+		opt.upsertSchema = f
+	}
+}
+
+// WithUpsertPolicy sets custom upsert policy function.
+func WithUpsertPolicy(f upsertPolicyFunc) DBOpt {
+	return func(opt *dbOpt) {
+		opt.upsertPolicy = f
+	}
+}

--- a/internal/storage/db/internal/funcs.go
+++ b/internal/storage/db/internal/funcs.go
@@ -10,9 +10,17 @@ import (
 	"github.com/doug-martin/goqu/v9/exp"
 )
 
+func DialectFalseValue(dialect string) interface{} {
+	if dialect == "sqlserver" {
+		return 0
+	}
+
+	return false
+}
+
 func ConcatWithSepFunc(dialect string) func(string, ...interface{}) exp.Expression {
 	switch dialect {
-	case "mysql", "mysql8":
+	case "mysql", "mysql8", "sqlserver":
 		return mysqlConcatWithSep
 	default:
 		return ansiConcatWithSep

--- a/internal/storage/db/internal/funcs.go
+++ b/internal/storage/db/internal/funcs.go
@@ -10,14 +10,6 @@ import (
 	"github.com/doug-martin/goqu/v9/exp"
 )
 
-func DialectFalseValue(dialect string) interface{} {
-	if dialect == "sqlserver" {
-		return 0
-	}
-
-	return false
-}
-
 func ConcatWithSepFunc(dialect string) func(string, ...interface{}) exp.Expression {
 	switch dialect {
 	case "mysql", "mysql8", "sqlserver":

--- a/internal/storage/db/internal/funcs_test.go
+++ b/internal/storage/db/internal/funcs_test.go
@@ -29,41 +29,46 @@ func TestConcatWithSep(t *testing.T) {
 	}{
 		{
 			want: map[string]string{
-				"mysql":    "SELECT CONCAT_WS('.') FROM `table`",
-				"postgres": `SELECT '.' FROM "table"`,
-				"sqlite3":  "SELECT '.' FROM `table`",
+				"sqlserver": "SELECT CONCAT_WS('.') FROM \"table\"",
+				"mysql":     "SELECT CONCAT_WS('.') FROM `table`",
+				"postgres":  `SELECT '.' FROM "table"`,
+				"sqlite3":   "SELECT '.' FROM `table`",
 			},
 		},
 		{
 			args: []interface{}{"a"},
 			want: map[string]string{
-				"mysql":    "SELECT CONCAT_WS('.', 'a') FROM `table`",
-				"postgres": `SELECT 'a' || '.' FROM "table"`,
-				"sqlite3":  "SELECT 'a' || '.' FROM `table`",
+				"sqlserver": "SELECT CONCAT_WS('.', 'a') FROM \"table\"",
+				"mysql":     "SELECT CONCAT_WS('.', 'a') FROM `table`",
+				"postgres":  `SELECT 'a' || '.' FROM "table"`,
+				"sqlite3":   "SELECT 'a' || '.' FROM `table`",
 			},
 		},
 		{
 			args: []interface{}{"a", "b"},
 			want: map[string]string{
-				"mysql":    "SELECT CONCAT_WS('.', 'a', 'b') FROM `table`",
-				"postgres": `SELECT 'a' || '.' || 'b' FROM "table"`,
-				"sqlite3":  "SELECT 'a' || '.' || 'b' FROM `table`",
+				"sqlserver": "SELECT CONCAT_WS('.', 'a', 'b') FROM \"table\"",
+				"mysql":     "SELECT CONCAT_WS('.', 'a', 'b') FROM `table`",
+				"postgres":  `SELECT 'a' || '.' || 'b' FROM "table"`,
+				"sqlite3":   "SELECT 'a' || '.' || 'b' FROM `table`",
 			},
 		},
 		{
 			args: []interface{}{"a", "b", "c"},
 			want: map[string]string{
-				"mysql":    "SELECT CONCAT_WS('.', 'a', 'b', 'c') FROM `table`",
-				"postgres": `SELECT 'a' || '.' || 'b' || '.' || 'c' FROM "table"`,
-				"sqlite3":  "SELECT 'a' || '.' || 'b' || '.' || 'c' FROM `table`",
+				"sqlserver": `SELECT CONCAT_WS('.', 'a', 'b', 'c') FROM "table"`,
+				"mysql":     "SELECT CONCAT_WS('.', 'a', 'b', 'c') FROM `table`",
+				"postgres":  `SELECT 'a' || '.' || 'b' || '.' || 'c' FROM "table"`,
+				"sqlite3":   "SELECT 'a' || '.' || 'b' || '.' || 'c' FROM `table`",
 			},
 		},
 		{
 			args: []interface{}{goqu.C("a"), goqu.C("b"), "c", "d"},
 			want: map[string]string{
-				"mysql":    "SELECT CONCAT_WS('.', `a`, `b`, 'c', 'd') FROM `table`",
-				"postgres": `SELECT "a" || '.' || "b" || '.' || 'c' || '.' || 'd' FROM "table"`,
-				"sqlite3":  "SELECT `a` || '.' || `b` || '.' || 'c' || '.' || 'd' FROM `table`",
+				"sqlserver": `SELECT CONCAT_WS('.', "a", "b", 'c', 'd') FROM "table"`,
+				"mysql":     "SELECT CONCAT_WS('.', `a`, `b`, 'c', 'd') FROM `table`",
+				"postgres":  `SELECT "a" || '.' || "b" || '.' || 'c' || '.' || 'd' FROM "table"`,
+				"sqlite3":   "SELECT `a` || '.' || `b` || '.' || 'c' || '.' || 'd' FROM `table`",
 			},
 		},
 	}

--- a/internal/storage/db/internal/funcs_test.go
+++ b/internal/storage/db/internal/funcs_test.go
@@ -86,3 +86,20 @@ func TestConcatWithSep(t *testing.T) {
 		})
 	}
 }
+
+func TestDialectFalseValue(t *testing.T) {
+	tests := []struct {
+		dialect string
+		want    interface{}
+	}{
+		{dialect: "mysql", want: false},
+		{dialect: "postgres", want: false},
+		{dialect: "sqlserver", want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.dialect, func(t *testing.T) {
+			got := internal.DialectFalseValue(tt.dialect)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/storage/db/internal/funcs_test.go
+++ b/internal/storage/db/internal/funcs_test.go
@@ -86,20 +86,3 @@ func TestConcatWithSep(t *testing.T) {
 		})
 	}
 }
-
-func TestDialectFalseValue(t *testing.T) {
-	tests := []struct {
-		dialect string
-		want    interface{}
-	}{
-		{dialect: "mysql", want: false},
-		{dialect: "postgres", want: false},
-		{dialect: "sqlserver", want: 0},
-	}
-	for _, tt := range tests {
-		t.Run(tt.dialect, func(t *testing.T) {
-			got := internal.DialectFalseValue(tt.dialect)
-			require.Equal(t, tt.want, got)
-		})
-	}
-}

--- a/internal/storage/db/mysql/mysql_test.go
+++ b/internal/storage/db/mysql/mysql_test.go
@@ -17,11 +17,11 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
-	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cerbos/cerbos/internal/storage/db/internal"
 	"github.com/cerbos/cerbos/internal/storage/db/mysql"
+	"github.com/ory/dockertest/v3"
 )
 
 //go:embed schema.sql

--- a/internal/storage/db/sqlserver/conf.go
+++ b/internal/storage/db/sqlserver/conf.go
@@ -1,0 +1,23 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package sqlserver
+
+import (
+	"github.com/cerbos/cerbos/internal/storage"
+	"github.com/cerbos/cerbos/internal/storage/db/internal"
+)
+
+const confKey = storage.ConfKey + ".sqlserver"
+
+// Conf is required (if driver is set to 'sqlserver') configuration for mssql driver.
+//+desc=This section is required only if storage.driver is sqlserver.
+type Conf struct {
+	ConnPool *internal.ConnPoolConf `yaml:"connPool" conf:",example=\n  maxLifeTime: 60m\n  maxIdleTime: 45s\n  maxOpen: 4\n  maxIdle: 1"`
+	// URL is the Postgres connection URL. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+	URL string `yaml:"url" conf:"required,example=\"sqlserver://username:password@host/instance?param1=value&param2=value\""`
+}
+
+func (c *Conf) Key() string {
+	return confKey
+}

--- a/internal/storage/db/sqlserver/conf.go
+++ b/internal/storage/db/sqlserver/conf.go
@@ -14,7 +14,7 @@ const confKey = storage.ConfKey + ".sqlserver"
 //+desc=This section is required only if storage.driver is sqlserver.
 type Conf struct {
 	ConnPool *internal.ConnPoolConf `yaml:"connPool" conf:",example=\n  maxLifeTime: 60m\n  maxIdleTime: 45s\n  maxOpen: 4\n  maxIdle: 1"`
-	// URL is the Postgres connection URL. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+	// URL is the SQL Server connection URL. See https://github.com/denisenkom/go-mssqldb#connection-parameters-and-dsn
 	URL string `yaml:"url" conf:"required,example=\"sqlserver://username:password@host/instance?param1=value&param2=value\""`
 }
 

--- a/internal/storage/db/sqlserver/schema.sql
+++ b/internal/storage/db/sqlserver/schema.sql
@@ -1,0 +1,102 @@
+IF SUSER_ID('cerbos_user') IS NULL
+CREATE LOGIN cerbos_user WITH PASSWORD = 'ChangeMe(1!!)';
+
+GO
+
+IF NOT EXISTS (
+    SELECT [name]
+        FROM sys.databases
+        WHERE [name] = N'cerbos'
+)
+CREATE DATABASE cerbos;
+GO
+
+USE cerbos;
+
+IF OBJECT_ID('[dbo].[policy]', 'U') IS NULL
+CREATE TABLE [dbo].[policy] (
+    id BIGINT PRIMARY KEY,
+    kind VARCHAR(128) NOT NULL,
+    name VARCHAR(1024) NOT NULL,
+    version VARCHAR(128) NOT NULL,
+    description NVARCHAR(MAX),
+    disabled BIT default 'FALSE',
+    definition VARBINARY(MAX));
+
+IF OBJECT_ID('[dbo].[policy_dependency]', 'U') IS NULL
+CREATE TABLE [dbo].[policy_dependency] (
+    policy_id BIGINT NOT NULL,
+    dependency_id BIGINT  NOT NULL,
+    PRIMARY KEY (policy_id, dependency_id),
+    FOREIGN KEY (policy_id) REFERENCES [policy](id) ON DELETE CASCADE);
+
+IF OBJECT_ID('[dbo].[policy_revision]', 'U') IS NULL
+CREATE TABLE [dbo].[policy_revision] (
+    revision_id INT NOT NULL IDENTITY PRIMARY KEY,
+    action VARCHAR(255) NOT NULL CHECK ([action] IN('INSERT', 'UPDATE', 'DELETE')),
+    id BIGINT NOT NULL,
+    kind VARCHAR(128),
+    name VARCHAR(1024),
+    version VARCHAR(128),
+    description NVARCHAR(MAX),
+    disabled BIT,
+    definition VARBINARY(MAX),
+    update_timestamp DATETIME DEFAULT CURRENT_TIMESTAMP);
+
+IF OBJECT_ID('[dbo].[attr_schema_defs]', 'U') IS NULL
+CREATE TABLE [dbo].[attr_schema_defs] (
+    id VARCHAR(255) NOT NULL PRIMARY KEY,
+    definition VARBINARY(MAX));
+
+DROP TRIGGER IF EXISTS dbo.policy_on_insert;
+DROP TRIGGER IF EXISTS dbo.policy_on_updatea;
+DROP TRIGGER IF EXISTS dbo.policy_on_delete;
+
+GO
+
+USE cerbos;
+
+IF USER_ID('cerbos_user') IS NULL
+CREATE USER cerbos_user for LOGIN cerbos_user;
+
+GRANT SELECT,INSERT,UPDATE,DELETE ON [dbo].[policy] TO cerbos_user;
+GRANT SELECT,INSERT,UPDATE,DELETE ON dbo.attr_schema_defs TO cerbos_user;
+GRANT SELECT,INSERT,UPDATE,DELETE ON dbo.policy_dependency TO cerbos_user;
+GRANT SELECT,INSERT ON dbo.policy_revision TO cerbos_user;
+
+GO
+
+CREATE TRIGGER dbo.policy_on_insert ON dbo.[policy] AFTER INSERT
+AS
+BEGIN
+    SET NOCOUNT ON;
+INSERT INTO dbo.policy_revision(action, id, kind, name, version, description, disabled, definition)
+SELECT
+    'INSERT', i.id, i.kind, i.name, i.version, i.description, i.disabled, i.definition
+FROM inserted i
+END;
+
+GO
+
+CREATE TRIGGER dbo.policy_on_update ON dbo.[policy] AFTER UPDATE
+                                                              AS
+BEGIN
+    SET NOCOUNT ON;
+INSERT INTO dbo.policy_revision(action, id, kind, name, version, description, disabled, definition)
+SELECT
+    'UPDATE', i.id, i.kind, i.name, i.version, i.description, i.disabled, i.definition
+FROM inserted i
+END;
+
+GO
+
+CREATE TRIGGER dbo.policy_on_delete ON dbo.[policy] AFTER DELETE
+AS
+BEGIN
+    SET NOCOUNT ON;
+INSERT INTO dbo.policy_revision(action, id, kind, name, version, description, disabled, definition)
+SELECT
+    'DELETE', d.id, d.kind, d.name, d.version, d.description, d.disabled, d.definition
+FROM deleted d
+END;
+

--- a/internal/storage/db/sqlserver/schema.sql
+++ b/internal/storage/db/sqlserver/schema.sql
@@ -49,7 +49,7 @@ CREATE TABLE [dbo].[attr_schema_defs] (
     definition VARBINARY(MAX));
 
 DROP TRIGGER IF EXISTS dbo.policy_on_insert;
-DROP TRIGGER IF EXISTS dbo.policy_on_updatea;
+DROP TRIGGER IF EXISTS dbo.policy_on_update;
 DROP TRIGGER IF EXISTS dbo.policy_on_delete;
 
 GO
@@ -70,22 +70,22 @@ CREATE TRIGGER dbo.policy_on_insert ON dbo.[policy] AFTER INSERT
 AS
 BEGIN
     SET NOCOUNT ON;
-INSERT INTO dbo.policy_revision(action, id, kind, name, version, description, disabled, definition)
-SELECT
-    'INSERT', i.id, i.kind, i.name, i.version, i.description, i.disabled, i.definition
-FROM inserted i
+    INSERT INTO dbo.policy_revision(action, id, kind, name, version, description, disabled, definition)
+    SELECT
+        'INSERT', i.id, i.kind, i.name, i.version, i.description, i.disabled, i.definition
+    FROM inserted i
 END;
 
 GO
 
 CREATE TRIGGER dbo.policy_on_update ON dbo.[policy] AFTER UPDATE
-                                                              AS
+AS
 BEGIN
     SET NOCOUNT ON;
-INSERT INTO dbo.policy_revision(action, id, kind, name, version, description, disabled, definition)
-SELECT
-    'UPDATE', i.id, i.kind, i.name, i.version, i.description, i.disabled, i.definition
-FROM inserted i
+    INSERT INTO dbo.policy_revision(action, id, kind, name, version, description, disabled, definition)
+    SELECT
+        'UPDATE', i.id, i.kind, i.name, i.version, i.description, i.disabled, i.definition
+    FROM inserted i
 END;
 
 GO
@@ -94,9 +94,9 @@ CREATE TRIGGER dbo.policy_on_delete ON dbo.[policy] AFTER DELETE
 AS
 BEGIN
     SET NOCOUNT ON;
-INSERT INTO dbo.policy_revision(action, id, kind, name, version, description, disabled, definition)
-SELECT
-    'DELETE', d.id, d.kind, d.name, d.version, d.description, d.disabled, d.definition
-FROM deleted d
+    INSERT INTO dbo.policy_revision(action, id, kind, name, version, description, disabled, definition)
+    SELECT
+        'DELETE', d.id, d.kind, d.name, d.version, d.description, d.disabled, d.definition
+    FROM deleted d
 END;
 

--- a/internal/storage/db/sqlserver/sqlserver.go
+++ b/internal/storage/db/sqlserver/sqlserver.go
@@ -1,0 +1,187 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package sqlserver
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	// Import the mssql driver.
+	_ "github.com/denisenkom/go-mssqldb"
+	"github.com/doug-martin/goqu/v9"
+
+	// Import the mssql dialect.
+	_ "github.com/doug-martin/goqu/v9/dialect/sqlserver"
+	"github.com/jackc/pgtype"
+	"github.com/jmoiron/sqlx"
+
+	schemav1 "github.com/cerbos/cerbos/api/genpb/cerbos/schema/v1"
+	"github.com/cerbos/cerbos/internal/config"
+	"github.com/cerbos/cerbos/internal/observability/logging"
+	"github.com/cerbos/cerbos/internal/policy"
+	"github.com/cerbos/cerbos/internal/storage"
+	"github.com/cerbos/cerbos/internal/storage/db/internal"
+)
+
+const DriverName = "sqlserver"
+
+var _ storage.MutableStore = (*Store)(nil)
+
+func init() {
+	storage.RegisterDriver(DriverName, func(ctx context.Context) (storage.Store, error) {
+		conf := &Conf{}
+		if err := config.GetSection(conf); err != nil {
+			return nil, err
+		}
+
+		return NewStore(ctx, conf)
+	})
+}
+
+func NewStore(ctx context.Context, conf *Conf) (*Store, error) {
+	log := logging.FromContext(ctx).Named("sqlserver")
+	log.Info("Initialising SQL Server storage")
+
+	db, err := sqlx.Connect(DriverName, conf.URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %w", err)
+	}
+
+	conf.ConnPool.Configure(db)
+
+	database := goqu.New("sqlserver", db)
+	dbStorage, err := internal.NewDBStorage(ctx, database)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Store{DBStorage: dbStorage, db: database}, nil
+}
+
+type Store struct {
+	internal.DBStorage
+	db *goqu.Database
+}
+
+func (s *Store) Driver() string {
+	return DriverName
+}
+
+func (s *Store) AddOrUpdate(ctx context.Context, policies ...policy.Wrapper) error {
+	events := make([]storage.Event, len(policies))
+	err := s.db.WithTx(func(tx *goqu.TxDatabase) error {
+		for i, p := range policies {
+			// try to upsert this policy record
+			id, _ := p.ID.Value()
+			stm, err := tx.Prepare(`
+UPDATE dbo.[policy] WITH (UPDLOCK, SERIALIZABLE) SET "definition"=@definition, "description"=@description,"disabled"=@disabled,"kind"=@kind,"name"=@name,"version"=@version where [id] = @id 
+IF @@ROWCOUNT = 0
+BEGIN
+  INSERT INTO dbo.[policy] ("definition", "description", "disabled", "kind", "name", "version", "id") VALUES (@definition, @description, @disabled, @kind, @name, @version, @id)
+END
+`)
+			if err != nil {
+				return fmt.Errorf("failed to prepare policy upsert %s: %w", p.FQN, err)
+			}
+
+			defer stm.Close()
+
+			definition, err := internal.PolicyDefWrapper{Policy: p.Policy}.Value()
+			if err != nil {
+				return fmt.Errorf("failed to get definition value: %w", err)
+			}
+
+			_, err = stm.ExecContext(ctx, sql.Named("definition", definition),
+				sql.Named("description", p.Description), sql.Named("disabled", p.Disabled),
+				sql.Named("kind", p.Kind), sql.Named("name", p.Name), sql.Named("version", p.Version), sql.Named("id", int64(id.(uint64))))
+
+			if err != nil {
+				return fmt.Errorf("failed to upsert %s: %w", p.FQN, err)
+			}
+
+			if len(p.Dependencies) > 0 {
+				// delete the existing dependency records
+				if _, err := tx.Delete(internal.PolicyDepTbl).
+					Prepared(true).
+					Where(goqu.I(internal.PolicyDepTblPolicyIDCol).Eq(p.ID)).
+					Executor().ExecContext(ctx); err != nil {
+					return fmt.Errorf("failed to delete dependencies of %s: %w", p.FQN, err)
+				}
+
+				// insert the new dependency records
+				depRows := make([]interface{}, len(p.Dependencies))
+				for i, d := range p.Dependencies {
+					depRows[i] = internal.PolicyDependency{PolicyID: p.ID, DependencyID: d}
+				}
+
+				if _, err := tx.Insert(internal.PolicyDepTbl).
+					Prepared(true).
+					Rows(depRows...).
+					Executor().ExecContext(ctx); err != nil {
+					return fmt.Errorf("failed to insert dependencies of %s: %w", p.FQN, err)
+				}
+			}
+
+			events[i] = storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: p.ID}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	s.NotifySubscribers(events...)
+	return nil
+}
+
+func (s *Store) AddOrUpdateSchema(ctx context.Context, schemas ...*schemav1.Schema) error {
+	events := make([]storage.Event, 0, len(schemas))
+	err := s.db.WithTx(func(tx *goqu.TxDatabase) error {
+		for _, sch := range schemas {
+			var def json.RawMessage
+			if err := json.Unmarshal(sch.Definition, &def); err != nil {
+				return storage.NewInvalidSchemaError(err, "schema definition with ID %q is not valid", sch.Id)
+			}
+
+			defJSON := pgtype.JSON{}
+			if err := defJSON.UnmarshalJSON(def); err != nil {
+				return storage.NewInvalidSchemaError(err, "schema definition with ID %q is not valid", sch.Id)
+			}
+
+			stm, err := tx.Prepare(`
+UPDATE dbo.[attr_schema_defs] WITH (UPDLOCK, SERIALIZABLE) SET "definition"=@definition WHERE [id] = @id 
+IF @@ROWCOUNT = 0
+BEGIN
+  INSERT INTO dbo.[attr_schema_defs] ("definition", "id") VALUES (@definition, @id)
+END
+`)
+			if err != nil {
+				return fmt.Errorf("failed to prepare schema upsert %s: %w", sch.Id, err)
+			}
+
+			defer stm.Close()
+
+			definition, err := defJSON.MarshalJSON()
+			if err != nil {
+				return fmt.Errorf("failed to marshal defJson: %w", err)
+			}
+			_, err = stm.ExecContext(ctx, sql.Named("definition", definition), sql.Named("id", sch.Id))
+			if err != nil {
+				return fmt.Errorf("failed to upsert the schema with id %s: %w", sch.Id, err)
+			}
+
+			events = append(events, storage.NewSchemaEvent(storage.EventAddOrUpdateSchema, sch.Id))
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	s.NotifySubscribers(events...)
+	return nil
+}

--- a/internal/storage/db/sqlserver/sqlserver.go
+++ b/internal/storage/db/sqlserver/sqlserver.go
@@ -6,7 +6,6 @@ package sqlserver
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 
 	// Import the mssql driver.
@@ -15,10 +14,8 @@ import (
 
 	// Import the mssql dialect.
 	_ "github.com/doug-martin/goqu/v9/dialect/sqlserver"
-	"github.com/jackc/pgtype"
 	"github.com/jmoiron/sqlx"
 
-	schemav1 "github.com/cerbos/cerbos/api/genpb/cerbos/schema/v1"
 	"github.com/cerbos/cerbos/internal/config"
 	"github.com/cerbos/cerbos/internal/observability/logging"
 	"github.com/cerbos/cerbos/internal/policy"
@@ -52,136 +49,69 @@ func NewStore(ctx context.Context, conf *Conf) (*Store, error) {
 
 	conf.ConnPool.Configure(db)
 
-	database := goqu.New("sqlserver", db)
-	dbStorage, err := internal.NewDBStorage(ctx, database)
+	dbStorage, err := internal.NewDBStorage(ctx, goqu.New("sqlserver", db), internal.WithUpsertPolicy(upsertPolicy), internal.WithUpsertSchema(upsertSchema))
 	if err != nil {
 		return nil, err
 	}
 
-	return &Store{DBStorage: dbStorage, db: database}, nil
+	return &Store{DBStorage: dbStorage}, nil
 }
 
 type Store struct {
 	internal.DBStorage
-	db *goqu.Database
 }
 
 func (s *Store) Driver() string {
 	return DriverName
 }
 
-func (s *Store) AddOrUpdate(ctx context.Context, policies ...policy.Wrapper) error {
-	events := make([]storage.Event, len(policies))
-	err := s.db.WithTx(func(tx *goqu.TxDatabase) error {
-		for i, p := range policies {
-			// try to upsert this policy record
-			id, _ := p.ID.Value()
-			stm, err := tx.Prepare(`
+func upsertPolicy(ctx context.Context, tx *goqu.TxDatabase, p policy.Wrapper) error {
+	stm, err := tx.Prepare(`
 UPDATE dbo.[policy] WITH (UPDLOCK, SERIALIZABLE) SET "definition"=@definition, "description"=@description,"disabled"=@disabled,"kind"=@kind,"name"=@name,"version"=@version where [id] = @id 
 IF @@ROWCOUNT = 0
 BEGIN
   INSERT INTO dbo.[policy] ("definition", "description", "disabled", "kind", "name", "version", "id") VALUES (@definition, @description, @disabled, @kind, @name, @version, @id)
 END
 `)
-			if err != nil {
-				return fmt.Errorf("failed to prepare policy upsert %s: %w", p.FQN, err)
-			}
-
-			defer stm.Close()
-
-			definition, err := internal.PolicyDefWrapper{Policy: p.Policy}.Value()
-			if err != nil {
-				return fmt.Errorf("failed to get definition value: %w", err)
-			}
-
-			_, err = stm.ExecContext(ctx, sql.Named("definition", definition),
-				sql.Named("description", p.Description), sql.Named("disabled", p.Disabled),
-				sql.Named("kind", p.Kind), sql.Named("name", p.Name), sql.Named("version", p.Version), sql.Named("id", int64(id.(uint64))))
-
-			if err != nil {
-				return fmt.Errorf("failed to upsert %s: %w", p.FQN, err)
-			}
-
-			if len(p.Dependencies) > 0 {
-				// delete the existing dependency records
-				if _, err := tx.Delete(internal.PolicyDepTbl).
-					Prepared(true).
-					Where(goqu.I(internal.PolicyDepTblPolicyIDCol).Eq(p.ID)).
-					Executor().ExecContext(ctx); err != nil {
-					return fmt.Errorf("failed to delete dependencies of %s: %w", p.FQN, err)
-				}
-
-				// insert the new dependency records
-				depRows := make([]interface{}, len(p.Dependencies))
-				for i, d := range p.Dependencies {
-					depRows[i] = internal.PolicyDependency{PolicyID: p.ID, DependencyID: d}
-				}
-
-				if _, err := tx.Insert(internal.PolicyDepTbl).
-					Prepared(true).
-					Rows(depRows...).
-					Executor().ExecContext(ctx); err != nil {
-					return fmt.Errorf("failed to insert dependencies of %s: %w", p.FQN, err)
-				}
-			}
-
-			events[i] = storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: p.ID}
-		}
-
-		return nil
-	})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to prepare policy upsert %s: %w", p.FQN, err)
 	}
 
-	s.NotifySubscribers(events...)
-	return nil
+	defer stm.Close()
+
+	definition, err := internal.PolicyDefWrapper{Policy: p.Policy}.Value()
+	if err != nil {
+		return fmt.Errorf("failed to get definition value: %w", err)
+	}
+
+	id, _ := p.ID.Value()
+
+	_, err = stm.ExecContext(ctx, sql.Named("definition", definition),
+		sql.Named("description", p.Description), sql.Named("disabled", p.Disabled),
+		sql.Named("kind", p.Kind), sql.Named("name", p.Name), sql.Named("version", p.Version), sql.Named("id", int64(id.(uint64))))
+
+	return err
 }
 
-func (s *Store) AddOrUpdateSchema(ctx context.Context, schemas ...*schemav1.Schema) error {
-	events := make([]storage.Event, 0, len(schemas))
-	err := s.db.WithTx(func(tx *goqu.TxDatabase) error {
-		for _, sch := range schemas {
-			var def json.RawMessage
-			if err := json.Unmarshal(sch.Definition, &def); err != nil {
-				return storage.NewInvalidSchemaError(err, "schema definition with ID %q is not valid", sch.Id)
-			}
-
-			defJSON := pgtype.JSON{}
-			if err := defJSON.UnmarshalJSON(def); err != nil {
-				return storage.NewInvalidSchemaError(err, "schema definition with ID %q is not valid", sch.Id)
-			}
-
-			stm, err := tx.Prepare(`
+func upsertSchema(ctx context.Context, tx *goqu.TxDatabase, schema internal.Schema) error {
+	stm, err := tx.Prepare(`
 UPDATE dbo.[attr_schema_defs] WITH (UPDLOCK, SERIALIZABLE) SET "definition"=@definition WHERE [id] = @id 
 IF @@ROWCOUNT = 0
 BEGIN
   INSERT INTO dbo.[attr_schema_defs] ("definition", "id") VALUES (@definition, @id)
 END
 `)
-			if err != nil {
-				return fmt.Errorf("failed to prepare schema upsert %s: %w", sch.Id, err)
-			}
-
-			defer stm.Close()
-
-			definition, err := defJSON.MarshalJSON()
-			if err != nil {
-				return fmt.Errorf("failed to marshal defJson: %w", err)
-			}
-			_, err = stm.ExecContext(ctx, sql.Named("definition", definition), sql.Named("id", sch.Id))
-			if err != nil {
-				return fmt.Errorf("failed to upsert the schema with id %s: %w", sch.Id, err)
-			}
-
-			events = append(events, storage.NewSchemaEvent(storage.EventAddOrUpdateSchema, sch.Id))
-		}
-		return nil
-	})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to prepare schema upsert %s: %w", schema.ID, err)
 	}
 
-	s.NotifySubscribers(events...)
-	return nil
+	defer stm.Close()
+
+	definition, err := schema.Definition.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("failed to marshal defJson: %w", err)
+	}
+	_, err = stm.ExecContext(ctx, sql.Named("definition", definition), sql.Named("id", schema.ID))
+
+	return err
 }

--- a/internal/storage/db/sqlserver/sqlserver_test.go
+++ b/internal/storage/db/sqlserver/sqlserver_test.go
@@ -1,0 +1,142 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package sqlserver_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	_ "embed"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cerbos/cerbos/internal/storage/db/internal"
+	"github.com/cerbos/cerbos/internal/storage/db/sqlserver"
+)
+
+//go:embed schema.sql
+var schemaSQL []byte
+
+const password = "MyPassword1!"
+
+func TestSqlServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	is := require.New(t)
+	pool, err := dockertest.NewPool("")
+	is.NoError(err, "Could not connect to docker: %s", err)
+
+	options := &dockertest.RunOptions{
+		Repository: "mcr.microsoft.com/azure-sql-edge",
+		Tag:        "latest",
+		CapAdd:     []string{"SYS_PTRACE"},
+		Env:        []string{"ACCEPT_EULA=1", "MSSQL_SA_PASSWORD=" + password},
+	}
+
+	resource, err := pool.RunWithOptions(options)
+	is.NoError(err, "Could not start resource: %s", err)
+
+	t.Cleanup(func() {
+		if err := pool.Purge(resource); err != nil {
+			t.Errorf("Failed to cleanup resources: %v", err)
+		}
+	})
+
+	deadline, ok := t.Deadline()
+	if !ok {
+		deadline = time.Now().Add(5 * time.Minute)
+	}
+
+	ctx, cancelFunc := context.WithDeadline(context.Background(), deadline)
+	defer cancelFunc()
+
+	port := resource.GetPort("1433/tcp")
+	getConnString := func(dbname string) string {
+		return fmt.Sprintf("sqlserver://sa:%s@127.0.0.1:%s?database=%s", password, port, dbname)
+	}
+
+	is.NoError(pool.Retry(func() error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		db, err := sqlx.Connect("sqlserver", getConnString("master"))
+		if err != nil {
+			return err
+		}
+
+		return createSchema(db, func() (*sqlx.DB, error) {
+			return sqlx.Connect("sqlserver", getConnString("cerbos"))
+		})
+	}), "Container did not start or couldn't create schema")
+
+	store, err := sqlserver.NewStore(ctx, &sqlserver.Conf{
+		URL: fmt.Sprintf("sqlserver://cerbos_user:ChangeMe(1!!)@127.0.0.1:%s?database=cerbos", port),
+		ConnPool: &internal.ConnPoolConf{
+			MaxLifetime: 1 * time.Minute,
+			MaxIdleTime: 45 * time.Second,
+			MaxOpen:     4,
+			MaxIdle:     1,
+		},
+	})
+	require.NoError(t, err)
+	t.Run("suite", internal.TestSuite(store))
+}
+
+func createSchema(db *sqlx.DB, f func() (*sqlx.DB, error)) error {
+	s := bufio.NewScanner(bytes.NewReader(schemaSQL))
+	s.Split(splitOnGo)
+	var c *sqlx.DB
+	var err error
+
+	for s.Scan() {
+		query := s.Text()
+
+		if strings.HasPrefix(query, "CREATE TRIGGER") {
+			if c == nil {
+				c, err = f()
+				if err != nil {
+					return fmt.Errorf("failed to connect to \"cerbos\" database")
+				}
+			}
+			if _, err = c.Exec(query); err != nil {
+				return fmt.Errorf("failed to execute [%s]: %w", query, err)
+			}
+			break
+		}
+
+		if _, err := db.Exec(query); err != nil {
+			return fmt.Errorf("failed to execute [%s]: %w", query, err)
+		}
+	}
+
+	return s.Err()
+}
+
+var sep = []byte("\nGO\n")
+
+func splitOnGo(data []byte, atEOF bool) (int, []byte, error) {
+	// no more data to process
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+
+	if i := bytes.Index(data, sep); i >= 0 {
+		return i + len(sep), bytes.TrimSpace(data[:i-1]), nil
+	}
+	// at the end of input
+	if atEOF {
+		return len(data), bytes.TrimSpace(data), nil
+	}
+
+	// get more data
+	return 0, nil, nil
+}

--- a/internal/storage/db/sqlserver/sqlserver_test.go
+++ b/internal/storage/db/sqlserver/sqlserver_test.go
@@ -110,7 +110,7 @@ func createSchema(db *sqlx.DB, f func() (*sqlx.DB, error)) error {
 			if _, err = c.Exec(query); err != nil {
 				return fmt.Errorf("failed to execute [%s]: %w", query, err)
 			}
-			break
+			continue
 		}
 
 		if _, err := db.Exec(query); err != nil {


### PR DESCRIPTION
Signed-off-by: Dennis Buduev <dennis@cerbos.dev>

#### Description

Adds SQL Server as a cerbos policies storage.

#### TODO

- [ ] Manual testing
- [ ] E2E test
- [x] Documentation
 
#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
