### PR TITLE
chore(fix): Convert regular expressions to ECMAScript-compatible syntax in JSON schemas

### DIFF
--- a/schema/jsonschema/cerbos/audit/v1/DecisionLogEntry.schema.json
+++ b/schema/jsonschema/cerbos/audit/v1/DecisionLogEntry.schema.json
@@ -136,13 +136,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -150,7 +150,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -175,15 +175,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/engine/v1/CheckInput.schema.json
+++ b/schema/jsonschema/cerbos/engine/v1/CheckInput.schema.json
@@ -34,13 +34,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -48,7 +48,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -73,15 +73,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/engine/v1/Principal.schema.json
+++ b/schema/jsonschema/cerbos/engine/v1/Principal.schema.json
@@ -26,13 +26,13 @@
     },
     "policyVersion": {
       "type": "string",
-      "pattern": "^[[:word:]]*$"
+      "pattern": "^[0-9A-Z_a-z]*$"
     },
     "roles": {
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^[[:word:]\\-\\.]+$"
+        "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
       },
       "maxItems": 20,
       "minItems": 1,
@@ -40,7 +40,7 @@
     },
     "scope": {
       "type": "string",
-      "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+      "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
     }
   }
 }

--- a/schema/jsonschema/cerbos/engine/v1/Resource.schema.json
+++ b/schema/jsonschema/cerbos/engine/v1/Resource.schema.json
@@ -27,15 +27,15 @@
     "kind": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+      "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
     },
     "policyVersion": {
       "type": "string",
-      "pattern": "^[[:word:]]*$"
+      "pattern": "^[0-9A-Z_a-z]*$"
     },
     "scope": {
       "type": "string",
-      "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+      "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
     }
   }
 }

--- a/schema/jsonschema/cerbos/engine/v1/ResourcesQueryPlanRequest.schema.json
+++ b/schema/jsonschema/cerbos/engine/v1/ResourcesQueryPlanRequest.schema.json
@@ -34,13 +34,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -48,7 +48,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -68,15 +68,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/policy/v1/DerivedRoles.schema.json
+++ b/schema/jsonschema/cerbos/policy/v1/DerivedRoles.schema.json
@@ -113,13 +113,13 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^[[:word:]\\-\\.]+$"
+          "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
         },
         "parentRoles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "minItems": 1,
           "uniqueItems": true
@@ -144,7 +144,7 @@
     "name": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^[[:word:]\\-\\.]+$"
+      "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
     }
   }
 }

--- a/schema/jsonschema/cerbos/policy/v1/Policy.schema.json
+++ b/schema/jsonschema/cerbos/policy/v1/Policy.schema.json
@@ -61,7 +61,7 @@
         "name": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:word:]\\-\\.]+$"
+          "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
         }
       }
     },
@@ -172,7 +172,7 @@
         "principal": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-]*(\\:[[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^[A-Za-z][\\--\\.0-9@-Z_a-z]*(:[A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         },
         "rules": {
           "type": "array",
@@ -182,11 +182,11 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         },
         "version": {
           "type": "string",
-          "pattern": "^[[:word:]]+$"
+          "pattern": "^[0-9A-Z_a-z]+$"
         }
       }
     },
@@ -208,7 +208,7 @@
         "resource": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         }
       }
     },
@@ -243,7 +243,7 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         }
       }
     },
@@ -259,14 +259,14 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         },
         "resource": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "rules": {
           "type": "array",
@@ -279,11 +279,11 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         },
         "version": {
           "type": "string",
-          "pattern": "^[[:word:]]+$"
+          "pattern": "^[0-9A-Z_a-z]+$"
         }
       }
     },
@@ -311,7 +311,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         },
@@ -331,13 +331,13 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         }
@@ -356,13 +356,13 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^[[:word:]\\-\\.]+$"
+          "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
         },
         "parentRoles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "minItems": 1,
           "uniqueItems": true

--- a/schema/jsonschema/cerbos/policy/v1/PrincipalPolicy.schema.json
+++ b/schema/jsonschema/cerbos/policy/v1/PrincipalPolicy.schema.json
@@ -127,7 +127,7 @@
         "resource": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         }
       }
     },
