### PR TITLE
chore(test): Add support for load testing with the postgres store

### DIFF
--- a/hack/loadtest/README.md
+++ b/hack/loadtest/README.md
@@ -12,13 +12,13 @@ The following environment variables are used to determine the test parameters.
 - `MAX_VUS`: Maximum virtual users. Default `100`.
 - `MIN_VUS`: Minimum virtual users. Default `25`.
 - `NUM_POLICIES`: Number of policies. Default `1000`.
+- `PASSWORD`: Cerbos Admin API password. Default `cerbosAdmin`.
 - `REQ_COUNT`: Number of requests on disk. Default `1000`.
 - `REQ_KIND`: Kind (prefix) of the requests to use for the test. Default `crs_req01`.
 - `RPS`: Request rate to sustain per virtual user. Default `200`.
+- `SERVER`: Cerbos server host address. Default `localhost:3592`.
 - `STORE`: Store to use. Default `disk`.
-- `SERVER`: Cerbos server host address. Default `localhost:3593`.
 - `USERNAME`: Cerbos Admin API username. Default `cerbos`.
-- `PASSWORD`: Cerbos Admin API password. Default `cerbosAdmin`.
 
 Start the Cerbos instance
 

--- a/hack/loadtest/README.md
+++ b/hack/loadtest/README.md
@@ -1,20 +1,24 @@
 # Load test scripts
 
 Requires [K6](https://k6.io/docs/) and docker-compose.
+Requires `cerbosctl` binary to be in the PATH.
 
 ## Usage
 
 The following environment variables are used to determine the test parameters.
 
-- `DURATION`: How long to run the tests for. Default 120s.
+- `DURATION`: How long to run the tests for. Default `120s`.
 - `ITERATIONS`: Number of requests to send using MAX_VUS.
-- `MAX_VUS`: Maximum virtual users. Default 100.
-- `MIN_VUS`: Minimum virtual users. Default 25.
-- `NUM_POLICIES`: Number of policies. Default 1000.
-- `REQ_COUNT`: Number of requests on disk. Default 1000.
+- `MAX_VUS`: Maximum virtual users. Default `100`.
+- `MIN_VUS`: Minimum virtual users. Default `25`.
+- `NUM_POLICIES`: Number of policies. Default `1000`.
+- `REQ_COUNT`: Number of requests on disk. Default `1000`.
 - `REQ_KIND`: Kind (prefix) of the requests to use for the test. Default `crs_req01`.
-- `RPS`: Request rate to sustain per virtual user. Default 200.
-- `STORE`: Store to use. Default disk.
+- `RPS`: Request rate to sustain per virtual user. Default `200`.
+- `STORE`: Store to use. Default `disk`.
+- `SERVER`: Cerbos server host address. Default `localhost:3593`.
+- `USERNAME`: Cerbos Admin API username. Default `cerbos`.
+- `PASSWORD`: Cerbos Admin API password. Default `cerbosAdmin`.
 
 Start the Cerbos instance
 

--- a/hack/loadtest/check.js
+++ b/hack/loadtest/check.js
@@ -41,7 +41,7 @@ export const options = {
 };
 
 const requestsDir = "work/requests"
-const host = "http://127.0.0.1:3592"
+const host = `http://${__ENV.SERVER}`
 
 const fileName = (prefix, num) => `${requestsDir}/${prefix}_${num.toString().padStart(5, 0)}.json`;
 

--- a/hack/loadtest/loadtest.sh
+++ b/hack/loadtest/loadtest.sh
@@ -17,6 +17,9 @@ REQ_COUNT=${REQ_COUNT:-"$NUM_POLICIES"}
 REQ_KIND=${REQ_KIND:-"crs_req01"}
 RPS=${RPS:-"200"}
 STORE=${STORE:-"disk"}
+SERVER=${SERVER:-"localhost:3593"}
+USERNAME=${USERNAME:-"cerbos"}
+PASSWORD=${PASSWORD:-"cerbosAdmin"}
 
 clean() {
   printf "Cleaning up\n"
@@ -27,6 +30,10 @@ clean() {
 generateResources() {
   printf "Generating %s policy sets\n" "$NUM_POLICIES"
   go run ./generate.go --out="${WORK_DIR}" --count="$NUM_POLICIES"
+}
+
+put() {
+  cerbosctl --server="${SERVER}" --username="${USERNAME}" --password="${PASSWORD}" --plaintext put "${1}" "${2}"
 }
 
 down() {
@@ -58,10 +65,17 @@ up() {
   printf "Starting all services\n"
   docker-compose up -d
 
-  while [[ "$(curl -s -o /dev/null -w '%{http_code}' 'http://localhost:3592/_cerbos/health')" != "200" ]]; do 
-      echo "Waiting for Cerbos..."
-      sleep 1 
+  while [[ "$(curl -s -o /dev/null -w '%{http_code}' 'http://localhost:3592/_cerbos/health')" != "200" ]]; do
+    echo "Waiting for Cerbos..."
+    sleep 1
   done
+
+  if [[ "${STORE}" == "postgres" ]]; then
+    printf "Putting schemas\n"
+    put schemas ./"${WORK_DIR}"/policies/_schemas
+    printf "Putting policies\n"
+    put policies ./"${WORK_DIR}"/policies
+  fi
 
   docker-compose logs -f 
 }

--- a/hack/loadtest/loadtest.sh
+++ b/hack/loadtest/loadtest.sh
@@ -17,7 +17,7 @@ REQ_COUNT=${REQ_COUNT:-"$NUM_POLICIES"}
 REQ_KIND=${REQ_KIND:-"crs_req01"}
 RPS=${RPS:-"200"}
 STORE=${STORE:-"disk"}
-SERVER=${SERVER:-"localhost:3593"}
+SERVER=${SERVER:-"localhost:3592"}
 USERNAME=${USERNAME:-"cerbos"}
 PASSWORD=${PASSWORD:-"cerbosAdmin"}
 
@@ -65,7 +65,7 @@ up() {
   printf "Starting all services\n"
   docker-compose up -d
 
-  while [[ "$(curl -s -o /dev/null -w '%{http_code}' 'http://localhost:3592/_cerbos/health')" != "200" ]]; do
+  while [[ "$(curl -s -o /dev/null -w '%{http_code}' "http://${SERVER}/_cerbos/health")" != "200" ]]; do
     echo "Waiting for Cerbos..."
     sleep 1
   done
@@ -91,6 +91,7 @@ executeTest() {
     -e REQ_COUNT="$REQ_COUNT" \
     -e REQ_KIND="$REQ_KIND" \
     -e RPS="$RPS" \
+    -e SERVER="$SERVER" \
     check.js
 }
 


### PR DESCRIPTION
Signed-off-by: Oğuzhan Durgun <oguzhandurgun95@gmail.com>

#### Description

As we didn't have a sensible approach to add policies using Admin API to the `postgres` store, the support for load testing with `postgres` store was not complete. With the addition of `cerbosctl put` command, we are able to put policies or schemas into the store. This PR fixes this issue and now we are able to load test using `postgres` store.