### PR TITLE
feat: Add cerbos run command

### DIFF
--- a/cmd/cerbos/compile/compile.go
+++ b/cmd/cerbos/compile/compile.go
@@ -37,9 +37,8 @@ var (
 )
 
 const (
-	formatJSON   = "json"
-	formatPlain  = "plain"
-	formatPretty = "pretty"
+	formatJSON  = "json"
+	formatPlain = "plain"
 )
 
 const help = `
@@ -133,9 +132,9 @@ func (c *Cmd) Help() string {
 }
 
 type printer struct {
-	format  string
 	stdout  io.Writer
 	stderr  io.Writer
+	format  string
 	verbose bool
 }
 

--- a/cmd/cerbos/compile/compile.go
+++ b/cmd/cerbos/compile/compile.go
@@ -8,12 +8,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
-	"strings"
 
+	"github.com/alecthomas/kong"
 	"github.com/fatih/color"
-	"github.com/spf13/cobra"
 
 	"github.com/cerbos/cerbos/internal/compile"
 	"github.com/cerbos/cerbos/internal/engine"
@@ -34,56 +34,60 @@ var (
 	skippedTest    = color.New(color.FgHiWhite).SprintFunc()
 	failedTest     = color.New(color.FgHiRed).SprintFunc()
 	successfulTest = color.New(color.FgHiGreen).SprintFunc()
-
-	format        string
-	skipTests     bool
-	ignoreSchemas bool
-	verbose       bool
-	verifyConf    = verify.Config{}
 )
 
 const (
-	formatJSON  = "json"
-	formatPlain = "plain"
+	formatJSON   = "json"
+	formatPlain  = "plain"
+	formatPretty = "pretty"
 )
 
-func NewCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:           "compile DIR",
-		Short:         "Compile the policy files found in the directory",
-		RunE:          doRun,
-		Args:          cobra.ExactArgs(1),
-		SilenceErrors: true,
-	}
+const help = `
+Examples:
 
-	cmd.Flags().StringVarP(&format, "format", "f", "", "Output format (valid values: json,plain)")
-	cmd.Flags().StringVar(&verifyConf.TestsDir, "tests", "", "Path to the directory containing tests")
-	cmd.Flags().StringVar(&verifyConf.Run, "run", "", "Run only tests that match this regex")
-	cmd.Flags().BoolVar(&skipTests, "skip-tests", false, "Skip tests")
-	cmd.Flags().BoolVar(&ignoreSchemas, "ignore-schemas", false, "Ignore schemas during compilation")
-	cmd.Flags().BoolVar(&verbose, "verbose", false, "Verbose output on test failure")
+# Compile and run tests found in /path/to/policy/repo
 
