### PR TITLE
enhancement: Add `--color` flag to `cerbos compile`

### DIFF
--- a/cmd/cerbos/compile/internal/compilation/display.go
+++ b/cmd/cerbos/compile/internal/compilation/display.go
@@ -7,14 +7,15 @@ import (
 	internalerrors "github.com/cerbos/cerbos/cmd/cerbos/compile/internal/errors"
 	"github.com/cerbos/cerbos/cmd/cerbos/compile/internal/flagset"
 	"github.com/cerbos/cerbos/internal/compile"
+	"github.com/cerbos/cerbos/internal/outputcolor"
 	"github.com/cerbos/cerbos/internal/printer"
 	"github.com/cerbos/cerbos/internal/printer/colored"
 )
 
-func Display(p *printer.Printer, errs compile.ErrorList, output flagset.OutputFormat, noColor bool) error {
+func Display(p *printer.Printer, errs compile.ErrorList, output flagset.OutputFormat, colorLevel outputcolor.Level) error {
 	switch output {
 	case flagset.OutputFormatJSON:
-		return displayJSON(p, errs, noColor)
+		return displayJSON(p, errs, colorLevel)
 	case flagset.OutputFormatList, flagset.OutputFormatTree:
 		return displayList(p, errs)
 	}
@@ -22,8 +23,8 @@ func Display(p *printer.Printer, errs compile.ErrorList, output flagset.OutputFo
 	return internalerrors.ErrFailed
 }
 
-func displayJSON(p *printer.Printer, errs compile.ErrorList, noColor bool) error {
-	if err := p.PrintJSON(map[string]compile.ErrorList{"compileErrors": errs}, noColor); err != nil {
+func displayJSON(p *printer.Printer, errs compile.ErrorList, colorLevel outputcolor.Level) error {
+	if err := p.PrintJSON(map[string]compile.ErrorList{"compileErrors": errs}, colorLevel); err != nil {
 		return err
 	}
 

--- a/cmd/cerbos/compile/internal/lint/display.go
+++ b/cmd/cerbos/compile/internal/lint/display.go
@@ -6,15 +6,16 @@ package lint
 import (
 	internalerrors "github.com/cerbos/cerbos/cmd/cerbos/compile/internal/errors"
 	"github.com/cerbos/cerbos/cmd/cerbos/compile/internal/flagset"
+	"github.com/cerbos/cerbos/internal/outputcolor"
 	"github.com/cerbos/cerbos/internal/printer"
 	"github.com/cerbos/cerbos/internal/printer/colored"
 	"github.com/cerbos/cerbos/internal/storage/index"
 )
 
-func Display(p *printer.Printer, errs *index.BuildError, output flagset.OutputFormat, noColor bool) error {
+func Display(p *printer.Printer, errs *index.BuildError, output flagset.OutputFormat, colorLevel outputcolor.Level) error {
 	switch output {
 	case flagset.OutputFormatJSON:
-		return displayJSON(p, errs, noColor)
+		return displayJSON(p, errs, colorLevel)
 	case flagset.OutputFormatList, flagset.OutputFormatTree:
 		return displayList(p, errs)
 	}
@@ -22,8 +23,8 @@ func Display(p *printer.Printer, errs *index.BuildError, output flagset.OutputFo
 	return internalerrors.ErrFailed
 }
 
-func displayJSON(p *printer.Printer, errs *index.BuildError, noColor bool) error {
-	if err := p.PrintJSON(map[string]*index.BuildError{"lintErrors": errs}, noColor); err != nil {
+func displayJSON(p *printer.Printer, errs *index.BuildError, colorLevel outputcolor.Level) error {
+	if err := p.PrintJSON(map[string]*index.BuildError{"lintErrors": errs}, colorLevel); err != nil {
 		return err
 	}
 

--- a/cmd/cerbos/compile/internal/verification/display.go
+++ b/cmd/cerbos/compile/internal/verification/display.go
@@ -12,14 +12,15 @@ import (
 	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
 	"github.com/cerbos/cerbos/cmd/cerbos/compile/internal/flagset"
 	"github.com/cerbos/cerbos/cmd/cerbos/compile/internal/verification/internal/traces"
+	"github.com/cerbos/cerbos/internal/outputcolor"
 	"github.com/cerbos/cerbos/internal/printer"
 	"github.com/cerbos/cerbos/internal/printer/colored"
 )
 
-func Display(p *printer.Printer, results *policyv1.TestResults, output flagset.OutputFormat, verbose, noColor bool) error {
+func Display(p *printer.Printer, results *policyv1.TestResults, output flagset.OutputFormat, verbose bool, colorLevel outputcolor.Level) error {
 	switch output {
 	case flagset.OutputFormatJSON:
-		return p.PrintProtoJSON(results, noColor)
+		return p.PrintProtoJSON(results, colorLevel)
 	case flagset.OutputFormatTree:
 		return displayTree(p, results, verbose)
 	case flagset.OutputFormatList:

--- a/cmd/cerbos/main.go
+++ b/cmd/cerbos/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cerbos/cerbos/cmd/cerbos/healthcheck"
 	"github.com/cerbos/cerbos/cmd/cerbos/run"
 	"github.com/cerbos/cerbos/cmd/cerbos/server"
+	"github.com/cerbos/cerbos/internal/outputcolor"
 	"github.com/cerbos/cerbos/internal/util"
 )
 
@@ -27,6 +28,7 @@ func main() {
 		kong.Description("Painless access controls for cloud-native applications"),
 		kong.UsageOnError(),
 		kong.Vars{"version": util.AppVersion()},
+		outputcolor.TypeMapper,
 	)
 
 	ctx.FatalIfErrorf(ctx.Run())

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/jwalton/gchalk v1.2.1
+	github.com/jwalton/go-supportscolor v1.1.0
 	github.com/kavu/go_reuseport v1.5.0
 	github.com/lestrrat-go/jwx v1.2.20
 	github.com/mattn/go-isatty v0.0.14
@@ -156,7 +157,6 @@ require (
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/jwalton/go-supportscolor v1.1.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kevinburke/ssh_config v1.1.0 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect

--- a/internal/outputcolor/level.go
+++ b/internal/outputcolor/level.go
@@ -1,0 +1,101 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package outputcolor
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+
+	"github.com/alecthomas/kong"
+	"github.com/jwalton/go-supportscolor"
+)
+
+type Level uint8
+
+const (
+	None    = Level(supportscolor.None)
+	Basic   = Level(supportscolor.Basic)
+	Ansi256 = Level(supportscolor.Ansi256)
+	Ansi16m = Level(supportscolor.Ansi16m)
+)
+
+var TypeMapper = kong.TypeMapper(reflect.TypeOf((*Level)(nil)), kong.MapperFunc(decode))
+
+func (l *Level) Resolve(disable bool) Level {
+	if disable {
+		return None
+	}
+
+	if l != nil {
+		return *l
+	}
+
+	return Level(supportscolor.SupportsColor(os.Stdout.Fd(), supportscolor.SniffFlagsOption(false)).Level)
+}
+
+func (l Level) Enabled() bool {
+	return l > None
+}
+
+func decode(ctx *kong.DecodeContext, target reflect.Value) error {
+	level, err := scan(ctx)
+	if err != nil {
+		return err
+	}
+
+	target.Set(reflect.ValueOf(level))
+	return nil
+}
+
+func scan(ctx *kong.DecodeContext) (*Level, error) {
+	token := ctx.Scan.Peek()
+
+	switch token.Type {
+	case kong.FlagValueToken:
+		return parse(ctx.Scan.Pop().Value)
+
+	case kong.ShortFlagTailToken, kong.UntypedToken:
+		level, err := parse(token.Value)
+		if err == nil {
+			ctx.Scan.Pop()
+			return level, nil
+		}
+
+	default:
+	}
+
+	return pointer(Basic), nil
+}
+
+func parse(v interface{}) (*Level, error) {
+	s, ok := v.(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid flag value (expected string, got %T)", v)
+	}
+
+	switch s {
+	case "auto":
+		return nil, nil
+
+	case "false", "never":
+		return pointer(None), nil
+
+	case "true", "always":
+		return pointer(Basic), nil
+
+	case "256":
+		return pointer(Ansi256), nil
+
+	case "16m", "full", "truecolor":
+		return pointer(Ansi16m), nil
+
+	default:
+		return nil, fmt.Errorf("invalid value for output color level: %q", s)
+	}
+}
+
+func pointer(level Level) *Level {
+	return &level
+}

--- a/internal/outputcolor/level_test.go
+++ b/internal/outputcolor/level_test.go
@@ -1,0 +1,250 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package outputcolor_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/cerbos/cerbos/internal/outputcolor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLevelEnabled(t *testing.T) {
+	assert.False(t, outputcolor.None.Enabled(), "None")
+	assert.True(t, outputcolor.Basic.Enabled(), "Basic")
+	assert.True(t, outputcolor.Ansi256.Enabled(), "Ansi256")
+	assert.True(t, outputcolor.Ansi16m.Enabled(), "Ansi16m")
+}
+
+func TestTypeMapper(t *testing.T) {
+	tests := []struct {
+		args          []string
+		wantLevel     outputcolor.Level
+		wantLeftovers []string
+		wantNil       bool
+		wantErr       string
+	}{
+		{
+			args:    []string{},
+			wantNil: true,
+		},
+		{
+			args:    []string{"-cauto"},
+			wantNil: true,
+		},
+		{
+			args:    []string{"-c", "auto"},
+			wantNil: true,
+		},
+		{
+			args:    []string{"--color=auto"},
+			wantNil: true,
+		},
+		{
+			args:    []string{"--color", "auto"},
+			wantNil: true,
+		},
+		{
+			args:      []string{"-cfalse"},
+			wantLevel: outputcolor.None,
+		},
+		{
+			args:      []string{"-c", "false"},
+			wantLevel: outputcolor.None,
+		},
+		{
+			args:      []string{"--color=false"},
+			wantLevel: outputcolor.None,
+		},
+		{
+			args:      []string{"--color", "false"},
+			wantLevel: outputcolor.None,
+		},
+		{
+			args:      []string{"-cnever"},
+			wantLevel: outputcolor.None,
+		},
+		{
+			args:      []string{"-c", "never"},
+			wantLevel: outputcolor.None,
+		},
+		{
+			args:      []string{"--color=never"},
+			wantLevel: outputcolor.None,
+		},
+		{
+			args:      []string{"--color", "never"},
+			wantLevel: outputcolor.None,
+		},
+		{
+			args:      []string{"-c"},
+			wantLevel: outputcolor.Basic,
+		},
+		{
+			args:      []string{"--color"},
+			wantLevel: outputcolor.Basic,
+		},
+		{
+			args:      []string{"-ctrue"},
+			wantLevel: outputcolor.Basic,
+		},
+		{
+			args:      []string{"-c", "true"},
+			wantLevel: outputcolor.Basic,
+		},
+		{
+			args:      []string{"--color=true"},
+			wantLevel: outputcolor.Basic,
+		},
+		{
+			args:      []string{"--color", "true"},
+			wantLevel: outputcolor.Basic,
+		},
+		{
+			args:      []string{"-calways"},
+			wantLevel: outputcolor.Basic,
+		},
+		{
+			args:      []string{"-c", "always"},
+			wantLevel: outputcolor.Basic,
+		},
+		{
+			args:      []string{"--color=always"},
+			wantLevel: outputcolor.Basic,
+		},
+		{
+			args:      []string{"--color", "always"},
+			wantLevel: outputcolor.Basic,
+		},
+		{
+			args:      []string{"-c256"},
+			wantLevel: outputcolor.Ansi256,
+		},
+		{
+			args:      []string{"-c", "256"},
+			wantLevel: outputcolor.Ansi256,
+		},
+		{
+			args:      []string{"--color=256"},
+			wantLevel: outputcolor.Ansi256,
+		},
+		{
+			args:      []string{"--color", "256"},
+			wantLevel: outputcolor.Ansi256,
+		},
+		{
+			args:      []string{"-c16m"},
+			wantLevel: outputcolor.Ansi16m,
+		},
+		{
+			args:      []string{"-c", "16m"},
+			wantLevel: outputcolor.Ansi16m,
+		},
+		{
+			args:      []string{"--color=16m"},
+			wantLevel: outputcolor.Ansi16m,
+		},
+		{
+			args:      []string{"--color", "16m"},
+			wantLevel: outputcolor.Ansi16m,
+		},
+		{
+			args:      []string{"-cfull"},
+			wantLevel: outputcolor.Ansi16m,
+		},
+		{
+			args:      []string{"-c", "full"},
+			wantLevel: outputcolor.Ansi16m,
+		},
+		{
+			args:      []string{"--color=full"},
+			wantLevel: outputcolor.Ansi16m,
+		},
+		{
+			args:      []string{"--color", "full"},
+			wantLevel: outputcolor.Ansi16m,
+		},
+		{
+			args:      []string{"-ctruecolor"},
+			wantLevel: outputcolor.Ansi16m,
+		},
+		{
+			args:      []string{"-c", "truecolor"},
+			wantLevel: outputcolor.Ansi16m,
+		},
+		{
+			args:      []string{"--color=truecolor"},
+			wantLevel: outputcolor.Ansi16m,
+		},
+		{
+			args:      []string{"--color", "truecolor"},
+			wantLevel: outputcolor.Ansi16m,
+		},
+		{
+			args:    []string{"-cfoo"},
+			wantErr: "unknown flag -f",
+		},
+		{
+			args:          []string{"-c", "foo"},
+			wantLevel:     outputcolor.Basic,
+			wantLeftovers: []string{"foo"},
+		},
+		{
+			args:    []string{"--color=foo"},
+			wantErr: `invalid value for output color level: "foo"`,
+		},
+		{
+			args:          []string{"--color", "foo"},
+			wantLevel:     outputcolor.Basic,
+			wantLeftovers: []string{"foo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(strings.Join(tt.args, " "), func(t *testing.T) {
+			level, leftovers, err := parse(t, tt.args)
+
+			if tt.wantErr != "" {
+				require.Error(t, err, tt.wantErr)
+				require.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.wantNil {
+				assert.Nil(t, level)
+			} else if assert.NotNil(t, level) {
+				assert.Equal(t, tt.wantLevel, *level)
+			}
+
+			assert.Equal(t, tt.wantLeftovers, leftovers)
+		})
+	}
+}
+
+func parse(t *testing.T, args []string) (*outputcolor.Level, []string, error) {
+	t.Helper()
+
+	var cli struct {
+		Color     *outputcolor.Level `short:"c"`
+		Leftovers []string           `arg:"" optional:""`
+	}
+
+	parser, err := kong.New(&cli, outputcolor.TypeMapper)
+	require.NoError(t, err, "failed to create command-line argument parser")
+
+	var parseError *kong.ParseError
+	_, err = parser.Parse(args)
+	if err == nil || errors.As(err, &parseError) {
+		return cli.Color, cli.Leftovers, err
+	}
+	require.NoError(t, err, "failed to parse command-line arguments")
+
+	return nil, nil, nil
+}


### PR DESCRIPTION
#### Description

Fixes #752 (the color level is now set for `pterm` as well as the `color` library, so `--no-color` turns off all coloring in the tree output)
Fixes #753 

This PR introduces a complimentary `--color` flag in addition to the existing `--no-color`.

With the default of `--color=auto`, the output color level is detected from the environment by checking if stdout is a TTY and looking for various environment variables (see https://pkg.go.dev/github.com/jwalton/go-supportscolor for details).

Otherwise, the output color level is set to:
- none for `--no-color`, `--color=false`, or `--color=never`;
- basic for `--color`, `--color=true`, or `--color=always`;
- 256-color for `--color=256`; and
- truecolor for `--color=16m`, `--color=full`, or `--color=truecolor`

This is basically a translation of `go-supportscolor`'s ["sniff flags"](https://pkg.go.dev/github.com/jwalton/go-supportscolor#SniffFlagsOption) functionality to make it compatible with Kong (which barfs on unknown flags, so we need to explicitly define them).