@@ -162,7 +162,7 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         }
       }
     }
@@ -177,7 +177,7 @@
     "principal": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-]*(\\:[[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+      "pattern": "^[A-Za-z][\\--\\.0-9@-Z_a-z]*(:[A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
     },
     "rules": {
       "type": "array",
@@ -187,11 +187,11 @@
     },
     "scope": {
       "type": "string",
-      "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+      "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
     },
     "version": {
       "type": "string",
-      "pattern": "^[[:word:]]+$"
+      "pattern": "^[0-9A-Z_a-z]+$"
     }
   }
 }

--- a/schema/jsonschema/cerbos/policy/v1/PrincipalRule.schema.json
+++ b/schema/jsonschema/cerbos/policy/v1/PrincipalRule.schema.json
@@ -140,7 +140,7 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         }
       }
     }
@@ -162,7 +162,7 @@
     "resource": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+      "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
     }
   }
 }

--- a/schema/jsonschema/cerbos/policy/v1/ResourcePolicy.schema.json
+++ b/schema/jsonschema/cerbos/policy/v1/ResourcePolicy.schema.json
@@ -133,7 +133,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         },
@@ -153,13 +153,13 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         }
@@ -223,14 +223,14 @@
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^[[:word:]\\-\\.]+$"
+        "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
       },
       "uniqueItems": true
     },
     "resource": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+      "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
     },
     "rules": {
       "type": "array",
@@ -243,11 +243,11 @@
     },
     "scope": {
       "type": "string",
-      "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+      "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
     },
     "version": {
       "type": "string",
-      "pattern": "^[[:word:]]+$"
+      "pattern": "^[0-9A-Z_a-z]+$"
     }
   }
 }

--- a/schema/jsonschema/cerbos/policy/v1/ResourceRule.schema.json
+++ b/schema/jsonschema/cerbos/policy/v1/ResourceRule.schema.json
@@ -133,7 +133,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^[[:word:]\\-\\.]+$"
+        "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
       },
       "uniqueItems": true
     },
@@ -153,13 +153,13 @@
     },
     "name": {
       "type": "string",
-      "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+      "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
     },
     "roles": {
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^[[:word:]\\-\\.]+$"
+        "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
       },
       "uniqueItems": true
     }

--- a/schema/jsonschema/cerbos/policy/v1/RoleDef.schema.json
+++ b/schema/jsonschema/cerbos/policy/v1/RoleDef.schema.json
@@ -113,13 +113,13 @@
     },
     "name": {
       "type": "string",
-      "pattern": "^[[:word:]\\-\\.]+$"
+      "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
     },
     "parentRoles": {
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^[[:word:]\\-\\.]+$"
+        "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
       },
       "minItems": 1,
       "uniqueItems": true

--- a/schema/jsonschema/cerbos/policy/v1/Test.schema.json
+++ b/schema/jsonschema/cerbos/policy/v1/Test.schema.json
@@ -73,13 +73,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -87,7 +87,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -112,15 +112,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/policy/v1/TestSuite.schema.json
+++ b/schema/jsonschema/cerbos/policy/v1/TestSuite.schema.json
@@ -43,13 +43,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -57,7 +57,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -82,15 +82,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/private/v1/CelTestCase.schema.json
+++ b/schema/jsonschema/cerbos/private/v1/CelTestCase.schema.json
@@ -64,13 +64,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -78,7 +78,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -103,15 +103,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/private/v1/CodeGenTestCase.schema.json
+++ b/schema/jsonschema/cerbos/private/v1/CodeGenTestCase.schema.json
@@ -61,7 +61,7 @@
         "name": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:word:]\\-\\.]+$"
+          "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
         }
       }
     },