-	return cmd
+cerbos compile /path/to/policy/repo
+
+# Compile and run tests that contain "Delete" in their name
+
+cerbos compile --run=Delete /path/to/policy/repo
+
+# Compile but skip tests
+
+cerbos compile --skip-tests /path/to/policy/repo
+`
+
+type Cmd struct {
+	Dir           string `help:"Policy directory" arg:"" required:"" type:"existingdir"`
+	Format        string `help:"Output format (${enum})" default:"pretty" enum:"pretty,plain,json" short:"f"`
+	Tests         string `help:"Path to the directory containing tests. Defaults to policy directory." type:"existingdir"`
+	RunRegex      string `help:"Run only tests that match this regex" name:"run"`
+	SkipTests     bool   `help:"Skip tests"`
+	IgnoreSchemas bool   `help:"Ignore schemas during compilation"`
+	Verbose       bool   `help:"Verbose output on test failure"`
 }
 
-func doRun(cmd *cobra.Command, args []string) error {
+func (c *Cmd) Run(k *kong.Kong) error {
 	ctx, stopFunc := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stopFunc()
 
-	idx, err := index.Build(ctx, os.DirFS(args[0]))
+	p := &printer{format: c.Format, verbose: c.Verbose, stdout: k.Stdout, stderr: k.Stderr}
+
+	idx, err := index.Build(ctx, os.DirFS(c.Dir))
 	if err != nil {
 		idxErr := new(index.BuildError)
 		if errors.As(err, &idxErr) {
-			return displayLintErrors(cmd, idxErr)
+			return displayLintErrors(p, idxErr)
 		}
 
-		return fmt.Errorf("failed to open directory %s: %w", args[0], err)
+		return fmt.Errorf("failed to open directory %s: %w", c.Dir, err)
 	}
 
 	store := disk.NewFromIndexWithConf(idx, &disk.Conf{})
 
 	enforcement := schema.EnforcementReject
-	if ignoreSchemas {
+	if c.IgnoreSchemas {
 		enforcement = schema.EnforcementNone
 	}
 	schemaMgr := schema.NewWithConf(ctx, store, &schema.Conf{Enforcement: enforcement})
@@ -91,17 +95,22 @@ func doRun(cmd *cobra.Command, args []string) error {
 	if err := compile.BatchCompile(idx.GetAllCompilationUnits(ctx), schemaMgr); err != nil {
 		compErr := new(compile.ErrorList)
 		if errors.As(err, compErr) {
-			return displayCompileErrors(cmd, *compErr)
+			return displayCompileErrors(p, *compErr)
 		}
 
 		return fmt.Errorf("failed to create engine: %w", err)
 	}
 
-	if verifyConf.TestsDir == "" {
-		verifyConf.TestsDir = args[0]
-	}
+	if !c.SkipTests {
+		verifyConf := verify.Config{
+			TestsDir: c.Tests,
+			Run:      c.RunRegex,
+		}
 
-	if !skipTests {
+		if verifyConf.TestsDir == "" {
+			verifyConf.TestsDir = c.Dir
+		}
+
 		compiler := compile.NewManager(ctx, store, schemaMgr)
 		eng, err := engine.NewEphemeral(ctx, compiler, schemaMgr)
 		if err != nil {
@@ -113,16 +122,39 @@ func doRun(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to run tests: %w", err)
 		}
 
-		return displayVerificationResult(cmd, result)
+		return displayVerificationResult(p, result)
 	}
 
 	return nil
 }
 
-func displayLintErrors(cmd *cobra.Command, errs *index.BuildError) error {
-	switch strings.ToLower(format) {
+func (c *Cmd) Help() string {
+	return help
+}
+
+type printer struct {
+	format  string
+	stdout  io.Writer
+	stderr  io.Writer
+	verbose bool
+}
+
+func (p *printer) Println(args ...interface{}) {
+	fmt.Fprintln(p.stdout, args...)
+}
+
+func (p *printer) Printf(format string, args ...interface{}) {
+	fmt.Fprintf(p.stdout, format, args...)
+}
+
+func (p *printer) OutOrStdout() io.Writer {
+	return p.stdout
+}
+
+func displayLintErrors(p *printer, errs *index.BuildError) error {
+	switch p.format {
 	case formatJSON:
-		if err := outputJSON(cmd, map[string]*index.BuildError{"lintErrors": errs}); err != nil {
+		if err := outputJSON(p, map[string]*index.BuildError{"lintErrors": errs}); err != nil {
 			return err
 		}
 
@@ -132,44 +164,44 @@ func displayLintErrors(cmd *cobra.Command, errs *index.BuildError) error {
 	}
 
 	if len(errs.DuplicateDefs) > 0 {
-		cmd.Println(header("Duplicate definitions"))
+		p.Println(header("Duplicate definitions"))
 		for _, dd := range errs.DuplicateDefs {
-			cmd.Printf("%s is a duplicate of %s\n", fileName(dd.File), fileName(dd.OtherFile))
+			p.Printf("%s is a duplicate of %s\n", fileName(dd.File), fileName(dd.OtherFile))
 		}
-		cmd.Println()
+		p.Println()
 	}
 
 	if len(errs.MissingImports) > 0 {
-		cmd.Println(header("Missing Imports"))
+		p.Println(header("Missing Imports"))
 		for _, mi := range errs.MissingImports {
-			cmd.Printf("%s: %s\n", fileName(mi.ImportingFile), errorMsg(mi.Desc))
+			p.Printf("%s: %s\n", fileName(mi.ImportingFile), errorMsg(mi.Desc))
 		}
-		cmd.Println()
+		p.Println()
 	}
 
 	if len(errs.LoadFailures) > 0 {
-		cmd.Println(header("Load failures"))
+		p.Println(header("Load failures"))
 		for _, lf := range errs.LoadFailures {
-			cmd.Printf("%s: %s\n", fileName(lf.File), errorMsg(lf.Err.Error()))
+			p.Printf("%s: %s\n", fileName(lf.File), errorMsg(lf.Err.Error()))
 		}
-		cmd.Println()
+		p.Println()
 	}
 
 	if len(errs.Disabled) > 0 {
-		cmd.Println(header("Disabled policies"))
+		p.Println(header("Disabled policies"))
 		for _, d := range errs.Disabled {
-			cmd.Println(fileName(d))
+			p.Println(fileName(d))
 		}
-		cmd.Println()
+		p.Println()
 	}
 
 	return ErrFailed
 }
 
-func displayCompileErrors(cmd *cobra.Command, errs compile.ErrorList) error {
-	switch strings.ToLower(format) {
+func displayCompileErrors(p *printer, errs compile.ErrorList) error {
+	switch p.format {
 	case formatJSON:
-		if err := outputJSON(cmd, map[string]compile.ErrorList{"compileErrors": errs}); err != nil {
+		if err := outputJSON(p, map[string]compile.ErrorList{"compileErrors": errs}); err != nil {
 			return err
 		}
 
@@ -178,18 +210,18 @@ func displayCompileErrors(cmd *cobra.Command, errs compile.ErrorList) error {
 		color.NoColor = true
 	}
 
-	cmd.Println(header("Compilation errors"))
+	p.Println(header("Compilation errors"))
 	for _, err := range errs {
-		cmd.Printf("%s: %s (%s)\n", fileName(err.File), errorMsg(err.Description), err.Err.Error())
+		p.Printf("%s: %s (%s)\n", fileName(err.File), errorMsg(err.Description), err.Err.Error())
 	}
 
 	return ErrFailed
 }
 
-func displayVerificationResult(cmd *cobra.Command, result *verify.Result) error {
-	switch strings.ToLower(format) {
+func displayVerificationResult(p *printer, result *verify.Result) error {
+	switch p.format {
 	case formatJSON:
-		if err := outputJSON(cmd, result); err != nil {
+		if err := outputJSON(p, result); err != nil {
 			return err
 		}
 
@@ -202,32 +234,32 @@ func displayVerificationResult(cmd *cobra.Command, result *verify.Result) error 
 		color.NoColor = true
 	}
 
-	cmd.Println(header("Test results"))
+	p.Println(header("Test results"))
 	for _, sr := range result.Results {
-		cmd.Printf("= %s %s ", testName(sr.Suite), fileName("(", sr.File, ")"))
+		p.Printf("= %s %s ", testName(sr.Suite), fileName("(", sr.File, ")"))
 		if sr.Skipped {
-			cmd.Println(skippedTest("[SKIPPED]"))
+			p.Println(skippedTest("[SKIPPED]"))
 			continue
 		}
 
-		cmd.Println()
+		p.Println()
 		for _, tr := range sr.Tests {
-			cmd.Printf("== %s ", testName(tr.Name.String()))
+			p.Printf("== %s ", testName(tr.Name.String()))
 			if tr.Skipped {
-				cmd.Println(skippedTest("[SKIPPED]"))
+				p.Println(skippedTest("[SKIPPED]"))
 				continue
 			}
 
 			if tr.Failed {
-				cmd.Println(failedTest("[FAILED]"))
-				cmd.Printf("\tError: %s\n", tr.Error)
-				if verbose {
-					cmd.Printf("\tTrace: \n%s\n", tr.EngineTrace)
+				p.Println(failedTest("[FAILED]"))
+				p.Printf("\tError: %s\n", tr.Error)
+				if p.verbose {
+					p.Printf("\tTrace: \n%s\n", tr.EngineTrace)
 				}
 				continue
 			}
 
-			cmd.Println(successfulTest("[OK]"))
+			p.Println(successfulTest("[OK]"))
 		}
 	}
 
@@ -238,8 +270,8 @@ func displayVerificationResult(cmd *cobra.Command, result *verify.Result) error 
 	return nil
 }
 
-func outputJSON(cmd *cobra.Command, val interface{}) error {
-	enc := json.NewEncoder(cmd.OutOrStdout())
+func outputJSON(p *printer, val interface{}) error {
+	enc := json.NewEncoder(p.OutOrStdout())
 	enc.SetIndent("", "  ")
 	return enc.Encode(val)
 }

--- a/cmd/cerbos/main.go
+++ b/cmd/cerbos/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alecthomas/kong"
 
 	"github.com/cerbos/cerbos/cmd/cerbos/compile"
+	"github.com/cerbos/cerbos/cmd/cerbos/run"
 	"github.com/cerbos/cerbos/cmd/cerbos/server"
 	"github.com/cerbos/cerbos/internal/util"
 )
@@ -15,6 +16,7 @@ func main() {
 	var cli struct {
 		Server  server.Cmd  `cmd:"" help:"Start Cerbos server (PDP)"`
 		Compile compile.Cmd `cmd:"" help:"Compile and test policies"`
+		Run     run.Cmd     `cmd:"" help:"Run a command in the context of a Cerbos PDP"`
 		Version kong.VersionFlag
 	}
 

--- a/cmd/cerbos/main.go
+++ b/cmd/cerbos/main.go
@@ -4,9 +4,7 @@
 package main
 
 import (
-	"os"
-
-	"github.com/spf13/cobra"
+	"github.com/alecthomas/kong"
 
 	"github.com/cerbos/cerbos/cmd/cerbos/compile"
 	"github.com/cerbos/cerbos/cmd/cerbos/server"
@@ -14,17 +12,18 @@ import (
 )
 
 func main() {
-	cmd := &cobra.Command{
-		Use:           util.AppName,
-		Short:         "Painless access controls for cloud-native applications",
-		Version:       util.AppVersion(),
-		SilenceUsage:  true,
-		SilenceErrors: true,
+	var cli struct {
+		Server  server.Cmd  `cmd:"" help:"Start Cerbos server (PDP)"`
+		Compile compile.Cmd `cmd:"" help:"Compile and test policies"`
+		Version kong.VersionFlag
 	}
 
-	cmd.AddCommand(server.NewCommand(), compile.NewCommand())
-	if err := cmd.Execute(); err != nil {
-		cmd.PrintErrf("ERROR: %v\n", err)
-		os.Exit(1)
-	}
+	ctx := kong.Parse(&cli,
+		kong.Name(util.AppName),
+		kong.Description("Painless access controls for cloud-native applications"),
+		kong.UsageOnError(),
+		kong.Vars{"version": util.AppVersion()},
+	)
+
+	ctx.FatalIfErrorf(ctx.Run())
 }

--- a/cmd/cerbos/run/run.go
+++ b/cmd/cerbos/run/run.go
@@ -5,73 +5,314 @@ package run
 
 import (
 	"context"
+	"crypto/tls"
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
 	"syscall"
+	"time"
+
+	"github.com/alecthomas/kong"
+	"github.com/go-cmd/cmd"
+	"go.uber.org/automaxprocs/maxprocs"
+	"go.uber.org/zap"
+	"helm.sh/helm/v3/pkg/strvals"
 
 	"github.com/cerbos/cerbos/internal/config"
 	"github.com/cerbos/cerbos/internal/observability/logging"
-	"github.com/cerbos/cerbos/internal/observability/tracing"
 	"github.com/cerbos/cerbos/internal/server"
-	"github.com/spf13/cobra"
-	"go.uber.org/zap"
-	"helm.sh/helm/v3/pkg/strvals"
 )
 
-type runArgs struct {
-	configFile      string
-	logLevel        string
-	configOverrides []string
-	runCmd          []string
+const (
+	help = `
+Launches a command within the context of a Cerbos PDP. The policies are loaded by default from a directory named "policies" in the current working directory. The launched application can access Cerbos endpoints using the values from CERBOS_HTTP or CERBOS_GRPC environment variables.
+
+If a file named "cerbos.yaml" exists in the current working directory, it will be used as the configuration file for the PDP. You can override the config file and/or other configuration options using the flags described below. 
+
+Examples:
+
+# Launch Go tests within a Cerbos context
+
+cerbos run -- go test ./...
+
+# Start Cerbos with a custom configuration file and run Python tests within the context
+
+cerbos run --config=myconf.yaml -- python -m unittest
+
+# Silence Cerbos log output
+
+cerbos run --log-level=error -- curl -I http://127.0.0.1:3592/_cerbos/health
+	`
+
+	confDefault = `
+server:
+  httpListenAddr: "127.0.0.1:3592"
+  grpcListenAddr: "127.0.0.1:3593"
+storage:
+  driver: "disk"
+  disk:
+    directory: %q
+    watchForChanges: true
+`
+
+	requestTimeout = 100 * time.Millisecond
+	retryInterval  = 141 * time.Millisecond
+)
+
+type Cmd struct {
+	LogLevel string         `help:"Log level (${enum})" default:"info" enum:"debug,info,warn,error"`
+	Config   string         `help:"Path to config file" type:"existingfile" placeholder:"./cerbos.yaml"`
+	Set      []string       `help:"Config overrides" placeholder:"server.adminAPI.enabled=true"`
+	Command  []string       `help:"Command to run" arg:"" passthrough:"" required:""`
+	Timeout  time.Duration  `help:"Cerbos startup timeout" default:"30s"`
+	wg       sync.WaitGroup `kong:"-"`
 }
 
-var args = runArgs{}
-
-func NewCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:          "run",
-		Short:        "Run a program within the context of Cerbos",
-		RunE:         doRun,
-		SilenceUsage: true,
-	}
-
-	cmd.Flags().StringVar(&args.configFile, "config", "", "Path to config file")
-	cmd.Flags().StringSliceVar(&args.configOverrides, "set", nil, "Config overrides")
-	cmd.Flags().StringVar(&args.logLevel, "log-level", "INFO", "Log level")
-
-	_ = cmd.MarkFlagFilename("config")
-
-	return cmd
-}
-
-func doRun(_ *cobra.Command, _ []string) error {
-	logging.InitLogging(args.logLevel)
+func (c *Cmd) Run(k *kong.Kong) error {
+	logging.InitLogging(c.LogLevel)
 	defer zap.L().Sync() //nolint:errcheck
 
-	log := zap.S().Named("server")
+	log := zap.S().Named("run")
 
-	ctx, stopFunc := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	undo, _ := maxprocs.Set(maxprocs.Logger(log.Infof))
+	defer undo()
+
+	notifyCtx, stopFunc := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stopFunc()
 
+	if err := c.loadConfig(); err != nil {
+		log.Errorw("Failed to load configuration", "error", err)
+		return err
+	}
+
+	pdp, err := c.startPDP(notifyCtx)
+	if err != nil {
+		log.Errorw("Failed to start the PDP", "error", err)
+		return err
+	}
+
+	command := c.prepCommand(pdp, k.Stdout, k.Stderr)
+	statusChan := command.Start()
+
+	cleanup := func() {
+		if cerr := command.Stop(); cerr != nil && !errors.Is(cerr, cmd.ErrNotStarted) {
+			log.Errorw("Error stopping command", "error", cerr)
+		}
+
+		pdp.stopFn()
+		c.wg.Wait()
+	}
+
+	select {
+	case err := <-pdp.errors:
+		log.Errorw("Cerbos PDP error", "error", err)
+		cleanup()
+
+		return err
+	case status := <-statusChan:
+		if status.Error != nil {
+			log.Errorw("Command execution error", "error", err)
+			cleanup()
+
+			return err
+		}
+
+		if status.Complete {
+			log.Infof("Command finished with status %d", status.Exit)
+		}
+
+		cleanup()
+
+		if status.Exit != 0 {
+			stopFunc()
+			undo()
+			k.Exit(status.Exit)
+		}
+	case <-notifyCtx.Done():
+		log.Info("Terminated by signal")
+		cleanup()
+	}
+
+	return nil
+}
+
+func (c *Cmd) loadConfig() error {
 	// load any config overrides
 	confOverrides := map[string]interface{}{}
-	for _, override := range args.configOverrides {
+	for _, override := range c.Set {
 		if err := strvals.ParseInto(override, confOverrides); err != nil {
 			return fmt.Errorf("failed to parse config override [%s]: %w", override, err)
 		}
 	}
 
 	// load configuration
-	if err := config.Load(args.configFile, confOverrides); err != nil {
-		log.Errorw("Failed to load configuration", "error", err)
+	//nolint:nestif
+	if c.Config != "" {
+		if err := config.Load(c.Config, confOverrides); err != nil {
+			return fmt.Errorf("failed to load configuration from %s: %w", c.Config, err)
+		}
+	} else if fd, err := os.Stat("cerbos.yaml"); err == nil && !fd.IsDir() {
+		if err := config.Load("cerbos.yaml", confOverrides); err != nil {
+			return fmt.Errorf("failed to load configuration from cerbos.yaml: %w", err)
+		}
+	} else {
+		wd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to determine current working directory: %w", err)
+		}
+
+		confYAML := fmt.Sprintf(confDefault, filepath.Join(wd, "policies"))
+		if err := config.LoadReader(strings.NewReader(confYAML), confOverrides); err != nil {
+			return fmt.Errorf("failed to load default Cerbos configuration: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Cmd) startPDP(ctx context.Context) (*pdpInstance, error) {
+	var conf server.Conf
+	if err := config.GetSection(&conf); err != nil {
+		return nil, fmt.Errorf("failed to obtain server config; %w", err)
+	}
+
+	protocol := "http"
+	if conf.TLS != nil && conf.TLS.Cert != "" && conf.TLS.Key != "" {
+		protocol = "https"
+	}
+
+	instance := &pdpInstance{
+		httpAddr: fmt.Sprintf("%s://%s", protocol, conf.HTTPListenAddr),
+		grpcAddr: conf.GRPCListenAddr,
+		errors:   make(chan error, 1),
+	}
+
+	serverCtx, stopFn := context.WithCancel(context.Background())
+	instance.stopFn = stopFn
+
+	c.goroutine(func() {
+		instance.errors <- server.Start(serverCtx, false)
+		close(instance.errors)
+	})
+
+	waitCtx, cancelFn := context.WithTimeout(ctx, c.Timeout)
+	defer cancelFn()
+	if err := instance.waitForReady(waitCtx); err != nil {
+		return nil, fmt.Errorf("error starting Cerbos PDP: %w", err)
+	}
+
+	return instance, nil
+}
+
+func (c *Cmd) prepCommand(pdp *pdpInstance, stdout, stderr io.Writer) *cmd.Cmd {
+	httpAddr := fmt.Sprintf("CERBOS_HTTP=%s", pdp.httpAddr)
+	grpcAddr := fmt.Sprintf("CERBOS_GRPC=%s", pdp.grpcAddr)
+
+	env := os.Environ()
+	env = append([]string{httpAddr, grpcAddr}, env...)
+
+	opt := cmd.Options{Streaming: true}
+	command := cmd.NewCmdOptions(opt, c.Command[0], c.Command[1:]...)
+	command.Env = env
+
+	c.goroutine(func() {
+		for line := range command.Stdout {
+			fmt.Fprintln(stdout, line)
+		}
+	})
+
+	c.goroutine(func() {
+		for line := range command.Stderr {
+			fmt.Fprintln(stderr, line)
+		}
+	})
+
+	return command
+}
+
+func (c *Cmd) goroutine(fn func()) {
+	c.wg.Add(1)
+	go func() {
+		fn()
+		c.wg.Done()
+	}()
+}
+
+func (c *Cmd) Help() string {
+	return help
+}
+
+type pdpInstance struct {
+	errors   chan error
+	stopFn   context.CancelFunc
+	httpAddr string
+	grpcAddr string
+}
+
+func (pdp *pdpInstance) waitForReady(ctx context.Context) error {
+	client := pdp.client()
+	healthURL := fmt.Sprintf("%s/_cerbos/health", pdp.httpAddr)
+
+	lastErr := pdp.checkHealth(client, healthURL)
+	if lastErr == nil {
+		return nil
+	}
+
+	ticker := time.NewTicker(retryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return lastErr
+		case err := <-pdp.errors:
+			return err
+		case <-ticker.C:
+			lastErr = pdp.checkHealth(client, healthURL)
+			if lastErr == nil {
+				return nil
+			}
+		}
+	}
+}
+
+func (pdp *pdpInstance) client() *http.Client {
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()      //nolint:forcetypeassert
+	customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+
+	return &http.Client{Transport: customTransport}
+}
+
+func (pdp *pdpInstance) checkHealth(client *http.Client, healthURL string) error {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancelFunc()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, http.NoBody)
+	if err != nil {
 		return err
 	}
 
-	// initialize tracing
-	if err := tracing.Init(ctx); err != nil {
+	resp, err := client.Do(req)
+	if err != nil {
 		return err
 	}
 
-	return server.Start(ctx, false)
+	defer func() {
+		if resp.Body != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("received status %q", resp.Status)
+	}
+
+	return nil
 }

--- a/cmd/cerbos/run/run.go
+++ b/cmd/cerbos/run/run.go
@@ -1,0 +1,77 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/cerbos/cerbos/internal/config"
+	"github.com/cerbos/cerbos/internal/observability/logging"
+	"github.com/cerbos/cerbos/internal/observability/tracing"
+	"github.com/cerbos/cerbos/internal/server"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"helm.sh/helm/v3/pkg/strvals"
+)
+
+type runArgs struct {
+	configFile      string
+	logLevel        string
+	configOverrides []string
+	runCmd          []string
+}
+
+var args = runArgs{}
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "run",
+		Short:        "Run a program within the context of Cerbos",
+		RunE:         doRun,
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().StringVar(&args.configFile, "config", "", "Path to config file")
+	cmd.Flags().StringSliceVar(&args.configOverrides, "set", nil, "Config overrides")
+	cmd.Flags().StringVar(&args.logLevel, "log-level", "INFO", "Log level")
+
+	_ = cmd.MarkFlagFilename("config")
+
+	return cmd
+}
+
+func doRun(_ *cobra.Command, _ []string) error {
+	logging.InitLogging(args.logLevel)
+	defer zap.L().Sync() //nolint:errcheck
+
+	log := zap.S().Named("server")
+
+	ctx, stopFunc := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopFunc()
+
+	// load any config overrides
+	confOverrides := map[string]interface{}{}
+	for _, override := range args.configOverrides {
+		if err := strvals.ParseInto(override, confOverrides); err != nil {
+			return fmt.Errorf("failed to parse config override [%s]: %w", override, err)
+		}
+	}
+
+	// load configuration
+	if err := config.Load(args.configFile, confOverrides); err != nil {
+		log.Errorw("Failed to load configuration", "error", err)
+		return err
+	}
+
+	// initialize tracing
+	if err := tracing.Init(ctx); err != nil {
+		return err
+	}
+
+	return server.Start(ctx, false)
+}

--- a/cmd/cerbos/run/run.go
+++ b/cmd/cerbos/run/run.go
@@ -167,7 +167,14 @@ func (c *Cmd) loadConfig() error {
 			return fmt.Errorf("failed to determine current working directory: %w", err)
 		}
 
-		confYAML := fmt.Sprintf(confDefault, filepath.Join(wd, "policies"))
+		policyDir := filepath.Join(wd, "policies")
+		if _, err := os.Stat(policyDir); err != nil && errors.Is(err, os.ErrNotExist) {
+			if err := os.Mkdir(policyDir, 0o744); err != nil { //nolint:gomnd
+				return fmt.Errorf("unable to create policies directory: %w", err)
+			}
+		}
+
+		confYAML := fmt.Sprintf(confDefault, policyDir)
 		if err := config.LoadReader(strings.NewReader(confYAML), confOverrides); err != nil {
 			return fmt.Errorf("failed to load default Cerbos configuration: %w", err)
 		}

--- a/cmd/cerbos/server/server.go
+++ b/cmd/cerbos/server/server.go
@@ -33,10 +33,10 @@ cerbos server --config=/path/to/config.yaml
 cerbos server --config=/path/to/config.yaml --set=server.adminAPI.enabled=true --set=storage.driver=sqlite3 --set=storage.sqlite3.dsn=':memory:'`
 
 type Cmd struct {
-	Config          string   `help:"Path to config file" type:"existingfile" required:"" placeholder:"./config.yaml"`
-	Set             []string `help:"Config overrides" placeholder:"server.adminAPI.enabled=true"`
 	DebugListenAddr string   `help:"Address to start the gops listener" placeholder:":6666"`
 	LogLevel        string   `help:"Log level (${enum})" default:"info" enum:"debug,info,warn,error"`
+	Config          string   `help:"Path to config file" type:"existingfile" required:"" placeholder:"./config.yaml"`
+	Set             []string `help:"Config overrides" placeholder:"server.adminAPI.enabled=true"`
 	ZPagesEnabled   bool     `help:"Enable zpages" hidden:""`
 }
 

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -54,7 +54,7 @@ See xref:cli:cerbos.adoc#compile[Compile command] for more information.
 
 == Quick run
 
