### PR TITLE
fix: cerbosctl get subcommands retrieve unmatching policy types

### DIFF
--- a/cmd/cerbosctl/cerbosctl_test.go
+++ b/cmd/cerbosctl/cerbosctl_test.go
@@ -188,6 +188,28 @@ func testGetCmd(fn internal.WithClient) func(*testing.T) {
 					require.JSONEq(t, string(expected), out.String())
 				}
 			})
+
+			t.Run("invalid policy key type for commands", func(t *testing.T) {
+				testCases := []struct {
+					args    []string
+				}{
+					{strings.Split("derived_roles principal.donald_duck_1.default", " ")},
+					{strings.Split("derived_roles resource.leave_request_1.default", " ")},
+					{strings.Split("principal_policies derived_roles.my_derived_roles_1", " ")},
+					{strings.Split("principal_policies resource.leave_request_1.default", " ")},
+					{strings.Split("resource_policies derived_roles.my_derived_roles_1", " ")},
+					{strings.Split("resource_policies principal.donald_duck_1.default", " ")},
+				}
+
+				for _, tc := range testCases {
+					out := bytes.NewBufferString("")
+					cmd := get.NewGetCmd(fn)
+					cmd.SetOut(out)
+					cmd.SetArgs(tc.args)
+					err := cmd.Execute()
+					require.Error(t, err)
+				}
+			})
 		})
 	}
 }

--- a/cmd/cerbosctl/get/internal/policy/policy.go
+++ b/cmd/cerbosctl/get/internal/policy/policy.go
@@ -106,12 +106,7 @@ func Get(c client.AdminClient, cmd *cobra.Command, format *flagset.Format, resTy
 				foundPolicy = true
 			}
 
-			p := make([]*policyv1.Policy, 0, len(filtered))
-			for _, wrappedPolicy := range filtered {
-				p = append(p, wrappedPolicy.Policy)
-			}
-
-			if err = printPolicy(cmd.OutOrStdout(), p, format.Output); err != nil {
+			if err = printPolicy(cmd.OutOrStdout(), filtered, format.Output); err != nil {
 				return fmt.Errorf("could not print policies: %w", err)
 			}
 		}
@@ -152,7 +147,7 @@ func filter(policies []policy.Wrapper, policyIds, name, version []string, resTyp
 	return filtered
 }
 
-func printPolicy(w io.Writer, policies []*policyv1.Policy, format string) error {
+func printPolicy(w io.Writer, policies map[string]policy.Wrapper, format string) error {
 	switch format {
 	case "json":
 		return internal.PrintPolicyJSON(w, policies)

--- a/cmd/cerbosctl/internal/print.go
+++ b/cmd/cerbosctl/internal/print.go
@@ -7,11 +7,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/cerbos/cerbos/internal/policy"
 	"io"
 
 	"google.golang.org/protobuf/encoding/protojson"
 
-	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
 	schemav1 "github.com/cerbos/cerbos/api/genpb/cerbos/schema/v1"
 	"github.com/cerbos/cerbos/internal/util"
 )
@@ -43,9 +43,9 @@ func PrintSchemaJSON(w io.Writer, schemas []*schemav1.Schema) error {
 	return nil
 }
 
-func PrintPolicyJSON(w io.Writer, policies []*policyv1.Policy) error {
+func PrintPolicyJSON(w io.Writer, policies map[string]policy.Wrapper) error {
 	for _, p := range policies {
-		b, err := protojson.Marshal(p)
+		b, err := protojson.Marshal(p.Policy)
 		if err != nil {
 			return fmt.Errorf("could not marshal policy: %w", err)
 		}
@@ -57,9 +57,9 @@ func PrintPolicyJSON(w io.Writer, policies []*policyv1.Policy) error {
 	return nil
 }
 
-func PrintPolicyPrettyJSON(w io.Writer, policies []*policyv1.Policy) error {
+func PrintPolicyPrettyJSON(w io.Writer, policies map[string]policy.Wrapper) error {
 	for _, p := range policies {
-		s := protojson.Format(p)
+		s := protojson.Format(p.Policy)
 
 		_, err := fmt.Fprintf(w, "%s\n", s)
 		if err != nil {
@@ -69,14 +69,14 @@ func PrintPolicyPrettyJSON(w io.Writer, policies []*policyv1.Policy) error {
 	return nil
 }
 
-func PrintPolicyYAML(w io.Writer, policies []*policyv1.Policy) error {
+func PrintPolicyYAML(w io.Writer, policies map[string]policy.Wrapper) error {
 	for _, p := range policies {
 		_, err := fmt.Fprintln(w, "---")
 		if err != nil {
 			return fmt.Errorf("failed to print header: %w", err)
 		}
 
-		err = util.WriteYAML(w, p)
+		err = util.WriteYAML(w, p.Policy)
 		if err != nil {
 			return fmt.Errorf("could not write policy: %w", err)
 		}


### PR DESCRIPTION
#### Description

Fixes #593 and adds tests