### PR TITLE
chore(ci): Delete JSON schemas from latest when removed in a release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,7 +89,7 @@ jobs:
           VERSION="${GITHUB_REF#refs/tags/}"
           GCS_BUCKET="${{ secrets.API_GCS_BUCKET }}"
           hack/scripts/publish-json-schemas.sh "${VERSION}" "${GCS_BUCKET}"
-          gsutil -m rsync -r "gs://${GCS_BUCKET}/${VERSION}" "gs://${GCS_BUCKET}/latest"
+          gsutil -m rsync -d -r "gs://${GCS_BUCKET}/${VERSION}" "gs://${GCS_BUCKET}/latest"
 
   releaseDocs:
     name: Release Documentation


### PR DESCRIPTION
#### Description

I didn't realise that by default `gsutil rsync` doesn't delete files from the target that aren't present in the source - we need the `-d` flag to ensure that the `latest` directory exactly matches the `vX.Y.Z` directory.