-Create a directory named `policies`, optionally add some policies to that directory, and try Cerbos out using an application of your choice:
+Add some policies to a directory named `policies` and try Cerbos out using an application of your choice:
 
 
 .Using the binary

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -21,6 +21,8 @@ docker run -i -t -p 3592:3592 \
     server --config=/config/conf.yaml --set=server.httpListenAddr=:3592
 ----
 
+See xref:cli:cerbos.adoc#server[Server command] for more information.
+
 == Compiling and testing policies
 
 After authoring your policies you should run the compiler over the files to make sure they are valid. If you have policy tests they can be executed at this time as well.
@@ -47,3 +49,18 @@ docker run -i -t \
     {app-docker-img} \
     compile --tests=/tests /policies
 ----
+
+See xref:cli:cerbos.adoc#compile[Compile command] for more information.
+
+== Quick run
+
+Create a directory named `policies`, optionally add some policies to that directory, and try Cerbos out using an application of your choice:
+
+
+.Using the binary
+[source,sh,subs="attributes"]
+----
+./{app-name} run -- curl -I http://127.0.0.1:3592/_cerbos/health
+----
+
+See xref:cli:cerbos.adoc#run[Run command] for more information.

--- a/docs/modules/cli/pages/cerbos.adoc
+++ b/docs/modules/cli/pages/cerbos.adoc
@@ -5,10 +5,11 @@ include::ROOT:partial$attributes.adoc[]
 
 See xref:ROOT:installation/binary.adoc[] or xref:ROOT:installation/container.adoc[] for instructions on how to install the `cerbos` binary.
 
