### PR TITLE
chore(e2e): Update Postgres E2E deploy script

### DIFF
--- a/e2e/cleanup.sh
+++ b/e2e/cleanup.sh
@@ -5,13 +5,9 @@ set -euo pipefail
 
 if [[ $# -ne 2 ]]; then
   echo "Usage: $0 <context_id> <run_id>"
+fi
 
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-E2E_SRC_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-E2E_CONTEXT_ID="$1"
-E2E_NS="e2e-$2"
-E2E_RUN_ID="$2"
-
-helmfile -f "${SCRIPT_DIR}/${1}/helmfile.yaml" destroy
+E2E_SRC_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)" E2E_CONTEXT_ID="$1" E2E_NS="e2e-$2" E2E_RUN_ID="$2" helmfile -f "${SCRIPT_DIR}/${1}/helmfile.yaml" destroy
 

--- a/e2e/postgres/helmfile.yaml
+++ b/e2e/postgres/helmfile.yaml
@@ -51,11 +51,13 @@ releases:
           - '{{ requiredEnv "E2E_NS" }}'
     values:
       - nameOverride: '{{ requiredEnv "E2E_CONTEXT_ID" }}'
-      - postgresqlUsername: postgres
-      - postgresqlPassword: passw0rd
-      - persistence:
-          enabled: false
-      - initdbScriptsConfigMap: postgres-init
+      - auth:
+          postgresPassword: passw0rd
+      - primary:
+          initdb:
+            scriptsConfigMap: postgres-init
+          persistence:
+            enabled: false
 
   - name: cerbos
     namespace: '{{ requiredEnv "E2E_NS" }}'


### PR DESCRIPTION
The Bitnami Postgres Helm chart has been changed recently and some of
the parameters in the values file are now different. This was causing
the E2E tests to fail in the last couple of days.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
