### PR TITLE
fix: Validate that test files match schema

### DIFF
--- a/internal/test/testdata/verify/invalid_fixture/testdata/principals.yaml
+++ b/internal/test/testdata/verify/invalid_fixture/testdata/principals.yaml
@@ -1,1 +1,2 @@
-x
+principals:
+  invalid: {}

--- a/internal/test/testdata/verify/invalid_test/did_not_expected_key_test.yaml
+++ b/internal/test/testdata/verify/invalid_test/did_not_expected_key_test.yaml
@@ -4,5 +4,5 @@ principals:
   john:
     id: john
     policyVersion: '20210210'
-      roles:
-        - employee
+    roles:
+      - employee

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -131,7 +131,11 @@ func doVerify(ctx context.Context, fsys fs.FS, eng *engine.Engine, conf Config) 
 
 	for _, sd := range suiteDefs {
 		suite := &policyv1.TestSuite{}
-		if err := util.LoadFromJSONOrYAML(fsys, sd, suite); err != nil {
+		err := util.LoadFromJSONOrYAML(fsys, sd, suite)
+		if err == nil {
+			err = suite.Validate()
+		}
+		if err != nil {
 			result.Results = append(result.Results, SuiteResult{
 				File:    sd,
 				Suite:   fmt.Sprintf("UNKNOWN: failed to load test suite: %v", err),

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -72,7 +72,7 @@ func TestVerify(t *testing.T) {
 
 		is.Len(result.Results[0].Tests, 1)
 		is.True(result.Results[0].Tests[0].Failed)
-		is.NotEmpty(result.Results[0].Tests[0].Error)
+		is.Contains(result.Results[0].Tests[0].Error, "invalid Principal.Id")
 	})
 
 	t.Run("invalid_test", func(t *testing.T) {
@@ -93,8 +93,7 @@ func TestVerify(t *testing.T) {
 			case "did_not_expected_key_test.yaml":
 				is.False(sr.Skipped)
 				is.True(sr.Failed)
-				is.True(strings.HasPrefix(sr.Suite, "UNKNOWN: failed to load test suite: failed to convert YAML to JSON"))
-				is.True(strings.Contains(sr.Suite, "did not find expected key"))
+				is.Equal(sr.Suite, "UNKNOWN: failed to load test suite: invalid TestSuite.Tests: value must contain at least 1 item(s)")
 				is.Empty(sr.Tests)
 			}
 		}


### PR DESCRIPTION
#### Description

Fixes #723 

This PR calls `Validate` on the values read from test suite and fixture files, so that the rules specified in the proto message definition are enforced.