### PR TITLE
chore(ci): Upgrade to Go 1.18 on CI

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: 1.18.x
 
       - name: Generate notice
         run: "make deps generate-notice"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.17.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.1.0
         with:

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -95,7 +95,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.1.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/snaphot.yaml
+++ b/.github/workflows/snaphot.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/test-matrix.yaml
+++ b/.github/workflows/test-matrix.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Note that this only upgrades CI workflows to use Go 1.18. The minimum Go
version in `go.mod` is still `1.17` because we don't use any new Go 1.18
features yet. Using the new Go compiler should still bring some of the
performance improvements to the builds. (20% improvement on ARM64
allegedly)

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
