### PR TITLE
feat: Add healthcheck command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ RUN apk add -U --no-cache ca-certificates && update-ca-certificates
 
 FROM scratch
 EXPOSE 3592 3593
+ENV CERBOS_CONFIG="/conf.default.yaml"
 VOLUME ["/policies"]
 ENTRYPOINT ["/cerbos"]
-CMD ["server", "--config=/conf.default.yaml"]
+CMD ["server"]
+HEALTHCHECK --interval=1m --timeout=3s CMD ["/cerbos", "healthcheck"]
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY cerbos /cerbos
 COPY conf.default.yaml /conf.default.yaml

--- a/cmd/cerbos/healthcheck/healthcheck.go
+++ b/cmd/cerbos/healthcheck/healthcheck.go
@@ -1,0 +1,192 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package healthcheck
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/alecthomas/kong"
+	svcv1 "github.com/cerbos/cerbos/api/genpb/cerbos/svc/v1"
+	"github.com/cerbos/cerbos/internal/util"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/local"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+const (
+	defaultGRPCHostPort = "127.0.0.1:3593"
+	defaultHTTPHostPort = "127.0.0.1:3592"
+
+	help = `
+Performs a healthcheck on a Cerbos PDP. This can be used as a Docker HEALTHCHECK command.
+By default, the local Cerbos gRPC endpoint (127.0.0.1:3593) will be checked using the gRPC healthcheck protocol. This is usually sufficient for most cases as the Cerbos REST API is built on top of the gRPC API as well.   
+
+Examples:
+
+# Check gRPC endpoint
+
+cerbos healthcheck
+
+# Check gRPC endpoint and ignore server certificate verification
+
+cerbos healthcheck --insecure
+
+# Check https endpoint, ignoring server certificate verification and with a custom timeout
+
+cerbos healthcheck --kind=https --insecure --timeout=2s
+
+# Use a different host address
+
+cerbos healthcheck --kind=http --host-port=10.0.1.5:3592
+`
+)
+
+type Cmd struct {
+	Kind      string        `help:"Healthcheck kind (${enum})" default:"grpc" enum:"grpc,http,https" env:"CERBOS_HC_KIND"`
+	HostPort  string        `help:"Host and port to check. Defaults to 127.0.0.1:3592 for http/https and 127.0.0.1:3593 for grpc" env:"CERBOS_HC_HOST"`
+	CACert    string        `help:"CA Certificate to use to verify the server certificate" type:"existingfile"`
+	Insecure  bool          `help:"Do not verify server certificate" default:"false"`
+	Plaintext bool          `help:"No TLS (gRPC only)" default:"false"`
+	Timeout   time.Duration `help:"Healthcheck timeout" default:"10s" env:"CERBOS_HC_TIMEOUT"`
+}
+
+func (c *Cmd) Run(k *kong.Kong) error {
+	switch c.Kind {
+	case "grpc":
+		return c.grpcCheck(k)
+	case "http", "https":
+		return c.httpCheck(k)
+	default:
+		return fmt.Errorf("unknown healthcheck kind %q", c.Kind)
+	}
+}
+
+func (c *Cmd) grpcCheck(k *kong.Kong) error {
+	var dialOpts []grpc.DialOption
+	if c.Plaintext {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(local.NewCredentials()))
+	} else {
+		tlsConf, err := c.mkTLSConfig()
+		if err != nil {
+			return err
+		}
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConf)))
+	}
+
+	address := defaultGRPCHostPort
+	if c.HostPort != "" {
+		address = c.HostPort
+	}
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancelFunc()
+
+	conn, err := grpc.DialContext(ctx, address, dialOpts...)
+	if err != nil {
+		return fmt.Errorf("failed to connect to gRPC service at %q: %w", c.HostPort, err)
+	}
+
+	hc := healthpb.NewHealthClient(conn)
+	resp, err := hc.Check(ctx, &healthpb.HealthCheckRequest{Service: svcv1.CerbosService_ServiceDesc.ServiceName})
+	if err != nil {
+		return fmt.Errorf("failed to execute healthcheck RPC: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(k.Stdout, resp.Status.String())
+
+	switch resp.Status {
+	case healthpb.HealthCheckResponse_SERVING, healthpb.HealthCheckResponse_UNKNOWN:
+		return nil
+	default:
+		return fmt.Errorf("service status is %q", resp.Status.String())
+	}
+}
+
+func (c *Cmd) httpCheck(k *kong.Kong) error {
+	client := &http.Client{Timeout: c.Timeout}
+
+	if c.Kind == "https" {
+		tlsConf, err := c.mkTLSConfig()
+		if err != nil {
+			return err
+		}
+
+		//nolint:forcetypeassert
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = tlsConf
+
+		client.Transport = transport
+	}
+
+	address := defaultHTTPHostPort
+	if c.HostPort != "" {
+		address = c.HostPort
+	}
+	url := fmt.Sprintf("%s://%s/_cerbos/health", c.Kind, address)
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancelFunc()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+
+	defer func() {
+		if resp.Body != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("server returned status %s (%d)", resp.Status, resp.StatusCode)
+	}
+
+	_, _ = io.Copy(k.Stdout, resp.Body)
+
+	return nil
+}
+
+func (c *Cmd) mkTLSConfig() (*tls.Config, error) {
+	tlsConfig := util.DefaultTLSConfig()
+	if c.Insecure {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	if c.CACert != "" {
+		certPool := x509.NewCertPool()
+		bs, err := os.ReadFile(c.CACert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load CA certificate from %q: %w", c.CACert, err)
+		}
+
+		ok := certPool.AppendCertsFromPEM(bs)
+		if !ok {
+			return nil, errors.New("failed to append certificates to the pool")
+		}
+
+		tlsConfig.RootCAs = certPool
+	}
+
+	return tlsConfig, nil
+}
+
+func (c *Cmd) Help() string {
+	return help
+}

--- a/cmd/cerbos/healthcheck/healthcheck.go
+++ b/cmd/cerbos/healthcheck/healthcheck.go
@@ -10,12 +10,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"time"
 
 	"github.com/alecthomas/kong"
 	svcv1 "github.com/cerbos/cerbos/api/genpb/cerbos/svc/v1"
+	"github.com/cerbos/cerbos/internal/config"
+	"github.com/cerbos/cerbos/internal/server"
 	"github.com/cerbos/cerbos/internal/util"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -26,154 +29,154 @@ import (
 const (
 	defaultGRPCHostPort = "127.0.0.1:3593"
 	defaultHTTPHostPort = "127.0.0.1:3592"
+	grpcKind            = "grpc"
+	httpKind            = "http"
 
 	help = `
 Performs a healthcheck on a Cerbos PDP. This can be used as a Docker HEALTHCHECK command.
-By default, the local Cerbos gRPC endpoint (127.0.0.1:3593) will be checked using the gRPC healthcheck protocol. This is usually sufficient for most cases as the Cerbos REST API is built on top of the gRPC API as well.   
+When the path to the Cerbos config file is provided via the '--config' flag or the CERBOS_CONFIG environment variable, the healthcheck will be automatically configured based on the settings from the file. 
+By default, the gRPC endpoint will be checked using the gRPC healthcheck protocol. This is usually sufficient for most cases as the Cerbos REST API is built on top of the gRPC API as well.   
 
 Examples:
 
 # Check gRPC endpoint
 
-cerbos healthcheck
+cerbos healthcheck --config=/path/to/config.yaml
 
-# Check gRPC endpoint and ignore server certificate verification
+# Check HTTP endpoint and ignore server certificate verification
 
-cerbos healthcheck --insecure
+cerbos healthcheck --config=/path/to/config.yaml --kind=http --insecure
 
-# Check https endpoint, ignoring server certificate verification and with a custom timeout
+# Check the HTTP endpoint of a specific host with no TLS.
 
-cerbos healthcheck --kind=https --insecure --timeout=2s
-
-# Use a different host address
-
-cerbos healthcheck --kind=http --host-port=10.0.1.5:3592
+cerbos healthcheck --kind=http --host-port=10.0.1.5:3592 --no-tls
 `
 )
 
 type Cmd struct {
-	Kind      string        `help:"Healthcheck kind (${enum})" default:"grpc" enum:"grpc,http,https" env:"CERBOS_HC_KIND"`
-	HostPort  string        `help:"Host and port to check. Defaults to 127.0.0.1:3592 for http/https and 127.0.0.1:3593 for grpc" env:"CERBOS_HC_HOST"`
-	CACert    string        `help:"CA Certificate to use to verify the server certificate" type:"existingfile"`
-	Insecure  bool          `help:"Do not verify server certificate" default:"false"`
-	Plaintext bool          `help:"No TLS (gRPC only)" default:"false"`
-	Timeout   time.Duration `help:"Healthcheck timeout" default:"10s" env:"CERBOS_HC_TIMEOUT"`
+	Config   string        `help:"Cerbos config file" type:"existingfile" group:"config" xor:"hostport,cacert,notls" env:"CERBOS_CONFIG"`
+	Kind     string        `help:"Healthcheck kind (${enum})" default:"grpc" enum:"grpc,http" env:"CERBOS_HC_KIND"`
+	HostPort string        `help:"Host and port to connect to" group:"manual" xor:"hostport" env:"CERBOS_HC_HOSTPORT"`
+	CACert   string        `help:"Path to CA cert for validating server cert" type:"existingfile" group:"manual" xor:"cacert" env:"CERBOS_HC_CACERT"`
+	NoTLS    bool          `help:"Don't use TLS" group:"manual" xor:"notls" env:"CERBOS_HC_NOTLS"`
+	Insecure bool          `help:"Do not verify server certificate" default:"false" env:"CERBOS_HC_INSECURE"`
+	Timeout  time.Duration `help:"Healthcheck timeout" default:"10s" env:"CERBOS_HC_TIMEOUT"`
+}
+
+type checker interface {
+	check(context.Context, io.Writer) error
+}
+
+func (c *Cmd) Help() string {
+	return help
 }
 
 func (c *Cmd) Run(k *kong.Kong) error {
+	chk, err := c.buildCheck()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	return chk.check(ctx, k.Stdout)
+}
+
+func (c *Cmd) buildCheck() (checker, error) {
+	if c.Config != "" {
+		if err := config.Load(c.Config, nil); err != nil {
+			return nil, fmt.Errorf("failed to load config file %q: %w", c.Config, err)
+		}
+
+		serverConf := &server.Conf{}
+		if err := config.GetSection(serverConf); err != nil {
+			return nil, fmt.Errorf("failed to read configuration: %w", err)
+		}
+
+		return c.doBuildCheckFromConf(serverConf)
+	}
+
+	return c.doBuildCheckManual()
+}
+
+func (c *Cmd) doBuildCheckFromConf(serverConf *server.Conf) (checker, error) {
+	var tlsConf *tls.Config
+	if serverConf.TLS != nil {
+		var err error
+		tlsConf, err = mkTLSConfig(serverConf.TLS, c.Insecure)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	switch c.Kind {
-	case "grpc":
-		return c.grpcCheck(k)
-	case "http", "https":
-		return c.httpCheck(k)
-	default:
-		return fmt.Errorf("unknown healthcheck kind %q", c.Kind)
-	}
-}
-
-func (c *Cmd) grpcCheck(k *kong.Kong) error {
-	var dialOpts []grpc.DialOption
-	if c.Plaintext {
-		dialOpts = append(dialOpts, grpc.WithTransportCredentials(local.NewCredentials()))
-	} else {
-		tlsConf, err := c.mkTLSConfig()
+	case grpcKind:
+		return grpcCheck{addr: serverConf.GRPCListenAddr, tlsConf: tlsConf}, nil
+	case httpKind:
+		host, port, err := net.SplitHostPort(serverConf.HTTPListenAddr)
 		if err != nil {
-			return err
+			return nil, fmt.Errorf("failed to parse httpListenAddr %q: %w", serverConf.HTTPListenAddr, err)
 		}
-		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConf)))
+
+		if host == "" {
+			host = "127.0.0.1"
+		}
+
+		hostPort := net.JoinHostPort(host, port)
+		return newHTTPCheck(hostPort, tlsConf), nil
 	}
 
-	address := defaultGRPCHostPort
-	if c.HostPort != "" {
-		address = c.HostPort
-	}
-
-	ctx, cancelFunc := context.WithTimeout(context.Background(), c.Timeout)
-	defer cancelFunc()
-
-	conn, err := grpc.DialContext(ctx, address, dialOpts...)
-	if err != nil {
-		return fmt.Errorf("failed to connect to gRPC service at %q: %w", c.HostPort, err)
-	}
-
-	hc := healthpb.NewHealthClient(conn)
-	resp, err := hc.Check(ctx, &healthpb.HealthCheckRequest{Service: svcv1.CerbosService_ServiceDesc.ServiceName})
-	if err != nil {
-		return fmt.Errorf("failed to execute healthcheck RPC: %w", err)
-	}
-
-	_, _ = fmt.Fprintln(k.Stdout, resp.Status.String())
-
-	switch resp.Status {
-	case healthpb.HealthCheckResponse_SERVING, healthpb.HealthCheckResponse_UNKNOWN:
-		return nil
-	default:
-		return fmt.Errorf("service status is %q", resp.Status.String())
-	}
+	return nil, fmt.Errorf("unknown check kind %q", c.Kind)
 }
 
-func (c *Cmd) httpCheck(k *kong.Kong) error {
-	client := &http.Client{Timeout: c.Timeout}
-
-	if c.Kind == "https" {
-		tlsConf, err := c.mkTLSConfig()
+func (c *Cmd) doBuildCheckManual() (checker, error) {
+	var tlsConf *tls.Config
+	if !c.NoTLS {
+		var err error
+		tc := &server.TLSConf{CACert: c.CACert}
+		tlsConf, err = mkTLSConfig(tc, c.Insecure)
 		if err != nil {
-			return err
+			return nil, err
+		}
+	}
+
+	switch c.Kind {
+	case grpcKind:
+		hostPort := c.HostPort
+		if hostPort == "" {
+			hostPort = defaultGRPCHostPort
 		}
 
-		//nolint:forcetypeassert
-		transport := http.DefaultTransport.(*http.Transport).Clone()
-		transport.TLSClientConfig = tlsConf
-
-		client.Transport = transport
-	}
-
-	address := defaultHTTPHostPort
-	if c.HostPort != "" {
-		address = c.HostPort
-	}
-	url := fmt.Sprintf("%s://%s/_cerbos/health", c.Kind, address)
-
-	ctx, cancelFunc := context.WithTimeout(context.Background(), c.Timeout)
-	defer cancelFunc()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
-	}
-
-	defer func() {
-		if resp.Body != nil {
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
+		return grpcCheck{addr: hostPort, tlsConf: tlsConf}, nil
+	case httpKind:
+		hostPort := c.HostPort
+		if hostPort == "" {
+			hostPort = defaultHTTPHostPort
 		}
-	}()
 
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("server returned status %s (%d)", resp.Status, resp.StatusCode)
+		return newHTTPCheck(hostPort, tlsConf), nil
 	}
 
-	_, _ = io.Copy(k.Stdout, resp.Body)
-
-	return nil
+	return nil, fmt.Errorf("unknown check kind %q", c.Kind)
 }
 
-func (c *Cmd) mkTLSConfig() (*tls.Config, error) {
+func mkTLSConfig(tc *server.TLSConf, insecure bool) (*tls.Config, error) {
 	tlsConfig := util.DefaultTLSConfig()
-	if c.Insecure {
+	if insecure {
 		tlsConfig.InsecureSkipVerify = true
 	}
 
-	if c.CACert != "" {
+	cert := tc.CACert
+	if cert == "" {
+		cert = tc.Cert
+	}
+
+	if cert != "" {
 		certPool := x509.NewCertPool()
-		bs, err := os.ReadFile(c.CACert)
+		bs, err := os.ReadFile(cert)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load CA certificate from %q: %w", c.CACert, err)
+			return nil, fmt.Errorf("failed to load certificate from %q: %w", cert, err)
 		}
 
 		ok := certPool.AppendCertsFromPEM(bs)
@@ -187,6 +190,88 @@ func (c *Cmd) mkTLSConfig() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-func (c *Cmd) Help() string {
-	return help
+type grpcCheck struct {
+	tlsConf *tls.Config
+	addr    string
+}
+
+func (gc grpcCheck) check(ctx context.Context, out io.Writer) error {
+	var dialOpts []grpc.DialOption
+	if gc.tlsConf == nil {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(local.NewCredentials()))
+	} else {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(gc.tlsConf)))
+	}
+
+	conn, err := grpc.DialContext(ctx, gc.addr, dialOpts...)
+	if err != nil {
+		return fmt.Errorf("failed to connect to gRPC service at %q: %w", gc.addr, err)
+	}
+
+	hc := healthpb.NewHealthClient(conn)
+	resp, err := hc.Check(ctx, &healthpb.HealthCheckRequest{Service: svcv1.CerbosService_ServiceDesc.ServiceName})
+	if err != nil {
+		return fmt.Errorf("failed to execute healthcheck RPC: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(out, resp.Status.String())
+
+	switch resp.Status {
+	case healthpb.HealthCheckResponse_SERVING, healthpb.HealthCheckResponse_UNKNOWN:
+		return nil
+	default:
+		return fmt.Errorf("service status is %q", resp.Status.String())
+	}
+}
+
+type httpCheck struct {
+	tlsConf *tls.Config
+	url     string
+}
+
+func newHTTPCheck(hostPort string, tlsConf *tls.Config) httpCheck {
+	protocol := "http"
+	if tlsConf != nil {
+		protocol = "https"
+	}
+
+	url := fmt.Sprintf("%s://%s/_cerbos/health", protocol, hostPort)
+	return httpCheck{url: url, tlsConf: tlsConf}
+}
+
+func (hc httpCheck) check(ctx context.Context, out io.Writer) error {
+	client := &http.Client{}
+
+	if hc.tlsConf != nil {
+		//nolint:forcetypeassert
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = hc.tlsConf
+
+		client.Transport = transport
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, hc.url, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create request to %q: %w", hc.url, err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request to %q failed: %w", hc.url, err)
+	}
+
+	defer func() {
+		if resp.Body != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("server returned status %s (%d)", resp.Status, resp.StatusCode)
+	}
+
+	_, _ = io.Copy(out, resp.Body)
+
+	return nil
 }

--- a/cmd/cerbos/healthcheck/healthcheck.go
+++ b/cmd/cerbos/healthcheck/healthcheck.go
@@ -60,7 +60,7 @@ type Cmd struct {
 	CACert   string        `help:"Path to CA cert for validating server cert" type:"existingfile" group:"manual" xor:"cacert" env:"CERBOS_HC_CACERT"`
 	NoTLS    bool          `help:"Don't use TLS" group:"manual" xor:"notls" env:"CERBOS_HC_NOTLS"`
 	Insecure bool          `help:"Do not verify server certificate" default:"false" env:"CERBOS_HC_INSECURE"`
-	Timeout  time.Duration `help:"Healthcheck timeout" default:"10s" env:"CERBOS_HC_TIMEOUT"`
+	Timeout  time.Duration `help:"Healthcheck timeout" default:"2s" env:"CERBOS_HC_TIMEOUT"`
 }
 
 type checker interface {

--- a/cmd/cerbos/healthcheck/healthcheck_test.go
+++ b/cmd/cerbos/healthcheck/healthcheck_test.go
@@ -1,0 +1,217 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package healthcheck
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cerbos/cerbos/internal/server"
+	"github.com/cerbos/cerbos/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildFromServerConf(t *testing.T) {
+	testdataDir := test.PathToDir(t, "server")
+	certPath := filepath.Join(testdataDir, "tls.crt")
+	keyPath := filepath.Join(testdataDir, "tls.key")
+
+	testCases := []struct {
+		name     string
+		cmd      *Cmd
+		conf     *server.Conf
+		wantAddr string
+		wantErr  bool
+	}{
+		{
+			name: "grpc/tls/secure",
+			cmd:  &Cmd{Kind: "grpc"},
+			conf: &server.Conf{
+				HTTPListenAddr: ":3592",
+				GRPCListenAddr: ":3593",
+				TLS: &server.TLSConf{
+					Cert: certPath,
+					Key:  keyPath,
+				},
+			},
+			wantAddr: ":3593",
+		},
+		{
+			name: "grpc/tls/insecure",
+			cmd:  &Cmd{Kind: "grpc", Insecure: true},
+			conf: &server.Conf{
+				HTTPListenAddr: ":3592",
+				GRPCListenAddr: ":3593",
+				TLS: &server.TLSConf{
+					Cert: certPath,
+					Key:  keyPath,
+				},
+			},
+			wantAddr: ":3593",
+		},
+		{
+			name: "grpc/no-tls",
+			cmd:  &Cmd{Kind: "grpc"},
+			conf: &server.Conf{
+				HTTPListenAddr: ":3592",
+				GRPCListenAddr: ":3593",
+			},
+			wantAddr: ":3593",
+		},
+		{
+			name: "http/tls/secure",
+			cmd:  &Cmd{Kind: "http"},
+			conf: &server.Conf{
+				HTTPListenAddr: ":3592",
+				GRPCListenAddr: ":3593",
+				TLS: &server.TLSConf{
+					Cert: certPath,
+					Key:  keyPath,
+				},
+			},
+			wantAddr: "https://127.0.0.1:3592/_cerbos/health",
+		},
+		{
+			name: "http/tls/insecure",
+			cmd:  &Cmd{Kind: "http", Insecure: true},
+			conf: &server.Conf{
+				HTTPListenAddr: ":3592",
+				GRPCListenAddr: ":3593",
+				TLS: &server.TLSConf{
+					Cert: certPath,
+					Key:  keyPath,
+				},
+			},
+			wantAddr: "https://127.0.0.1:3592/_cerbos/health",
+		},
+		{
+			name: "http/no-tls",
+			cmd:  &Cmd{Kind: "http"},
+			conf: &server.Conf{
+				HTTPListenAddr: ":3592",
+				GRPCListenAddr: ":3593",
+			},
+			wantAddr: "http://127.0.0.1:3592/_cerbos/health",
+		},
+		{
+			name: "http/specific-host",
+			cmd:  &Cmd{Kind: "http"},
+			conf: &server.Conf{
+				HTTPListenAddr: "10.0.1.5:3592",
+				GRPCListenAddr: ":3593",
+			},
+			wantAddr: "http://10.0.1.5:3592/_cerbos/health",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			have, err := tc.cmd.doBuildCheckFromConf(tc.conf)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			if tc.cmd.Kind == httpKind {
+				hc, ok := have.(httpCheck)
+				require.True(t, ok)
+				require.Equal(t, tc.wantAddr, hc.url)
+				if tc.conf.TLS != nil {
+					require.NotNil(t, hc.tlsConf)
+					require.Equal(t, tc.cmd.Insecure, hc.tlsConf.InsecureSkipVerify)
+				}
+				return
+			}
+
+			gc, ok := have.(grpcCheck)
+			require.True(t, ok)
+			require.Equal(t, tc.wantAddr, gc.addr)
+			if tc.conf.TLS != nil {
+				require.NotNil(t, gc.tlsConf)
+				require.Equal(t, tc.cmd.Insecure, gc.tlsConf.InsecureSkipVerify)
+			}
+		})
+	}
+}
+
+func TestBuildManual(t *testing.T) {
+	testdataDir := test.PathToDir(t, "server")
+	certPath := filepath.Join(testdataDir, "tls.crt")
+
+	testCases := []struct {
+		name     string
+		cmd      *Cmd
+		wantTLS  bool
+		wantAddr string
+		wantErr  bool
+	}{
+		{
+			name:     "grpc/tls/secure",
+			cmd:      &Cmd{Kind: "grpc"},
+			wantTLS:  true,
+			wantAddr: "127.0.0.1:3593",
+		},
+		{
+			name:     "grpc/tls/insecure",
+			cmd:      &Cmd{Kind: "grpc", Insecure: true, HostPort: "10.0.1.5:3593", CACert: certPath},
+			wantTLS:  true,
+			wantAddr: "10.0.1.5:3593",
+		},
+		{
+			name:     "grpc/no-tls",
+			cmd:      &Cmd{Kind: "grpc", HostPort: "10.0.1.5:3593", NoTLS: true},
+			wantAddr: "10.0.1.5:3593",
+		},
+		{
+			name:     "http/tls/secure",
+			cmd:      &Cmd{Kind: "http"},
+			wantTLS:  true,
+			wantAddr: "https://127.0.0.1:3592/_cerbos/health",
+		},
+		{
+			name:     "http/tls/insecure",
+			cmd:      &Cmd{Kind: "http", Insecure: true, HostPort: "10.0.1.5:3592"},
+			wantTLS:  true,
+			wantAddr: "https://10.0.1.5:3592/_cerbos/health",
+		},
+		{
+			name:     "http/no-tls",
+			cmd:      &Cmd{Kind: "http", NoTLS: true},
+			wantAddr: "http://127.0.0.1:3592/_cerbos/health",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			have, err := tc.cmd.doBuildCheckManual()
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			if tc.cmd.Kind == httpKind {
+				hc, ok := have.(httpCheck)
+				require.True(t, ok)
+				require.Equal(t, tc.wantAddr, hc.url)
+				if tc.wantTLS {
+					require.NotNil(t, hc.tlsConf)
+					require.Equal(t, tc.cmd.Insecure, hc.tlsConf.InsecureSkipVerify)
+				}
+				return
+			}
+
+			gc, ok := have.(grpcCheck)
+			require.True(t, ok)
+			require.Equal(t, tc.wantAddr, gc.addr)
+			if tc.wantTLS {
+				require.NotNil(t, gc.tlsConf)
+				require.Equal(t, tc.cmd.Insecure, gc.tlsConf.InsecureSkipVerify)
+			}
+		})
+	}
+}

--- a/cmd/cerbos/main.go
+++ b/cmd/cerbos/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alecthomas/kong"
 
 	"github.com/cerbos/cerbos/cmd/cerbos/compile"
+	"github.com/cerbos/cerbos/cmd/cerbos/healthcheck"
 	"github.com/cerbos/cerbos/cmd/cerbos/run"
 	"github.com/cerbos/cerbos/cmd/cerbos/server"
 	"github.com/cerbos/cerbos/internal/util"
@@ -14,10 +15,11 @@ import (
 
 func main() {
 	var cli struct {
-		Server  server.Cmd  `cmd:"" help:"Start Cerbos server (PDP)"`
-		Compile compile.Cmd `cmd:"" help:"Compile and test policies"`
-		Run     run.Cmd     `cmd:"" help:"Run a command in the context of a Cerbos PDP"`
-		Version kong.VersionFlag
+		Compile     compile.Cmd     `cmd:"" help:"Compile and test policies"`
+		Server      server.Cmd      `cmd:"" help:"Start Cerbos server (PDP)"`
+		Healthcheck healthcheck.Cmd `cmd:"" help:"Healthcheck utility" aliases:"hc"`
+		Run         run.Cmd         `cmd:"" help:"Run a command in the context of a Cerbos PDP"`
+		Version     kong.VersionFlag
 	}
 
 	ctx := kong.Parse(&cli,

--- a/cmd/cerbos/server/server.go
+++ b/cmd/cerbos/server/server.go
@@ -49,7 +49,7 @@ func (ll *LogLevelFlag) Decode(ctx *kong.DecodeContext) error {
 type Cmd struct {
 	DebugListenAddr string       `help:"Address to start the gops listener" placeholder:":6666"`
 	LogLevel        LogLevelFlag `help:"Log level (${enum})" default:"info" enum:"debug,info,warn,error"`
-	Config          string       `help:"Path to config file" type:"existingfile" required:"" placeholder:"./config.yaml"`
+	Config          string       `help:"Path to config file" type:"existingfile" required:"" placeholder:"./config.yaml" env:"CERBOS_CONFIG"`
 	Set             []string     `help:"Config overrides" placeholder:"server.adminAPI.enabled=true"`
 	ZPagesEnabled   bool         `help:"Enable zpages" hidden:""`
 }
@@ -84,6 +84,7 @@ func (c *Cmd) Run() error {
 	}
 
 	// load configuration
+	log.Infof("Loading configuration from %s", c.Config)
 	if err := config.Load(c.Config, confOverrides); err != nil {
 		log.Errorw("Failed to load configuration", "error", err)
 		return err

--- a/docs/modules/cli/pages/cerbos.adoc
+++ b/docs/modules/cli/pages/cerbos.adoc
@@ -68,7 +68,18 @@ Flags:
 [#healthcheck]
 == `healthcheck` Command
 
-Utility to perform healthchecks on a Cerbos PDP. Can be used as a link:https://docs.docker.com/engine/reference/builder/#healthcheck[Docker HEALTHCHECK] command.
+Utility to perform healthchecks on a Cerbos PDP. Can be used as a link:https://docs.docker.com/engine/reference/builder/#healthcheck[Docker HEALTHCHECK] command. 
+
+You can share the configuration between Cerbos PDP and the healthcheck by using the `CERBOS_CONFIG` environment variable to define the path to the config file.
+
+.Example: Docker healthcheck based on mounted config file
+[source,sh,subs="attributes"]
+----
+docker run -i -t -p 3592:3592 -p 3593:3593 \
+    -v /path/to/conf/dir:/config \
+    -e CERBOS_CONFIG=/config/conf.yaml \
+    {app-docker-img}
+----
 
 [source]
 ----
@@ -76,37 +87,39 @@ Usage: cerbos healthcheck (hc)
 
 Healthcheck utility
 
-Performs a healthcheck on a Cerbos PDP. This can be used as a Docker HEALTHCHECK command. By default, the local Cerbos gRPC endpoint (127.0.0.1:3593) will be checked using the gRPC healthcheck protocol. This is usually
-sufficient for most cases as the Cerbos REST API is built on top of the gRPC API as well.
+Performs a healthcheck on a Cerbos PDP. This can be used as a Docker HEALTHCHECK command. When the path to the Cerbos config file is provided via the '--config' flag or the CERBOS_CONFIG environment variable, the
+healthcheck will be automatically configured based on the settings from the file. By default, the gRPC endpoint will be checked using the gRPC healthcheck protocol. This is usually sufficient for most cases as the Cerbos
+REST API is built on top of the gRPC API as well.
 
 Examples:
 
 # Check gRPC endpoint
 
-cerbos healthcheck
+cerbos healthcheck --config=/path/to/config.yaml
 
-# Check gRPC endpoint and ignore server certificate verification
+# Check HTTP endpoint and ignore server certificate verification
 
-cerbos healthcheck --insecure
+cerbos healthcheck --config=/path/to/config.yaml --kind=http --insecure
 
-# Check https endpoint, ignoring server certificate verification and with a custom timeout
+# Check the HTTP endpoint of a specific host with no TLS.
 
-cerbos healthcheck --kind=https --insecure --timeout=2s
-
-# Use a different host address
-
-cerbos healthcheck --kind=http --host-port=10.0.1.5:3592
+cerbos healthcheck --kind=http --host-port=10.0.1.5:3592 --no-tls
 
 Flags:
-  -h, --help                Show context-sensitive help.
+  -h, --help           Show context-sensitive help.
       --version
 
-      --kind="grpc"         Healthcheck kind (grpc,http,https) ($CERBOS_HC_KIND)
-      --host-port=STRING    Host and port to check. Defaults to 127.0.0.1:3592 for http/https and 127.0.0.1:3593 for grpc ($CERBOS_HC_HOST)
-      --ca-cert=STRING      CA Certificate to use to verify the server certificate
-      --insecure            Do not verify server certificate
-      --plaintext           No TLS (gRPC only)
-      --timeout=10s         Healthcheck timeout ($CERBOS_HC_TIMEOUT)
+      --kind="grpc"    Healthcheck kind (grpc,http) ($CERBOS_HC_KIND)
+      --insecure       Do not verify server certificate ($CERBOS_HC_INSECURE)
+      --timeout=10s    Healthcheck timeout ($CERBOS_HC_TIMEOUT)
+
+config
+  --config=STRING    Cerbos config file ($CERBOS_CONFIG)
+
+manual
+  --host-port=STRING    Host and port to connect to ($CERBOS_HC_HOSTPORT)
+  --ca-cert=STRING      Path to CA cert for validating server cert ($CERBOS_HC_CACERT)
+  --no-tls              Don't use TLS ($CERBOS_HC_NOTLS)
 ----
 
 [#run]

--- a/docs/modules/cli/pages/cerbos.adoc
+++ b/docs/modules/cli/pages/cerbos.adoc
@@ -7,9 +7,10 @@ See xref:ROOT:installation/binary.adoc[] or xref:ROOT:installation/container.ado
 
 This binary provides the following sub commands:
 
-`server`:: Start the PDP server
 `compile`:: Validate, compile and run tests on a policy repo
+`healthcheck`:: Perform a healthcheck on a Cerbos PDP
 `run`:: Start a PDP and run a command within its context
+`server`:: Start the PDP server
 
 .Example: Running `compile` using the binary
 [source,sh,subs="attributes"]
@@ -23,36 +24,6 @@ This binary provides the following sub commands:
 docker run -i -t {app-docker-img} compile --help 
 ----
 
-[#server]
-== `server` Command
-
-Starts the Cerbos PDP. 
-
-[source]
-----
-Usage: cerbos server --config=./config.yaml
-
-Start Cerbos server (PDP)
-
-Examples:
-
-# Start the server
-
-cerbos server --config=/path/to/config.yaml
-
-# Start the server with the Admin API enabled and the 'sqlite' storage driver
-
-cerbos server --config=/path/to/config.yaml --set=server.adminAPI.enabled=true --set=storage.driver=sqlite3 --set=storage.sqlite3.dsn=':memory:'
-
-Flags:
-  -h, --help                                    Show context-sensitive help.
-      --version
-
-      --debug-listen-addr=:6666                 Address to start the gops listener
-      --log-level="info"                        Log level (debug,info,warn,error)
-      --config=./config.yaml                    Path to config file
-      --set=server.adminAPI.enabled=true,...    Config overrides
-----
 
 [#compile]
 == `compile` Command
@@ -92,6 +63,50 @@ Flags:
       --skip-tests         Skip tests
       --ignore-schemas     Ignore schemas during compilation
       --verbose            Verbose output on test failure
+----
+
+[#healthcheck]
+== `healthcheck` Command
+
+Utility to perform healthchecks on a Cerbos PDP. Can be used as a link:https://docs.docker.com/engine/reference/builder/#healthcheck[Docker HEALTHCHECK] command.
+
+[source]
+----
+Usage: cerbos healthcheck (hc)
+
+Healthcheck utility
+
+Performs a healthcheck on a Cerbos PDP. This can be used as a Docker HEALTHCHECK command. By default, the local Cerbos gRPC endpoint (127.0.0.1:3593) will be checked using the gRPC healthcheck protocol. This is usually
+sufficient for most cases as the Cerbos REST API is built on top of the gRPC API as well.
+
+Examples:
+
+# Check gRPC endpoint
+
+cerbos healthcheck
+
+# Check gRPC endpoint and ignore server certificate verification
+
+cerbos healthcheck --insecure
+
+# Check https endpoint, ignoring server certificate verification and with a custom timeout
+
+cerbos healthcheck --kind=https --insecure --timeout=2s
+
+# Use a different host address
+
+cerbos healthcheck --kind=http --host-port=10.0.1.5:3592
+
+Flags:
+  -h, --help                Show context-sensitive help.
+      --version
+
+      --kind="grpc"         Healthcheck kind (grpc,http,https) ($CERBOS_HC_KIND)
+      --host-port=STRING    Host and port to check. Defaults to 127.0.0.1:3592 for http/https and 127.0.0.1:3593 for grpc ($CERBOS_HC_HOST)
+      --ca-cert=STRING      CA Certificate to use to verify the server certificate
+      --insecure            Do not verify server certificate
+      --plaintext           No TLS (gRPC only)
+      --timeout=10s         Healthcheck timeout ($CERBOS_HC_TIMEOUT)
 ----
 
 [#run]
@@ -146,4 +161,36 @@ Flags:
       --config=./cerbos.yaml                    Path to config file
       --set=server.adminAPI.enabled=true,...    Config overrides
       --timeout=30s                             Cerbos startup timeout
+----
+
+
+[#server]
+== `server` Command
+
+Starts the Cerbos PDP. 
+
+[source]
+----
+Usage: cerbos server --config=./config.yaml
+
+Start Cerbos server (PDP)
+
+Examples:
+
+# Start the server
+
+cerbos server --config=/path/to/config.yaml
+
+# Start the server with the Admin API enabled and the 'sqlite' storage driver
+
+cerbos server --config=/path/to/config.yaml --set=server.adminAPI.enabled=true --set=storage.driver=sqlite3 --set=storage.sqlite3.dsn=':memory:'
+
+Flags:
+  -h, --help                                    Show context-sensitive help.
+      --version
+
+      --debug-listen-addr=:6666                 Address to start the gops listener
+      --log-level="info"                        Log level (debug,info,warn,error)
+      --config=./config.yaml                    Path to config file
+      --set=server.adminAPI.enabled=true,...    Config overrides
 ----


### PR DESCRIPTION
Adds a `healthcheck` subcommand to the `cerbos` binary so that
in-container healthchecks (Docker HEALTHCHECK) can be performed without
resorting to an external binary.

Fixes #666

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