@@ -235,7 +235,7 @@
         "principal": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-]*(\\:[[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^[A-Za-z][\\--\\.0-9@-Z_a-z]*(:[A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         },
         "rules": {
           "type": "array",
@@ -245,11 +245,11 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         },
         "version": {
           "type": "string",
-          "pattern": "^[[:word:]]+$"
+          "pattern": "^[0-9A-Z_a-z]+$"
         }
       }
     },
@@ -271,7 +271,7 @@
         "resource": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         }
       }
     },
@@ -306,7 +306,7 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         }
       }
     },
@@ -322,14 +322,14 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         },
         "resource": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "rules": {
           "type": "array",
@@ -342,11 +342,11 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         },
         "version": {
           "type": "string",
-          "pattern": "^[[:word:]]+$"
+          "pattern": "^[0-9A-Z_a-z]+$"
         }
       }
     },
@@ -374,7 +374,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         },
@@ -394,13 +394,13 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         }
@@ -419,13 +419,13 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^[[:word:]\\-\\.]+$"
+          "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
         },
         "parentRoles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "minItems": 1,
           "uniqueItems": true

--- a/schema/jsonschema/cerbos/private/v1/CompileTestCase.schema.json
+++ b/schema/jsonschema/cerbos/private/v1/CompileTestCase.schema.json
@@ -61,7 +61,7 @@
         "name": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:word:]\\-\\.]+$"
+          "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
         }
       }
     },
@@ -235,7 +235,7 @@
         "principal": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-]*(\\:[[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^[A-Za-z][\\--\\.0-9@-Z_a-z]*(:[A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         },
         "rules": {
           "type": "array",
@@ -245,11 +245,11 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         },
         "version": {
           "type": "string",
-          "pattern": "^[[:word:]]+$"
+          "pattern": "^[0-9A-Z_a-z]+$"
         }
       }
     },
@@ -271,7 +271,7 @@
         "resource": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         }
       }
     },
@@ -306,7 +306,7 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         }
       }
     },
@@ -322,14 +322,14 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         },
         "resource": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "rules": {
           "type": "array",
@@ -342,11 +342,11 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         },
         "version": {
           "type": "string",
-          "pattern": "^[[:word:]]+$"
+          "pattern": "^[0-9A-Z_a-z]+$"
         }
       }
     },
@@ -374,7 +374,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         },
@@ -394,13 +394,13 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         }
@@ -419,13 +419,13 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^[[:word:]\\-\\.]+$"
+          "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
         },
         "parentRoles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "minItems": 1,
           "uniqueItems": true

--- a/schema/jsonschema/cerbos/private/v1/EngineTestCase.schema.json
+++ b/schema/jsonschema/cerbos/private/v1/EngineTestCase.schema.json
@@ -118,13 +118,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -132,7 +132,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -157,15 +157,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/private/v1/QueryPlannerTestSuite.schema.json
+++ b/schema/jsonschema/cerbos/private/v1/QueryPlannerTestSuite.schema.json
@@ -22,13 +22,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -36,7 +36,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -56,15 +56,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/private/v1/SchemaTestCase.schema.json
+++ b/schema/jsonschema/cerbos/private/v1/SchemaTestCase.schema.json
@@ -64,13 +64,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -78,7 +78,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -103,15 +103,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/private/v1/ServerTestCase.schema.json
+++ b/schema/jsonschema/cerbos/private/v1/ServerTestCase.schema.json
@@ -31,13 +31,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -45,7 +45,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -70,15 +70,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -98,15 +98,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -160,7 +160,7 @@
         "name": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:word:]\\-\\.]+$"
+          "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
         }
       }
     },
@@ -334,7 +334,7 @@
         "principal": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-]*(\\:[[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^[A-Za-z][\\--\\.0-9@-Z_a-z]*(:[A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         },
         "rules": {
           "type": "array",
@@ -344,11 +344,11 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         },
         "version": {
           "type": "string",
-          "pattern": "^[[:word:]]+$"
+          "pattern": "^[0-9A-Z_a-z]+$"
         }
       }
     },
@@ -370,7 +370,7 @@
         "resource": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         }
       }
     },
@@ -405,7 +405,7 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         }
       }
     },
