### PR TITLE
chore(test): Remove casts from CEL numeric expressions

### DIFF
--- a/internal/test/testdata/cel_eval/arithmetic.yaml
+++ b/internal/test/testdata/cel_eval/arithmetic.yaml
@@ -2,11 +2,13 @@
 condition:
   all:
     of:
-      - expr: int(R.attr.intVal1) - int(R.attr.intVal2) == -40
+      - expr: R.attr.intVal1 - R.attr.intVal2 == -40
+      - expr: R.attr.intVal1 - R.attr.intVal2 == -40
       - expr: R.attr.floatVal2 - R.attr.floatVal1 == 5.0
-      - expr: double(R.attr.intVal1 / R.attr.intVal2) < 0.75
-      - expr: >- 
-          (R.attr.intVal1 < R.attr.intVal2) ? double(R.attr.intVal2 - R.attr.intVal1) / double(R.attr.intVal1) < 0.4 : double(R.attr.intVal1 - R.attr.intVal2) / double(R.attr.intVal1) < 0.4
+      - expr: R.attr.intVal1 / R.attr.intVal2 < 0.75
+      - expr: R.attr.floatVal1 < R.attr.intVal1
+      - expr: >-
+          (R.attr.intVal1 < R.attr.intVal2) ? (R.attr.intVal2 - R.attr.intVal1) / R.attr.intVal1 < 0.4 : (R.attr.intVal1 - R.attr.intVal2) / R.attr.intVal1 < 0.4
 input: {
   "requestId": "test",
   "actions": ["*"],


### PR DESCRIPTION
The new CEL release supports comparisons between different numeric types
and explicit casting is no longer necessary.

Fixes #538

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
