### PR TITLE
enhancement: Make no-scope policy the root of the tree

### DIFF
--- a/internal/namer/namer.go
+++ b/internal/namer/namer.go
@@ -92,7 +92,8 @@ func FQN(p *policyv1.Policy) string {
 // For example, if the policy has scope a.b.c, the returned tree will contain the FQNs in the following order:
 // - a.b.c
 // - a.b
-// - a.
+// - a
+// - "" (empty scope).
 func FQNTree(p *policyv1.Policy) []string {
 	var fqn string
 	var scope string
@@ -121,6 +122,9 @@ func FQNTree(p *policyv1.Policy) []string {
 			fqnTree = append(fqnTree, withScope(fqn, scope[:i]))
 		}
 	}
+
+	// add the no scope FQN as the root
+	fqnTree = append(fqnTree, fqn)
 
 	return fqnTree
 }

--- a/internal/namer/namer_test.go
+++ b/internal/namer/namer_test.go
@@ -90,6 +90,7 @@ func TestFQNTree(t *testing.T) {
 				"cerbos.resource.leave_request.vdefault/acme.base.cloud",
 				"cerbos.resource.leave_request.vdefault/acme.base",
 				"cerbos.resource.leave_request.vdefault/acme",
+				"cerbos.resource.leave_request.vdefault",
 			},
 		},
 		{
@@ -108,6 +109,7 @@ func TestFQNTree(t *testing.T) {
 				"cerbos.principal.donald_duck.vdefault/acme.base.cloud",
 				"cerbos.principal.donald_duck.vdefault/acme.base",
 				"cerbos.principal.donald_duck.vdefault/acme",
+				"cerbos.principal.donald_duck.vdefault",
 			},
 		},
 	}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -71,12 +71,15 @@ func TestAncestors(t *testing.T) {
 		},
 		{
 			scope: "foo",
-			want:  nil,
+			want: []namer.ModuleID{
+				namer.GenModuleIDFromFQN("cerbos.resource.leave_request.vdefault"),
+			},
 		},
 		{
 			scope: "foo.bar",
 			want: []namer.ModuleID{
 				namer.GenModuleIDFromFQN("cerbos.resource.leave_request.vdefault/foo"),
+				namer.GenModuleIDFromFQN("cerbos.resource.leave_request.vdefault"),
 			},
 		},
 		{
@@ -84,6 +87,7 @@ func TestAncestors(t *testing.T) {
 			want: []namer.ModuleID{
 				namer.GenModuleIDFromFQN("cerbos.resource.leave_request.vdefault/foo.bar"),
 				namer.GenModuleIDFromFQN("cerbos.resource.leave_request.vdefault/foo"),
+				namer.GenModuleIDFromFQN("cerbos.resource.leave_request.vdefault"),
 			},
 		},
 	}
@@ -110,12 +114,15 @@ func TestRequiredAncestors(t *testing.T) {
 		},
 		{
 			scope: "foo",
-			want:  nil,
+			want: map[namer.ModuleID]string{
+				namer.GenModuleIDFromFQN("cerbos.resource.leave_request.vdefault"): "cerbos.resource.leave_request.vdefault",
+			},
 		},
 		{
 			scope: "foo.bar",
 			want: map[namer.ModuleID]string{
 				namer.GenModuleIDFromFQN("cerbos.resource.leave_request.vdefault/foo"): "cerbos.resource.leave_request.vdefault/foo",
+				namer.GenModuleIDFromFQN("cerbos.resource.leave_request.vdefault"):     "cerbos.resource.leave_request.vdefault",
 			},
 		},
 		{
@@ -123,6 +130,7 @@ func TestRequiredAncestors(t *testing.T) {
 			want: map[namer.ModuleID]string{
 				namer.GenModuleIDFromFQN("cerbos.resource.leave_request.vdefault/foo.bar"): "cerbos.resource.leave_request.vdefault/foo.bar",
 				namer.GenModuleIDFromFQN("cerbos.resource.leave_request.vdefault/foo"):     "cerbos.resource.leave_request.vdefault/foo",
+				namer.GenModuleIDFromFQN("cerbos.resource.leave_request.vdefault"):         "cerbos.resource.leave_request.vdefault",
 			},
 		},
 	}

--- a/internal/storage/blob/cloner_test.go
+++ b/internal/storage/blob/cloner_test.go
@@ -22,5 +22,5 @@ func TestCloneResult(t *testing.T) {
 	is.NoError(err)
 	result, err := cloner.Clone(ctx)
 	is.NoError(err)
-	is.Len(result.updateOrAdd, 18)
+	is.Len(result.updateOrAdd, 20)
 }

--- a/internal/storage/db/internal/tests.go
+++ b/internal/storage/db/internal/tests.go
@@ -107,13 +107,15 @@ func TestSuite(store DBStorage) func(*testing.T) {
 
 			haveRec := have[rpAcmeHRUK.ID]
 			require.Equal(t, rpAcmeHRUK.ID, haveRec.ModID)
-			require.Len(t, haveRec.Definitions, 4)
+			require.Len(t, haveRec.Definitions, 5)
 			require.Contains(t, haveRec.Definitions, rpAcmeHRUK.ID)
 			require.Empty(t, cmp.Diff(rpAcmeHRUK, haveRec.Definitions[rpAcmeHRUK.ID], protocmp.Transform()))
 			require.Contains(t, haveRec.Definitions, rpAcmeHR.ID)
 			require.Empty(t, cmp.Diff(rpAcmeHR, haveRec.Definitions[rpAcmeHR.ID], protocmp.Transform()))
 			require.Contains(t, haveRec.Definitions, rpAcme.ID)
 			require.Empty(t, cmp.Diff(rpAcme, haveRec.Definitions[rpAcme.ID], protocmp.Transform()))
+			require.Contains(t, haveRec.Definitions, rp.ID)
+			require.Empty(t, cmp.Diff(rp, haveRec.Definitions[rp.ID], protocmp.Transform()))
 			require.Contains(t, haveRec.Definitions, dr.ID)
 			require.Empty(t, cmp.Diff(dr, haveRec.Definitions[dr.ID], protocmp.Transform()))
 		})