@@ -421,14 +421,14 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         },
         "resource": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "rules": {
           "type": "array",
@@ -441,11 +441,11 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         },
         "version": {
           "type": "string",
-          "pattern": "^[[:word:]]+$"
+          "pattern": "^[0-9A-Z_a-z]+$"
         }
       }
     },
@@ -473,7 +473,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         },
@@ -493,13 +493,13 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         }
@@ -518,13 +518,13 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^[[:word:]\\-\\.]+$"
+          "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
         },
         "parentRoles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "minItems": 1,
           "uniqueItems": true
@@ -1009,15 +1009,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/private/v1/VerifyTestFixtureGetTestsTestCase.schema.json
+++ b/schema/jsonschema/cerbos/private/v1/VerifyTestFixtureGetTestsTestCase.schema.json
@@ -73,13 +73,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -87,7 +87,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -112,15 +112,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/request/v1/AddOrUpdatePolicyRequest.schema.json
+++ b/schema/jsonschema/cerbos/request/v1/AddOrUpdatePolicyRequest.schema.json
@@ -61,7 +61,7 @@
         "name": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:word:]\\-\\.]+$"
+          "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
         }
       }
     },
@@ -235,7 +235,7 @@
         "principal": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-]*(\\:[[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^[A-Za-z][\\--\\.0-9@-Z_a-z]*(:[A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         },
         "rules": {
           "type": "array",
@@ -245,11 +245,11 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         },
         "version": {
           "type": "string",
-          "pattern": "^[[:word:]]+$"
+          "pattern": "^[0-9A-Z_a-z]+$"
         }
       }
     },
@@ -271,7 +271,7 @@
         "resource": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         }
       }
     },
@@ -306,7 +306,7 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         }
       }
     },
@@ -322,14 +322,14 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         },
         "resource": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "rules": {
           "type": "array",
@@ -342,11 +342,11 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         },
         "version": {
           "type": "string",
-          "pattern": "^[[:word:]]+$"
+          "pattern": "^[0-9A-Z_a-z]+$"
         }
       }
     },
@@ -374,7 +374,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         },
@@ -394,13 +394,13 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         }
@@ -419,13 +419,13 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^[[:word:]\\-\\.]+$"
+          "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
         },
         "parentRoles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "minItems": 1,
           "uniqueItems": true

--- a/schema/jsonschema/cerbos/request/v1/CheckResourceBatchRequest.schema.json
+++ b/schema/jsonschema/cerbos/request/v1/CheckResourceBatchRequest.schema.json
@@ -22,13 +22,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -36,7 +36,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -61,15 +61,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/request/v1/CheckResourceSetRequest.schema.json
+++ b/schema/jsonschema/cerbos/request/v1/CheckResourceSetRequest.schema.json
@@ -22,13 +22,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -36,7 +36,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -96,15 +96,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/request/v1/ListAuditLogEntriesRequest.schema.json
+++ b/schema/jsonschema/cerbos/request/v1/ListAuditLogEntriesRequest.schema.json
@@ -66,7 +66,7 @@
         },
         "lookup": {
           "type": "string",
-          "pattern": "^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$"
+          "pattern": "^[0-9A-HJ-KM-NP-TV-Z]{26}$"
         },
         "since": {
           "$ref": "#/definitions/google.protobuf.Duration"

--- a/schema/jsonschema/cerbos/request/v1/PlaygroundEvaluateRequest.schema.json
+++ b/schema/jsonschema/cerbos/request/v1/PlaygroundEvaluateRequest.schema.json
@@ -22,13 +22,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -36,7 +36,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -61,15 +61,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/request/v1/PlaygroundProxyRequest.schema.json
+++ b/schema/jsonschema/cerbos/request/v1/PlaygroundProxyRequest.schema.json
@@ -22,13 +22,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -36,7 +36,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -61,15 +61,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -89,15 +89,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -272,15 +272,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/request/v1/ResourceSet.schema.json
+++ b/schema/jsonschema/cerbos/request/v1/ResourceSet.schema.json
@@ -37,15 +37,15 @@
     "kind": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+      "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
     },
     "policyVersion": {
       "type": "string",
-      "pattern": "^[[:word:]]*$"
+      "pattern": "^[0-9A-Z_a-z]*$"
     },
     "scope": {
       "type": "string",
-      "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+      "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
     }
   }
 }

