### PR TITLE
chore(fix): Restrict set of JSON schema enums to match validation rule

### DIFF
--- a/hack/tools/protoc-gen-jsonschema/module/enum.go
+++ b/hack/tools/protoc-gen-jsonschema/module/enum.go
@@ -21,9 +21,10 @@ func (m *Module) defineEnum(enum pgs.Enum) *jsonschema.StringSchema {
 
 func (m *Module) schemaForEnum(enum pgs.Enum, rules *validate.EnumRules) (jsonschema.Schema, bool) {
 	required := false
-	schemas := []jsonschema.NonTrivialSchema{m.enumRef(enum)}
 
 	if rules != nil {
+		var schemas []jsonschema.NonTrivialSchema
+
 		if rules.Const != nil {
 			schemas = append(schemas, m.schemaForEnumConst(enum, rules.GetConst()))
 			required = true
@@ -36,10 +37,13 @@ func (m *Module) schemaForEnum(enum pgs.Enum, rules *validate.EnumRules) (jsonsc
 
 		if len(rules.NotIn) > 0 {
 			schemas = append(schemas, jsonschema.Not(m.schemaForEnumIn(enum, rules.NotIn)))
+			required = true
 		}
+
+		return jsonschema.AllOf(schemas...), required
 	}
 
-	return jsonschema.AllOf(schemas...), required
+	return m.enumRef(enum), required
 }
 
 func (m *Module) schemaForEnumConst(enum pgs.Enum, value int32) *jsonschema.StringSchema {

--- a/hack/tools/protoc-gen-jsonschema/module/enum.go
+++ b/hack/tools/protoc-gen-jsonschema/module/enum.go
@@ -40,7 +40,9 @@ func (m *Module) schemaForEnum(enum pgs.Enum, rules *validate.EnumRules) (jsonsc
 			required = true
 		}
 
-		return jsonschema.AllOf(schemas...), required
+		if len(schemas) > 0 {
+			return jsonschema.AllOf(schemas...), required
+		}
 	}
 
 	return m.enumRef(enum), required

--- a/hack/tools/protoc-gen-jsonschema/module/enum.go
+++ b/hack/tools/protoc-gen-jsonschema/module/enum.go
@@ -20,46 +20,59 @@ func (m *Module) defineEnum(enum pgs.Enum) *jsonschema.StringSchema {
 }
 
 func (m *Module) schemaForEnum(enum pgs.Enum, rules *validate.EnumRules) (jsonschema.Schema, bool) {
-	required := false
-
 	if rules != nil {
-		var schemas []jsonschema.NonTrivialSchema
-
-		if rules.Const != nil {
-			schemas = append(schemas, m.schemaForEnumConst(enum, rules.GetConst()))
-			required = true
-		}
-
-		if len(rules.In) > 0 {
-			schemas = append(schemas, m.schemaForEnumIn(enum, rules.In))
-			required = true
-		}
-
-		if len(rules.NotIn) > 0 {
-			schemas = append(schemas, jsonschema.Not(m.schemaForEnumIn(enum, rules.NotIn)))
-			required = true
-		}
-
-		if len(schemas) > 0 {
-			return jsonschema.AllOf(schemas...), required
+		switch {
+		case rules.Const != nil:
+			return m.schemaForEnumConst(enum, rules.GetConst())
+		case len(rules.In) > 0:
+			return m.schemaForEnumIn(enum, rules.In)
+		case len(rules.NotIn) > 0:
+			return m.schemaForEnumNotIn(enum, rules.NotIn)
 		}
 	}
 
-	return m.enumRef(enum), required
+	return m.enumRef(enum), false
 }
 
-func (m *Module) schemaForEnumConst(enum pgs.Enum, value int32) *jsonschema.StringSchema {
+func (m *Module) schemaForEnumConst(enum pgs.Enum, value int32) (*jsonschema.StringSchema, bool) {
 	schema := jsonschema.NewStringSchema()
 	schema.Const = jsonschema.String(m.lookUpEnumName(enum, value))
-	return schema
+	return schema, value != 0
 }
 
-func (m *Module) schemaForEnumIn(enum pgs.Enum, values []int32) *jsonschema.StringSchema {
+func (m *Module) schemaForEnumIn(enum pgs.Enum, values []int32) (*jsonschema.StringSchema, bool) {
 	schema := jsonschema.NewStringSchema()
+	required := true
+
 	for _, value := range values {
 		schema.Enum = append(schema.Enum, m.lookUpEnumName(enum, value))
+		if value == 0 {
+			required = false
+		}
 	}
-	return schema
+	return schema, required
+}
+
+func (m *Module) schemaForEnumNotIn(enum pgs.Enum, values []int32) (*jsonschema.StringSchema, bool) {
+	exclude := make(map[int32]struct{}, len(values))
+	for _, v := range values {
+		exclude[v] = struct{}{}
+	}
+
+	schema := jsonschema.NewStringSchema()
+	required := true
+
+	for _, v := range enum.Values() {
+		value := v.Value()
+		if _, ok := exclude[value]; !ok {
+			schema.Enum = append(schema.Enum, v.Name().String())
+			if value == 0 {
+				required = false
+			}
+		}
+	}
+
+	return schema, required
 }
 
 func (m *Module) lookUpEnumName(enum pgs.Enum, value int32) string {

--- a/hack/tools/protoc-gen-jsonschema/module/module.go
+++ b/hack/tools/protoc-gen-jsonschema/module/module.go
@@ -27,7 +27,7 @@ func (*Module) Name() string {
 }
 
 func (m *Module) Execute(targets map[string]pgs.File, pkgs map[string]pgs.Package) []pgs.Artifact {
-	baseURL := m.Parameters().StrDefault("baseurl", "https://api.cerbos.dev/")
+	baseURL := m.Parameters().StrDefault("baseurl", "https://protoc-gen-jsonschema.cerbos.dev/")
 	if !strings.HasSuffix(baseURL, "/") {
 		baseURL += "/"
 	}

--- a/hack/tools/protoc-gen-jsonschema/module/module.go
+++ b/hack/tools/protoc-gen-jsonschema/module/module.go
@@ -6,6 +6,7 @@ package module
 import (
 	"encoding/json"
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/cerbos/cerbos/hack/tools/protoc-gen-jsonschema/jsonschema"
@@ -27,6 +28,8 @@ func (*Module) Name() string {
 }
 
 func (m *Module) Execute(targets map[string]pgs.File, pkgs map[string]pgs.Package) []pgs.Artifact {
+	baseURL := m.Parameters().StrDefault("baseurl", "https://api.cerbos.dev")
+
 	for _, file := range targets {
 		m.Push(fmt.Sprintf("file:%s", file.Name()))
 
@@ -34,7 +37,7 @@ func (m *Module) Execute(targets map[string]pgs.File, pkgs map[string]pgs.Packag
 			filename := m.filename(message)
 
 			schema := m.defineMessage(message)
-			schema.TopLevel("https://api.cerbos.dev/" + filename)
+			schema.TopLevel(path.Join(baseURL, filename))
 
 			content, err := json.MarshalIndent(schema, "", "  ")
 			m.CheckErr(err, "failed to marshal JSON schema")

--- a/hack/tools/protoc-gen-jsonschema/module/module.go
+++ b/hack/tools/protoc-gen-jsonschema/module/module.go
@@ -6,7 +6,6 @@ package module
 import (
 	"encoding/json"
 	"fmt"
-	"path"
 	"strings"
 
 	"github.com/cerbos/cerbos/hack/tools/protoc-gen-jsonschema/jsonschema"
@@ -28,7 +27,10 @@ func (*Module) Name() string {
 }
 
 func (m *Module) Execute(targets map[string]pgs.File, pkgs map[string]pgs.Package) []pgs.Artifact {
-	baseURL := m.Parameters().StrDefault("baseurl", "https://api.cerbos.dev")
+	baseURL := m.Parameters().StrDefault("baseurl", "https://api.cerbos.dev/")
+	if !strings.HasSuffix(baseURL, "/") {
+		baseURL += "/"
+	}
 
 	for _, file := range targets {
 		m.Push(fmt.Sprintf("file:%s", file.Name()))
@@ -37,7 +39,7 @@ func (m *Module) Execute(targets map[string]pgs.File, pkgs map[string]pgs.Packag
 			filename := m.filename(message)
 
 			schema := m.defineMessage(message)
-			schema.TopLevel(path.Join(baseURL, filename))
+			schema.TopLevel(baseURL + filename)
 
 			content, err := json.MarshalIndent(schema, "", "  ")
 			m.CheckErr(err, "failed to marshal JSON schema")

--- a/schema/jsonschema/cerbos/policy/v1/Policy.schema.json
+++ b/schema/jsonschema/cerbos/policy/v1/Policy.schema.json
@@ -2,15 +2,6 @@
   "$id": "https://api.cerbos.dev/cerbos/policy/v1/Policy.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "cerbos.effect.v1.Effect": {
-      "type": "string",
-      "enum": [
-        "EFFECT_UNSPECIFIED",
-        "EFFECT_ALLOW",
-        "EFFECT_DENY",
-        "EFFECT_NO_MATCH"
-      ]
-    },
     "cerbos.policy.v1.Condition": {
       "allOf": [
         {
@@ -228,17 +219,10 @@
           "$ref": "#/definitions/cerbos.policy.v1.Condition"
         },
         "effect": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.effect.v1.Effect"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "EFFECT_ALLOW",
-                "EFFECT_DENY"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "EFFECT_ALLOW",
+            "EFFECT_DENY"
           ]
         },
         "name": {
@@ -316,17 +300,10 @@
           "uniqueItems": true
         },
         "effect": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.effect.v1.Effect"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "EFFECT_ALLOW",
-                "EFFECT_DENY"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "EFFECT_ALLOW",
+            "EFFECT_DENY"
           ]
         },
         "name": {

--- a/schema/jsonschema/cerbos/policy/v1/PrincipalPolicy.schema.json
+++ b/schema/jsonschema/cerbos/policy/v1/PrincipalPolicy.schema.json
@@ -2,15 +2,6 @@
   "$id": "https://api.cerbos.dev/cerbos/policy/v1/PrincipalPolicy.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "cerbos.effect.v1.Effect": {
-      "type": "string",
-      "enum": [
-        "EFFECT_UNSPECIFIED",
-        "EFFECT_ALLOW",
-        "EFFECT_DENY",
-        "EFFECT_NO_MATCH"
-      ]
-    },
     "cerbos.policy.v1.Condition": {
       "allOf": [
         {
@@ -147,17 +138,10 @@
           "$ref": "#/definitions/cerbos.policy.v1.Condition"
         },
         "effect": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.effect.v1.Effect"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "EFFECT_ALLOW",
-                "EFFECT_DENY"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "EFFECT_ALLOW",
+            "EFFECT_DENY"
           ]
         },
         "name": {

--- a/schema/jsonschema/cerbos/policy/v1/PrincipalRule.schema.json
+++ b/schema/jsonschema/cerbos/policy/v1/PrincipalRule.schema.json
@@ -2,15 +2,6 @@
   "$id": "https://api.cerbos.dev/cerbos/policy/v1/PrincipalRule.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "cerbos.effect.v1.Effect": {
-      "type": "string",
-      "enum": [
-        "EFFECT_UNSPECIFIED",
-        "EFFECT_ALLOW",
-        "EFFECT_DENY",
-        "EFFECT_NO_MATCH"
-      ]
-    },
     "cerbos.policy.v1.Condition": {
       "allOf": [
         {
@@ -125,17 +116,10 @@
           "$ref": "#/definitions/cerbos.policy.v1.Condition"
         },
         "effect": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.effect.v1.Effect"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "EFFECT_ALLOW",
-                "EFFECT_DENY"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "EFFECT_ALLOW",
+            "EFFECT_DENY"
           ]
         },
         "name": {

--- a/schema/jsonschema/cerbos/policy/v1/ResourcePolicy.schema.json
+++ b/schema/jsonschema/cerbos/policy/v1/ResourcePolicy.schema.json
@@ -2,15 +2,6 @@
   "$id": "https://api.cerbos.dev/cerbos/policy/v1/ResourcePolicy.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "cerbos.effect.v1.Effect": {
-      "type": "string",
-      "enum": [
-        "EFFECT_UNSPECIFIED",
-        "EFFECT_ALLOW",
-        "EFFECT_DENY",
-        "EFFECT_NO_MATCH"
-      ]
-    },
     "cerbos.policy.v1.Condition": {
       "allOf": [
         {
@@ -138,17 +129,10 @@
           "uniqueItems": true
         },
         "effect": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.effect.v1.Effect"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "EFFECT_ALLOW",
-                "EFFECT_DENY"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "EFFECT_ALLOW",
+            "EFFECT_DENY"
           ]
         },
         "name": {

--- a/schema/jsonschema/cerbos/policy/v1/ResourceRule.schema.json
+++ b/schema/jsonschema/cerbos/policy/v1/ResourceRule.schema.json
@@ -2,15 +2,6 @@
   "$id": "https://api.cerbos.dev/cerbos/policy/v1/ResourceRule.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "cerbos.effect.v1.Effect": {
-      "type": "string",
-      "enum": [
-        "EFFECT_UNSPECIFIED",
-        "EFFECT_ALLOW",
-        "EFFECT_DENY",
-        "EFFECT_NO_MATCH"
-      ]
-    },
     "cerbos.policy.v1.Condition": {
       "allOf": [
         {
@@ -138,17 +129,10 @@
       "uniqueItems": true
     },
     "effect": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/cerbos.effect.v1.Effect"
-        },
-        {
-          "type": "string",
-          "enum": [
-            "EFFECT_ALLOW",
-            "EFFECT_DENY"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "EFFECT_ALLOW",
+        "EFFECT_DENY"
       ]
     },
     "name": {

--- a/schema/jsonschema/cerbos/private/v1/CodeGenTestCase.schema.json
+++ b/schema/jsonschema/cerbos/private/v1/CodeGenTestCase.schema.json
@@ -2,15 +2,6 @@
   "$id": "https://api.cerbos.dev/cerbos/private/v1/CodeGenTestCase.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "cerbos.effect.v1.Effect": {
-      "type": "string",
-      "enum": [
-        "EFFECT_UNSPECIFIED",
-        "EFFECT_ALLOW",
-        "EFFECT_DENY",
-        "EFFECT_NO_MATCH"
-      ]
-    },
     "cerbos.policy.v1.Condition": {
       "allOf": [
         {
@@ -291,17 +282,10 @@
           "$ref": "#/definitions/cerbos.policy.v1.Condition"
         },
         "effect": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.effect.v1.Effect"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "EFFECT_ALLOW",
-                "EFFECT_DENY"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "EFFECT_ALLOW",
+            "EFFECT_DENY"
           ]
         },
         "name": {
@@ -379,17 +363,10 @@
           "uniqueItems": true
         },
         "effect": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.effect.v1.Effect"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "EFFECT_ALLOW",
-                "EFFECT_DENY"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "EFFECT_ALLOW",
+            "EFFECT_DENY"
           ]
         },
         "name": {

--- a/schema/jsonschema/cerbos/private/v1/CompileTestCase.schema.json
+++ b/schema/jsonschema/cerbos/private/v1/CompileTestCase.schema.json
@@ -2,15 +2,6 @@
   "$id": "https://api.cerbos.dev/cerbos/private/v1/CompileTestCase.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "cerbos.effect.v1.Effect": {
-      "type": "string",
-      "enum": [
-        "EFFECT_UNSPECIFIED",
-        "EFFECT_ALLOW",
-        "EFFECT_DENY",
-        "EFFECT_NO_MATCH"
-      ]
-    },
     "cerbos.policy.v1.Condition": {
       "allOf": [
         {
@@ -291,17 +282,10 @@
           "$ref": "#/definitions/cerbos.policy.v1.Condition"
         },
         "effect": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.effect.v1.Effect"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "EFFECT_ALLOW",
-                "EFFECT_DENY"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "EFFECT_ALLOW",
+            "EFFECT_DENY"
           ]
         },
         "name": {
@@ -379,17 +363,10 @@
           "uniqueItems": true
         },
         "effect": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.effect.v1.Effect"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "EFFECT_ALLOW",
-                "EFFECT_DENY"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "EFFECT_ALLOW",
+            "EFFECT_DENY"
           ]
         },
         "name": {

--- a/schema/jsonschema/cerbos/private/v1/ServerTestCase.schema.json
+++ b/schema/jsonschema/cerbos/private/v1/ServerTestCase.schema.json
@@ -390,17 +390,10 @@
           "$ref": "#/definitions/cerbos.policy.v1.Condition"
         },
         "effect": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.effect.v1.Effect"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "EFFECT_ALLOW",
-                "EFFECT_DENY"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "EFFECT_ALLOW",
+            "EFFECT_DENY"
           ]
         },
         "name": {
@@ -478,17 +471,10 @@
           "uniqueItems": true
         },
         "effect": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.effect.v1.Effect"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "EFFECT_ALLOW",
-                "EFFECT_DENY"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "EFFECT_ALLOW",
+            "EFFECT_DENY"
           ]
         },
         "name": {

--- a/schema/jsonschema/cerbos/request/v1/AddOrUpdatePolicyRequest.schema.json
+++ b/schema/jsonschema/cerbos/request/v1/AddOrUpdatePolicyRequest.schema.json
@@ -2,15 +2,6 @@
   "$id": "https://api.cerbos.dev/cerbos/request/v1/AddOrUpdatePolicyRequest.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "cerbos.effect.v1.Effect": {
-      "type": "string",
-      "enum": [
-        "EFFECT_UNSPECIFIED",
-        "EFFECT_ALLOW",
-        "EFFECT_DENY",
-        "EFFECT_NO_MATCH"
-      ]
-    },
     "cerbos.policy.v1.Condition": {
       "allOf": [
         {
@@ -291,17 +282,10 @@
           "$ref": "#/definitions/cerbos.policy.v1.Condition"
         },
         "effect": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.effect.v1.Effect"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "EFFECT_ALLOW",
-                "EFFECT_DENY"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "EFFECT_ALLOW",
+            "EFFECT_DENY"
           ]
         },
         "name": {
@@ -379,17 +363,10 @@
           "uniqueItems": true
         },
         "effect": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.effect.v1.Effect"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "EFFECT_ALLOW",
-                "EFFECT_DENY"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "EFFECT_ALLOW",
+            "EFFECT_DENY"
           ]
         },
         "name": {

--- a/schema/jsonschema/cerbos/request/v1/ListAuditLogEntriesRequest.schema.json
+++ b/schema/jsonschema/cerbos/request/v1/ListAuditLogEntriesRequest.schema.json
@@ -2,14 +2,6 @@
   "$id": "https://api.cerbos.dev/cerbos/request/v1/ListAuditLogEntriesRequest.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "cerbos.request.v1.ListAuditLogEntriesRequest.Kind": {
-      "type": "string",
-      "enum": [
-        "KIND_UNSPECIFIED",
-        "KIND_ACCESS",
-        "KIND_DECISION"
-      ]
-    },
     "cerbos.request.v1.ListAuditLogEntriesRequest.TimeRange": {
       "type": "object",
       "required": [
@@ -51,17 +43,10 @@
           "$ref": "#/definitions/cerbos.request.v1.ListAuditLogEntriesRequest.TimeRange"
         },
         "kind": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.request.v1.ListAuditLogEntriesRequest.Kind"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "KIND_ACCESS",
-                "KIND_DECISION"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "KIND_ACCESS",
+            "KIND_DECISION"
           ]
         },
         "lookup": {

--- a/schema/jsonschema/cerbos/response/v1/GetPolicyResponse.schema.json
+++ b/schema/jsonschema/cerbos/response/v1/GetPolicyResponse.schema.json
@@ -2,15 +2,6 @@
   "$id": "https://api.cerbos.dev/cerbos/response/v1/GetPolicyResponse.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "cerbos.effect.v1.Effect": {
-      "type": "string",
-      "enum": [
-        "EFFECT_UNSPECIFIED",
-        "EFFECT_ALLOW",
-        "EFFECT_DENY",
-        "EFFECT_NO_MATCH"
-      ]
-    },
     "cerbos.policy.v1.Condition": {
       "allOf": [
         {
@@ -291,17 +282,10 @@
           "$ref": "#/definitions/cerbos.policy.v1.Condition"
         },
         "effect": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.effect.v1.Effect"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "EFFECT_ALLOW",
-                "EFFECT_DENY"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "EFFECT_ALLOW",
+            "EFFECT_DENY"
           ]
         },
         "name": {
@@ -379,17 +363,10 @@
           "uniqueItems": true
         },
         "effect": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/cerbos.effect.v1.Effect"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "EFFECT_ALLOW",
-                "EFFECT_DENY"
-              ]
-            }
+          "type": "string",
+          "enum": [
+            "EFFECT_ALLOW",
+            "EFFECT_DENY"
           ]
         },
         "name": {

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -81,6 +81,9 @@ define BUF_GEN_TEMPLATE
     },\
     {\
       "name": "jsonschema",\
+      "opt": [\
+	    "baseurl=https://api.cerbos.dev"\
+      ],\
       "out": "$(JSONSCHEMA_DIR)",\
       "path": "$(PROTOC_GEN_JSONSCHEMA)",\
       "strategy": "all"\


### PR DESCRIPTION
In protoc-gen-jsonschema, when `enum.*` validation rules are detected, use those rules to determine the allowed set of enum values.

Also makes the base URL for schemas configurable.

Fixes #766 