### PR TITLE
chore(ci): Only report newly-introduced backwards-compatibility breakage

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -123,6 +123,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Check backwards compatibility
-        uses: bufbuild/buf-breaking-action@v1.0.0
+        uses: cerbos/buf-breaking-action@since
         with:
-          against: 'https://github.com/cerbos/cerbos.git#tag=${{ steps.latest-release.outputs.tag }}'
+          against: https://github.com/cerbos/cerbos.git#tag=${{ steps.latest-release.outputs.tag }}
+          since: https://github.com/cerbos/cerbos.git#branch=main


### PR DESCRIPTION
#### Description

As of #768 we check backwards compatibility against the latest release version instead of against the main branch. This is good because it allows us to make backwards-incompatible changes against unreleased features, but it does mean that if we deliberately introduce a breaking change in one PR (e.g. #775) then all subsequent PRs will fail the check until the breaking change is released.

This PR uses [a fork of buf-breaking-action](https://github.com/cerbos/buf-breaking-action/tree/since) to allow us to find breaking changes against the previous release, but then filter out ones that were introduced in previous PRs. The earlier breaking changes will be included in the CI logs but not annotated on the proto files.

<img width="1615" alt="Screenshot 2022-03-23 at 10 10 15" src="https://user-images.githubusercontent.com/785641/159675617-e2f58782-a723-48dd-92b1-4c30032cc48e.png">