--- a/schema/jsonschema/cerbos/request/v1/ResourcesQueryPlanRequest.schema.json
+++ b/schema/jsonschema/cerbos/request/v1/ResourcesQueryPlanRequest.schema.json
@@ -22,13 +22,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -36,7 +36,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -56,15 +56,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },

--- a/schema/jsonschema/cerbos/response/v1/GetPolicyResponse.schema.json
+++ b/schema/jsonschema/cerbos/response/v1/GetPolicyResponse.schema.json
@@ -61,7 +61,7 @@
         "name": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:word:]\\-\\.]+$"
+          "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
         }
       }
     },
@@ -235,7 +235,7 @@
         "principal": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-]*(\\:[[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^[A-Za-z][\\--\\.0-9@-Z_a-z]*(:[A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         },
         "rules": {
           "type": "array",
@@ -245,11 +245,11 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         },
         "version": {
           "type": "string",
-          "pattern": "^[[:word:]]+$"
+          "pattern": "^[0-9A-Z_a-z]+$"
         }
       }
     },
@@ -271,7 +271,7 @@
         "resource": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         }
       }
     },
@@ -306,7 +306,7 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         }
       }
     },
@@ -322,14 +322,14 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         },
         "resource": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "rules": {
           "type": "array",
@@ -342,11 +342,11 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         },
         "version": {
           "type": "string",
-          "pattern": "^[[:word:]]+$"
+          "pattern": "^[0-9A-Z_a-z]+$"
         }
       }
     },
@@ -374,7 +374,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         },
@@ -394,13 +394,13 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\@\\.\\-]*)*$"
+          "pattern": "^([A-Za-z][\\--\\.0-9@-Z_a-z]*)*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "uniqueItems": true
         }
@@ -419,13 +419,13 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^[[:word:]\\-\\.]+$"
+          "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
         },
         "parentRoles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "minItems": 1,
           "uniqueItems": true

--- a/schema/jsonschema/cerbos/response/v1/ListAuditLogEntriesResponse.schema.json
+++ b/schema/jsonschema/cerbos/response/v1/ListAuditLogEntriesResponse.schema.json
@@ -206,13 +206,13 @@
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[[:word:]\\-\\.]+$"
+            "pattern": "^[\\--\\.0-9A-Z_a-z]+$"
           },
           "maxItems": 20,
           "minItems": 1,
@@ -220,7 +220,7 @@
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },
@@ -245,15 +245,15 @@
         "kind": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[[:alpha:]][[:word:]\\@\\.\\-/]*(\\:[[:alpha:]][[:word:]\\@\\.\\-/]*)*$"
+          "pattern": "^[A-Za-z][\\--9@-Z_a-z]*(:[A-Za-z][\\--9@-Z_a-z]*)*$"
         },
         "policyVersion": {
           "type": "string",
-          "pattern": "^[[:word:]]*$"
+          "pattern": "^[0-9A-Z_a-z]*$"
         },
         "scope": {
           "type": "string",
-          "pattern": "^([[:alpha:]][[:word:]\\-]+(\\.[[:alpha:]][[:word:]\\-]*)*)*$"
+          "pattern": "^([A-Za-z][\\-0-9A-Z_a-z]+(\\.[A-Za-z][\\-0-9A-Z_a-z]*)*)*$"
         }
       }
     },


### PR DESCRIPTION
#### Description

`protoc-gen-validate` allows Go's regexp syntax, but unfortunately ECMAScript doesn't support the same set of features (most notably, POSIX character classes like `[:word:]`, which we use extensively).

This PR parses the regexps and rewrites them with simplified character classes. Simplification of the character classes is done for us by [`syntax.Parse`](https://pkg.go.dev/regexp/syntax#Parse) - we just have to convert the resulting syntax tree back into a string without using any Perlisms (which the default `String()` implementation unfortunately does introduce).