### PR TITLE
docs: Fix YAML syntax in testing documentation

### DIFF
--- a/docs/modules/policies/pages/compile.adoc
+++ b/docs/modules/policies/pages/compile.adoc
@@ -27,11 +27,11 @@ name: AlbumObjectTestSuite <1>
 description: Tests for verifying the album:object resource policy <2>
 resources: <3>
   alicia_album:
-    kind: "album:object",
+    kind: "album:object"
     attr:
-      owner: aliciaID,
-      id: XX125,
-      public: false,
+      owner: aliciaID
+      id: XX125
+      public: false
       flagged: false
 principals: <4>
   bradley:
@@ -109,11 +109,11 @@ principals:
 ---
 resources:
   alicia_album:
-    kind: "album:object",
+    kind: "album:object"
     attr:
-      owner: aliciaID,
-      id: XX125,
-      public: false,
+      owner: aliciaID
+      id: XX125
+      public: false
       flagged: false
 ----
 


### PR DESCRIPTION
#### Description

This PR removes spurious trailing commas from YAML in the "Testing policies" section of the docs.