### PR TITLE
docs:Add Okta & FusionAuth tutorials

### DIFF
--- a/docs/modules/tutorials/assets/images/fusionauth-add-roles.png
+++ b/docs/modules/tutorials/assets/images/fusionauth-add-roles.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efee1628c206169532eaa1fcdf53846068880cb77d3319b39a4c7ebb893107a5
+size 393442

--- a/docs/modules/tutorials/assets/images/fusionauth-application-form.png
+++ b/docs/modules/tutorials/assets/images/fusionauth-application-form.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f4e9f20d6fcb27b13b897d8c1dd46bcef287c0d4b46071202f21c0fbc9f5fdc
+size 204612

--- a/docs/modules/tutorials/assets/images/fusionauth-application-listing.png
+++ b/docs/modules/tutorials/assets/images/fusionauth-application-listing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0db5ebf82cc293e21ebf2e1067ca2ade4d6f4f158bef13fea9a94434177f7461
+size 95621

--- a/docs/modules/tutorials/assets/images/fusionauth-dashboard-applications.png
+++ b/docs/modules/tutorials/assets/images/fusionauth-dashboard-applications.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca84decda2b3ae55174e97cc142c6277e088d475f1783d7b43441c45d5d66791
+size 197781

--- a/docs/modules/tutorials/assets/images/fusionauth-video.png
+++ b/docs/modules/tutorials/assets/images/fusionauth-video.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34e246c3b5f1625014c156a2d26d2251c33802439cd38b804418896c3af4c6ee
+size 887527

--- a/docs/modules/tutorials/assets/images/okta-app-settings.png
+++ b/docs/modules/tutorials/assets/images/okta-app-settings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da6ee20f7af49517e0eeaf42f573cc76d838b16126f61ad168713124b024cc58
+size 148723

--- a/docs/modules/tutorials/assets/images/okta-create-app.png
+++ b/docs/modules/tutorials/assets/images/okta-create-app.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:204d4456f407aea280557bdf3355a205142f34039e51a23745cf0a9d589b47ce
+size 437236

--- a/docs/modules/tutorials/assets/images/okta-groups-claim.png
+++ b/docs/modules/tutorials/assets/images/okta-groups-claim.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8284593f7e3fa07e8092a5fd7da9864efea3f7fd4741363506480865a22003e7
+size 162351

--- a/docs/modules/tutorials/assets/images/okta-video.png
+++ b/docs/modules/tutorials/assets/images/okta-video.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ca3fef634328a9a0a444fbadd3573acfe2b5794f5e35c0e68e5be6e826cb91f
+size 724556

--- a/docs/modules/tutorials/nav.adoc
+++ b/docs/modules/tutorials/nav.adoc
@@ -2,8 +2,10 @@
 * Example Apps
 ** xref:photo-share/index.adoc[Photo-share application]
 * Authentication Integration
-** xref:authentication/jwt/index.adoc[JWT]
 ** xref:authentication/auth0/index.adoc[Auth0]
+** xref:authentication/fusionauth/index.adoc[FusionAuth]
+** xref:authentication/jwt/index.adoc[JWT]
 ** xref:authentication/magic/index.adoc[Magic]
+** xref:authentication/okta/index.adoc[Okta]
 * ORM Integration
 ** xref:orm/prisma/index.adoc[Prisma]

--- a/docs/modules/tutorials/pages/authentication/auth0/index.adoc
+++ b/docs/modules/tutorials/pages/authentication/auth0/index.adoc
@@ -87,9 +87,9 @@ and `user`. These roles are authorized as follows:
 |Action |User |Admin
 |list |Y |Y
 |read |Y |Y
-|create |N |Y
-|update |N |Y
-|delete |N |Y
+|create |Y |Y
+|update |If owner |Y
+|delete |If owner |Y
 |===
 
 This business logic is represented in Cerbos as a resource policy.

--- a/docs/modules/tutorials/pages/authentication/fusionauth/index.adoc
+++ b/docs/modules/tutorials/pages/authentication/fusionauth/index.adoc
@@ -126,20 +126,25 @@ and `user`. These roles are authorized as follows:
 |Action |User |Admin
 |list |Y |Y
 |read |Y |Y
-|create |N |Y
-|update |N |Y
-|delete |N |Y
+|create |Y |Y
+|update |If owner |Y
+|delete |If owner |Y
 |===
 
 == Request Flow
 
