### PR TITLE
chore(test): Handle non-deterministic ordering of output directory deletion

### DIFF
--- a/hack/loadtest/generate.go
+++ b/hack/loadtest/generate.go
@@ -97,7 +97,10 @@ func prepOutDirs(out string) error {
 		if err := os.RemoveAll(path); err != nil {
 			return fmt.Errorf("failed to remove %q: %w", path, err)
 		}
+	}
 
+	for _, outDir := range tmplOutConf {
+		path := filepath.Join(out, outDir)
 		//nolint:gomnd
 		if err := os.MkdirAll(path, 0o755); err != nil {
 			return fmt.Errorf("failed to create %q: %w", path, err)


### PR DESCRIPTION
#### Description

When generating data for the load tests, the output directories are deleted and recreated. This was flaky because the map iteration order is non-deterministic, meaning we could delete `policies` after recreating `policies/_schemas` (resulting in `no such file or directory` errors when generating schemas).