### PR TITLE
chore(test): Don't reuse the DB for client tests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -112,8 +112,10 @@ func TestClient(t *testing.T) {
 func mkServerOpts(t *testing.T, withTLS bool) []testutil.ServerOpt {
 	t.Helper()
 
+	dbName := test.RandomStr(5)
+
 	serverOpts := []testutil.ServerOpt{
-		testutil.WithPolicyRepositoryDatabase("sqlite3", fmt.Sprintf("%s?_fk=true", filepath.Join(t.TempDir(), "cerbos.db"))),
+		testutil.WithPolicyRepositoryDatabase("sqlite3", fmt.Sprintf("%s?_fk=true", filepath.Join(t.TempDir(), dbName))),
 		testutil.WithAdminAPI(adminUsername, adminPassword),
 	}
 


### PR DESCRIPTION
Client tests are flaky on CI (#704). This could be potentially due to
using the same database for all tests.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
