### PR TITLE
chore(ci): Increase Telepresence timeout for E2E tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -42,6 +42,7 @@ jobs:
           cat >~/.config/telepresence/config.yml <<EOF
           timeouts:
             helm: 60s
+            trafficManagerAPI: 30s
           EOF
 
       - name: Install KinD

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -25,7 +25,7 @@ jobs:
             revert
             test
           requireScope: false
-          subjectPattern: '^(?[A-Z]).+$'
+          subjectPattern: '^[A-Z].+$'
           subjectPatternError: |
             Subject "{subject}" does not start with an uppercase letter
           validateSingleCommit: true


### PR DESCRIPTION
Last two failures were due to a trafficManagerAPI timeout which defaults to 15s

Also updates the conventional commit check because it's unhappy with the regex.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
