### PR TITLE
chore(ci): Replace conventional commit check

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,6 +3,8 @@ name: Publish Documentation
 on:
   workflow_dispatch:
   push:
+    paths:
+      - 'docs/**'
     branches:
       - main
       - 'v*'

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -7,6 +7,7 @@ on:
       - 'v*'
 jobs:
   changes:
+    runs-on: ubuntu-latest
     outputs:
       docs: ${{ steps.filter.outputs.docs }}
       code: ${{ steps.filter.outputs.code }}

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -6,7 +6,22 @@ on:
       - main
       - 'v*'
 jobs:
+  changes:
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+            code:
+              - '!(docs/**)'
   test:
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     name: Test
     runs-on: ubuntu-latest
     steps:
@@ -48,6 +63,8 @@ jobs:
           files: "unit.cover,integration.cover"
 
   docs:
+    needs: changes
+    if: ${{ needs.changes.outputs.docs == 'true' }}
     name: Build docs
     runs-on: ubuntu-latest
     steps:
@@ -61,6 +78,8 @@ jobs:
         id: docs
 
   golangci:
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     name: Lint
     runs-on: ubuntu-latest
     steps:
@@ -72,6 +91,8 @@ jobs:
           args: '--config=.golangci.yaml -v'
 
   buf:
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     name: Proto check
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -9,17 +9,20 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      docs: ${{ steps.filter.outputs.docs }}
       code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
+      protos: ${{ steps.filter.outputs.protos }}
     steps:
       - uses: dorny/paths-filter@v2
         id: filter
         with:
           filters: |
-            docs:
-              - 'docs/**'
             code:
               - '!(docs/**)'
+            docs:
+              - 'docs/**'
+            protos:
+              - '**/*.proto'
   test:
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}
@@ -93,7 +96,7 @@ jobs:
 
   buf:
     needs: changes
-    if: ${{ needs.changes.outputs.code == 'true' }}
+    if: ${{ needs.changes.outputs.protos == 'true' }}
     name: Proto check
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,31 @@
+---
+name: "Conventional Commits"
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            chore
+            ci
+            docs
+            enhancement
+            feat
+            fix
+            revert
+            test
+          requireScope: false
+          subjectPattern: '^(?[A-Z]).+$'
+          subjectPatternError: |
+            Subject "{subject}" does not start with an uppercase letter
+          validateSingleCommit: true

--- a/.github/workflows/snaphot.yaml
+++ b/.github/workflows/snaphot.yaml
@@ -2,6 +2,8 @@
 name: Snapshots
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
     branches:
       - main
 jobs:


### PR DESCRIPTION
- Use a GitHub action to perform the conventional commit check because
  the Semantic app has been flaky recently. GH Actions can also be
  restarted unlike the app.
- Add path filters to avoid running jobs unnecessarily. For example,
  don't run tests if only docs have changed.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