@@ -126,11 +128,13 @@ func TestSuite(store DBStorage) func(*testing.T) {
 
 			haveRec := have[ppAcmeHR.ID]
 			require.Equal(t, ppAcmeHR.ID, haveRec.ModID)
-			require.Len(t, haveRec.Definitions, 2)
+			require.Len(t, haveRec.Definitions, 3)
 			require.Contains(t, haveRec.Definitions, ppAcmeHR.ID)
 			require.Empty(t, cmp.Diff(ppAcmeHR, haveRec.Definitions[ppAcmeHR.ID], protocmp.Transform()))
 			require.Contains(t, haveRec.Definitions, ppAcme.ID)
 			require.Empty(t, cmp.Diff(ppAcme, haveRec.Definitions[ppAcme.ID], protocmp.Transform()))
+			require.Contains(t, haveRec.Definitions, pp.ID)
+			require.Empty(t, cmp.Diff(pp, haveRec.Definitions[pp.ID], protocmp.Transform()))
 		})
 
 		t.Run("get_multiple_compilation_units", func(t *testing.T) {
@@ -157,13 +161,15 @@ func TestSuite(store DBStorage) func(*testing.T) {
 
 			haveRPAcmeHRUK := have[rpAcmeHRUK.ID]
 			require.Equal(t, rpAcmeHRUK.ID, haveRPAcmeHRUK.ModID)
-			require.Len(t, haveRPAcmeHRUK.Definitions, 4)
+			require.Len(t, haveRPAcmeHRUK.Definitions, 5)
 			require.Contains(t, haveRPAcmeHRUK.Definitions, rpAcmeHRUK.ID)
 			require.Empty(t, cmp.Diff(rpAcmeHRUK, haveRPAcmeHRUK.Definitions[rpAcmeHRUK.ID], protocmp.Transform()))
 			require.Contains(t, haveRPAcmeHRUK.Definitions, rpAcmeHR.ID)
 			require.Empty(t, cmp.Diff(rpAcmeHR, haveRPAcmeHRUK.Definitions[rpAcmeHR.ID], protocmp.Transform()))
 			require.Contains(t, haveRPAcmeHRUK.Definitions, rpAcme.ID)
 			require.Empty(t, cmp.Diff(rpAcme, haveRPAcmeHRUK.Definitions[rpAcme.ID], protocmp.Transform()))
+			require.Contains(t, haveRPAcmeHRUK.Definitions, rp.ID)
+			require.Empty(t, cmp.Diff(rp, haveRPAcmeHRUK.Definitions[rp.ID], protocmp.Transform()))
 			require.Contains(t, haveRPAcmeHRUK.Definitions, dr.ID)
 			require.Empty(t, cmp.Diff(dr, haveRPAcmeHRUK.Definitions[dr.ID], protocmp.Transform()))
 		})

--- a/internal/storage/index/builder_test.go
+++ b/internal/storage/index/builder_test.go
@@ -41,24 +41,26 @@ func TestBuildIndexWithDisk(t *testing.T) {
 
 	t.Run("check_contents", func(t *testing.T) {
 		data := idxImpl.Inspect()
-		require.Len(t, data, 14)
+		require.Len(t, data, 16)
 
 		rp1 := filepath.Join("resource_policies", "policy_01.yaml")
 		rp2 := filepath.Join("resource_policies", "policy_02.yaml")
 		rp3 := filepath.Join("resource_policies", "policy_03.yaml")
 		rp4 := filepath.Join("resource_policies", "policy_04.yaml")
-		rp5 := filepath.Join("resource_policies", "policy_05_acme.yaml")
-		rp6 := filepath.Join("resource_policies", "policy_05_acme.hr.yaml")
-		rp7 := filepath.Join("resource_policies", "policy_05_acme.hr.uk.yaml")
+		rp5 := filepath.Join("resource_policies", "policy_05.yaml")
+		rp6 := filepath.Join("resource_policies", "policy_05_acme.yaml")
+		rp7 := filepath.Join("resource_policies", "policy_05_acme.hr.yaml")
+		rp8 := filepath.Join("resource_policies", "policy_05_acme.hr.uk.yaml")
 		pp1 := filepath.Join("principal_policies", "policy_01.yaml")
-		pp2 := filepath.Join("principal_policies", "policy_02_acme.yaml")
-		pp3 := filepath.Join("principal_policies", "policy_02_acme.hr.yaml")
+		pp2 := filepath.Join("principal_policies", "policy_02.yaml")
+		pp3 := filepath.Join("principal_policies", "policy_02_acme.yaml")
+		pp4 := filepath.Join("principal_policies", "policy_02_acme.hr.yaml")
 		drCommon := filepath.Join("derived_roles", "common_roles.yaml")
 		dr1 := filepath.Join("derived_roles", "derived_roles_01.yaml")
 		dr2 := filepath.Join("derived_roles", "derived_roles_02.yaml")
 		dr3 := filepath.Join("derived_roles", "derived_roles_03.yaml")
 
-		for _, rp := range []string{rp1, rp5, rp6, rp7} {
+		for _, rp := range []string{rp1, rp5, rp6, rp7, rp8} {
 			require.Contains(t, data, rp)
 			require.Len(t, data[rp].Dependencies, 2)
 			require.Contains(t, data[rp].Dependencies, dr1)
@@ -85,7 +87,7 @@ func TestBuildIndexWithDisk(t *testing.T) {
 		require.Contains(t, data[rp3].Dependencies, dr3)
 		require.Empty(t, data[rp3].References)
 
-		for _, pp := range []string{pp1, pp2, pp3} {
+		for _, pp := range []string{pp1, pp2, pp3, pp4} {
 			require.Contains(t, data, pp)
 			require.Empty(t, data[pp].Dependencies)
 			require.Empty(t, data[pp].References)
@@ -97,11 +99,11 @@ func TestBuildIndexWithDisk(t *testing.T) {
 
 		require.Contains(t, data, dr1)
 		require.Empty(t, data[dr1].Dependencies)
-		require.Len(t, data[dr1].References, 4)
+		require.Len(t, data[dr1].References, 5)
 
 		require.Contains(t, data, dr2)
 		require.Empty(t, data[dr2].Dependencies)
-		require.Len(t, data[dr2].References, 4)
+		require.Len(t, data[dr2].References, 5)
 
 		require.Contains(t, data, dr3)
 		require.Empty(t, data[dr3].Dependencies)

--- a/internal/test/testdata/compile/multiple_imports.yaml.golden
+++ b/internal/test/testdata/compile/multiple_imports.yaml.golden
@@ -1,156 +1,156 @@
 {
-  "fqn": "cerbos.resource.leave_request.v20210210",
-  "resourcePolicy": {
-    "meta": {
-      "fqn": "cerbos.resource.leave_request.v20210210",
-      "resource": "leave_request",
-      "version": "20210210"
+  "fqn":  "cerbos.resource.leave_request.v20210210",
+  "resourcePolicy":  {
+    "meta":  {
+      "fqn":  "cerbos.resource.leave_request.v20210210",
+      "resource":  "leave_request",
+      "version":  "20210210"
     },
-    "policies": [
+    "policies":  [
       {
-        "derivedRoles": {
-          "any_employee": {
-            "name": "any_employee",
-            "parentRoles": {
-              "employee": {}
+        "derivedRoles":  {
+          "any_employee":  {
+            "name":  "any_employee",
+            "parentRoles":  {
+              "employee":  {}
             }
           },
-          "direct_manager": {
-            "name": "direct_manager",
-            "parentRoles": {
-              "manager": {}
+          "direct_manager":  {
+            "name":  "direct_manager",
+            "parentRoles":  {
+              "manager":  {}
             },
-            "condition": {
-              "all": {
-                "expr": [
+            "condition":  {
+              "all":  {
+                "expr":  [
                   {
-                    "expr": {
-                      "original": "request.resource.attr.geography == request.principal.attr.geography",
-                      "checked": {
-                        "referenceMap": {
-                          "1": {
-                            "name": "request"
+                    "expr":  {
+                      "original":  "request.resource.attr.geography == request.principal.attr.geography",
+                      "checked":  {
+                        "referenceMap":  {
+                          "1":  {
+                            "name":  "request"
                           },
-                          "5": {
-                            "overloadId": [
+                          "5":  {
+                            "overloadId":  [
                               "equals"
                             ]
                           },
-                          "6": {
-                            "name": "request"
+                          "6":  {
+                            "name":  "request"
                           }
                         },
-                        "typeMap": {
-                          "1": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                        "typeMap":  {
+                          "1":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "2": {
-                            "messageType": "cerbos.engine.v1.Resource"
+                          "2":  {
+                            "messageType":  "cerbos.engine.v1.Resource"
                           },
-                          "3": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "3":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "4": {
-                            "dyn": {}
+                          "4":  {
+                            "dyn":  {}
                           },
-                          "5": {
-                            "primitive": "BOOL"
+                          "5":  {
+                            "primitive":  "BOOL"
                           },
-                          "6": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                          "6":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Principal"
+                          "7":  {
+                            "messageType":  "cerbos.engine.v1.Principal"
                           },
-                          "8": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "8":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "9": {
-                            "dyn": {}
+                          "9":  {
+                            "dyn":  {}
                           }
                         },
-                        "sourceInfo": {
-                          "location": "<input>",
-                          "lineOffsets": [
+                        "sourceInfo":  {
+                          "location":  "<input>",
+                          "lineOffsets":  [
                             68
                           ],
-                          "positions": {
-                            "1": 0,
-                            "2": 7,
-                            "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                          "positions":  {
+                            "1":  0,
+                            "2":  7,
+                            "3":  16,
+                            "4":  21,
+                            "5":  32,
+                            "6":  35,
+                            "7":  42,
+                            "8":  52,
+                            "9":  57
                           }
                         },
-                        "expr": {
-                          "id": "5",
-                          "callExpr": {
-                            "function": "_==_",
-                            "args": [
+                        "expr":  {
+                          "id":  "5",
+                          "callExpr":  {
+                            "function":  "_==_",
+                            "args":  [
                               {
-                                "id": "4",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "3",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "2",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "1",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "4",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "3",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "2",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "1",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "resource"
+                                          "field":  "resource"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "geography"
+                                  "field":  "geography"
                                 }
                               },
                               {
-                                "id": "9",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "8",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "7",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "6",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "9",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "8",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "7",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "6",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "principal"
+                                          "field":  "principal"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "geography"
+                                  "field":  "geography"
                                 }
                               }
                             ]
@@ -160,133 +160,133 @@
                     }
                   },
                   {
-                    "expr": {
-                      "original": "request.resource.attr.geography == request.principal.attr.managed_geographies",
-                      "checked": {
-                        "referenceMap": {
-                          "1": {
-                            "name": "request"
+                    "expr":  {
+                      "original":  "request.resource.attr.geography == request.principal.attr.managed_geographies",
+                      "checked":  {
+                        "referenceMap":  {
+                          "1":  {
+                            "name":  "request"
                           },
-                          "5": {
-                            "overloadId": [
+                          "5":  {
+                            "overloadId":  [
                               "equals"
                             ]
                           },
-                          "6": {
-                            "name": "request"
+                          "6":  {
+                            "name":  "request"
                           }
                         },
-                        "typeMap": {
-                          "1": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                        "typeMap":  {
+                          "1":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "2": {
-                            "messageType": "cerbos.engine.v1.Resource"
+                          "2":  {
+                            "messageType":  "cerbos.engine.v1.Resource"
                           },
-                          "3": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "3":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "4": {
-                            "dyn": {}
+                          "4":  {
+                            "dyn":  {}
                           },
-                          "5": {
-                            "primitive": "BOOL"
+                          "5":  {
+                            "primitive":  "BOOL"
                           },
-                          "6": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                          "6":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Principal"
+                          "7":  {
+                            "messageType":  "cerbos.engine.v1.Principal"
                           },
-                          "8": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "8":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "9": {
-                            "dyn": {}
+                          "9":  {
+                            "dyn":  {}
                           }
                         },
-                        "sourceInfo": {
-                          "location": "<input>",
-                          "lineOffsets": [
+                        "sourceInfo":  {
+                          "location":  "<input>",
+                          "lineOffsets":  [
                             78
                           ],
-                          "positions": {
-                            "1": 0,
-                            "2": 7,
-                            "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                          "positions":  {
+                            "1":  0,
+                            "2":  7,
+                            "3":  16,
+                            "4":  21,
+                            "5":  32,
+                            "6":  35,
+                            "7":  42,
+                            "8":  52,
+                            "9":  57
                           }
                         },
-                        "expr": {
-                          "id": "5",
-                          "callExpr": {
-                            "function": "_==_",
-                            "args": [
+                        "expr":  {
+                          "id":  "5",
+                          "callExpr":  {
+                            "function":  "_==_",
+                            "args":  [
                               {
-                                "id": "4",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "3",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "2",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "1",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "4",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "3",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "2",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "1",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "resource"
+                                          "field":  "resource"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "geography"
+                                  "field":  "geography"
                                 }
                               },
                               {
-                                "id": "9",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "8",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "7",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "6",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "9",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "8",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "7",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "6",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "principal"
+                                          "field":  "principal"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "managed_geographies"
+                                  "field":  "managed_geographies"
                                 }
                               }
                             ]
@@ -299,102 +299,102 @@
               }
             }
           },
-          "employee_that_owns_the_record": {
-            "name": "employee_that_owns_the_record",
-            "parentRoles": {
-              "employee": {}
+          "employee_that_owns_the_record":  {
+            "name":  "employee_that_owns_the_record",
+            "parentRoles":  {
+              "employee":  {}
             },
-            "condition": {
-              "expr": {
-                "original": "R.attr.owner == P.id",
-                "checked": {
-                  "referenceMap": {
-                    "1": {
-                      "name": "R"
+            "condition":  {
+              "expr":  {
+                "original":  "R.attr.owner == P.id",
+                "checked":  {
+                  "referenceMap":  {
+                    "1":  {
+                      "name":  "R"
                     },
-                    "4": {
-                      "overloadId": [
+                    "4":  {
+                      "overloadId":  [
                         "equals"
                       ]
                     },
-                    "5": {
-                      "name": "P"
+                    "5":  {
+                      "name":  "P"
                     }
                   },
-                  "typeMap": {
-                    "1": {
-                      "messageType": "cerbos.engine.v1.Resource"
+                  "typeMap":  {
+                    "1":  {
+                      "messageType":  "cerbos.engine.v1.Resource"
                     },
-                    "2": {
-                      "mapType": {
-                        "keyType": {
-                          "primitive": "STRING"
+                    "2":  {
+                      "mapType":  {
+                        "keyType":  {
+                          "primitive":  "STRING"
                         },
-                        "valueType": {
-                          "dyn": {}
+                        "valueType":  {
+                          "dyn":  {}
                         }
                       }
                     },
-                    "3": {
-                      "dyn": {}
+                    "3":  {
+                      "dyn":  {}
                     },
-                    "4": {
-                      "primitive": "BOOL"
+                    "4":  {
+                      "primitive":  "BOOL"
                     },
-                    "5": {
-                      "messageType": "cerbos.engine.v1.Principal"
+                    "5":  {
+                      "messageType":  "cerbos.engine.v1.Principal"
                     },
-                    "6": {
-                      "primitive": "STRING"
+                    "6":  {
+                      "primitive":  "STRING"
                     }
                   },
-                  "sourceInfo": {
-                    "location": "<input>",
-                    "lineOffsets": [
+                  "sourceInfo":  {
+                    "location":  "<input>",
+                    "lineOffsets":  [
                       21
                     ],
-                    "positions": {
-                      "1": 0,
-                      "2": 1,
-                      "3": 6,
-                      "4": 13,
-                      "5": 16,
-                      "6": 17
+                    "positions":  {
+                      "1":  0,
+                      "2":  1,
+                      "3":  6,
+                      "4":  13,
+                      "5":  16,
+                      "6":  17
                     }
                   },
-                  "expr": {
-                    "id": "4",
-                    "callExpr": {
-                      "function": "_==_",
-                      "args": [
+                  "expr":  {
+                    "id":  "4",
+                    "callExpr":  {
+                      "function":  "_==_",
+                      "args":  [
                         {
-                          "id": "3",
-                          "selectExpr": {
-                            "operand": {
-                              "id": "2",
-                              "selectExpr": {
-                                "operand": {
-                                  "id": "1",
-                                  "identExpr": {
-                                    "name": "R"
+                          "id":  "3",
+                          "selectExpr":  {
+                            "operand":  {
+                              "id":  "2",
+                              "selectExpr":  {
+                                "operand":  {
+                                  "id":  "1",
+                                  "identExpr":  {
+                                    "name":  "R"
                                   }
                                 },
-                                "field": "attr"
+                                "field":  "attr"
                               }
                             },
-                            "field": "owner"
+                            "field":  "owner"
                           }
                         },
                         {
-                          "id": "6",
-                          "selectExpr": {
-                            "operand": {
-                              "id": "5",
-                              "identExpr": {
-                                "name": "P"
+                          "id":  "6",
+                          "selectExpr":  {
+                            "operand":  {
+                              "id":  "5",
+                              "identExpr":  {
+                                "name":  "P"
                               }
                             },
-                            "field": "id"
+                            "field":  "id"
                           }
                         }
                       ]
@@ -405,144 +405,144 @@
             }
           }
         },
-        "rules": [
+        "rules":  [
           {
-            "name": "rule-001",
-            "actions": {
-              "*": {}
+            "name":  "rule-001",
+            "actions":  {
+              "*":  {}
             },
-            "roles": {
-              "admin": {}
+            "roles":  {
+              "admin":  {}
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           },
           {
-            "name": "rule-002",
-            "actions": {
-              "create": {}
+            "name":  "rule-002",
+            "actions":  {
+              "create":  {}
             },
-            "derivedRoles": {
-              "employee_that_owns_the_record": {}
+            "derivedRoles":  {
+              "employee_that_owns_the_record":  {}
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           },
           {
-            "name": "rule-003",
-            "actions": {
-              "view:*": {}
+            "name":  "rule-003",
+            "actions":  {
+              "view:*":  {}
             },
-            "derivedRoles": {
-              "direct_manager": {},
-              "employee_that_owns_the_record": {}
+            "derivedRoles":  {
+              "direct_manager":  {},
+              "employee_that_owns_the_record":  {}
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           },
           {
-            "name": "rule-004",
-            "actions": {
-              "view:public": {}
+            "name":  "rule-004",
+            "actions":  {
+              "view:public":  {}
             },
-            "derivedRoles": {
-              "any_employee": {}
+            "derivedRoles":  {
+              "any_employee":  {}
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           },
           {
-            "name": "rule-005",
-            "actions": {
-              "approve": {}
+            "name":  "rule-005",
+            "actions":  {
+              "approve":  {}
             },
-            "derivedRoles": {
-              "direct_manager": {}
+            "derivedRoles":  {
+              "direct_manager":  {}
             },
-            "condition": {
-              "expr": {
-                "original": "request.resource.attr.status == \"PENDING_APPROVAL\"",
-                "checked": {
-                  "referenceMap": {
-                    "1": {
-                      "name": "request"
+            "condition":  {
+              "expr":  {
+                "original":  "request.resource.attr.status == \"PENDING_APPROVAL\"",
+                "checked":  {
+                  "referenceMap":  {
+                    "1":  {
+                      "name":  "request"
                     },
-                    "5": {
-                      "overloadId": [
+                    "5":  {
+                      "overloadId":  [
                         "equals"
                       ]
                     }
                   },
-                  "typeMap": {
-                    "1": {
-                      "messageType": "cerbos.engine.v1.CheckInput"
+                  "typeMap":  {
+                    "1":  {
+                      "messageType":  "cerbos.engine.v1.CheckInput"
                     },
-                    "2": {
-                      "messageType": "cerbos.engine.v1.Resource"
+                    "2":  {
+                      "messageType":  "cerbos.engine.v1.Resource"
                     },
-                    "3": {
-                      "mapType": {
-                        "keyType": {
-                          "primitive": "STRING"
+                    "3":  {
+                      "mapType":  {
+                        "keyType":  {
+                          "primitive":  "STRING"
                         },
-                        "valueType": {
-                          "dyn": {}
+                        "valueType":  {
+                          "dyn":  {}
                         }
                       }
                     },
-                    "4": {
-                      "dyn": {}
+                    "4":  {
+                      "dyn":  {}
                     },
-                    "5": {
-                      "primitive": "BOOL"
+                    "5":  {
+                      "primitive":  "BOOL"
                     },
-                    "6": {
-                      "primitive": "STRING"
+                    "6":  {
+                      "primitive":  "STRING"
                     }
                   },
-                  "sourceInfo": {
-                    "location": "<input>",
-                    "lineOffsets": [
+                  "sourceInfo":  {
+                    "location":  "<input>",
+                    "lineOffsets":  [
                       51
                     ],
-                    "positions": {
-                      "1": 0,
-                      "2": 7,
-                      "3": 16,
-                      "4": 21,
-                      "5": 29,
-                      "6": 32
+                    "positions":  {
+                      "1":  0,
+                      "2":  7,
+                      "3":  16,
+                      "4":  21,
+                      "5":  29,
+                      "6":  32
                     }
                   },
-                  "expr": {
-                    "id": "5",
-                    "callExpr": {
-                      "function": "_==_",
-                      "args": [
+                  "expr":  {
+                    "id":  "5",
+                    "callExpr":  {
+                      "function":  "_==_",
+                      "args":  [
                         {
-                          "id": "4",
-                          "selectExpr": {
-                            "operand": {
-                              "id": "3",
-                              "selectExpr": {
-                                "operand": {
-                                  "id": "2",
-                                  "selectExpr": {
-                                    "operand": {
-                                      "id": "1",
-                                      "identExpr": {
-                                        "name": "request"
+                          "id":  "4",
+                          "selectExpr":  {
+                            "operand":  {
+                              "id":  "3",
+                              "selectExpr":  {
+                                "operand":  {
+                                  "id":  "2",
+                                  "selectExpr":  {
+                                    "operand":  {
+                                      "id":  "1",
+                                      "identExpr":  {
+                                        "name":  "request"
                                       }
                                     },
-                                    "field": "resource"
+                                    "field":  "resource"
                                   }
                                 },
-                                "field": "attr"
+                                "field":  "attr"
                               }
                             },
-                            "field": "status"
+                            "field":  "status"
                           }
                         },
                         {
-                          "id": "6",
-                          "constExpr": {
-                            "stringValue": "PENDING_APPROVAL"
+                          "id":  "6",
+                          "constExpr":  {
+                            "stringValue":  "PENDING_APPROVAL"
                           }
                         }
                       ]
@@ -551,7 +551,7 @@
                 }
               }
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           }
         ]
       }

--- a/internal/test/testdata/compile/only_derived_roles.yaml.golden
+++ b/internal/test/testdata/compile/only_derived_roles.yaml.golden
@@ -1,152 +1,152 @@
 {
-  "fqn": "cerbos.derived_roles.my_derived_roles",
-  "derivedRoles": {
-    "meta": {
-      "fqn": "cerbos.derived_roles.my_derived_roles"
+  "fqn":  "cerbos.derived_roles.my_derived_roles",
+  "derivedRoles":  {
+    "meta":  {
+      "fqn":  "cerbos.derived_roles.my_derived_roles"
     },
-    "derivedRoles": {
-      "any_employee": {
-        "name": "any_employee",
-        "parentRoles": {
-          "employee": {}
+    "derivedRoles":  {
+      "any_employee":  {
+        "name":  "any_employee",
+        "parentRoles":  {
+          "employee":  {}
         }
       },
-      "direct_manager": {
-        "name": "direct_manager",
-        "parentRoles": {
-          "manager": {}
+      "direct_manager":  {
+        "name":  "direct_manager",
+        "parentRoles":  {
+          "manager":  {}
         },
-        "condition": {
-          "all": {
-            "expr": [
+        "condition":  {
+          "all":  {
+            "expr":  [
               {
-                "expr": {
-                  "original": "request.resource.attr.geography == request.principal.attr.geography",
-                  "checked": {
-                    "referenceMap": {
-                      "1": {
-                        "name": "request"
+                "expr":  {
+                  "original":  "request.resource.attr.geography == request.principal.attr.geography",
+                  "checked":  {
+                    "referenceMap":  {
+                      "1":  {
+                        "name":  "request"
                       },
-                      "5": {
-                        "overloadId": [
+                      "5":  {
+                        "overloadId":  [
                           "equals"
                         ]
                       },
-                      "6": {
-                        "name": "request"
+                      "6":  {
+                        "name":  "request"
                       }
                     },
-                    "typeMap": {
-                      "1": {
-                        "messageType": "cerbos.engine.v1.CheckInput"
+                    "typeMap":  {
+                      "1":  {
+                        "messageType":  "cerbos.engine.v1.CheckInput"
                       },
-                      "2": {
-                        "messageType": "cerbos.engine.v1.Resource"
+                      "2":  {
+                        "messageType":  "cerbos.engine.v1.Resource"
                       },
-                      "3": {
-                        "mapType": {
-                          "keyType": {
-                            "primitive": "STRING"
+                      "3":  {
+                        "mapType":  {
+                          "keyType":  {
+                            "primitive":  "STRING"
                           },
-                          "valueType": {
-                            "dyn": {}
+                          "valueType":  {
+                            "dyn":  {}
                           }
                         }
                       },
-                      "4": {
-                        "dyn": {}
+                      "4":  {
+                        "dyn":  {}
                       },
-                      "5": {
-                        "primitive": "BOOL"
+                      "5":  {
+                        "primitive":  "BOOL"
                       },
-                      "6": {
-                        "messageType": "cerbos.engine.v1.CheckInput"
+                      "6":  {
+                        "messageType":  "cerbos.engine.v1.CheckInput"
                       },
-                      "7": {
-                        "messageType": "cerbos.engine.v1.Principal"
+                      "7":  {
+                        "messageType":  "cerbos.engine.v1.Principal"
                       },
-                      "8": {
-                        "mapType": {
-                          "keyType": {
-                            "primitive": "STRING"
+                      "8":  {
+                        "mapType":  {
+                          "keyType":  {
+                            "primitive":  "STRING"
                           },
-                          "valueType": {
-                            "dyn": {}
+                          "valueType":  {
+                            "dyn":  {}
                           }
                         }
                       },
-                      "9": {
-                        "dyn": {}
+                      "9":  {
+                        "dyn":  {}
                       }
                     },
-                    "sourceInfo": {
-                      "location": "<input>",
-                      "lineOffsets": [
+                    "sourceInfo":  {
+                      "location":  "<input>",
+                      "lineOffsets":  [
                         68
                       ],
-                      "positions": {
-                        "1": 0,
-                        "2": 7,
-                        "3": 16,
-                        "4": 21,
-                        "5": 32,
-                        "6": 35,
-                        "7": 42,
-                        "8": 52,
-                        "9": 57
+                      "positions":  {
+                        "1":  0,
+                        "2":  7,
+                        "3":  16,
+                        "4":  21,
+                        "5":  32,
+                        "6":  35,
+                        "7":  42,
+                        "8":  52,
+                        "9":  57
                       }
                     },
-                    "expr": {
-                      "id": "5",
-                      "callExpr": {
-                        "function": "_==_",
-                        "args": [
+                    "expr":  {
+                      "id":  "5",
+                      "callExpr":  {
+                        "function":  "_==_",
+                        "args":  [
                           {
-                            "id": "4",
-                            "selectExpr": {
-                              "operand": {
-                                "id": "3",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "2",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "1",
-                                        "identExpr": {
-                                          "name": "request"
+                            "id":  "4",
+                            "selectExpr":  {
+                              "operand":  {
+                                "id":  "3",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "2",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "1",
+                                        "identExpr":  {
+                                          "name":  "request"
                                         }
                                       },
-                                      "field": "resource"
+                                      "field":  "resource"
                                     }
                                   },
-                                  "field": "attr"
+                                  "field":  "attr"
                                 }
                               },
-                              "field": "geography"
+                              "field":  "geography"
                             }
                           },
                           {
-                            "id": "9",
-                            "selectExpr": {
-                              "operand": {
-                                "id": "8",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "7",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "6",
-                                        "identExpr": {
-                                          "name": "request"
+                            "id":  "9",
+                            "selectExpr":  {
+                              "operand":  {
+                                "id":  "8",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "7",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "6",
+                                        "identExpr":  {
+                                          "name":  "request"
                                         }
                                       },
-                                      "field": "principal"
+                                      "field":  "principal"
                                     }
                                   },
-                                  "field": "attr"
+                                  "field":  "attr"
                                 }
                               },
-                              "field": "geography"
+                              "field":  "geography"
                             }
                           }
                         ]
@@ -156,133 +156,133 @@
                 }
               },
               {
-                "expr": {
-                  "original": "request.resource.attr.geography == request.principal.attr.managed_geographies",
-                  "checked": {
-                    "referenceMap": {
-                      "1": {
-                        "name": "request"
+                "expr":  {
+                  "original":  "request.resource.attr.geography == request.principal.attr.managed_geographies",
+                  "checked":  {
+                    "referenceMap":  {
+                      "1":  {
+                        "name":  "request"
                       },
-                      "5": {
-                        "overloadId": [
+                      "5":  {
+                        "overloadId":  [
                           "equals"
                         ]
                       },
-                      "6": {
-                        "name": "request"
+                      "6":  {
+                        "name":  "request"
                       }
                     },
-                    "typeMap": {
-                      "1": {
-                        "messageType": "cerbos.engine.v1.CheckInput"
+                    "typeMap":  {
+                      "1":  {
+                        "messageType":  "cerbos.engine.v1.CheckInput"
                       },
-                      "2": {
-                        "messageType": "cerbos.engine.v1.Resource"
+                      "2":  {
+                        "messageType":  "cerbos.engine.v1.Resource"
                       },
-                      "3": {
-                        "mapType": {
-                          "keyType": {
-                            "primitive": "STRING"
+                      "3":  {
+                        "mapType":  {
+                          "keyType":  {
+                            "primitive":  "STRING"
                           },
-                          "valueType": {
-                            "dyn": {}
+                          "valueType":  {
+                            "dyn":  {}
                           }
                         }
                       },
-                      "4": {
-                        "dyn": {}
+                      "4":  {
+                        "dyn":  {}
                       },
-                      "5": {
-                        "primitive": "BOOL"
+                      "5":  {
+                        "primitive":  "BOOL"
                       },
-                      "6": {
-                        "messageType": "cerbos.engine.v1.CheckInput"
+                      "6":  {
+                        "messageType":  "cerbos.engine.v1.CheckInput"
                       },
-                      "7": {
-                        "messageType": "cerbos.engine.v1.Principal"
+                      "7":  {
+                        "messageType":  "cerbos.engine.v1.Principal"
                       },
-                      "8": {
-                        "mapType": {
-                          "keyType": {
-                            "primitive": "STRING"
+                      "8":  {
+                        "mapType":  {
+                          "keyType":  {
+                            "primitive":  "STRING"
                           },
-                          "valueType": {
-                            "dyn": {}
+                          "valueType":  {
+                            "dyn":  {}
                           }
                         }
                       },
-                      "9": {
-                        "dyn": {}
+                      "9":  {
+                        "dyn":  {}
                       }
                     },
-                    "sourceInfo": {
-                      "location": "<input>",
-                      "lineOffsets": [
+                    "sourceInfo":  {
+                      "location":  "<input>",
+                      "lineOffsets":  [
                         78
                       ],
-                      "positions": {
-                        "1": 0,
-                        "2": 7,
-                        "3": 16,
-                        "4": 21,
-                        "5": 32,
-                        "6": 35,
-                        "7": 42,
-                        "8": 52,
-                        "9": 57
+                      "positions":  {
+                        "1":  0,
+                        "2":  7,
+                        "3":  16,
+                        "4":  21,
+                        "5":  32,
+                        "6":  35,
+                        "7":  42,
+                        "8":  52,
+                        "9":  57
                       }
                     },
-                    "expr": {
-                      "id": "5",
-                      "callExpr": {
-                        "function": "_==_",
-                        "args": [
+                    "expr":  {
+                      "id":  "5",
+                      "callExpr":  {
+                        "function":  "_==_",
+                        "args":  [
                           {
-                            "id": "4",
-                            "selectExpr": {
-                              "operand": {
-                                "id": "3",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "2",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "1",
-                                        "identExpr": {
-                                          "name": "request"
+                            "id":  "4",
+                            "selectExpr":  {
+                              "operand":  {
+                                "id":  "3",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "2",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "1",
+                                        "identExpr":  {
+                                          "name":  "request"
                                         }
                                       },
-                                      "field": "resource"
+                                      "field":  "resource"
                                     }
                                   },
-                                  "field": "attr"
+                                  "field":  "attr"
                                 }
                               },
-                              "field": "geography"
+                              "field":  "geography"
                             }
                           },
                           {
-                            "id": "9",
-                            "selectExpr": {
-                              "operand": {
-                                "id": "8",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "7",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "6",
-                                        "identExpr": {
-                                          "name": "request"
+                            "id":  "9",
+                            "selectExpr":  {
+                              "operand":  {
+                                "id":  "8",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "7",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "6",
+                                        "identExpr":  {
+                                          "name":  "request"
                                         }
                                       },
-                                      "field": "principal"
+                                      "field":  "principal"
                                     }
                                   },
-                                  "field": "attr"
+                                  "field":  "attr"
                                 }
                               },
-                              "field": "managed_geographies"
+                              "field":  "managed_geographies"
                             }
                           }
                         ]
@@ -295,122 +295,122 @@
           }
         }
       },
-      "employee_that_owns_the_record": {
-        "name": "employee_that_owns_the_record",
-        "parentRoles": {
-          "employee": {}
+      "employee_that_owns_the_record":  {
+        "name":  "employee_that_owns_the_record",
+        "parentRoles":  {
+          "employee":  {}
         },
-        "condition": {
-          "expr": {
-            "original": "request.resource.attr.owner == request.principal.id",
-            "checked": {
-              "referenceMap": {
-                "1": {
-                  "name": "request"
+        "condition":  {
+          "expr":  {
+            "original":  "request.resource.attr.owner == request.principal.id",
+            "checked":  {
+              "referenceMap":  {
+                "1":  {
+                  "name":  "request"
                 },
-                "5": {
-                  "overloadId": [
+                "5":  {
+                  "overloadId":  [
                     "equals"
                   ]
                 },
-                "6": {
-                  "name": "request"
+                "6":  {
+                  "name":  "request"
                 }
               },
-              "typeMap": {
-                "1": {
-                  "messageType": "cerbos.engine.v1.CheckInput"
+              "typeMap":  {
+                "1":  {
+                  "messageType":  "cerbos.engine.v1.CheckInput"
                 },
-                "2": {
-                  "messageType": "cerbos.engine.v1.Resource"
+                "2":  {
+                  "messageType":  "cerbos.engine.v1.Resource"
                 },
-                "3": {
-                  "mapType": {
-                    "keyType": {
-                      "primitive": "STRING"
+                "3":  {
+                  "mapType":  {
+                    "keyType":  {
+                      "primitive":  "STRING"
                     },
-                    "valueType": {
-                      "dyn": {}
+                    "valueType":  {
+                      "dyn":  {}
                     }
                   }
                 },
-                "4": {
-                  "dyn": {}
+                "4":  {
+                  "dyn":  {}
                 },
-                "5": {
-                  "primitive": "BOOL"
+                "5":  {
+                  "primitive":  "BOOL"
                 },
-                "6": {
-                  "messageType": "cerbos.engine.v1.CheckInput"
+                "6":  {
+                  "messageType":  "cerbos.engine.v1.CheckInput"
                 },
-                "7": {
-                  "messageType": "cerbos.engine.v1.Principal"
+                "7":  {
+                  "messageType":  "cerbos.engine.v1.Principal"
                 },
-                "8": {
-                  "primitive": "STRING"
+                "8":  {
+                  "primitive":  "STRING"
                 }
               },
-              "sourceInfo": {
-                "location": "<input>",
-                "lineOffsets": [
+              "sourceInfo":  {
+                "location":  "<input>",
+                "lineOffsets":  [
                   52
                 ],
-                "positions": {
-                  "1": 0,
-                  "2": 7,
-                  "3": 16,
-                  "4": 21,
-                  "5": 28,
-                  "6": 31,
-                  "7": 38,
-                  "8": 48
+                "positions":  {
+                  "1":  0,
+                  "2":  7,
+                  "3":  16,
+                  "4":  21,
+                  "5":  28,
+                  "6":  31,
+                  "7":  38,
+                  "8":  48
                 }
               },
-              "expr": {
-                "id": "5",
-                "callExpr": {
-                  "function": "_==_",
-                  "args": [
+              "expr":  {
+                "id":  "5",
+                "callExpr":  {
+                  "function":  "_==_",
+                  "args":  [
                     {
-                      "id": "4",
-                      "selectExpr": {
-                        "operand": {
-                          "id": "3",
-                          "selectExpr": {
-                            "operand": {
-                              "id": "2",
-                              "selectExpr": {
-                                "operand": {
-                                  "id": "1",
-                                  "identExpr": {
-                                    "name": "request"
+                      "id":  "4",
+                      "selectExpr":  {
+                        "operand":  {
+                          "id":  "3",
+                          "selectExpr":  {
+                            "operand":  {
+                              "id":  "2",
+                              "selectExpr":  {
+                                "operand":  {
+                                  "id":  "1",
+                                  "identExpr":  {
+                                    "name":  "request"
                                   }
                                 },
-                                "field": "resource"
+                                "field":  "resource"
                               }
                             },
-                            "field": "attr"
+                            "field":  "attr"
                           }
                         },
-                        "field": "owner"
+                        "field":  "owner"
                       }
                     },
                     {
-                      "id": "8",
-                      "selectExpr": {
-                        "operand": {
-                          "id": "7",
-                          "selectExpr": {
-                            "operand": {
-                              "id": "6",
-                              "identExpr": {
-                                "name": "request"
+                      "id":  "8",
+                      "selectExpr":  {
+                        "operand":  {
+                          "id":  "7",
+                          "selectExpr":  {
+                            "operand":  {
+                              "id":  "6",
+                              "identExpr":  {
+                                "name":  "request"
                               }
                             },
-                            "field": "principal"
+                            "field":  "principal"
                           }
                         },
-                        "field": "id"
+                        "field":  "id"
                       }
                     }
                   ]
@@ -420,11 +420,11 @@
           }
         }
       },
-      "tester": {
-        "name": "tester",
-        "parentRoles": {
-          "dev": {},
-          "qa": {}
+      "tester":  {
+        "name":  "tester",
+        "parentRoles":  {
+          "dev":  {},
+          "qa":  {}
         }
       }
     }

--- a/internal/test/testdata/compile/principal_policy.yaml.golden
+++ b/internal/test/testdata/compile/principal_policy.yaml.golden
@@ -1,106 +1,106 @@
 {
-  "fqn": "cerbos.principal.donald_duck.v20210210",
-  "principalPolicy": {
-    "meta": {
-      "fqn": "cerbos.principal.donald_duck.v20210210",
-      "principal": "donald_duck",
-      "version": "20210210"
+  "fqn":  "cerbos.principal.donald_duck.v20210210",
+  "principalPolicy":  {
+    "meta":  {
+      "fqn":  "cerbos.principal.donald_duck.v20210210",
+      "principal":  "donald_duck",
+      "version":  "20210210"
     },
-    "policies": [
+    "policies":  [
       {
-        "resourceRules": {
-          "leave_request": {
-            "actionRules": {
-              "*": {
-                "name": "leave_request_rule-001",
-                "condition": {
-                  "expr": {
-                    "original": "request.resource.attr.dev_record == true",
-                    "checked": {
-                      "referenceMap": {
-                        "1": {
-                          "name": "request"
+        "resourceRules":  {
+          "leave_request":  {
+            "actionRules":  {
+              "*":  {
+                "name":  "leave_request_rule-001",
+                "condition":  {
+                  "expr":  {
+                    "original":  "request.resource.attr.dev_record == true",
+                    "checked":  {
+                      "referenceMap":  {
+                        "1":  {
+                          "name":  "request"
                         },
-                        "5": {
-                          "overloadId": [
+                        "5":  {
+                          "overloadId":  [
                             "equals"
                           ]
                         }
                       },
-                      "typeMap": {
-                        "1": {
-                          "messageType": "cerbos.engine.v1.CheckInput"
+                      "typeMap":  {
+                        "1":  {
+                          "messageType":  "cerbos.engine.v1.CheckInput"
                         },
-                        "2": {
-                          "messageType": "cerbos.engine.v1.Resource"
+                        "2":  {
+                          "messageType":  "cerbos.engine.v1.Resource"
                         },
-                        "3": {
-                          "mapType": {
-                            "keyType": {
-                              "primitive": "STRING"
+                        "3":  {
+                          "mapType":  {
+                            "keyType":  {
+                              "primitive":  "STRING"
                             },
-                            "valueType": {
-                              "dyn": {}
+                            "valueType":  {
+                              "dyn":  {}
                             }
                           }
                         },
-                        "4": {
-                          "dyn": {}
+                        "4":  {
+                          "dyn":  {}
                         },
-                        "5": {
-                          "primitive": "BOOL"
+                        "5":  {
+                          "primitive":  "BOOL"
                         },
-                        "6": {
-                          "primitive": "BOOL"
+                        "6":  {
+                          "primitive":  "BOOL"
                         }
                       },
-                      "sourceInfo": {
-                        "location": "<input>",
-                        "lineOffsets": [
+                      "sourceInfo":  {
+                        "location":  "<input>",
+                        "lineOffsets":  [
                           41
                         ],
-                        "positions": {
-                          "1": 0,
-                          "2": 7,
-                          "3": 16,
-                          "4": 21,
-                          "5": 33,
-                          "6": 36
+                        "positions":  {
+                          "1":  0,
+                          "2":  7,
+                          "3":  16,
+                          "4":  21,
+                          "5":  33,
+                          "6":  36
                         }
                       },
-                      "expr": {
-                        "id": "5",
-                        "callExpr": {
-                          "function": "_==_",
-                          "args": [
+                      "expr":  {
+                        "id":  "5",
+                        "callExpr":  {
+                          "function":  "_==_",
+                          "args":  [
                             {
-                              "id": "4",
-                              "selectExpr": {
-                                "operand": {
-                                  "id": "3",
-                                  "selectExpr": {
-                                    "operand": {
-                                      "id": "2",
-                                      "selectExpr": {
-                                        "operand": {
-                                          "id": "1",
-                                          "identExpr": {
-                                            "name": "request"
+                              "id":  "4",
+                              "selectExpr":  {
+                                "operand":  {
+                                  "id":  "3",
+                                  "selectExpr":  {
+                                    "operand":  {
+                                      "id":  "2",
+                                      "selectExpr":  {
+                                        "operand":  {
+                                          "id":  "1",
+                                          "identExpr":  {
+                                            "name":  "request"
                                           }
                                         },
-                                        "field": "resource"
+                                        "field":  "resource"
                                       }
                                     },
-                                    "field": "attr"
+                                    "field":  "attr"
                                   }
                                 },
-                                "field": "dev_record"
+                                "field":  "dev_record"
                               }
                             },
                             {
-                              "id": "6",
-                              "constExpr": {
-                                "boolValue": true
+                              "id":  "6",
+                              "constExpr":  {
+                                "boolValue":  true
                               }
                             }
                           ]
@@ -109,15 +109,15 @@
                     }
                   }
                 },
-                "effect": "EFFECT_ALLOW"
+                "effect":  "EFFECT_ALLOW"
               }
             }
           },
-          "salary_record": {
-            "actionRules": {
-              "*": {
-                "name": "salary_record_rule-001",
-                "effect": "EFFECT_DENY"
+          "salary_record":  {
+            "actionRules":  {
+              "*":  {
+                "name":  "salary_record_rule-001",
+                "effect":  "EFFECT_DENY"
               }
             }
           }

--- a/internal/test/testdata/compile/scoped_pp_missing_ancestor.yaml
+++ b/internal/test/testdata/compile/scoped_pp_missing_ancestor.yaml
@@ -4,6 +4,10 @@ wantErrors:
     error: missing policy definition
     desc: |-
       Missing ancestor policy "principal.donald_duck.v20210210/acme"
+  - file: donald_duck.acme.hr.uk.yaml
+    error: missing policy definition
+    desc: |-
+      Missing ancestor policy "principal.donald_duck.v20210210"
 mainDef: "donald_duck.acme.hr.uk.yaml"
 inputDefs:
   "donald_duck.acme.hr.yaml":

--- a/internal/test/testdata/compile/scoped_principal_policy_set.yaml
+++ b/internal/test/testdata/compile/scoped_principal_policy_set.yaml
@@ -1,6 +1,17 @@
 ---
 mainDef: "donald_duck.acme.hr.uk.yaml"
 inputDefs:
+  "donald_duck.yaml":
+     apiVersion: "api.cerbos.dev/v1"
+     principalPolicy:
+       principal: donald_duck
+       version: "20210210"
+       rules:
+         - resource: leave_request
+           actions:
+             - action: "*"
+               effect: EFFECT_ALLOW
+
   "donald_duck.acme.yaml":
      apiVersion: "api.cerbos.dev/v1"
      principalPolicy:

--- a/internal/test/testdata/compile/scoped_principal_policy_set.yaml.golden
+++ b/internal/test/testdata/compile/scoped_principal_policy_set.yaml.golden
@@ -1,133 +1,133 @@
 {
-  "fqn": "cerbos.principal.donald_duck.v20210210/acme.hr.uk",
-  "principalPolicy": {
-    "meta": {
-      "fqn": "cerbos.principal.donald_duck.v20210210/acme.hr.uk",
-      "principal": "donald_duck",
-      "version": "20210210"
+  "fqn":  "cerbos.principal.donald_duck.v20210210/acme.hr.uk",
+  "principalPolicy":  {
+    "meta":  {
+      "fqn":  "cerbos.principal.donald_duck.v20210210/acme.hr.uk",
+      "principal":  "donald_duck",
+      "version":  "20210210"
     },
-    "policies": [
+    "policies":  [
       {
-        "scope": "acme.hr.uk",
-        "resourceRules": {
-          "leave_request": {
-            "actionRules": {
-              "*": {
-                "name": "leave_request_rule-001",
-                "effect": "EFFECT_DENY"
+        "scope":  "acme.hr.uk",
+        "resourceRules":  {
+          "leave_request":  {
+            "actionRules":  {
+              "*":  {
+                "name":  "leave_request_rule-001",
+                "effect":  "EFFECT_DENY"
               }
             }
           }
         }
       },
       {
-        "scope": "acme.hr",
-        "resourceRules": {
-          "leave_request": {
-            "actionRules": {
-              "*": {
-                "name": "leave_request_rule-001",
-                "effect": "EFFECT_ALLOW"
+        "scope":  "acme.hr",
+        "resourceRules":  {
+          "leave_request":  {
+            "actionRules":  {
+              "*":  {
+                "name":  "leave_request_rule-001",
+                "effect":  "EFFECT_ALLOW"
               }
             }
           }
         }
       },
       {
-        "scope": "acme",
-        "resourceRules": {
-          "leave_request": {
-            "actionRules": {
-              "*": {
-                "name": "leave_request_rule-001",
-                "condition": {
-                  "expr": {
-                    "original": "request.resource.attr.dev_record == true",
-                    "checked": {
-                      "referenceMap": {
-                        "1": {
-                          "name": "request"
+        "scope":  "acme",
+        "resourceRules":  {
+          "leave_request":  {
+            "actionRules":  {
+              "*":  {
+                "name":  "leave_request_rule-001",
+                "condition":  {
+                  "expr":  {
+                    "original":  "request.resource.attr.dev_record == true",
+                    "checked":  {
+                      "referenceMap":  {
+                        "1":  {
+                          "name":  "request"
                         },
-                        "5": {
-                          "overloadId": [
+                        "5":  {
+                          "overloadId":  [
                             "equals"
                           ]
                         }
                       },
-                      "typeMap": {
-                        "1": {
-                          "messageType": "cerbos.engine.v1.CheckInput"
+                      "typeMap":  {
+                        "1":  {
+                          "messageType":  "cerbos.engine.v1.CheckInput"
                         },
-                        "2": {
-                          "messageType": "cerbos.engine.v1.Resource"
+                        "2":  {
+                          "messageType":  "cerbos.engine.v1.Resource"
                         },
-                        "3": {
-                          "mapType": {
-                            "keyType": {
-                              "primitive": "STRING"
+                        "3":  {
+                          "mapType":  {
+                            "keyType":  {
+                              "primitive":  "STRING"
                             },
-                            "valueType": {
-                              "dyn": {}
+                            "valueType":  {
+                              "dyn":  {}
                             }
                           }
                         },
-                        "4": {
-                          "dyn": {}
+                        "4":  {
+                          "dyn":  {}
                         },
-                        "5": {
-                          "primitive": "BOOL"
+                        "5":  {
+                          "primitive":  "BOOL"
                         },
-                        "6": {
-                          "primitive": "BOOL"
+                        "6":  {
+                          "primitive":  "BOOL"
                         }
                       },
-                      "sourceInfo": {
-                        "location": "<input>",
-                        "lineOffsets": [
+                      "sourceInfo":  {
+                        "location":  "<input>",
+                        "lineOffsets":  [
                           41
                         ],
-                        "positions": {
-                          "1": 0,
-                          "2": 7,
-                          "3": 16,
-                          "4": 21,
-                          "5": 33,
-                          "6": 36
+                        "positions":  {
+                          "1":  0,
+                          "2":  7,
+                          "3":  16,
+                          "4":  21,
+                          "5":  33,
+                          "6":  36
                         }
                       },
-                      "expr": {
-                        "id": "5",
-                        "callExpr": {
-                          "function": "_==_",
-                          "args": [
+                      "expr":  {
+                        "id":  "5",
+                        "callExpr":  {
+                          "function":  "_==_",
+                          "args":  [
                             {
-                              "id": "4",
-                              "selectExpr": {
-                                "operand": {
-                                  "id": "3",
-                                  "selectExpr": {
-                                    "operand": {
-                                      "id": "2",
-                                      "selectExpr": {
-                                        "operand": {
-                                          "id": "1",
-                                          "identExpr": {
-                                            "name": "request"
+                              "id":  "4",
+                              "selectExpr":  {
+                                "operand":  {
+                                  "id":  "3",
+                                  "selectExpr":  {
+                                    "operand":  {
+                                      "id":  "2",
+                                      "selectExpr":  {
+                                        "operand":  {
+                                          "id":  "1",
+                                          "identExpr":  {
+                                            "name":  "request"
                                           }
                                         },
-                                        "field": "resource"
+                                        "field":  "resource"
                                       }
                                     },
-                                    "field": "attr"
+                                    "field":  "attr"
                                   }
                                 },
-                                "field": "dev_record"
+                                "field":  "dev_record"
                               }
                             },
                             {
-                              "id": "6",
-                              "constExpr": {
-                                "boolValue": true
+                              "id":  "6",
+                              "constExpr":  {
+                                "boolValue":  true
                               }
                             }
                           ]
@@ -136,15 +136,27 @@
                     }
                   }
                 },
-                "effect": "EFFECT_ALLOW"
+                "effect":  "EFFECT_ALLOW"
               }
             }
           },
-          "salary_record": {
-            "actionRules": {
-              "*": {
-                "name": "salary_record_rule-001",
-                "effect": "EFFECT_DENY"
+          "salary_record":  {
+            "actionRules":  {
+              "*":  {
+                "name":  "salary_record_rule-001",
+                "effect":  "EFFECT_DENY"
+              }
+            }
+          }
+        }
+      },
+      {
+        "resourceRules":  {
+          "leave_request":  {
+            "actionRules":  {
+              "*":  {
+                "name":  "leave_request_rule-001",
+                "effect":  "EFFECT_ALLOW"
               }
             }
           }

--- a/internal/test/testdata/compile/scoped_resource_policy_set.yaml
+++ b/internal/test/testdata/compile/scoped_resource_policy_set.yaml
@@ -1,6 +1,25 @@
 ---
 mainDef: "leave_request.acme.hr.uk.yaml"
 inputDefs:
+  "leave_request.yaml":
+     apiVersion: api.cerbos.dev/v1
+     resourcePolicy:
+       resource: leave_request
+       version: "20210210"
+       importDerivedRoles:
+         - my_derived_roles
+       schemas:
+         principalSchema:
+           ref: cerbos:///complex_object.json
+         resourceSchema:
+           ref: cerbos:///complex_object.json
+       rules:
+         - actions: ['*']
+           effect: EFFECT_ALLOW
+           roles:
+             - admin
+           name: wildcard
+
   "leave_request.acme.yaml":
      apiVersion: api.cerbos.dev/v1
      resourcePolicy:
@@ -15,11 +34,6 @@ inputDefs:
          resourceSchema:
            ref: cerbos:///complex_object.json
        rules:
-         - actions: ['*']
-           effect: EFFECT_ALLOW
-           roles:
-             - admin
-           name: wildcard
          - actions: ["create"]
            derivedRoles:
              - employee_that_owns_the_record

--- a/internal/test/testdata/compile/scoped_resource_policy_set.yaml.golden
+++ b/internal/test/testdata/compile/scoped_resource_policy_set.yaml.golden
@@ -1,151 +1,151 @@
 {
-  "fqn": "cerbos.resource.leave_request.v20210210/acme.hr.uk",
-  "resourcePolicy": {
-    "meta": {
-      "fqn": "cerbos.resource.leave_request.v20210210/acme.hr.uk",
-      "resource": "leave_request",
-      "version": "20210210"
+  "fqn":  "cerbos.resource.leave_request.v20210210/acme.hr.uk",
+  "resourcePolicy":  {
+    "meta":  {
+      "fqn":  "cerbos.resource.leave_request.v20210210/acme.hr.uk",
+      "resource":  "leave_request",
+      "version":  "20210210"
     },
-    "policies": [
+    "policies":  [
       {
-        "scope": "acme.hr.uk",
-        "derivedRoles": {
-          "direct_manager": {
-            "name": "direct_manager",
-            "parentRoles": {
-              "manager": {}
+        "scope":  "acme.hr.uk",
+        "derivedRoles":  {
+          "direct_manager":  {
+            "name":  "direct_manager",
+            "parentRoles":  {
+              "manager":  {}
             },
-            "condition": {
-              "all": {
-                "expr": [
+            "condition":  {
+              "all":  {
+                "expr":  [
                   {
-                    "expr": {
-                      "original": "request.resource.attr.geography == request.principal.attr.geography",
-                      "checked": {
-                        "referenceMap": {
-                          "1": {
-                            "name": "request"
+                    "expr":  {
+                      "original":  "request.resource.attr.geography == request.principal.attr.geography",
+                      "checked":  {
+                        "referenceMap":  {
+                          "1":  {
+                            "name":  "request"
                           },
-                          "5": {
-                            "overloadId": [
+                          "5":  {
+                            "overloadId":  [
                               "equals"
                             ]
                           },
-                          "6": {
-                            "name": "request"
+                          "6":  {
+                            "name":  "request"
                           }
                         },
-                        "typeMap": {
-                          "1": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                        "typeMap":  {
+                          "1":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "2": {
-                            "messageType": "cerbos.engine.v1.Resource"
+                          "2":  {
+                            "messageType":  "cerbos.engine.v1.Resource"
                           },
-                          "3": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "3":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "4": {
-                            "dyn": {}
+                          "4":  {
+                            "dyn":  {}
                           },
-                          "5": {
-                            "primitive": "BOOL"
+                          "5":  {
+                            "primitive":  "BOOL"
                           },
-                          "6": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                          "6":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Principal"
+                          "7":  {
+                            "messageType":  "cerbos.engine.v1.Principal"
                           },
-                          "8": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "8":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "9": {
-                            "dyn": {}
+                          "9":  {
+                            "dyn":  {}
                           }
                         },
-                        "sourceInfo": {
-                          "location": "<input>",
-                          "lineOffsets": [
+                        "sourceInfo":  {
+                          "location":  "<input>",
+                          "lineOffsets":  [
                             68
                           ],
-                          "positions": {
-                            "1": 0,
-                            "2": 7,
-                            "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                          "positions":  {
+                            "1":  0,
+                            "2":  7,
+                            "3":  16,
+                            "4":  21,
+                            "5":  32,
+                            "6":  35,
+                            "7":  42,
+                            "8":  52,
+                            "9":  57
                           }
                         },
-                        "expr": {
-                          "id": "5",
-                          "callExpr": {
-                            "function": "_==_",
-                            "args": [
+                        "expr":  {
+                          "id":  "5",
+                          "callExpr":  {
+                            "function":  "_==_",
+                            "args":  [
                               {
-                                "id": "4",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "3",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "2",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "1",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "4",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "3",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "2",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "1",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "resource"
+                                          "field":  "resource"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "geography"
+                                  "field":  "geography"
                                 }
                               },
                               {
-                                "id": "9",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "8",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "7",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "6",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "9",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "8",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "7",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "6",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "principal"
+                                          "field":  "principal"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "geography"
+                                  "field":  "geography"
                                 }
                               }
                             ]
@@ -155,133 +155,133 @@
                     }
                   },
                   {
-                    "expr": {
-                      "original": "request.resource.attr.geography == request.principal.attr.managed_geographies",
-                      "checked": {
-                        "referenceMap": {
-                          "1": {
-                            "name": "request"
+                    "expr":  {
+                      "original":  "request.resource.attr.geography == request.principal.attr.managed_geographies",
+                      "checked":  {
+                        "referenceMap":  {
+                          "1":  {
+                            "name":  "request"
                           },
-                          "5": {
-                            "overloadId": [
+                          "5":  {
+                            "overloadId":  [
                               "equals"
                             ]
                           },
-                          "6": {
-                            "name": "request"
+                          "6":  {
+                            "name":  "request"
                           }
                         },
-                        "typeMap": {
-                          "1": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                        "typeMap":  {
+                          "1":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "2": {
-                            "messageType": "cerbos.engine.v1.Resource"
+                          "2":  {
+                            "messageType":  "cerbos.engine.v1.Resource"
                           },
-                          "3": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "3":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "4": {
-                            "dyn": {}
+                          "4":  {
+                            "dyn":  {}
                           },
-                          "5": {
-                            "primitive": "BOOL"
+                          "5":  {
+                            "primitive":  "BOOL"
                           },
-                          "6": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                          "6":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Principal"
+                          "7":  {
+                            "messageType":  "cerbos.engine.v1.Principal"
                           },
-                          "8": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "8":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "9": {
-                            "dyn": {}
+                          "9":  {
+                            "dyn":  {}
                           }
                         },
-                        "sourceInfo": {
-                          "location": "<input>",
-                          "lineOffsets": [
+                        "sourceInfo":  {
+                          "location":  "<input>",
+                          "lineOffsets":  [
                             78
                           ],
-                          "positions": {
-                            "1": 0,
-                            "2": 7,
-                            "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                          "positions":  {
+                            "1":  0,
+                            "2":  7,
+                            "3":  16,
+                            "4":  21,
+                            "5":  32,
+                            "6":  35,
+                            "7":  42,
+                            "8":  52,
+                            "9":  57
                           }
                         },
-                        "expr": {
-                          "id": "5",
-                          "callExpr": {
-                            "function": "_==_",
-                            "args": [
+                        "expr":  {
+                          "id":  "5",
+                          "callExpr":  {
+                            "function":  "_==_",
+                            "args":  [
                               {
-                                "id": "4",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "3",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "2",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "1",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "4",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "3",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "2",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "1",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "resource"
+                                          "field":  "resource"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "geography"
+                                  "field":  "geography"
                                 }
                               },
                               {
-                                "id": "9",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "8",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "7",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "6",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "9",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "8",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "7",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "6",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "principal"
+                                          "field":  "principal"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "managed_geographies"
+                                  "field":  "managed_geographies"
                                 }
                               }
                             ]
@@ -295,106 +295,106 @@
             }
           }
         },
-        "rules": [
+        "rules":  [
           {
-            "name": "rule-001",
-            "actions": {
-              "approve": {}
+            "name":  "rule-001",
+            "actions":  {
+              "approve":  {}
             },
-            "derivedRoles": {
-              "direct_manager": {}
+            "derivedRoles":  {
+              "direct_manager":  {}
             },
-            "roles": {
-              "hr_bp": {}
+            "roles":  {
+              "hr_bp":  {}
             },
-            "condition": {
-              "expr": {
-                "original": "request.resource.attr.status == \"PENDING_APPROVAL\"",
-                "checked": {
-                  "referenceMap": {
-                    "1": {
-                      "name": "request"
+            "condition":  {
+              "expr":  {
+                "original":  "request.resource.attr.status == \"PENDING_APPROVAL\"",
+                "checked":  {
+                  "referenceMap":  {
+                    "1":  {
+                      "name":  "request"
                     },
-                    "5": {
-                      "overloadId": [
+                    "5":  {
+                      "overloadId":  [
                         "equals"
                       ]
                     }
                   },
-                  "typeMap": {
-                    "1": {
-                      "messageType": "cerbos.engine.v1.CheckInput"
+                  "typeMap":  {
+                    "1":  {
+                      "messageType":  "cerbos.engine.v1.CheckInput"
                     },
-                    "2": {
-                      "messageType": "cerbos.engine.v1.Resource"
+                    "2":  {
+                      "messageType":  "cerbos.engine.v1.Resource"
                     },
-                    "3": {
-                      "mapType": {
-                        "keyType": {
-                          "primitive": "STRING"
+                    "3":  {
+                      "mapType":  {
+                        "keyType":  {
+                          "primitive":  "STRING"
                         },
-                        "valueType": {
-                          "dyn": {}
+                        "valueType":  {
+                          "dyn":  {}
                         }
                       }
                     },
-                    "4": {
-                      "dyn": {}
+                    "4":  {
+                      "dyn":  {}
                     },
-                    "5": {
-                      "primitive": "BOOL"
+                    "5":  {
+                      "primitive":  "BOOL"
                     },
-                    "6": {
-                      "primitive": "STRING"
+                    "6":  {
+                      "primitive":  "STRING"
                     }
                   },
-                  "sourceInfo": {
-                    "location": "<input>",
-                    "lineOffsets": [
+                  "sourceInfo":  {
+                    "location":  "<input>",
+                    "lineOffsets":  [
                       51
                     ],
-                    "positions": {
-                      "1": 0,
-                      "2": 7,
-                      "3": 16,
-                      "4": 21,
-                      "5": 29,
-                      "6": 32
+                    "positions":  {
+                      "1":  0,
+                      "2":  7,
+                      "3":  16,
+                      "4":  21,
+                      "5":  29,
+                      "6":  32
                     }
                   },
-                  "expr": {
-                    "id": "5",
-                    "callExpr": {
-                      "function": "_==_",
-                      "args": [
+                  "expr":  {
+                    "id":  "5",
+                    "callExpr":  {
+                      "function":  "_==_",
+                      "args":  [
                         {
-                          "id": "4",
-                          "selectExpr": {
-                            "operand": {
-                              "id": "3",
-                              "selectExpr": {
-                                "operand": {
-                                  "id": "2",
-                                  "selectExpr": {
-                                    "operand": {
-                                      "id": "1",
-                                      "identExpr": {
-                                        "name": "request"
+                          "id":  "4",
+                          "selectExpr":  {
+                            "operand":  {
+                              "id":  "3",
+                              "selectExpr":  {
+                                "operand":  {
+                                  "id":  "2",
+                                  "selectExpr":  {
+                                    "operand":  {
+                                      "id":  "1",
+                                      "identExpr":  {
+                                        "name":  "request"
                                       }
                                     },
-                                    "field": "resource"
+                                    "field":  "resource"
                                   }
                                 },
-                                "field": "attr"
+                                "field":  "attr"
                               }
                             },
-                            "field": "status"
+                            "field":  "status"
                           }
                         },
                         {
-                          "id": "6",
-                          "constExpr": {
-                            "stringValue": "PENDING_APPROVAL"
+                          "id":  "6",
+                          "constExpr":  {
+                            "stringValue":  "PENDING_APPROVAL"
                           }
                         }
                       ]
@@ -403,171 +403,171 @@
                 }
               }
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           }
         ]
       },
       {
-        "scope": "acme.hr",
-        "rules": [
+        "scope":  "acme.hr",
+        "rules":  [
           {
-            "name": "wildcard",
-            "actions": {
-              "*": {}
+            "name":  "wildcard",
+            "actions":  {
+              "*":  {}
             },
-            "roles": {
-              "admin": {},
-              "hr_admin": {}
+            "roles":  {
+              "admin":  {},
+              "hr_admin":  {}
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           }
         ]
       },
       {
-        "scope": "acme",
-        "derivedRoles": {
-          "any_employee": {
-            "name": "any_employee",
-            "parentRoles": {
-              "employee": {}
+        "scope":  "acme",
+        "derivedRoles":  {
+          "any_employee":  {
+            "name":  "any_employee",
+            "parentRoles":  {
+              "employee":  {}
             }
           },
-          "direct_manager": {
-            "name": "direct_manager",
-            "parentRoles": {
-              "manager": {}
+          "direct_manager":  {
+            "name":  "direct_manager",
+            "parentRoles":  {
+              "manager":  {}
             },
-            "condition": {
-              "all": {
-                "expr": [
+            "condition":  {
+              "all":  {
+                "expr":  [
                   {
-                    "expr": {
-                      "original": "request.resource.attr.geography == request.principal.attr.geography",
-                      "checked": {
-                        "referenceMap": {
-                          "1": {
-                            "name": "request"
+                    "expr":  {
+                      "original":  "request.resource.attr.geography == request.principal.attr.geography",
+                      "checked":  {
+                        "referenceMap":  {
+                          "1":  {
+                            "name":  "request"
                           },
-                          "5": {
-                            "overloadId": [
+                          "5":  {
+                            "overloadId":  [
                               "equals"
                             ]
                           },
-                          "6": {
-                            "name": "request"
+                          "6":  {
+                            "name":  "request"
                           }
                         },
-                        "typeMap": {
-                          "1": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                        "typeMap":  {
+                          "1":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "2": {
-                            "messageType": "cerbos.engine.v1.Resource"
+                          "2":  {
+                            "messageType":  "cerbos.engine.v1.Resource"
                           },
-                          "3": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "3":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "4": {
-                            "dyn": {}
+                          "4":  {
+                            "dyn":  {}
                           },
-                          "5": {
-                            "primitive": "BOOL"
+                          "5":  {
+                            "primitive":  "BOOL"
                           },
-                          "6": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                          "6":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Principal"
+                          "7":  {
+                            "messageType":  "cerbos.engine.v1.Principal"
                           },
-                          "8": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "8":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "9": {
-                            "dyn": {}
+                          "9":  {
+                            "dyn":  {}
                           }
                         },
-                        "sourceInfo": {
-                          "location": "<input>",
-                          "lineOffsets": [
+                        "sourceInfo":  {
+                          "location":  "<input>",
+                          "lineOffsets":  [
                             68
                           ],
-                          "positions": {
-                            "1": 0,
-                            "2": 7,
-                            "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                          "positions":  {
+                            "1":  0,
+                            "2":  7,
+                            "3":  16,
+                            "4":  21,
+                            "5":  32,
+                            "6":  35,
+                            "7":  42,
+                            "8":  52,
+                            "9":  57
                           }
                         },
-                        "expr": {
-                          "id": "5",
-                          "callExpr": {
-                            "function": "_==_",
-                            "args": [
+                        "expr":  {
+                          "id":  "5",
+                          "callExpr":  {
+                            "function":  "_==_",
+                            "args":  [
                               {
-                                "id": "4",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "3",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "2",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "1",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "4",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "3",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "2",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "1",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "resource"
+                                          "field":  "resource"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "geography"
+                                  "field":  "geography"
                                 }
                               },
                               {
-                                "id": "9",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "8",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "7",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "6",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "9",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "8",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "7",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "6",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "principal"
+                                          "field":  "principal"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "geography"
+                                  "field":  "geography"
                                 }
                               }
                             ]
@@ -577,133 +577,133 @@
                     }
                   },
                   {
-                    "expr": {
-                      "original": "request.resource.attr.geography == request.principal.attr.managed_geographies",
-                      "checked": {
-                        "referenceMap": {
-                          "1": {
-                            "name": "request"
+                    "expr":  {
+                      "original":  "request.resource.attr.geography == request.principal.attr.managed_geographies",
+                      "checked":  {
+                        "referenceMap":  {
+                          "1":  {
+                            "name":  "request"
                           },
-                          "5": {
-                            "overloadId": [
+                          "5":  {
+                            "overloadId":  [
                               "equals"
                             ]
                           },
-                          "6": {
-                            "name": "request"
+                          "6":  {
+                            "name":  "request"
                           }
                         },
-                        "typeMap": {
-                          "1": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                        "typeMap":  {
+                          "1":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "2": {
-                            "messageType": "cerbos.engine.v1.Resource"
+                          "2":  {
+                            "messageType":  "cerbos.engine.v1.Resource"
                           },
-                          "3": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "3":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "4": {
-                            "dyn": {}
+                          "4":  {
+                            "dyn":  {}
                           },
-                          "5": {
-                            "primitive": "BOOL"
+                          "5":  {
+                            "primitive":  "BOOL"
                           },
-                          "6": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                          "6":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Principal"
+                          "7":  {
+                            "messageType":  "cerbos.engine.v1.Principal"
                           },
-                          "8": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "8":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "9": {
-                            "dyn": {}
+                          "9":  {
+                            "dyn":  {}
                           }
                         },
-                        "sourceInfo": {
-                          "location": "<input>",
-                          "lineOffsets": [
+                        "sourceInfo":  {
+                          "location":  "<input>",
+                          "lineOffsets":  [
                             78
                           ],
-                          "positions": {
-                            "1": 0,
-                            "2": 7,
-                            "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                          "positions":  {
+                            "1":  0,
+                            "2":  7,
+                            "3":  16,
+                            "4":  21,
+                            "5":  32,
+                            "6":  35,
+                            "7":  42,
+                            "8":  52,
+                            "9":  57
                           }
                         },
-                        "expr": {
-                          "id": "5",
-                          "callExpr": {
-                            "function": "_==_",
-                            "args": [
+                        "expr":  {
+                          "id":  "5",
+                          "callExpr":  {
+                            "function":  "_==_",
+                            "args":  [
                               {
-                                "id": "4",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "3",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "2",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "1",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "4",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "3",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "2",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "1",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "resource"
+                                          "field":  "resource"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "geography"
+                                  "field":  "geography"
                                 }
                               },
                               {
-                                "id": "9",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "8",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "7",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "6",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "9",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "8",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "7",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "6",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "principal"
+                                          "field":  "principal"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "managed_geographies"
+                                  "field":  "managed_geographies"
                                 }
                               }
                             ]
@@ -716,102 +716,102 @@
               }
             }
           },
-          "employee_that_owns_the_record": {
-            "name": "employee_that_owns_the_record",
-            "parentRoles": {
-              "employee": {}
+          "employee_that_owns_the_record":  {
+            "name":  "employee_that_owns_the_record",
+            "parentRoles":  {
+              "employee":  {}
             },
-            "condition": {
-              "expr": {
-                "original": "R.attr.owner == P.id",
-                "checked": {
-                  "referenceMap": {
-                    "1": {
-                      "name": "R"
+            "condition":  {
+              "expr":  {
+                "original":  "R.attr.owner == P.id",
+                "checked":  {
+                  "referenceMap":  {
+                    "1":  {
+                      "name":  "R"
                     },
-                    "4": {
-                      "overloadId": [
+                    "4":  {
+                      "overloadId":  [
                         "equals"
                       ]
                     },
-                    "5": {
-                      "name": "P"
+                    "5":  {
+                      "name":  "P"
                     }
                   },
-                  "typeMap": {
-                    "1": {
-                      "messageType": "cerbos.engine.v1.Resource"
+                  "typeMap":  {
+                    "1":  {
+                      "messageType":  "cerbos.engine.v1.Resource"
                     },
-                    "2": {
-                      "mapType": {
-                        "keyType": {
-                          "primitive": "STRING"
+                    "2":  {
+                      "mapType":  {
+                        "keyType":  {
+                          "primitive":  "STRING"
                         },
-                        "valueType": {
-                          "dyn": {}
+                        "valueType":  {
+                          "dyn":  {}
                         }
                       }
                     },
-                    "3": {
-                      "dyn": {}
+                    "3":  {
+                      "dyn":  {}
                     },
-                    "4": {
-                      "primitive": "BOOL"
+                    "4":  {
+                      "primitive":  "BOOL"
                     },
-                    "5": {
-                      "messageType": "cerbos.engine.v1.Principal"
+                    "5":  {
+                      "messageType":  "cerbos.engine.v1.Principal"
                     },
-                    "6": {
-                      "primitive": "STRING"
+                    "6":  {
+                      "primitive":  "STRING"
                     }
                   },
-                  "sourceInfo": {
-                    "location": "<input>",
-                    "lineOffsets": [
+                  "sourceInfo":  {
+                    "location":  "<input>",
+                    "lineOffsets":  [
                       21
                     ],
-                    "positions": {
-                      "1": 0,
-                      "2": 1,
-                      "3": 6,
-                      "4": 13,
-                      "5": 16,
-                      "6": 17
+                    "positions":  {
+                      "1":  0,
+                      "2":  1,
+                      "3":  6,
+                      "4":  13,
+                      "5":  16,
+                      "6":  17
                     }
                   },
-                  "expr": {
-                    "id": "4",
-                    "callExpr": {
-                      "function": "_==_",
-                      "args": [
+                  "expr":  {
+                    "id":  "4",
+                    "callExpr":  {
+                      "function":  "_==_",
+                      "args":  [
                         {
-                          "id": "3",
-                          "selectExpr": {
-                            "operand": {
-                              "id": "2",
-                              "selectExpr": {
-                                "operand": {
-                                  "id": "1",
-                                  "identExpr": {
-                                    "name": "R"
+                          "id":  "3",
+                          "selectExpr":  {
+                            "operand":  {
+                              "id":  "2",
+                              "selectExpr":  {
+                                "operand":  {
+                                  "id":  "1",
+                                  "identExpr":  {
+                                    "name":  "R"
                                   }
                                 },
-                                "field": "attr"
+                                "field":  "attr"
                               }
                             },
-                            "field": "owner"
+                            "field":  "owner"
                           }
                         },
                         {
-                          "id": "6",
-                          "selectExpr": {
-                            "operand": {
-                              "id": "5",
-                              "identExpr": {
-                                "name": "P"
+                          "id":  "6",
+                          "selectExpr":  {
+                            "operand":  {
+                              "id":  "5",
+                              "identExpr":  {
+                                "name":  "P"
                               }
                             },
-                            "field": "id"
+                            "field":  "id"
                           }
                         }
                       ]
@@ -822,144 +822,134 @@
             }
           }
         },
-        "rules": [
+        "rules":  [
           {
-            "name": "wildcard",
-            "actions": {
-              "*": {}
+            "name":  "rule-001",
+            "actions":  {
+              "create":  {}
             },
-            "roles": {
-              "admin": {}
+            "derivedRoles":  {
+              "employee_that_owns_the_record":  {}
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           },
           {
-            "name": "rule-002",
-            "actions": {
-              "create": {}
+            "name":  "rule-002",
+            "actions":  {
+              "view:*":  {}
             },
-            "derivedRoles": {
-              "employee_that_owns_the_record": {}
+            "derivedRoles":  {
+              "direct_manager":  {},
+              "employee_that_owns_the_record":  {}
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           },
           {
-            "name": "rule-003",
-            "actions": {
-              "view:*": {}
+            "name":  "rule-003",
+            "actions":  {
+              "view:public":  {}
             },
-            "derivedRoles": {
-              "direct_manager": {},
-              "employee_that_owns_the_record": {}
+            "derivedRoles":  {
+              "any_employee":  {}
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           },
           {
-            "name": "rule-004",
-            "actions": {
-              "view:public": {}
+            "name":  "rule-004",
+            "actions":  {
+              "approve":  {}
             },
-            "derivedRoles": {
-              "any_employee": {}
+            "derivedRoles":  {
+              "direct_manager":  {}
             },
-            "effect": "EFFECT_ALLOW"
-          },
-          {
-            "name": "rule-005",
-            "actions": {
-              "approve": {}
-            },
-            "derivedRoles": {
-              "direct_manager": {}
-            },
-            "condition": {
-              "expr": {
-                "original": "request.resource.attr.status == \"PENDING_APPROVAL\"",
-                "checked": {
-                  "referenceMap": {
-                    "1": {
-                      "name": "request"
+            "condition":  {
+              "expr":  {
+                "original":  "request.resource.attr.status == \"PENDING_APPROVAL\"",
+                "checked":  {
+                  "referenceMap":  {
+                    "1":  {
+                      "name":  "request"
                     },
-                    "5": {
-                      "overloadId": [
+                    "5":  {
+                      "overloadId":  [
                         "equals"
                       ]
                     }
                   },
-                  "typeMap": {
-                    "1": {
-                      "messageType": "cerbos.engine.v1.CheckInput"
+                  "typeMap":  {
+                    "1":  {
+                      "messageType":  "cerbos.engine.v1.CheckInput"
                     },
-                    "2": {
-                      "messageType": "cerbos.engine.v1.Resource"
+                    "2":  {
+                      "messageType":  "cerbos.engine.v1.Resource"
                     },
-                    "3": {
-                      "mapType": {
-                        "keyType": {
-                          "primitive": "STRING"
+                    "3":  {
+                      "mapType":  {
+                        "keyType":  {
+                          "primitive":  "STRING"
                         },
-                        "valueType": {
-                          "dyn": {}
+                        "valueType":  {
+                          "dyn":  {}
                         }
                       }
                     },
-                    "4": {
-                      "dyn": {}
+                    "4":  {
+                      "dyn":  {}
                     },
-                    "5": {
-                      "primitive": "BOOL"
+                    "5":  {
+                      "primitive":  "BOOL"
                     },
-                    "6": {
-                      "primitive": "STRING"
+                    "6":  {
+                      "primitive":  "STRING"
                     }
                   },
-                  "sourceInfo": {
-                    "location": "<input>",
-                    "lineOffsets": [
+                  "sourceInfo":  {
+                    "location":  "<input>",
+                    "lineOffsets":  [
                       51
                     ],
-                    "positions": {
-                      "1": 0,
-                      "2": 7,
-                      "3": 16,
-                      "4": 21,
-                      "5": 29,
-                      "6": 32
+                    "positions":  {
+                      "1":  0,
+                      "2":  7,
+                      "3":  16,
+                      "4":  21,
+                      "5":  29,
+                      "6":  32
                     }
                   },
-                  "expr": {
-                    "id": "5",
-                    "callExpr": {
-                      "function": "_==_",
-                      "args": [
+                  "expr":  {
+                    "id":  "5",
+                    "callExpr":  {
+                      "function":  "_==_",
+                      "args":  [
                         {
-                          "id": "4",
-                          "selectExpr": {
-                            "operand": {
-                              "id": "3",
-                              "selectExpr": {
-                                "operand": {
-                                  "id": "2",
-                                  "selectExpr": {
-                                    "operand": {
-                                      "id": "1",
-                                      "identExpr": {
-                                        "name": "request"
+                          "id":  "4",
+                          "selectExpr":  {
+                            "operand":  {
+                              "id":  "3",
+                              "selectExpr":  {
+                                "operand":  {
+                                  "id":  "2",
+                                  "selectExpr":  {
+                                    "operand":  {
+                                      "id":  "1",
+                                      "identExpr":  {
+                                        "name":  "request"
                                       }
                                     },
-                                    "field": "resource"
+                                    "field":  "resource"
                                   }
                                 },
-                                "field": "attr"
+                                "field":  "attr"
                               }
                             },
-                            "field": "status"
+                            "field":  "status"
                           }
                         },
                         {
-                          "id": "6",
-                          "constExpr": {
-                            "stringValue": "PENDING_APPROVAL"
+                          "id":  "6",
+                          "constExpr":  {
+                            "stringValue":  "PENDING_APPROVAL"
                           }
                         }
                       ]
@@ -968,25 +958,47 @@
                 }
               }
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           }
         ],
-        "schemas": {
-          "principalSchema": {
-            "ref": "cerbos:///complex_object.json"
+        "schemas":  {
+          "principalSchema":  {
+            "ref":  "cerbos:///complex_object.json"
           },
-          "resourceSchema": {
-            "ref": "cerbos:///complex_object.json"
+          "resourceSchema":  {
+            "ref":  "cerbos:///complex_object.json"
+          }
+        }
+      },
+      {
+        "rules":  [
+          {
+            "name":  "wildcard",
+            "actions":  {
+              "*":  {}
+            },
+            "roles":  {
+              "admin":  {}
+            },
+            "effect":  "EFFECT_ALLOW"
+          }
+        ],
+        "schemas":  {
+          "principalSchema":  {
+            "ref":  "cerbos:///complex_object.json"
+          },
+          "resourceSchema":  {
+            "ref":  "cerbos:///complex_object.json"
           }
         }
       }
     ],
-    "schemas": {
-      "principalSchema": {
-        "ref": "cerbos:///complex_object.json"
+    "schemas":  {
+      "principalSchema":  {
+        "ref":  "cerbos:///complex_object.json"
       },
-      "resourceSchema": {
-        "ref": "cerbos:///complex_object.json"
+      "resourceSchema":  {
+        "ref":  "cerbos:///complex_object.json"
       }
     }
   }

--- a/internal/test/testdata/compile/scoped_rp_missing_ancestor.yaml
+++ b/internal/test/testdata/compile/scoped_rp_missing_ancestor.yaml
@@ -4,6 +4,11 @@ wantErrors:
     error: missing policy definition
     desc: |-
       Missing ancestor policy "resource.leave_request.v20210210/acme.hr"
+
+  - file: leave_request.acme.hr.uk.yaml
+    error: missing policy definition
+    desc: |-
+      Missing ancestor policy "resource.leave_request.v20210210"
 mainDef: "leave_request.acme.hr.uk.yaml"
 inputDefs:
   "leave_request.acme.yaml":

--- a/internal/test/testdata/compile/simple_valid_policy_set.yaml.golden
+++ b/internal/test/testdata/compile/simple_valid_policy_set.yaml.golden
@@ -1,156 +1,156 @@
 {
-  "fqn": "cerbos.resource.leave_request.v20210210",
-  "resourcePolicy": {
-    "meta": {
-      "fqn": "cerbos.resource.leave_request.v20210210",
-      "resource": "leave_request",
-      "version": "20210210"
+  "fqn":  "cerbos.resource.leave_request.v20210210",
+  "resourcePolicy":  {
+    "meta":  {
+      "fqn":  "cerbos.resource.leave_request.v20210210",
+      "resource":  "leave_request",
+      "version":  "20210210"
     },
-    "policies": [
+    "policies":  [
       {
-        "derivedRoles": {
-          "any_employee": {
-            "name": "any_employee",
-            "parentRoles": {
-              "employee": {}
+        "derivedRoles":  {
+          "any_employee":  {
+            "name":  "any_employee",
+            "parentRoles":  {
+              "employee":  {}
             }
           },
-          "direct_manager": {
-            "name": "direct_manager",
-            "parentRoles": {
-              "manager": {}
+          "direct_manager":  {
+            "name":  "direct_manager",
+            "parentRoles":  {
+              "manager":  {}
             },
-            "condition": {
-              "all": {
-                "expr": [
+            "condition":  {
+              "all":  {
+                "expr":  [
                   {
-                    "expr": {
-                      "original": "request.resource.attr.geography == request.principal.attr.geography",
-                      "checked": {
-                        "referenceMap": {
-                          "1": {
-                            "name": "request"
+                    "expr":  {
+                      "original":  "request.resource.attr.geography == request.principal.attr.geography",
+                      "checked":  {
+                        "referenceMap":  {
+                          "1":  {
+                            "name":  "request"
                           },
-                          "5": {
-                            "overloadId": [
+                          "5":  {
+                            "overloadId":  [
                               "equals"
                             ]
                           },
-                          "6": {
-                            "name": "request"
+                          "6":  {
+                            "name":  "request"
                           }
                         },
-                        "typeMap": {
-                          "1": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                        "typeMap":  {
+                          "1":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "2": {
-                            "messageType": "cerbos.engine.v1.Resource"
+                          "2":  {
+                            "messageType":  "cerbos.engine.v1.Resource"
                           },
-                          "3": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "3":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "4": {
-                            "dyn": {}
+                          "4":  {
+                            "dyn":  {}
                           },
-                          "5": {
-                            "primitive": "BOOL"
+                          "5":  {
+                            "primitive":  "BOOL"
                           },
-                          "6": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                          "6":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Principal"
+                          "7":  {
+                            "messageType":  "cerbos.engine.v1.Principal"
                           },
-                          "8": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "8":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "9": {
-                            "dyn": {}
+                          "9":  {
+                            "dyn":  {}
                           }
                         },
-                        "sourceInfo": {
-                          "location": "<input>",
-                          "lineOffsets": [
+                        "sourceInfo":  {
+                          "location":  "<input>",
+                          "lineOffsets":  [
                             68
                           ],
-                          "positions": {
-                            "1": 0,
-                            "2": 7,
-                            "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                          "positions":  {
+                            "1":  0,
+                            "2":  7,
+                            "3":  16,
+                            "4":  21,
+                            "5":  32,
+                            "6":  35,
+                            "7":  42,
+                            "8":  52,
+                            "9":  57
                           }
                         },
-                        "expr": {
-                          "id": "5",
-                          "callExpr": {
-                            "function": "_==_",
-                            "args": [
+                        "expr":  {
+                          "id":  "5",
+                          "callExpr":  {
+                            "function":  "_==_",
+                            "args":  [
                               {
-                                "id": "4",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "3",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "2",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "1",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "4",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "3",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "2",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "1",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "resource"
+                                          "field":  "resource"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "geography"
+                                  "field":  "geography"
                                 }
                               },
                               {
-                                "id": "9",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "8",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "7",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "6",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "9",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "8",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "7",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "6",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "principal"
+                                          "field":  "principal"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "geography"
+                                  "field":  "geography"
                                 }
                               }
                             ]
@@ -160,133 +160,133 @@
                     }
                   },
                   {
-                    "expr": {
-                      "original": "request.resource.attr.geography == request.principal.attr.managed_geographies",
-                      "checked": {
-                        "referenceMap": {
-                          "1": {
-                            "name": "request"
+                    "expr":  {
+                      "original":  "request.resource.attr.geography == request.principal.attr.managed_geographies",
+                      "checked":  {
+                        "referenceMap":  {
+                          "1":  {
+                            "name":  "request"
                           },
-                          "5": {
-                            "overloadId": [
+                          "5":  {
+                            "overloadId":  [
                               "equals"
                             ]
                           },
-                          "6": {
-                            "name": "request"
+                          "6":  {
+                            "name":  "request"
                           }
                         },
-                        "typeMap": {
-                          "1": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                        "typeMap":  {
+                          "1":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "2": {
-                            "messageType": "cerbos.engine.v1.Resource"
+                          "2":  {
+                            "messageType":  "cerbos.engine.v1.Resource"
                           },
-                          "3": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "3":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "4": {
-                            "dyn": {}
+                          "4":  {
+                            "dyn":  {}
                           },
-                          "5": {
-                            "primitive": "BOOL"
+                          "5":  {
+                            "primitive":  "BOOL"
                           },
-                          "6": {
-                            "messageType": "cerbos.engine.v1.CheckInput"
+                          "6":  {
+                            "messageType":  "cerbos.engine.v1.CheckInput"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Principal"
+                          "7":  {
+                            "messageType":  "cerbos.engine.v1.Principal"
                           },
-                          "8": {
-                            "mapType": {
-                              "keyType": {
-                                "primitive": "STRING"
+                          "8":  {
+                            "mapType":  {
+                              "keyType":  {
+                                "primitive":  "STRING"
                               },
-                              "valueType": {
-                                "dyn": {}
+                              "valueType":  {
+                                "dyn":  {}
                               }
                             }
                           },
-                          "9": {
-                            "dyn": {}
+                          "9":  {
+                            "dyn":  {}
                           }
                         },
-                        "sourceInfo": {
-                          "location": "<input>",
-                          "lineOffsets": [
+                        "sourceInfo":  {
+                          "location":  "<input>",
+                          "lineOffsets":  [
                             78
                           ],
-                          "positions": {
-                            "1": 0,
-                            "2": 7,
-                            "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                          "positions":  {
+                            "1":  0,
+                            "2":  7,
+                            "3":  16,
+                            "4":  21,
+                            "5":  32,
+                            "6":  35,
+                            "7":  42,
+                            "8":  52,
+                            "9":  57
                           }
                         },
-                        "expr": {
-                          "id": "5",
-                          "callExpr": {
-                            "function": "_==_",
-                            "args": [
+                        "expr":  {
+                          "id":  "5",
+                          "callExpr":  {
+                            "function":  "_==_",
+                            "args":  [
                               {
-                                "id": "4",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "3",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "2",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "1",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "4",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "3",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "2",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "1",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "resource"
+                                          "field":  "resource"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "geography"
+                                  "field":  "geography"
                                 }
                               },
                               {
-                                "id": "9",
-                                "selectExpr": {
-                                  "operand": {
-                                    "id": "8",
-                                    "selectExpr": {
-                                      "operand": {
-                                        "id": "7",
-                                        "selectExpr": {
-                                          "operand": {
-                                            "id": "6",
-                                            "identExpr": {
-                                              "name": "request"
+                                "id":  "9",
+                                "selectExpr":  {
+                                  "operand":  {
+                                    "id":  "8",
+                                    "selectExpr":  {
+                                      "operand":  {
+                                        "id":  "7",
+                                        "selectExpr":  {
+                                          "operand":  {
+                                            "id":  "6",
+                                            "identExpr":  {
+                                              "name":  "request"
                                             }
                                           },
-                                          "field": "principal"
+                                          "field":  "principal"
                                         }
                                       },
-                                      "field": "attr"
+                                      "field":  "attr"
                                     }
                                   },
-                                  "field": "managed_geographies"
+                                  "field":  "managed_geographies"
                                 }
                               }
                             ]
@@ -299,102 +299,102 @@
               }
             }
           },
-          "employee_that_owns_the_record": {
-            "name": "employee_that_owns_the_record",
-            "parentRoles": {
-              "employee": {}
+          "employee_that_owns_the_record":  {
+            "name":  "employee_that_owns_the_record",
+            "parentRoles":  {
+              "employee":  {}
             },
-            "condition": {
-              "expr": {
-                "original": "R.attr.owner == P.id",
-                "checked": {
-                  "referenceMap": {
-                    "1": {
-                      "name": "R"
+            "condition":  {
+              "expr":  {
+                "original":  "R.attr.owner == P.id",
+                "checked":  {
+                  "referenceMap":  {
+                    "1":  {
+                      "name":  "R"
                     },
-                    "4": {
-                      "overloadId": [
+                    "4":  {
+                      "overloadId":  [
                         "equals"
                       ]
                     },
-                    "5": {
-                      "name": "P"
+                    "5":  {
+                      "name":  "P"
                     }
                   },
-                  "typeMap": {
-                    "1": {
-                      "messageType": "cerbos.engine.v1.Resource"
+                  "typeMap":  {
+                    "1":  {
+                      "messageType":  "cerbos.engine.v1.Resource"
                     },
-                    "2": {
-                      "mapType": {
-                        "keyType": {
-                          "primitive": "STRING"
+                    "2":  {
+                      "mapType":  {
+                        "keyType":  {
+                          "primitive":  "STRING"
                         },
-                        "valueType": {
-                          "dyn": {}
+                        "valueType":  {
+                          "dyn":  {}
                         }
                       }
                     },
-                    "3": {
-                      "dyn": {}
+                    "3":  {
+                      "dyn":  {}
                     },
-                    "4": {
-                      "primitive": "BOOL"
+                    "4":  {
+                      "primitive":  "BOOL"
                     },
-                    "5": {
-                      "messageType": "cerbos.engine.v1.Principal"
+                    "5":  {
+                      "messageType":  "cerbos.engine.v1.Principal"
                     },
-                    "6": {
-                      "primitive": "STRING"
+                    "6":  {
+                      "primitive":  "STRING"
                     }
                   },
-                  "sourceInfo": {
-                    "location": "<input>",
-                    "lineOffsets": [
+                  "sourceInfo":  {
+                    "location":  "<input>",
+                    "lineOffsets":  [
                       21
                     ],
-                    "positions": {
-                      "1": 0,
-                      "2": 1,
-                      "3": 6,
-                      "4": 13,
-                      "5": 16,
-                      "6": 17
+                    "positions":  {
+                      "1":  0,
+                      "2":  1,
+                      "3":  6,
+                      "4":  13,
+                      "5":  16,
+                      "6":  17
                     }
                   },
-                  "expr": {
-                    "id": "4",
-                    "callExpr": {
-                      "function": "_==_",
-                      "args": [
+                  "expr":  {
+                    "id":  "4",
+                    "callExpr":  {
+                      "function":  "_==_",
+                      "args":  [
                         {
-                          "id": "3",
-                          "selectExpr": {
-                            "operand": {
-                              "id": "2",
-                              "selectExpr": {
-                                "operand": {
-                                  "id": "1",
-                                  "identExpr": {
-                                    "name": "R"
+                          "id":  "3",
+                          "selectExpr":  {
+                            "operand":  {
+                              "id":  "2",
+                              "selectExpr":  {
+                                "operand":  {
+                                  "id":  "1",
+                                  "identExpr":  {
+                                    "name":  "R"
                                   }
                                 },
-                                "field": "attr"
+                                "field":  "attr"
                               }
                             },
-                            "field": "owner"
+                            "field":  "owner"
                           }
                         },
                         {
-                          "id": "6",
-                          "selectExpr": {
-                            "operand": {
-                              "id": "5",
-                              "identExpr": {
-                                "name": "P"
+                          "id":  "6",
+                          "selectExpr":  {
+                            "operand":  {
+                              "id":  "5",
+                              "identExpr":  {
+                                "name":  "P"
                               }
                             },
-                            "field": "id"
+                            "field":  "id"
                           }
                         }
                       ]
@@ -405,144 +405,144 @@
             }
           }
         },
-        "rules": [
+        "rules":  [
           {
-            "name": "wildcard",
-            "actions": {
-              "*": {}
+            "name":  "wildcard",
+            "actions":  {
+              "*":  {}
             },
-            "roles": {
-              "admin": {}
+            "roles":  {
+              "admin":  {}
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           },
           {
-            "name": "rule-002",
-            "actions": {
-              "create": {}
+            "name":  "rule-002",
+            "actions":  {
+              "create":  {}
             },
-            "derivedRoles": {
-              "employee_that_owns_the_record": {}
+            "derivedRoles":  {
+              "employee_that_owns_the_record":  {}
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           },
           {
-            "name": "rule-003",
-            "actions": {
-              "view:*": {}
+            "name":  "rule-003",
+            "actions":  {
+              "view:*":  {}
             },
-            "derivedRoles": {
-              "direct_manager": {},
-              "employee_that_owns_the_record": {}
+            "derivedRoles":  {
+              "direct_manager":  {},
+              "employee_that_owns_the_record":  {}
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           },
           {
-            "name": "rule-004",
-            "actions": {
-              "view:public": {}
+            "name":  "rule-004",
+            "actions":  {
+              "view:public":  {}
             },
-            "derivedRoles": {
-              "any_employee": {}
+            "derivedRoles":  {
+              "any_employee":  {}
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           },
           {
-            "name": "rule-005",
-            "actions": {
-              "approve": {}
+            "name":  "rule-005",
+            "actions":  {
+              "approve":  {}
             },
-            "derivedRoles": {
-              "direct_manager": {}
+            "derivedRoles":  {
+              "direct_manager":  {}
             },
-            "condition": {
-              "expr": {
-                "original": "request.resource.attr.status == \"PENDING_APPROVAL\"",
-                "checked": {
-                  "referenceMap": {
-                    "1": {
-                      "name": "request"
+            "condition":  {
+              "expr":  {
+                "original":  "request.resource.attr.status == \"PENDING_APPROVAL\"",
+                "checked":  {
+                  "referenceMap":  {
+                    "1":  {
+                      "name":  "request"
                     },
-                    "5": {
-                      "overloadId": [
+                    "5":  {
+                      "overloadId":  [
                         "equals"
                       ]
                     }
                   },
-                  "typeMap": {
-                    "1": {
-                      "messageType": "cerbos.engine.v1.CheckInput"
+                  "typeMap":  {
+                    "1":  {
+                      "messageType":  "cerbos.engine.v1.CheckInput"
                     },
-                    "2": {
-                      "messageType": "cerbos.engine.v1.Resource"
+                    "2":  {
+                      "messageType":  "cerbos.engine.v1.Resource"
                     },
-                    "3": {
-                      "mapType": {
-                        "keyType": {
-                          "primitive": "STRING"
+                    "3":  {
+                      "mapType":  {
+                        "keyType":  {
+                          "primitive":  "STRING"
                         },
-                        "valueType": {
-                          "dyn": {}
+                        "valueType":  {
+                          "dyn":  {}
                         }
                       }
                     },
-                    "4": {
-                      "dyn": {}
+                    "4":  {
+                      "dyn":  {}
                     },
-                    "5": {
-                      "primitive": "BOOL"
+                    "5":  {
+                      "primitive":  "BOOL"
                     },
-                    "6": {
-                      "primitive": "STRING"
+                    "6":  {
+                      "primitive":  "STRING"
                     }
                   },
-                  "sourceInfo": {
-                    "location": "<input>",
-                    "lineOffsets": [
+                  "sourceInfo":  {
+                    "location":  "<input>",
+                    "lineOffsets":  [
                       51
                     ],
-                    "positions": {
-                      "1": 0,
-                      "2": 7,
-                      "3": 16,
-                      "4": 21,
-                      "5": 29,
-                      "6": 32
+                    "positions":  {
+                      "1":  0,
+                      "2":  7,
+                      "3":  16,
+                      "4":  21,
+                      "5":  29,
+                      "6":  32
                     }
                   },
-                  "expr": {
-                    "id": "5",
-                    "callExpr": {
-                      "function": "_==_",
-                      "args": [
+                  "expr":  {
+                    "id":  "5",
+                    "callExpr":  {
+                      "function":  "_==_",
+                      "args":  [
                         {
-                          "id": "4",
-                          "selectExpr": {
-                            "operand": {
-                              "id": "3",
-                              "selectExpr": {
-                                "operand": {
-                                  "id": "2",
-                                  "selectExpr": {
-                                    "operand": {
-                                      "id": "1",
-                                      "identExpr": {
-                                        "name": "request"
+                          "id":  "4",
+                          "selectExpr":  {
+                            "operand":  {
+                              "id":  "3",
+                              "selectExpr":  {
+                                "operand":  {
+                                  "id":  "2",
+                                  "selectExpr":  {
+                                    "operand":  {
+                                      "id":  "1",
+                                      "identExpr":  {
+                                        "name":  "request"
                                       }
                                     },
-                                    "field": "resource"
+                                    "field":  "resource"
                                   }
                                 },
-                                "field": "attr"
+                                "field":  "attr"
                               }
                             },
-                            "field": "status"
+                            "field":  "status"
                           }
                         },
                         {
-                          "id": "6",
-                          "constExpr": {
-                            "stringValue": "PENDING_APPROVAL"
+                          "id":  "6",
+                          "constExpr":  {
+                            "stringValue":  "PENDING_APPROVAL"
                           }
                         }
                       ]
@@ -551,25 +551,25 @@
                 }
               }
             },
-            "effect": "EFFECT_ALLOW"
+            "effect":  "EFFECT_ALLOW"
           }
         ],
-        "schemas": {
-          "principalSchema": {
-            "ref": "cerbos:///complex_object.json"
+        "schemas":  {
+          "principalSchema":  {
+            "ref":  "cerbos:///complex_object.json"
           },
-          "resourceSchema": {
-            "ref": "cerbos:///complex_object.json"
+          "resourceSchema":  {
+            "ref":  "cerbos:///complex_object.json"
           }
         }
       }
     ],
-    "schemas": {
-      "principalSchema": {
-        "ref": "cerbos:///complex_object.json"
+    "schemas":  {
+      "principalSchema":  {
+        "ref":  "cerbos:///complex_object.json"
       },
-      "resourceSchema": {
-        "ref": "cerbos:///complex_object.json"
+      "resourceSchema":  {
+        "ref":  "cerbos:///complex_object.json"
       }
     }
   }

--- a/internal/test/testdata/engine/case_06.yaml
+++ b/internal/test/testdata/engine/case_06.yaml
@@ -20,6 +20,7 @@ inputs: [
     },
     "resource": {
       "kind": "leave_request",
+      "policyVersion": "xxx",
       "id": "XX125",
       "attr": {
         "department": "marketing",

--- a/internal/test/testdata/index/disabled_ancestor.yaml
+++ b/internal/test/testdata/index/disabled_ancestor.yaml
@@ -10,6 +10,20 @@ wantErrJson: |-
     ]
   }
 files:
+  "resource.yaml": |-
+    ---
+    apiVersion: api.cerbos.dev/v1
+    resourcePolicy:
+      importDerivedRoles:
+      - my_derived_roles
+      resource: leave_request
+      rules:
+      - actions: ['*']
+        effect: EFFECT_ALLOW
+        roles:
+        - admin
+      version: "20210210"
+
   "resource_acme.yaml": |-
     ---
     apiVersion: api.cerbos.dev/v1
@@ -19,10 +33,6 @@ files:
       resource: leave_request
       scope: "acme"
       rules:
-      - actions: ['*']
-        effect: EFFECT_ALLOW
-        roles:
-        - admin
       - actions: ["create"]
         derivedRoles:
         - employee_that_owns_the_record

--- a/internal/test/testdata/index/duplicate_scoped_policies.yaml
+++ b/internal/test/testdata/index/duplicate_scoped_policies.yaml
@@ -77,21 +77,6 @@ files:
         effect: EFFECT_ALLOW
       version: "20210210"
 
-  "resource_acme_default.yaml": |-
-    ---
-    apiVersion: api.cerbos.dev/v1
-    resourcePolicy:
-      importDerivedRoles:
-      - my_derived_roles
-      resource: leave_request
-      scope: "acme"
-      rules:
-      - actions: ["view:public"]
-        derivedRoles:
-        - any_employee
-        effect: EFFECT_ALLOW
-      version: "default"
-
   "derived.yaml": |-
     ---
     apiVersion: "api.cerbos.dev/v1"

--- a/internal/test/testdata/index/valid_files.yaml
+++ b/internal/test/testdata/index/valid_files.yaml
@@ -14,26 +14,6 @@ files:
         effect: EFFECT_ALLOW
         roles:
         - admin
-      - actions: ["create"]
-        derivedRoles:
-        - employee_that_owns_the_record
-        effect: EFFECT_ALLOW
-      - actions: ["view:*"]
-        derivedRoles:
-        - employee_that_owns_the_record
-        - direct_manager
-        effect: EFFECT_ALLOW
-      - actions: ["view:public"]
-        derivedRoles:
-        - any_employee
-        effect: EFFECT_ALLOW
-      - actions: ["approve"]
-        condition:
-          match:
-            expr: request.resource.attr.status == "PENDING_APPROVAL"
-        derivedRoles:
-        - direct_manager
-        effect: EFFECT_ALLOW
       version: "20210210"
 
   "resource_acme.yaml": |-
@@ -45,10 +25,6 @@ files:
       resource: leave_request
       scope: "acme"
       rules:
-      - actions: ['*']
-        effect: EFFECT_ALLOW
-        roles:
-        - admin
       - actions: ["create"]
         derivedRoles:
         - employee_that_owns_the_record
@@ -189,13 +165,18 @@ wantCompilationUnits:
   - mainFqn: cerbos.principal.donald_duck.v20210210/acme
     definitionFqns: 
       - cerbos.principal.donald_duck.v20210210/acme
+      - cerbos.principal.donald_duck.v20210210
+    ancestorFqns:
+      - cerbos.principal.donald_duck.v20210210
 
   - mainFqn: cerbos.principal.donald_duck.v20210210/acme.corp
     definitionFqns: 
       - cerbos.principal.donald_duck.v20210210/acme.corp
       - cerbos.principal.donald_duck.v20210210/acme
+      - cerbos.principal.donald_duck.v20210210
     ancestorFqns:
       - cerbos.principal.donald_duck.v20210210/acme
+      - cerbos.principal.donald_duck.v20210210
 
   - mainFqn: cerbos.resource.leave_request.v20210210
     definitionFqns:
@@ -205,22 +186,29 @@ wantCompilationUnits:
   - mainFqn: cerbos.resource.leave_request.v20210210/acme
     definitionFqns:
       - cerbos.resource.leave_request.v20210210/acme
+      - cerbos.resource.leave_request.v20210210
       - cerbos.derived_roles.my_derived_roles
+    ancestorFqns:
+      - cerbos.resource.leave_request.v20210210
 
   - mainFqn: cerbos.resource.leave_request.v20210210/acme.hr
     definitionFqns:
       - cerbos.resource.leave_request.v20210210/acme.hr
       - cerbos.resource.leave_request.v20210210/acme
+      - cerbos.resource.leave_request.v20210210
       - cerbos.derived_roles.my_derived_roles
     ancestorFqns:
       - cerbos.resource.leave_request.v20210210/acme
+      - cerbos.resource.leave_request.v20210210
 
   - mainFqn: cerbos.resource.leave_request.v20210210/acme.hr.uk
     definitionFqns:
       - cerbos.resource.leave_request.v20210210/acme.hr.uk
       - cerbos.resource.leave_request.v20210210/acme.hr
       - cerbos.resource.leave_request.v20210210/acme
+      - cerbos.resource.leave_request.v20210210
       - cerbos.derived_roles.my_derived_roles
     ancestorFqns:
       - cerbos.resource.leave_request.v20210210/acme.hr
       - cerbos.resource.leave_request.v20210210/acme
+      - cerbos.resource.leave_request.v20210210

--- a/internal/test/testdata/server/admin/add_or_update_policy/case_00.yaml
+++ b/internal/test/testdata/server/admin/add_or_update_policy/case_00.yaml
@@ -9,6 +9,7 @@ adminAddOrUpdatePolicy:
       {{- readPolicy "store/derived_roles/derived_roles_01.yaml" | toPolicyJSON  }},
       {{- readPolicy "store/derived_roles/derived_roles_02.yaml" | toPolicyJSON }},
       {{- readPolicy "store/resource_policies/policy_01.yaml" | toPolicyJSON }},
+      {{- readPolicy "store/resource_policies/policy_05.yaml" | toPolicyJSON }},
       {{- readPolicy "store/resource_policies/policy_05_acme.yaml" | toPolicyJSON }},
       {{- readPolicy "store/resource_policies/policy_05_acme.hr.yaml" | toPolicyJSON }},
       {{- readPolicy "store/resource_policies/policy_05_acme.hr.uk.yaml" | toPolicyJSON }},

--- a/internal/test/testdata/server/checks/check_resource_set/crs_case_06.yaml
+++ b/internal/test/testdata/server/checks/check_resource_set/crs_case_06.yaml
@@ -24,6 +24,7 @@ checkResourceSet:
     },
     "resource": {
       "kind": "leave_request",
+      "policyVersion": "xxx",
       "instances": {
         "XX125": {
           "attr": {

--- a/internal/test/testdata/server/playground/proxy/pgp_crb_case_02.yaml
+++ b/internal/test/testdata/server/playground/proxy/pgp_crb_case_02.yaml
@@ -16,6 +16,10 @@ playgroundProxy:
         "contents": "{{ fileString `store/derived_roles/derived_roles_02.yaml` | b64enc }}",
       },
       {
+        "fileName": "policy_05.yaml",
+        "contents": "{{ fileString `store/resource_policies/policy_05.yaml` | b64enc }}",
+      },
+      {
         "fileName": "policy_05_acme.yaml",
         "contents": "{{ fileString `store/resource_policies/policy_05_acme.yaml` | b64enc }}",
       },

--- a/internal/test/testdata/server/playground/proxy/pgp_crs_case_03.yaml
+++ b/internal/test/testdata/server/playground/proxy/pgp_crs_case_03.yaml
@@ -16,6 +16,10 @@ playgroundProxy:
         "contents": "{{ fileString `store/derived_roles/derived_roles_02.yaml` | b64enc }}",
       },
       {
+        "fileName": "policy_05.yaml",
+        "contents": "{{ fileString `store/resource_policies/policy_05.yaml` | b64enc }}",
+      },
+      {
         "fileName": "policy_05_acme.yaml",
         "contents": "{{ fileString `store/resource_policies/policy_05_acme.yaml` | b64enc }}",
       },

--- a/internal/test/testdata/store/principal_policies/policy_02.yaml
+++ b/internal/test/testdata/store/principal_policies/policy_02.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: "api.cerbos.dev/v1"
+variables:
+  is_dev_record: request.resource.attr.dev_record == true
+principalPolicy:
+  principal: donald_duck
+  version: "default"
+  rules:
+    - resource: leave_request
+      actions:
+        - action: "*"
+          effect: EFFECT_ALLOW
+          name: wildcard

--- a/internal/test/testdata/store/resource_policies/policy_05.yaml
+++ b/internal/test/testdata/store/resource_policies/policy_05.yaml
@@ -2,7 +2,6 @@
 apiVersion: api.cerbos.dev/v1
 resourcePolicy:
   version: "default"
-  scope: "acme"
   importDerivedRoles:
     - alpha
     - beta
@@ -13,14 +12,8 @@ resourcePolicy:
       ref: cerbos:///leave_request.json
   resource: leave_request
   rules:
-    - actions: ["create"]
-      derivedRoles:
-        - employee_that_owns_the_record
+    - actions: ['*']
       effect: EFFECT_ALLOW
-
-    - actions: ["view:public"]
-      derivedRoles:
-        - any_employee
-      effect: EFFECT_ALLOW
-      name: public-view
-
+      roles:
+        - admin
+      name: wildcard


### PR DESCRIPTION
Makes no-scope policies the root of the tree when evaluating scoped policies.

```mermaid
stateDiagram-v2
    state "resource.leave_request.vdefault/acme.corp" as grandchild
    state "resource.leave_request.vdefault/acme" as child
    state "resource.leave_request.vdefault" as parent
    [*] --> grandchild
    grandchild --> child
    child --> parent
    parent --> [*]
``` 


Signed-off-by: Charith Ellawala <charith@cerbos.dev>

