### PR TITLE
chore(ci): Fix linter issues when running `make lint`, but not in CI

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -117,8 +117,6 @@ linters:
 issues:
   max-same-issues: 30
 
-  fix: true
-
   exclude-rules:
     - path: _test\.go
       linters:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ clean-tools:
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) $(BUF)
-	@ $(GOLANGCI_LINT) run --config=.golangci.yaml 
+	@ $(GOLANGCI_LINT) run --config=.golangci.yaml --fix
 	@ $(BUF) lint
 
 .PHONY: lint-helm

--- a/internal/conditions/cerbos_lib.go
+++ b/internal/conditions/cerbos_lib.go
@@ -174,7 +174,7 @@ func program(env *cel.Env, ast *cel.Ast, opts ...cel.ProgramOption) (cel.Program
 
 		&functions.Overload{
 			Operator: timeSinceFn,
-			Unary: callInTimestampOutDuration(now.Sub),
+			Unary:    callInTimestampOutDuration(now.Sub),
 		},
 	))
 


### PR DESCRIPTION
#### Description

I accidentally introduced a formatting error in #670, but CI didn't catch it. The golangci-lint GitHub Action does not override the `fix` setting from the config file, so when auto-fixable linter issues are found in CI they were fixed and not reported. This PR switches to using the `--fix` flag in the Makefile instead.