### PR TITLE
docs: Update photo-share tutorial tests

### DIFF
--- a/docs/modules/tutorials/examples/photo-share/tests/album_object_test.yaml
+++ b/docs/modules/tutorials/examples/photo-share/tests/album_object_test.yaml
@@ -40,74 +40,65 @@ principals:
     roles: ["moderator", "user"]
 
 tests:
-  - name: View private album
-    input:
-      requestId: "test01"
-      actions: ["view"]
-      resource: alicia_private_album
+  - name: View album
+    input: &testInput
+      principals:
+        - alicia
+        - bradley
+        - maria
+      actions:
+        - view
+      resources:
+        - alicia_private_album
+        - alicia_public_album
+        - alicia_flagged_album
     expected:
-      - principal: alicia
+      - &viewExp
+        principal: alicia
+        resource: alicia_private_album
         actions:
           view: EFFECT_ALLOW
 
-      - principal: bradley
-        actions:
-          view: EFFECT_DENY
+      - <<: *viewExp
+        resource: alicia_public_album
 
-      - principal: maria
-        actions:
-          view: EFFECT_DENY
+      - <<: *viewExp
+        resource: alicia_flagged_album
 
-  - name: View public album
+      - <<: *viewExp
+        principal: bradley
+        resource: alicia_public_album
+
+      - <<: *viewExp
+        principal: bradley
+        resource: alicia_flagged_album
+
+      - <<: *viewExp
+        principal: maria
+        resource: alicia_public_album
+
+      - <<: *viewExp
+        principal: maria
+        resource: alicia_flagged_album
+
+  - name: Delete album
     input:
-      requestId: "test02"
-      actions: ["view"]
-      resource: alicia_public_album
+      <<: *testInput
+      actions:
+        - delete
     expected:
-      - principal: alicia
-        actions:
-          view: EFFECT_ALLOW
-
-      - principal: bradley
-        actions:
-          view: EFFECT_ALLOW
-
-      - principal: maria
-        actions:
-          view: EFFECT_ALLOW
-
-  - name: Delete unflagged album
-    input:
-      requestId: "test03"
-      actions: ["delete"]
-      resource: alicia_public_album
-    expected:
-      - principal: alicia
+      - &deleteExp
+        principal: alicia
+        resource: alicia_private_album
         actions:
           delete: EFFECT_ALLOW
 
-      - principal: bradley
-        actions:
-          delete: EFFECT_DENY
+      - <<: *deleteExp
+        resource: alicia_public_album
 
-      - principal: maria
-        actions:
-          delete: EFFECT_DENY
+      - <<: *deleteExp
+        resource: alicia_flagged_album
 
-  - name: Delete flagged album
-    input:
-      requestId: "test04"
-      actions: ["delete"]
-      resource: alicia_flagged_album
-    expected:
-      - principal: alicia
-        actions:
-          delete: EFFECT_ALLOW
-
-      - principal: bradley
-        actions:
-          delete: EFFECT_DENY
-
-      - principal: maria
-        actions:
-          delete: EFFECT_ALLOW
+      - <<: *deleteExp
+        principal: maria
+        resource: alicia_flagged_album

--- a/docs/modules/tutorials/pages/photo-share/index.adoc
+++ b/docs/modules/tutorials/pages/photo-share/index.adoc
@@ -285,19 +285,25 @@ docker run -it -v $(pwd):/photo-share {app-docker-img} \
 
 ----
 Test results
-= AlbumObjectTestSuite (album_object_test.yaml)
-== 'View private album' by principal 'alicia' [OK]
-== 'View private album' by principal 'bradley' [OK]
-== 'View private album' by principal 'maria' [OK]
-== 'View public album' by principal 'alicia' [OK]
-== 'View public album' by principal 'bradley' [OK]
-== 'View public album' by principal 'maria' [OK]
-== 'Delete unflagged album' by principal 'alicia' [OK]
-== 'Delete unflagged album' by principal 'bradley' [OK]
-== 'Delete unflagged album' by principal 'maria' [OK]
-== 'Delete flagged album' by principal 'alicia' [OK]
-== 'Delete flagged album' by principal 'bradley' [OK]
-== 'Delete flagged album' by principal 'maria' [OK]
+= AlbumObjectTestSuite (album_object_test.yaml) 
+== 'View album' for resource 'alicia_private_album' by principal 'alicia' [OK]
+== 'View album' for resource 'alicia_public_album' by principal 'alicia' [OK]
+== 'View album' for resource 'alicia_flagged_album' by principal 'alicia' [OK]
+== 'View album' for resource 'alicia_private_album' by principal 'bradley' [OK]
+== 'View album' for resource 'alicia_public_album' by principal 'bradley' [OK]
+== 'View album' for resource 'alicia_flagged_album' by principal 'bradley' [OK]
+== 'View album' for resource 'alicia_private_album' by principal 'maria' [OK]
+== 'View album' for resource 'alicia_public_album' by principal 'maria' [OK]
+== 'View album' for resource 'alicia_flagged_album' by principal 'maria' [OK]
+== 'Delete album' for resource 'alicia_private_album' by principal 'alicia' [OK]
+== 'Delete album' for resource 'alicia_public_album' by principal 'alicia' [OK]
+== 'Delete album' for resource 'alicia_flagged_album' by principal 'alicia' [OK]
+== 'Delete album' for resource 'alicia_private_album' by principal 'bradley' [OK]
+== 'Delete album' for resource 'alicia_public_album' by principal 'bradley' [OK]
+== 'Delete album' for resource 'alicia_flagged_album' by principal 'bradley' [OK]
+== 'Delete album' for resource 'alicia_private_album' by principal 'maria' [OK]
+== 'Delete album' for resource 'alicia_public_album' by principal 'maria' [OK]
+== 'Delete album' for resource 'alicia_flagged_album' by principal 'maria' [OK]
 ----
 
 NOTE: See https://github.com/cerbos/photo-share-tutorial for an example of using Cerbos GitHub Actions in a CI workflow to compile and test policies. 


### PR DESCRIPTION
Update the test definitions in the photo-share tutorial to match the new
changes introduced by #701.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
