### PR TITLE
enhancement: Add scope to cerbosctl output

### DIFF
--- a/cmd/cerbosctl/cerbosctl_test.go
+++ b/cmd/cerbosctl/cerbosctl_test.go
@@ -1,8 +1,7 @@
 // Copyright 2021-2022 Zenauth Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build tests
-// +build tests
+//go:build !race
 
 package main_test
 
@@ -256,8 +255,9 @@ func noOfPoliciesInCmdOutput(t *testing.T, cmdOut string) int {
 func loadPolicies(t *testing.T, ac client.AdminClient) {
 	t.Helper()
 
-	ps := client.NewPolicySet()
 	for i := 0; i < policiesPerType; i++ {
+		ps := client.NewPolicySet()
+
 		ps.AddPolicies(test.GenPrincipalPolicy(test.Suffix(strconv.Itoa(i))))
 		ps.AddPolicies(test.GenResourcePolicy(test.Suffix(strconv.Itoa(i))))
 		ps.AddPolicies(test.GenDerivedRoles(test.Suffix(strconv.Itoa(i))))
@@ -266,9 +266,9 @@ func loadPolicies(t *testing.T, ac client.AdminClient) {
 		ps.AddPolicies(withScope(test.GenResourcePolicy(test.Suffix(strconv.Itoa(i))), "acme.hr.uk"))
 		ps.AddPolicies(withScope(test.GenPrincipalPolicy(test.Suffix(strconv.Itoa(i))), "acme"))
 		ps.AddPolicies(withScope(test.GenPrincipalPolicy(test.Suffix(strconv.Itoa(i))), "acme.hr"))
-	}
 
-	require.NoError(t, ac.AddOrUpdatePolicy(context.Background(), ps))
+		require.NoError(t, ac.AddOrUpdatePolicy(context.Background(), ps))
+	}
 }
 
 func withTestAdminClient(fn internal.AdminCommand) func(cmd *cobra.Command, args []string) error {

--- a/cmd/cerbosctl/get/internal/policy/filter.go
+++ b/cmd/cerbosctl/get/internal/policy/filter.go
@@ -9,32 +9,47 @@ import (
 	"github.com/cerbos/cerbos/internal/policy"
 )
 
-func stringInSlice(a string, s []string) bool {
-	for _, b := range s {
-		if strings.EqualFold(b, a) {
-			return true
-		}
-	}
-	return false
+type filterDef struct {
+	names    map[string]struct{}
+	versions map[string]struct{}
+	kind     policy.Kind
 }
 
-func filter(policies []policy.Wrapper, name, version []string, kind policy.Kind) []policy.Wrapper {
-	filtered := make([]policy.Wrapper, 0, len(policies))
-	for _, p := range policies {
-		if len(name) != 0 && !stringInSlice(p.Name, name) {
-			continue
+func newFilterDef(kind policy.Kind, names, versions []string) *filterDef {
+	f := &filterDef{kind: kind}
+	if len(names) > 0 {
+		f.names = make(map[string]struct{}, len(names))
+		for _, n := range names {
+			f.names[strings.ToLower(n)] = struct{}{}
 		}
-		if len(version) != 0 && !stringInSlice(p.Version, version) {
-			continue
-		}
-
-		policyKind := policy.GetKind(p.Policy)
-		if policyKind != kind {
-			continue
-		}
-
-		filtered = append(filtered, p)
 	}
 
-	return filtered
+	if len(versions) > 0 {
+		f.versions = make(map[string]struct{}, len(versions))
+		for _, v := range versions {
+			f.versions[strings.ToLower(v)] = struct{}{}
+		}
+	}
+
+	return f
+}
+
+func (fd *filterDef) filter(p policy.Wrapper) bool {
+	if p.Kind != fd.kind {
+		return false
+	}
+
+	if len(fd.names) > 0 {
+		if _, ok := fd.names[strings.ToLower(p.Name)]; !ok {
+			return false
+		}
+	}
+
+	if len(fd.versions) > 0 {
+		if _, ok := fd.versions[strings.ToLower(p.Version)]; !ok {
+			return false
+		}
+	}
+
+	return true
 }

--- a/cmd/cerbosctl/get/internal/policy/filter_test.go
+++ b/cmd/cerbosctl/get/internal/policy/filter_test.go
@@ -99,6 +99,17 @@ func TestFilter(t *testing.T) {
 	})
 }
 
+func filter(policies []policy.Wrapper, names, versions []string, kind policy.Kind) []policy.Wrapper {
+	fd := newFilterDef(kind, names, versions)
+	filtered := make([]policy.Wrapper, 0, len(policies))
+	for _, p := range policies {
+		if fd.filter(p) {
+			filtered = append(filtered, p)
+		}
+	}
+	return filtered
+}
+
 func mkDerivedRolesForFilter(t *testing.T, noOfPolicies int) []policy.Wrapper {
 	t.Helper()
 

--- a/cmd/cerbosctl/get/internal/policy/print.go
+++ b/cmd/cerbosctl/get/internal/policy/print.go
@@ -71,5 +71,5 @@ func getHeaders(kind policy.Kind) []string {
 	if kind == policy.DerivedRolesKind {
 		return []string{"POLICY ID", "NAME"}
 	}
-	return []string{"POLICY ID", "NAME", "VERSION"}
+	return []string{"POLICY ID", "NAME", "VERSION", "SCOPE"}
 }

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -35,6 +35,10 @@ func Compile(unit *policy.CompilationUnit, schemaMgr schema.Manager) (rps *runti
 	uc := newUnitCtx(unit)
 	mc := uc.moduleCtx(unit.ModID)
 
+	if mc == nil || mc.def == nil {
+		return nil, fmt.Errorf("missing policy definition %d: %w", unit.ModID, errInvalidCompilationUnit)
+	}
+
 	switch pt := mc.def.PolicyType.(type) {
 	case *policyv1.Policy_ResourcePolicy:
 		rps = compileResourcePolicySet(mc, schemaMgr)

--- a/internal/compile/errors.go
+++ b/internal/compile/errors.go
@@ -14,14 +14,15 @@ import (
 )
 
 var (
-	errAmbiguousDerivedRole = errors.New("ambiguous derived role")
-	errImportNotFound       = errors.New("import not found")
-	errInvalidResourceRule  = errors.New("invalid resource rule")
-	errInvalidSchema        = errors.New("invalid schema")
-	errMissingDefinition    = errors.New("missing policy definition")
-	errScriptsUnsupported   = errors.New("scripts in conditions are no longer supported")
-	errUnexpectedErr        = errors.New("unexpected error")
-	errUnknownDerivedRole   = errors.New("unknown derived role")
+	errAmbiguousDerivedRole   = errors.New("ambiguous derived role")
+	errImportNotFound         = errors.New("import not found")
+	errInvalidCompilationUnit = errors.New("invalid compilation unit")
+	errInvalidResourceRule    = errors.New("invalid resource rule")
+	errInvalidSchema          = errors.New("invalid schema")
+        errMissingDefinition      = errors.New("missing policy definition")
+	errScriptsUnsupported     = errors.New("scripts in conditions are no longer supported")
+	errUnexpectedErr          = errors.New("unexpected error")
+	errUnknownDerivedRole     = errors.New("unknown derived role")
 )
 
 type ErrorList []*Error

--- a/internal/compile/errors.go
+++ b/internal/compile/errors.go
@@ -19,7 +19,7 @@ var (
 	errInvalidCompilationUnit = errors.New("invalid compilation unit")
 	errInvalidResourceRule    = errors.New("invalid resource rule")
 	errInvalidSchema          = errors.New("invalid schema")
-        errMissingDefinition      = errors.New("missing policy definition")
+	errMissingDefinition      = errors.New("missing policy definition")
 	errScriptsUnsupported     = errors.New("scripts in conditions are no longer supported")
 	errUnexpectedErr          = errors.New("unexpected error")
 	errUnknownDerivedRole     = errors.New("unknown derived role")

--- a/internal/storage/db/sqlserver/sqlserver.go
+++ b/internal/storage/db/sqlserver/sqlserver.go
@@ -97,7 +97,7 @@ END
 		sql.Named("definition", definition),
 		sql.Named("description", p.Description),
 		sql.Named("disabled", p.Disabled),
-		sql.Named("kind", p.Kind),
+		sql.Named("kind", p.Kind.String()),
 		sql.Named("name", p.Name),
 		sql.Named("version", p.Version),
 		sql.Named("scope", p.Scope),

--- a/internal/storage/index/builder.go
+++ b/internal/storage/index/builder.go
@@ -186,7 +186,7 @@ func (idx *indexBuilder) addPolicy(file string, p policy.Wrapper) {
 	delete(idx.missing, p.ID)
 	delete(idx.missingScopes, p.ID)
 
-	if p.Kind != policy.DerivedRolesKindStr {
+	if p.Kind != policy.DerivedRolesKind {
 		idx.executables[p.ID] = struct{}{}
 	}
 

--- a/internal/storage/index/index.go
+++ b/internal/storage/index/index.go
@@ -222,11 +222,11 @@ func (idx *index) AddOrUpdate(entry Entry) (evt storage.Event, err error) {
 	idx.fileToModID[entry.File] = modID
 	idx.modIDToFile[modID] = entry.File
 
-	if entry.Policy.Kind != policy.DerivedRolesKindStr {
+	if entry.Policy.Kind != policy.DerivedRolesKind {
 		idx.executables[modID] = struct{}{}
 	}
 
-	for _, dep := range entry.Policy.Dependencies {
+	for _, dep := range entry.Policy.Dependencies() {
 		idx.addDep(modID, dep)
 	}
 

--- a/internal/storage/subscriptionmgr.go
+++ b/internal/storage/subscriptionmgr.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const eventBufferSize = 16
+const eventBufferSize = 32
 
 type SubscriptionManager struct {
 	eventChan   chan Event


### PR DESCRIPTION
- Add scope column to `cerbosctl` get output
- Refactor filter code to avoid an extra slice allocation
- Refactor `policy.Wrapper` to avoid unnecessarily computing dependencies 
 
Signed-off-by: Charith Ellawala <charith@cerbos.dev>

