### PR TITLE
docs: Add context to policy documentation

### DIFF
--- a/docs/modules/policies/pages/derived_roles.adoc
+++ b/docs/modules/policies/pages/derived_roles.adoc
@@ -2,6 +2,8 @@ include::ROOT:partial$attributes.adoc[]
 
 = Derived roles
 
+Traditional RBAC roles are usually broad groupings with no context awareness. Derived roles are a way of augmenting those broad roles with contextual data to provide more fine-grained control at runtime. For example, a person with the broad `manager` role can be augmented to `manager_of_scranton_branch` by taking into account the geographic location (or another factor) and giving that derived role bearer extra privileges on resources that belong to the Scranton branch.
+
 [source,yaml,linenums]
 ----
 ---

--- a/docs/modules/policies/pages/principal_policies.adoc
+++ b/docs/modules/policies/pages/principal_policies.adoc
@@ -2,6 +2,8 @@ include::ROOT:partial$attributes.adoc[]
 
 = Principal policies
 
+Principal policies define overrides for a specific user.
+
 [source,yaml,linenums]
 ----
 ---

--- a/docs/modules/policies/pages/resource_policies.adoc
+++ b/docs/modules/policies/pages/resource_policies.adoc
@@ -2,6 +2,8 @@ include::ROOT:partial$attributes.adoc[]
 
 = Resource policies
 
+Resource policies define rules for actions that can be performed on a given resource. A resource is an application-specific concept that applies to anything that requires access rules. For example, in an HR application, a resource can be as coarse-grained as a full employee record or as fine-grained as a single field in the record.
+
 [source,yaml,linenums]
 ----
 ---


### PR DESCRIPTION
#### Description

If I land directly on https://docs.cerbos.dev/cerbos/latest/policies/resource_policies.html (either coming via Google, deep-linking, or navigating through the sidebar), I don't get any context before diving into the YAML syntax.

This PR resolves that by copying the contextual information from the policies index page down to the child pages (we might consider expanding on it but for now it's better than nothing!).