### PR TITLE
chore(ci): Use the same format for GCS buckets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,9 +142,9 @@ jobs:
 
       - name: Publish to download site
         run: |-
-          gsutil cp ${{ secrets.DOWNLOAD_GCS_BUCKET }}/helm-charts/index.yaml ${{ env.CHARTS_DIR }}/index.yaml
+          gsutil cp "gs://${{ secrets.DOWNLOAD_GCS_BUCKET }}/helm-charts/index.yaml" "${{ env.CHARTS_DIR }}/index.yaml"
           helm repo index --url=https://download.cerbos.dev/helm-charts --merge=${{ env.CHARTS_DIR }}/index.yaml ${{ env.CHARTS_DIR }}
-          gsutil rsync -r ${{ env.CHARTS_DIR }}/ ${{ secrets.DOWNLOAD_GCS_BUCKET }}/helm-charts/
+          gsutil rsync -r ${{ env.CHARTS_DIR }}/ "gs://${{ secrets.DOWNLOAD_GCS_BUCKET }}/helm-charts/"
 
       - name: Publish to OCI registry
         run: |-


### PR DESCRIPTION
The `DOWNLOAD_GCS_BUCKET` secret is expected to have the `gs://` prefix
but the `API_GCS_BUCKET` does not. This change updates the action to add
the `gs://` prefix to the `DOWNLOAD_GCS_BUCKET` to keep things
consistent.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
