### PR TITLE
chore: Set minimum Go version to 1.18

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -41,7 +41,7 @@ body:
         - **OS**: Ubuntu 20.04
         - **Cerbos version**: 0.4.0
         - **Docker version (if used)**: 20.10
-        - **Go version (if compiled)**: 1.17
+        - **Go version (if compiled)**: 1.18
     value: |
         - OS:
         - Cerbos version:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,6 @@
 ---
 run:
+  go: "1.17" # Until issues with Go 1.18 are fixed https://github.com/golangci/golangci-lint/issues/2649
   timeout: 300s
   skip-dirs:
     - api

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Submitting pull requests
 Developing Cerbos
 -----------------
 
-Cerbos is developed using the [Go programming language](https://golang.org). We currently require Go 1.17.x for development.
+Cerbos is developed using the [Go programming language](https://golang.org). We currently require Go 1.18.x for development.
 
 The `Makefile` automatically installs required build tools using the versions defined in `tools/go.mod`. Run `make clean-tools` to clear the cache and force the installation of new versions.
 

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ confdocs:
 
 .PHONY: deps
 deps:
-	@ go mod tidy -compat=1.17
+	@ go mod tidy -compat=1.18
 
 .PHONY: test-all
 test-all: test-race test-integration

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cerbos/cerbos
 
-go 1.17
+go 1.18
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.1

--- a/hack/tools/protoc-gen-jsonschema/go.mod
+++ b/hack/tools/protoc-gen-jsonschema/go.mod
@@ -1,6 +1,6 @@
 module github.com/cerbos/cerbos/hack/tools/protoc-gen-jsonschema
 
-go 1.17
+go 1.18
 
 require (
 	github.com/envoyproxy/protoc-gen-validate v0.6.7

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/cerbos/cerbos/tools
 
-go 1.17
+go 1.18
 
 require (
 	github.com/bojand/ghz v0.106.1


### PR DESCRIPTION
Signed-off-by: Charith Ellawala <charith@cerbos.dev>
