### PR TITLE
fix: Handle comments at the beginning of YAML files

### DIFF
--- a/internal/test/testdata/policy_formats/derived_roles_01.yaml
+++ b/internal/test/testdata/policy_formats/derived_roles_01.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
 ---
 apiVersion: "api.cerbos.dev/v1"
 derivedRoles:

--- a/internal/test/testdata/policy_formats/principal_policy_01.yaml
+++ b/internal/test/testdata/policy_formats/principal_policy_01.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
 ---
 apiVersion: "api.cerbos.dev/v1"
 principalPolicy:

--- a/internal/test/testdata/policy_formats/resource_policy_01.yaml
+++ b/internal/test/testdata/policy_formats/resource_policy_01.yaml
@@ -1,4 +1,5 @@
-# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+  
+  # yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
 ---
 apiVersion: "api.cerbos.dev/v1"
 resourcePolicy:

--- a/internal/test/testdata/policy_formats/resource_policy_01.yaml
+++ b/internal/test/testdata/policy_formats/resource_policy_01.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
 ---
 apiVersion: "api.cerbos.dev/v1"
 resourcePolicy:
@@ -5,6 +6,7 @@ resourcePolicy:
   version: "default"
   importDerivedRoles:
     - my_derived_roles
+  # rules
   rules:
     - actions: ["*"]
       roles:

--- a/internal/util/serdeio.go
+++ b/internal/util/serdeio.go
@@ -79,14 +79,15 @@ func newYAMLDecoder(src *bufio.Reader) decoderFunc {
 		seenContent := false
 		for s.Scan() {
 			line := s.Bytes()
+			trimmedLine := bytes.TrimSpace(line)
 
 			// ignore comments
-			if bytes.HasPrefix(line, yamlComment) {
+			if bytes.HasPrefix(trimmedLine, yamlComment) {
 				continue
 			}
 
 			// ignore empty lines at the beginning of the file
-			if !seenContent && len(bytes.TrimSpace(line)) == 0 {
+			if !seenContent && len(trimmedLine) == 0 {
 				continue
 			}
 			seenContent = true

--- a/internal/util/serdeio.go
+++ b/internal/util/serdeio.go
@@ -25,6 +25,7 @@ const (
 var (
 	jsonStart           = []byte("{")
 	yamlSep             = []byte("---")
+	yamlComment         = []byte("#")
 	ErrMultipleYAMLDocs = errors.New("more than one YAML document detected")
 )
 
@@ -78,6 +79,11 @@ func newYAMLDecoder(src *bufio.Reader) decoderFunc {
 		seenContent := false
 		for s.Scan() {
 			line := s.Bytes()
+
+			// ignore comments
+			if bytes.HasPrefix(line, yamlComment) {
+				continue
+			}
 
 			// ignore empty lines at the beginning of the file
 			if !seenContent && len(bytes.TrimSpace(line)) == 0 {


### PR DESCRIPTION
If the first line of the YAML file contains a comment, the
multiple-document detector incorrectly classifies the file as containing
more than one YAML document and fails. This patch fixes that issue.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
