### PR TITLE
fix: Configure GoReleaser to generate Homebrew formula in tap's `Formula` subdirectory

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -142,6 +142,7 @@ brews:
       name: homebrew-tap
       branch: main
       token: "{{ .Env.HOMEBREW_GITHUB_TOKEN }}"
+    folder: Formula
     ids:
       - cerbos
     homepage: "https://cerbos.dev"


### PR DESCRIPTION
#### Description

Relates to https://github.com/cerbos/homebrew-tap/issues/1, see also https://github.com/cerbos/homebrew-tap/pull/2

This PR updates the GoReleaser configuration to generate the `cerbos` Homebrew formula in the `Formula` subdirectory of https://github.com/cerbos/homebrew-tap. Currently, it's being generated in the root of the tap repository, and `brew install` is picking up the older version from the `Formula` directory.