-. User access the application and clicks Login
-. User is directed to the Okta UI and authenticates
+. User access the application and clicks `Login`
+. User is directed to the FusionAuth UI and authenticates
 . A token is returned back in the redirect URL to the application
 . That token is then exchanged for the user profile information
-. The user profile from Okta being stored (user Id, roles etc).
-. Any requests to the /contacts endpoints fetch the data required about the resource being accessed from the data store
-. Call the Cerbos PDP with the principal, resource and action to check the authorization and then return an error if the user is not authorized. The Cerbos package is used for this.
+. The user profile from FusionAuth being stored (user Id, email, roles
+etc).
+. Any requests to the `/contacts` endpoints fetch the data required
+about the resource being accessed from the data store
+. Call the Cerbos PDP with the principal, resource and action to check
+the authorization and then return an error if the user is not
+authorized. The https://www.npmjs.com/package/cerbos[Cerbos package] is
+used for this.
 [source,javascript]
 ---
 const allowed = await cerbos.check({

--- a/docs/modules/tutorials/pages/authentication/fusionauth/index.adoc
+++ b/docs/modules/tutorials/pages/authentication/fusionauth/index.adoc
@@ -1,0 +1,167 @@
+include::ROOT:partial$attributes.adoc[]
+
+[#tutorial-auth-fusionauth]
+= Tutorial: Using Cerbos with FusionAuth
+
+
+An example stack of integrating https://cerbos.dev[Cerbos] with an https://expressjs.com/[Express] server using https://fusionauth.com/[FusionAuth] for authentication.
+
+This example is based off the https://github.com/fusionauth/fusionauth-example-node[FusionAuth/fusionauth-example-node] repo.
+
+image:fusionauth-video.png[role="center-img", link="https://cerbos.dev/video/using-cerbos-with-fusionauth"]
+
+https://cerbos.dev/video/using-cerbos-with-fusionauth[Demo Video]
+
+== Dependencies
+
+* docker-compose
+
+== Getting Started
+
+. Clone the repo
++
+[source,bash]
+----
+git clone git@github.com:cerbos/express-fusionauth-cerbos.git
+----
+
+=== Start Stack
+
+Start up the stack `docker compose up` - this will take some time to
+pull down all the images and launch them, but once started the following
+services will be running.
+
+* FusionAuth http://localhost:9011[`http://localhost:9011`]
+* Cerbos http://localhost:3592/[`http://localhost:3592/`]
+* Node App http://localhost:8080/[`http://localhost:8080/`]
+* Postgres DB for FustionAuth on port `5432`
+
+=== Configure FusionAuth
+
+This example is based off the
+https://fusionauth.io/docs/v1/tech/5-minute-setup-guide/[FusionAuth 5
+Minute Guide] - and most of the steps have bee handled by the
+`docker compose` setup.
+
+The only manual steps required are creating the application. To do this,
+open up http://localhost:9011[`http://localhost:9011`] and complete the
+setup wizard, then:
+
+Once we arrive in the FusionAuth admin UI, the first thing we need to do
+is create an Application. An Application is something that a user can
+log into. This is the application we are building or that we are
+migrating to use FusionAuth. We'll click the Application menu option on
+the left side of the page or the Setup button in the box at the top of
+the page.
+
+image:fusionauth-dashboard-applications.png[role="center-img"]
+
+This will take us to the listing page for Applications. Next, we'll
+click the green plus button (the add button) at the top of the page:
+
+image:fusionauth-application-listing.png[role="center-img"]
+
+On the Application form, we'll need to provide a name for our
+Application (only used for display purposes) and a couple of items on
+the OAuth tab. We'll start with a simple setup that allows existing
+users to log into your application. Therefore, we won't need to define
+any roles or registration configuration. If we click on the OAuth tab,
+we'll see these options:
+
+image:fusionauth-application-form.png[role="center-img"]
+
+Most of the defaults will work, but we also need to provide these items:
+
+* An authorized redirect URL. This is the route/controller in our
+application's backend that will complete the OAuth workflow. This is
+also known as the 'Backend for Frontend' or BFF pattern, and is a
+lightweight proxy. In our example, we set this to
+`http://localhost:8080/auth/callback`. We'll show some Node.js example
+code below for this route.
+* Optionally, we can specify a valid Logout URL. This is where the user
+will be redirected to after they are logged out of FusionAuth's OAuth
+front-end: our application.
+* We need to ensure that the Authorization Code grant is selected in the
+Enabled Grants.
+
+Next we need to add the roles that will be used by our policies. Back on
+the application listing page press the 'Manage Roles' button next to our
+application and add roles for `user` and `editor` (admin should already
+exist). These roles will be passed back with the user information to our
+application, and then passed onto Cerbos for use in authorization
+decisions.
+
+image:fusionauth-add-roles.png[role="center-img"]
+
+Once we have all of this configured, we can then copy the Client ID and
+Client Secret and move to the next step.
+
+=== Configure Node App
+
+Now that our application has been created, we need to add the Client ID
+and Client Secret from FusionAuth into the top of `app/index.js` (line
+12 & 13). These will be used to identify the app through the login flow.
+
+=== Test the app
+
+Now that everything is wired up you should be able to goto
+http://localhost:8080[`http://localhost:8080`] and press the login link
+to authenticate with your FusionAuth account.
+
+== Policies
+
+This example has a simple CRUD policy in place for a resource kind of
+`contact` - like a CRM system would have. The policy file can be found
+in the `cerbos/policies` folder
+https://github.com/cerbos/express-fusionauth-cerbos/blob/main/cerbos/policies/contact.yaml[here].
+
+Should you wish to experiment with this policy, you can try it in the
+https://play.cerbos.dev/p/g561543292ospj7w0zOrFx7H5DzhmLu2[Cerbos Playground].
+
+The policy expects one of two roles to be set on the principal - `admin`
+and `user`. These roles are authorized as follows:
+
+[cols=",,",options="header",]
+|===
+|Action |User |Admin
+|list |Y |Y
+|read |Y |Y
+|create |N |Y
+|update |N |Y
+|delete |N |Y
+|===
+
+== Request Flow
+
+. User access the application and clicks Login
+. User is directed to the Okta UI and authenticates
+. A token is returned back in the redirect URL to the application
+. That token is then exchanged for the user profile information
+. The user profile from Okta being stored (user Id, roles etc).
+. Any requests to the /contacts endpoints fetch the data required about the resource being accessed from the data store
+. Call the Cerbos PDP with the principal, resource and action to check the authorization and then return an error if the user is not authorized. The Cerbos package is used for this.
+[source,javascript]
+---
+const allowed = await cerbos.check({
+  principal: { //pass in the Okta user ID and groups
+    id: req.userContext.userinfo.sub,
+    roles: req.userContext.userinfo.groups,
+  },
+  resource: {
+    kind: "contact",
+    instances: {
+      //a map of the resource(s) being accessed
+      [contact.id]: {
+        attr: contact,
+      },
+    },
+  },
+  actions: ["read"], //the list of actions being performed
+});
+
+// not authorized for read action
+if (!allowed.isAuthorized(contact.id, "read")) {
+  return res.status(403).json({ error: "Unauthorized" });
+}
+---
+Implementation at this stage will be dependant on your business requirements.

--- a/docs/modules/tutorials/pages/authentication/okta/index.adoc
+++ b/docs/modules/tutorials/pages/authentication/okta/index.adoc
@@ -1,0 +1,160 @@
+include::ROOT:partial$attributes.adoc[]
+
+[#tutorial-auth-okta]
+= Tutorial: Using Cerbos with Okta
+
+An example application of integrating https://cerbos.dev[Cerbos] with an https://expressjs.com/[Express] server using https://okta.com/[Okta] for authentication.
+
+image:okta-video.png[role="center-img", link="https://cerbos.dev/video/using-cerbos-with-okta"]
+
+https://cerbos.dev/video/using-cerbos-with-okta[Demo Video]
+
+== Dependencies
+
+* Node.js
+* An https://okta.com/[Okta] account
+
+---
+For simplicity this demo is using the hosted Cerbos Demo PDP avaliable in the Playground so running the Cerbos container locally isn't required. For production use cases a deployed Cerbos PDP is required and the code updated to point to your instance. You can read more about the deployment options https://docs.cerbos.dev/cerbos/latest/deployment/index.html[here].
+---
+
+== Setup
+
+=== Install Deps
+
+. Clone the repo
++
+[source,bash]
+----
+git clone git@github.com:cerbos/express-okta-cerbos.git
+----
+
+=== Create an Okta Application
+
+In your Okta instance you need to create a new application. For this
+example we will be making use of Okta's ExpressOIDC package so the
+application's sign-in method needs to be `OIDC - OpenID Connect` and the
+application type is `Web Application`.
+
+image:okta-create-app.png[alt="Okta Create App",role="center-img"]
+
+=== Set Redirect URLs
+
+The default redirect URLs for sign-in and sign-out are correct if you
+are running this demo app on the default 8080 port. If you have chanaged
+this in your `.env` file then you will need to update accordingly.
+
+image:okta-app-settings.png[alt="Okta App Settings",role="center-img"]
+
+=== Enabling Groups in the Okta Token
+
+By default the groups the user belongs to are not passed to the
+application in the Okta token - this needs enabling as these groups will
+be passed from Okta to Cerbos for use in authorization decisions.
+
+To do this, goto _Security > API_ in the sidebar, and edit the default
+_Authorization Server_.
+
+On this page, got the _Claims_ tab and press _Add Claim_. Add a new
+claim called groups which includes the groups of the user in the ID
+token.
+
+image:okta-groups-claim.png[alt="Okta Groups Claim",role="center-img"]
+
+____
+In production you will likely want to filter this down, but for this
+example we are enabling all groups to be added to the token.
+____
+
+
+=== Create an example `admin` group.
+
+In a new Okta account the only group that exists is the _Everyone_
+group. For our demo application policies we expect users to be in
+`admin` or `user` group as this is what is checked.
+
+Under _Directory > Groups_ press _Add Group_ and create the two groups
+and add your example users to them.
+
+=== Setup Environment Variables
+
+Make a copy of the `.env.sample` file and call it `.env`. You will then
+need to populate the feilds that begin with `OKTA_` with the information
+provided in the new application you created.
+
+....
+PORT=8080
+CERBOS_HOSTNAME=https://demo-pdp.cerbos.cloud
+CERBOS_PLAYGROUND=ygW612cc9c9xXOsOZjI40ovY2LZvXf43
+OKTA_DOMAIN=
+OKTA_CLIENTID=
+OKTA_CLIENTSECRET=
+OKTA_APP_BASE_URL=http://localhost:8080
+....
+
+____
+This example is using the hosted Demo PDP of Cerbos and an example
+Playground instance. If you are running your own Cerbos PDP then update
+the `CERBOS_HOSTNAME` feild to your own instance and remove the
+`CERBOS_PLAYGROUND` feild.
+____
+
+=== Test the app
+
+Now that everything is wired up you should be able to goto
+http://localhost:8080[`http://localhost:8080`] and press the login link
+to authenticate with your Okta account.
+
+== Policies
+
+This example has a simple CRUD policy in place for a resource kind of
+`contact` - like a CRM system would have. Should you wish to experiment with this policy, you can try it in the
+https://play.cerbos.dev/p/g561543292ospj7w0zOrFx7H5DzhmLu2[Cerbos Playground].
+
+The policy expects one of two roles to be set on the principal - `admin`
+and `user`. These roles are authorized as follows:
+
+[cols=",,",options="header",]
+|===
+|Action |User |Admin
+|list |Y |Y
+|read |Y |Y
+|create |N |Y
+|update |N |Y
+|delete |N |Y
+|===
+
+== Request Flow
+
+. User access the application and clicks Login
+. User is directed to the Okta UI and authenticates
+. A token is returned back in the redirect URL to the application
+. That token is then exchanged for the user profile information
+. The user profile from Okta being stored (user Id, roles etc).
+. Any requests to the /contacts endpoints fetch the data required about the resource being accessed from the data store
+. Call the Cerbos PDP with the principal, resource and action to check the authorization and then return an error if the user is not authorized. The Cerbos package is used for this.
+[source,javascript]
+---
+const allowed = await cerbos.check({
+  principal: { //pass in the Okta user ID and groups
+    id: req.userContext.userinfo.sub,
+    roles: req.userContext.userinfo.groups,
+  },
+  resource: {
+    kind: "contact",
+    instances: {
+      //a map of the resource(s) being accessed
+      [contact.id]: {
+        attr: contact,
+      },
+    },
+  },
+  actions: ["read"], //the list of actions being performed
+});
+
+// not authorized for read action
+if (!allowed.isAuthorized(contact.id, "read")) {
+  return res.status(403).json({ error: "Unauthorized" });
+}
+---
+Implementation at this stage will be dependant on your business requirements.


### PR DESCRIPTION
#### Description
Add in the missing Okta and FusionAuth tutorials to the docs site.

#### Checklist 

- [X] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