-This binary provides two sub commands:
+This binary provides the following sub commands:
 
 `server`:: Start the PDP server
 `compile`:: Validate, compile and run tests on a policy repo
+`run`:: Start a PDP and run a command within its context
 
 .Example: Running `compile` using the binary
 [source,sh,subs="attributes"]
@@ -22,47 +23,127 @@ This binary provides two sub commands:
 docker run -i -t {app-docker-img} compile --help 
 ----
 
+[#server]
 == `server` Command
 
 Starts the Cerbos PDP. 
 
-[source,sh]
+[source]
 ----
-Usage:
-  cerbos server [flags]
+Usage: cerbos server --config=./config.yaml
+
+Start Cerbos server (PDP)
 
 Examples:
 
-# Start the server 
+# Start the server
+
 cerbos server --config=/path/to/config.yaml
 
 # Start the server with the Admin API enabled and the 'sqlite' storage driver
+
 cerbos server --config=/path/to/config.yaml --set=server.adminAPI.enabled=true --set=storage.driver=sqlite3 --set=storage.sqlite3.dsn=':memory:'
 
 Flags:
-      --config string              Path to config file
-      --debug-listen-addr string   Address to start the gops listener
-  -h, --help                       help for server
-      --log-level string           Log level (default "INFO")
-      --set strings                Config overrides
+  -h, --help                                    Show context-sensitive help.
+      --version
+
+      --debug-listen-addr=:6666                 Address to start the gops listener
+      --log-level="info"                        Log level (debug,info,warn,error)
+      --config=./config.yaml                    Path to config file
+      --set=server.adminAPI.enabled=true,...    Config overrides
 ----
 
-
+[#compile]
 == `compile` Command
 
 Runs the Cerbos compiler to validate policy definitions and run any test suites. See xref:policies:compile.adoc[Policy compilation] for more information.
 
-[source,sh]
+[source]
 ----
-Usage:
-  cerbos compile DIR [flags]
+Usage: cerbos compile <dir>
+
+Compile and test policies
+
+Examples:
+
+# Compile and run tests found in /path/to/policy/repo
+
+cerbos compile /path/to/policy/repo
+
+# Compile and run tests that contain "Delete" in their name
+
+cerbos compile --run=Delete /path/to/policy/repo
+
+# Compile but skip tests
+
+cerbos compile --skip-tests /path/to/policy/repo
+
+Arguments:
+  <dir>    Policy directory
 
 Flags:
-  -f, --format string    Output format (valid values: json,plain)
-  -h, --help             help for compile
-      --ignore-schemas   Ignore schemas during compilation
-      --run string       Run only tests that match this regex
-      --skip-tests       Skip tests
-      --tests string     Path to the directory containing tests
-      --verbose          Verbose output on test failure
+  -h, --help               Show context-sensitive help.
+      --version
+
+  -f, --format="pretty"    Output format (pretty,plain,json)
+      --tests=STRING       Path to the directory containing tests. Defaults to policy directory.
+      --run=STRING         Run only tests that match this regex
+      --skip-tests         Skip tests
+      --ignore-schemas     Ignore schemas during compilation
+      --verbose            Verbose output on test failure
+----
+
+[#run]
+== `run` Command
+
+This provides a quick way to try out Cerbos. It launches a Cerbos PDP instance and then invokes a command of your choice that can then use the PDP to make access decisions. A good use case for this command is as an integration test runner. If you have written some tests that make use of Cerbos, you can run them within the context of an actual PDP instance as follows:
+
+[source,sh]
+----
+cerbos run -- python -m unittest
+----
+
+By default, the policies are loaded from the `policies` directory in the current working directory and HTTP and gRPC endpoints will be exposed on `127.0.0.1:3592` and `127.0.0.1:3593` respectively. Your application can obtain the actual endpoint addresses by inspecting the `CERBOS_HTTP` or `CERBOS_GRPC` environment variables. 
+
+If a file named `cerbos.yaml` exists in the current working directory, that file will be used as the Cerbos xref:configuration:index.adoc[configuration file]. You can use a different config file or override specific config values using the same flags as the `server` command above.
+
+
+[source]
+----
+Usage: cerbos run <command> ...
+
+Run a command in the context of a Cerbos PDP
+
+Launches a command within the context of a Cerbos PDP. The policies are loaded by default from a directory named "policies" in the current working directory. The launched application can access Cerbos endpoints using the
+values from CERBOS_HTTP or CERBOS_GRPC environment variables.
+
+If a file named "cerbos.yaml" exists in the current working directory, it will be used as the configuration file for the PDP. You can override the config file and/or other configuration options using the flags described
+below.
+
+Examples:
+
+# Launch Go tests within a Cerbos context
+
+cerbos run -- go test ./...
+
+# Start Cerbos with a custom configuration file and run Python tests within the context
+
+cerbos run --config=myconf.yaml -- python -m unittest
+
+# Silence Cerbos log output
+
+cerbos run --log-level=error -- curl -I http://127.0.0.1:3592/_cerbos/health
+
+Arguments:
+  <command> ...    Command to run
+
+Flags:
+  -h, --help                                    Show context-sensitive help.
+      --version
+
+      --log-level="info"                        Log level (debug,info,warn,error)
+      --config=./cerbos.yaml                    Path to config file
+      --set=server.adminAPI.enabled=true,...    Config overrides
+      --timeout=30s                             Cerbos startup timeout
 ----

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/alecthomas/chroma v0.10.0
+	github.com/alecthomas/kong v0.4.0
 	github.com/aws/aws-sdk-go v1.42.23
 	github.com/bluele/gcache v0.0.2
 	github.com/cespare/xxhash v1.1.0
@@ -90,7 +91,6 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210512092938-c05353c2d58c // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
-	github.com/alecthomas/kong v0.4.0 // indirect
 	github.com/antlr/antlr4 v0.0.0-20200503195918-621b933c7a7f // indirect
 	github.com/aws/aws-sdk-go-v2 v1.9.0 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210512092938-c05353c2d58c // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/alecthomas/kong v0.4.0 // indirect
 	github.com/antlr/antlr4 v0.0.0-20200503195918-621b933c7a7f // indirect
 	github.com/aws/aws-sdk-go-v2 v1.9.0 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,9 @@ github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
+github.com/alecthomas/kong v0.4.0 h1:uj5Xe5RaoSRu2sUIy6XZk5QO9NaLU7/+2HXq7GRas/4=
+github.com/alecthomas/kong v0.4.0/go.mod h1:uzxf/HUh0tj43x1AyJROl3JT7SgsZ5m+icOv1csRhc0=
+github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,7 @@ github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbf
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/alecthomas/kong v0.4.0 h1:uj5Xe5RaoSRu2sUIy6XZk5QO9NaLU7/+2HXq7GRas/4=
 github.com/alecthomas/kong v0.4.0/go.mod h1:uzxf/HUh0tj43x1AyJROl3JT7SgsZ5m+icOv1csRhc0=
+github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142 h1:8Uy0oSf5co/NZXje7U1z8Mpep++QJOldL2hs/sBQf48=
 github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,8 +47,8 @@ func Load(confFile string, overrides map[string]interface{}) error {
 	return doLoad(config.File(confFile), config.Static(overrides))
 }
 
-func LoadReader(reader io.Reader) error {
-	return doLoad(config.Source(reader))
+func LoadReader(reader io.Reader, overrides map[string]interface{}) error {
+	return doLoad(config.Source(reader), config.Static(overrides))
 }
 
 func LoadMap(m map[string]interface{}) error {


### PR DESCRIPTION
Adds a new command called `cerbos run` which should reduce the friction of starting a separate Cerbos instance for testing and development. 

```sh
cerbos run -- curl -k -I http://127.0.0.1:3592/_cerbos/health
```

By default, it looks for policies in the `./policies` directory and launches the user provided command while setting `CERBOS_HTTP` and `CERBOS_GRPC` environment variables so that the application can figure out how to access Cerbos. When the command exits, the Cerbos instance is shutdown automatically and the user does not need to worry about managing another process.

This PR necessitated replacing `cobra` with [`kong`](https://github.com/alecthomas/kong) because `cobra` does not have support for unknown argument parsing (see https://github.com/spf13/cobra/issues/739). Overall I think that `kong` is a better choice anyway because it is simpler and much lighter in terms of dependencies while still providing a lot of features. 