### PR TITLE
chore: Rename interface{} to any and use Go build info

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -153,14 +153,14 @@ func testGRPCClient(c client.Client) func(*testing.T) {
 				client.NewPrincipal("john").
 					WithRoles("employee").
 					WithPolicyVersion("20210210").
-					WithAttributes(map[string]interface{}{
+					WithAttributes(map[string]any{
 						"department": "marketing",
 						"geography":  "GB",
 						"team":       "design",
 					}),
 				client.NewResourceSet("leave_request").
 					WithPolicyVersion("20210210").
-					AddResourceInstance("XX125", map[string]interface{}{
+					AddResourceInstance("XX125", map[string]any{
 						"department": "marketing",
 						"geography":  "GB",
 						"id":         "XX125",
@@ -184,7 +184,7 @@ func testGRPCClient(c client.Client) func(*testing.T) {
 				client.NewPrincipal("john").
 					WithRoles("employee").
 					WithPolicyVersion("20210210").
-					WithAttributes(map[string]interface{}{
+					WithAttributes(map[string]any{
 						"department": "marketing",
 						"geography":  "GB",
 						"team":       "design",
@@ -193,7 +193,7 @@ func testGRPCClient(c client.Client) func(*testing.T) {
 					Add(client.
 						NewResource("leave_request", "XX125").
 						WithPolicyVersion("20210210").
-						WithAttributes(map[string]interface{}{
+						WithAttributes(map[string]any{
 							"department": "marketing",
 							"geography":  "GB",
 							"id":         "XX125",
@@ -203,7 +203,7 @@ func testGRPCClient(c client.Client) func(*testing.T) {
 					Add(client.
 						NewResource("leave_request", "XX125").
 						WithPolicyVersion("20210210").
-						WithAttributes(map[string]interface{}{
+						WithAttributes(map[string]any{
 							"department": "marketing",
 							"geography":  "GB",
 							"id":         "XX125",
@@ -213,7 +213,7 @@ func testGRPCClient(c client.Client) func(*testing.T) {
 					Add(client.
 						NewResource("leave_request", "XX225").
 						WithPolicyVersion("20210210").
-						WithAttributes(map[string]interface{}{
+						WithAttributes(map[string]any{
 							"department": "engineering",
 							"geography":  "GB",
 							"id":         "XX225",
@@ -238,14 +238,14 @@ func testGRPCClient(c client.Client) func(*testing.T) {
 				client.NewPrincipal("john").
 					WithRoles("employee").
 					WithPolicyVersion("20210210").
-					WithAttributes(map[string]interface{}{
+					WithAttributes(map[string]any{
 						"department": "marketing",
 						"geography":  "GB",
 						"team":       "design",
 					}),
 				client.NewResource("leave_request", "XX125").
 					WithPolicyVersion("20210210").
-					WithAttributes(map[string]interface{}{
+					WithAttributes(map[string]any{
 						"department": "marketing",
 						"geography":  "GB",
 						"id":         "XX125",

--- a/client/model.go
+++ b/client/model.go
@@ -59,7 +59,7 @@ func (p *Principal) WithRoles(roles ...string) *Principal {
 }
 
 // WithAttributes merges the given attributes to principal's existing attributes.
-func (p *Principal) WithAttributes(attr map[string]interface{}) *Principal {
+func (p *Principal) WithAttributes(attr map[string]any) *Principal {
 	if p.p.Attr == nil {
 		p.p.Attr = make(map[string]*structpb.Value, len(attr))
 	}
@@ -78,7 +78,7 @@ func (p *Principal) WithAttributes(attr map[string]interface{}) *Principal {
 
 // WithAttr adds a new attribute to the principal.
 // It will overwrite any existing attribute having the same key.
-func (p *Principal) WithAttr(key string, value interface{}) *Principal {
+func (p *Principal) WithAttr(key string, value any) *Principal {
 	if p.p.Attr == nil {
 		p.p.Attr = make(map[string]*structpb.Value)
 	}
@@ -127,7 +127,7 @@ func (r *Resource) WithPolicyVersion(policyVersion string) *Resource {
 }
 
 // WithAttributes merges the given attributes to the resource's existing attributes.
-func (r *Resource) WithAttributes(attr map[string]interface{}) *Resource {
+func (r *Resource) WithAttributes(attr map[string]any) *Resource {
 	if r.r.Attr == nil {
 		r.r.Attr = make(map[string]*structpb.Value, len(attr))
 	}
@@ -146,7 +146,7 @@ func (r *Resource) WithAttributes(attr map[string]interface{}) *Resource {
 
 // WithAttr adds a new attribute to the resource.
 // It will overwrite any existing attribute having the same key.
-func (r *Resource) WithAttr(key string, value interface{}) *Resource {
+func (r *Resource) WithAttr(key string, value any) *Resource {
 	if r.r.Attr == nil {
 		r.r.Attr = make(map[string]*structpb.Value)
 	}
@@ -195,7 +195,7 @@ func (rs *ResourceSet) WithPolicyVersion(policyVersion string) *ResourceSet {
 }
 
 // AddResourceInstance adds a new resource instance to the resource set.
-func (rs *ResourceSet) AddResourceInstance(id string, attr map[string]interface{}) *ResourceSet {
+func (rs *ResourceSet) AddResourceInstance(id string, attr map[string]any) *ResourceSet {
 	if rs.rs.Instances == nil {
 		rs.rs.Instances = make(map[string]*requestv1.AttributesMap)
 	}

--- a/client/testutil/example_test.go
+++ b/client/testutil/example_test.go
@@ -33,7 +33,7 @@ func ExampleStartCerbosServer() {
 			WithAttr("department", "marketing").
 			WithAttr("geography", "GB"),
 		client.NewResourceSet("leave_request").
-			AddResourceInstance("XX125", map[string]interface{}{
+			AddResourceInstance("XX125", map[string]any{
 				"department": "marketing",
 				"geography":  "GB",
 				"owner":      "harry",

--- a/client/testutil/server.go
+++ b/client/testutil/server.go
@@ -141,7 +141,7 @@ func (so *serverOpt) addOverride(key, value string) {
 }
 
 func (so *serverOpt) toConfigWrapper() (*config.Wrapper, error) {
-	confOverrides := map[string]interface{}{}
+	confOverrides := map[string]any{}
 
 	if so.configSrc == nil {
 		defaults := map[string]string{

--- a/cmd/cerbos/compile/internal/verification/display.go
+++ b/cmd/cerbos/compile/internal/verification/display.go
@@ -27,7 +27,7 @@ const (
 )
 
 var (
-	labelColors = map[policyv1.TestResults_Result]func(...interface{}) string{
+	labelColors = map[policyv1.TestResults_Result]func(...any) string{
 		policyv1.TestResults_RESULT_PASSED:  colored.PassedTest,
 		policyv1.TestResults_RESULT_SKIPPED: colored.SkippedTest,
 		policyv1.TestResults_RESULT_FAILED:  colored.FailedTest,

--- a/cmd/cerbos/repl/internal/repl.go
+++ b/cmd/cerbos/repl/internal/repl.go
@@ -41,8 +41,8 @@ var (
 	errExit        = errors.New("exit")
 	errInvalidExpr = errors.New("invalid expr")
 
-	listType = reflect.TypeOf([]interface{}{})
-	mapType  = reflect.TypeOf(map[string]interface{}{})
+	listType = reflect.TypeOf([]any{})
+	mapType  = reflect.TypeOf(map[string]any{})
 )
 
 const (
@@ -58,7 +58,7 @@ type REPL struct {
 	reader   *liner.State
 	parser   *participle.Parser
 	output   Output
-	toRefVal func(interface{}) ref.Val
+	toRefVal func(any) ref.Val
 }
 
 func NewREPL(reader *liner.State, output Output) (*REPL, error) {
@@ -257,7 +257,7 @@ func (r *REPL) setSpecialVar(name, value string) error {
 		r.vars[conditions.CELResourceAbbrev] = resourceVal
 
 	case conditions.CELVariablesIdent, conditions.CELVariablesAbbrev:
-		var v map[string]interface{}
+		var v map[string]any
 		if err := json.Unmarshal([]byte(value), &v); err != nil {
 			return fmt.Errorf("failed to unmarshal JSON as %q: %w", name, err)
 		}
@@ -332,7 +332,7 @@ func (r *REPL) mkEnv() (*cel.Env, error) {
 // variables is a type that provides the interpreter.Activation interface.
 type variables map[string]ref.Val
 
-func (v variables) ResolveName(name string) (interface{}, bool) {
+func (v variables) ResolveName(name string) (any, bool) {
 	val, ok := v[name]
 	return val, ok
 }
@@ -342,10 +342,10 @@ func (v variables) Parent() interpreter.Activation {
 }
 
 type Output interface {
-	Print(string, ...interface{})
-	Println(...interface{})
+	Print(string, ...any)
+	Println(...any)
 	PrintResult(string, ref.Val)
-	PrintJSON(interface{})
+	PrintJSON(any)
 	PrintErr(string, error)
 }
 
@@ -361,7 +361,7 @@ func NewPrinterOutput(stdout, stderr io.Writer) *PrinterOutput {
 	}
 }
 
-func (po *PrinterOutput) Print(format string, args ...interface{}) {
+func (po *PrinterOutput) Print(format string, args ...any) {
 	po.Printf(format, args...)
 	po.Println()
 }
@@ -399,7 +399,7 @@ func (po *PrinterOutput) PrintResult(name string, value ref.Val) {
 	}
 }
 
-func (po *PrinterOutput) PrintJSON(obj interface{}) {
+func (po *PrinterOutput) PrintJSON(obj any) {
 	if err := po.Printer.PrintJSON(obj, po.level); err != nil {
 		po.Println("<...>")
 	}

--- a/cmd/cerbos/repl/internal/repl_test.go
+++ b/cmd/cerbos/repl/internal/repl_test.go
@@ -244,7 +244,7 @@ func TestREPL(t *testing.T) {
 						t.Helper()
 						require.Equal(t, "V", m.resultName)
 
-						want := map[string]interface{}{"foo": "bar"}
+						want := map[string]any{"foo": "bar"}
 						require.Equal(t, want, m.resultVal.Value())
 					},
 				},
@@ -285,19 +285,19 @@ func TestREPL(t *testing.T) {
 
 type mockOutput struct {
 	msg        string
-	args       []interface{}
-	jsonObj    interface{}
+	args       []any
+	jsonObj    any
 	resultName string
 	resultVal  ref.Val
 	err        error
 }
 
-func (mo *mockOutput) Print(msg string, args ...interface{}) {
+func (mo *mockOutput) Print(msg string, args ...any) {
 	mo.msg = msg
 	mo.args = args
 }
 
-func (mo *mockOutput) Println(args ...interface{}) {
+func (mo *mockOutput) Println(args ...any) {
 	mo.args = args
 }
 
@@ -306,7 +306,7 @@ func (mo *mockOutput) PrintResult(name string, val ref.Val) {
 	mo.resultVal = val
 }
 
-func (mo *mockOutput) PrintJSON(obj interface{}) {
+func (mo *mockOutput) PrintJSON(obj any) {
 	mo.jsonObj = obj
 }
 

--- a/cmd/cerbos/run/run.go
+++ b/cmd/cerbos/run/run.go
@@ -144,7 +144,7 @@ func (c *Cmd) Run(k *kong.Kong) error {
 
 func (c *Cmd) loadConfig() error {
 	// load any config overrides
-	confOverrides := map[string]interface{}{}
+	confOverrides := map[string]any{}
 	for _, override := range c.Set {
 		if err := strvals.ParseInto(override, confOverrides); err != nil {
 			return fmt.Errorf("failed to parse config override [%s]: %w", override, err)

--- a/cmd/cerbos/server/server.go
+++ b/cmd/cerbos/server/server.go
@@ -76,7 +76,7 @@ func (c *Cmd) Run() error {
 	defer stopFunc()
 
 	// load any config overrides
-	confOverrides := map[string]interface{}{}
+	confOverrides := map[string]any{}
 	for _, override := range c.Set {
 		if err := strvals.ParseInto(override, confOverrides); err != nil {
 			return fmt.Errorf("failed to parse config override [%s]: %w", override, err)

--- a/cmd/cerbosctl/get/get_test.go
+++ b/cmd/cerbosctl/get/get_test.go
@@ -334,7 +334,7 @@ func mkClients(t *testing.T, globals *flagset.Globals) *cmdclient.Context {
 	return &cmdclient.Context{Client: c, AdminClient: ac}
 }
 
-func mustNew(t *testing.T, cli interface{}) *kong.Kong {
+func mustNew(t *testing.T, cli any) *kong.Kong {
 	t.Helper()
 	options := []kong.Option{
 		kong.Name("cerbosctl"),

--- a/cmd/cerbosctl/put_test.go
+++ b/cmd/cerbosctl/put_test.go
@@ -223,7 +223,7 @@ func mkClients(t *testing.T, globals *flagset.Globals) *cmdclient.Context {
 	return &cmdclient.Context{Client: c, AdminClient: ac}
 }
 
-func mustNew(t *testing.T, cli interface{}) *kong.Kong {
+func mustNew(t *testing.T, cli any) *kong.Kong {
 	t.Helper()
 	options := []kong.Option{
 		kong.Name("cerbosctl"),

--- a/hack/tools/confdocs/confdocs.go
+++ b/hack/tools/confdocs/confdocs.go
@@ -358,7 +358,7 @@ func walkFields(out io.Writer, fields []FieldInfo, indent int) error {
 	return nil
 }
 
-func indentf(out io.Writer, n int, format string, args ...interface{}) error {
+func indentf(out io.Writer, n int, format string, args ...any) error {
 	if _, err := fmt.Fprint(out, strings.Repeat("  ", n)); err != nil {
 		return err
 	}

--- a/internal/audit/conf.go
+++ b/internal/audit/conf.go
@@ -30,7 +30,7 @@ type confHolder struct {
 	DecisionLogsEnabled bool `yaml:"decisionLogsEnabled" conf:",example=true"`
 }
 
-func (c *Conf) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *Conf) UnmarshalYAML(unmarshal func(any) error) error {
 	// This is a workaround to circumvent strict config parsing.
 	// Consider the following:
 	//
@@ -47,7 +47,7 @@ func (c *Conf) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// This hack is slightly inefficient because it marshals and unmarshals YAML twice. It is an
 	// acceptable sacrifice to make because config is only read once on startup.
 
-	var confMap map[string]interface{}
+	var confMap map[string]any
 	if err := unmarshal(&confMap); err != nil {
 		return fmt.Errorf("failed to unmarshal audit config: %w", err)
 	}

--- a/internal/audit/conf_test.go
+++ b/internal/audit/conf_test.go
@@ -13,11 +13,11 @@ import (
 )
 
 func TestLenientConfigLoad(t *testing.T) {
-	conf := map[string]interface{}{
-		"audit": map[string]interface{}{
+	conf := map[string]any{
+		"audit": map[string]any{
 			"enabled": true,
 			"backend": "local",
-			"local": map[string]interface{}{
+			"local": map[string]any{
 				"storagePath": t.TempDir(),
 			},
 			"wibble": "wobble",

--- a/internal/audit/context.go
+++ b/internal/audit/context.go
@@ -29,7 +29,7 @@ var callIDCtxKey = callIDCtxKeyType{}
 
 func NewContextWithCallID(ctx context.Context, id ID) context.Context {
 	tags := grpc_ctxtags.Extract(ctx)
-	tagCtx := grpc_ctxtags.SetInContext(ctx, tags.Set(util.AppName, map[string]interface{}{callIDTagKey: id}))
+	tagCtx := grpc_ctxtags.SetInContext(ctx, tags.Set(util.AppName, map[string]any{callIDTagKey: id}))
 
 	return context.WithValue(tagCtx, callIDCtxKey, id)
 }

--- a/internal/audit/interceptor.go
+++ b/internal/audit/interceptor.go
@@ -24,7 +24,7 @@ var excludeMetadataKeys = map[string]struct{}{
 type ExcludeMethod func(string) bool
 
 func NewUnaryInterceptor(log Log, exclude ExcludeMethod) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if exclude(info.FullMethod) {
 			return handler(ctx, req)
 		}

--- a/internal/audit/local/badgerdb.go
+++ b/internal/audit/local/badgerdb.go
@@ -479,6 +479,6 @@ type zapLogger struct {
 	*zap.SugaredLogger
 }
 
-func (zl zapLogger) Warningf(msg string, args ...interface{}) {
+func (zl zapLogger) Warningf(msg string, args ...any) {
 	zl.Warnf(msg, args...)
 }

--- a/internal/auxdata/conf_test.go
+++ b/internal/auxdata/conf_test.go
@@ -15,17 +15,17 @@ import (
 func TestConfigValidate(t *testing.T) {
 	testCases := []struct {
 		name    string
-		conf    map[string]interface{}
+		conf    map[string]any
 		wantErr bool
 	}{
 		{
 			name: "valid jwt",
-			conf: map[string]interface{}{
-				"auxData": map[string]interface{}{
-					"jwt": map[string]interface{}{
-						"keySets": []map[string]interface{}{
-							{"id": "foo", "remote": map[string]interface{}{"url": "https://domain.tld/.well-known/foo.jwks"}},
-							{"id": "bar", "local": map[string]interface{}{"data": "data"}},
+			conf: map[string]any{
+				"auxData": map[string]any{
+					"jwt": map[string]any{
+						"keySets": []map[string]any{
+							{"id": "foo", "remote": map[string]any{"url": "https://domain.tld/.well-known/foo.jwks"}},
+							{"id": "bar", "local": map[string]any{"data": "data"}},
 						},
 					},
 				},
@@ -33,12 +33,12 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			name: "duplicate jwt keyset ID",
-			conf: map[string]interface{}{
-				"auxData": map[string]interface{}{
-					"jwt": map[string]interface{}{
-						"keySets": []map[string]interface{}{
-							{"id": "foo", "remote": map[string]interface{}{"url": "https://domain.tld/.well-known/foo.jwks"}},
-							{"id": "foo", "local": map[string]interface{}{"data": "data"}},
+			conf: map[string]any{
+				"auxData": map[string]any{
+					"jwt": map[string]any{
+						"keySets": []map[string]any{
+							{"id": "foo", "remote": map[string]any{"url": "https://domain.tld/.well-known/foo.jwks"}},
+							{"id": "foo", "local": map[string]any{"data": "data"}},
 						},
 					},
 				},
@@ -47,12 +47,12 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			name: "empty jwt keyset",
-			conf: map[string]interface{}{
-				"auxData": map[string]interface{}{
-					"jwt": map[string]interface{}{
-						"keySets": []map[string]interface{}{
+			conf: map[string]any{
+				"auxData": map[string]any{
+					"jwt": map[string]any{
+						"keySets": []map[string]any{
 							{"id": "foo"},
-							{"id": "bar", "local": map[string]interface{}{"data": "data"}},
+							{"id": "bar", "local": map[string]any{"data": "data"}},
 						},
 					},
 				},
@@ -61,18 +61,18 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			name: "both remote and local defined in jwt keyset",
-			conf: map[string]interface{}{
-				"auxData": map[string]interface{}{
-					"jwt": map[string]interface{}{
-						"keySets": []map[string]interface{}{
+			conf: map[string]any{
+				"auxData": map[string]any{
+					"jwt": map[string]any{
+						"keySets": []map[string]any{
 							{
 								"id": "foo",
-								"remote": map[string]interface{}{
+								"remote": map[string]any{
 									"url":   "https://domain.tld/.well-known/foo.jwks",
-									"local": map[string]interface{}{"data": "data"},
+									"local": map[string]any{"data": "data"},
 								},
 							},
-							{"id": "bar", "local": map[string]interface{}{"data": "data"}},
+							{"id": "bar", "local": map[string]any{"data": "data"}},
 						},
 					},
 				},
@@ -81,12 +81,12 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			name: "empty remote URL in jwt keyset",
-			conf: map[string]interface{}{
-				"auxData": map[string]interface{}{
-					"jwt": map[string]interface{}{
-						"keySets": []map[string]interface{}{
-							{"id": "foo", "remote": map[string]interface{}{"url": ""}},
-							{"id": "bar", "local": map[string]interface{}{"data": "data"}},
+			conf: map[string]any{
+				"auxData": map[string]any{
+					"jwt": map[string]any{
+						"keySets": []map[string]any{
+							{"id": "foo", "remote": map[string]any{"url": ""}},
+							{"id": "bar", "local": map[string]any{"data": "data"}},
 						},
 					},
 				},
@@ -95,12 +95,12 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			name: "both local data and file defined in jwt keyset",
-			conf: map[string]interface{}{
-				"auxData": map[string]interface{}{
-					"jwt": map[string]interface{}{
-						"keySets": []map[string]interface{}{
-							{"id": "foo", "remote": map[string]interface{}{"url": "https://domain.tld/.well-known/foo.jwks"}},
-							{"id": "bar", "local": map[string]interface{}{"data": "data", "file": "/path"}},
+			conf: map[string]any{
+				"auxData": map[string]any{
+					"jwt": map[string]any{
+						"keySets": []map[string]any{
+							{"id": "foo", "remote": map[string]any{"url": "https://domain.tld/.well-known/foo.jwks"}},
+							{"id": "bar", "local": map[string]any{"data": "data", "file": "/path"}},
 						},
 					},
 				},
@@ -109,12 +109,12 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			name: "both local data and file not defined in jwt keyset",
-			conf: map[string]interface{}{
-				"auxData": map[string]interface{}{
-					"jwt": map[string]interface{}{
-						"keySets": []map[string]interface{}{
-							{"id": "foo", "remote": map[string]interface{}{"url": "https://domain.tld/.well-known/foo.jwks"}},
-							{"id": "bar", "local": map[string]interface{}{"data": "", "file": ""}},
+			conf: map[string]any{
+				"auxData": map[string]any{
+					"jwt": map[string]any{
+						"keySets": []map[string]any{
+							{"id": "foo", "remote": map[string]any{"url": "https://domain.tld/.well-known/foo.jwks"}},
+							{"id": "bar", "local": map[string]any{"data": "", "file": ""}},
 						},
 					},
 				},

--- a/internal/auxdata/jwt_test.go
+++ b/internal/auxdata/jwt_test.go
@@ -318,7 +318,7 @@ func mkSignedToken(t *testing.T, expiry time.Time) string {
 	require.NoError(t, token.Set("customString", "foobar"))
 	require.NoError(t, token.Set("customInt", 42))
 	require.NoError(t, token.Set("customArray", []string{"A", "B", "C"}))
-	require.NoError(t, token.Set("customMap", map[string]interface{}{"A": "AA", "B": "BB", "C": "CC"}))
+	require.NoError(t, token.Set("customMap", map[string]any{"A": "AA", "B": "BB", "C": "CC"}))
 
 	keyData, err := os.ReadFile(filepath.Join(test.PathToDir(t, "auxdata"), "signing_key.jwk"))
 	require.NoError(t, err)
@@ -335,13 +335,13 @@ func mkSignedToken(t *testing.T, expiry time.Time) string {
 func mkExpectedTokenData(t *testing.T, expiry time.Time) map[string]*structpb.Value {
 	t.Helper()
 
-	wantAud, err := structpb.NewList([]interface{}{"cerbos-jwt-tests"})
+	wantAud, err := structpb.NewList([]any{"cerbos-jwt-tests"})
 	require.NoError(t, err)
 
-	wantArray, err := structpb.NewList([]interface{}{"A", "B", "C"})
+	wantArray, err := structpb.NewList([]any{"A", "B", "C"})
 	require.NoError(t, err)
 
-	wantMap, err := structpb.NewStruct(map[string]interface{}{"A": "AA", "B": "BB", "C": "CC"})
+	wantMap, err := structpb.NewStruct(map[string]any{"A": "AA", "B": "BB", "C": "CC"})
 	require.NoError(t, err)
 
 	return map[string]*structpb.Value{

--- a/internal/compile/context.go
+++ b/internal/compile/context.go
@@ -49,6 +49,6 @@ func (mc *moduleCtx) error() error {
 	return mc.errors.ErrOrNil()
 }
 
-func (mc *moduleCtx) addErrWithDesc(err error, description string, params ...interface{}) {
+func (mc *moduleCtx) addErrWithDesc(err error, description string, params ...any) {
 	mc.errors.Add(newError(mc.sourceFile, fmt.Sprintf(description, params...), err))
 }

--- a/internal/compile/manager.go
+++ b/internal/compile/manager.go
@@ -232,10 +232,10 @@ func mkCache(size int) gcache.Cache {
 	gauge := metrics.MakeCacheGauge(cacheKind)
 	return gcache.New(size).
 		ARC().
-		AddedFunc(func(_, _ interface{}) {
+		AddedFunc(func(_, _ any) {
 			gauge.Add(1)
 		}).
-		EvictedFunc(func(_, _ interface{}) {
+		EvictedFunc(func(_, _ any) {
 			gauge.Add(-1)
 		}).Build()
 }

--- a/internal/conditions/cerbos_lib.go
+++ b/internal/conditions/cerbos_lib.go
@@ -150,7 +150,7 @@ func (clib cerbosLib) ProgramOptions() []cel.ProgramOption {
 // providing time-based functions with a static definition of the current time.
 //
 // See https://pkg.go.dev/github.com/google/cel-go/cel#Program.Eval.
-func Eval(env *cel.Env, ast *cel.Ast, vars interface{}, opts ...cel.ProgramOption) (ref.Val, *cel.EvalDetails, error) {
+func Eval(env *cel.Env, ast *cel.Ast, vars any, opts ...cel.ProgramOption) (ref.Val, *cel.EvalDetails, error) {
 	prg, err := program(env, ast, opts...)
 	if err != nil {
 		return nil, nil, err

--- a/internal/conditions/cerbos_lib_test.go
+++ b/internal/conditions/cerbos_lib_test.go
@@ -160,10 +160,10 @@ func TestPartialEvaluationWithMacroGlobalVars(t *testing.T) {
 		ext.Strings(),
 		cel.Macros(geo))
 
-	vars, _ := cel.PartialVars(map[string]interface{}{
+	vars, _ := cel.PartialVars(map[string]any{
 		"y": []string{"GB", "US"},
 		"z": "ca",
-		"v": map[string]interface{}{},
+		"v": map[string]any{},
 	}, cel.AttributePattern("R"))
 
 	expr := "v.geo() in (y + [z]).map(t, t.upperAscii())"
@@ -197,12 +197,12 @@ func TestPartialEvaluation(t *testing.T) {
 			decls.NewVar("R.attr.department", decls.String)),
 		ext.Strings())
 
-	vars, _ := cel.PartialVars(map[string]interface{}{
+	vars, _ := cel.PartialVars(map[string]any{
 		"y":                 []string{"GB", "US"},
 		"z":                 "ca",
 		"R.attr.department": "marketing",
-		"request.principal": map[string]interface{}{
-			"attr": map[string]interface{}{
+		"request.principal": map[string]any{
+			"attr": map[string]any{
 				"country": "NZ",
 			},
 		},

--- a/internal/conditions/types/hierarchy.go
+++ b/internal/conditions/types/hierarchy.go
@@ -173,7 +173,7 @@ var (
 type Hierarchy []string
 
 // ConvertToNative implements ref.Val.ConvertToNative.
-func (h Hierarchy) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+func (h Hierarchy) ConvertToNative(typeDesc reflect.Type) (any, error) {
 	//nolint:exhaustive
 	switch typeDesc.Kind() {
 	case reflect.String:
@@ -210,7 +210,7 @@ func (h Hierarchy) Type() ref.Type {
 }
 
 // Value implements ref.Val.Value.
-func (h Hierarchy) Value() interface{} {
+func (h Hierarchy) Value() any {
 	return []string(h)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ type Validator interface {
 }
 
 // Load loads the config file at the given path.
-func Load(confFile string, overrides map[string]interface{}) error {
+func Load(confFile string, overrides map[string]any) error {
 	finfo, err := os.Stat(confFile)
 	if err != nil {
 		return fmt.Errorf("failed to stat %s: %w", confFile, err)
@@ -44,11 +44,11 @@ func Load(confFile string, overrides map[string]interface{}) error {
 	return doLoad(config.File(confFile), config.Static(overrides))
 }
 
-func LoadReader(reader io.Reader, overrides map[string]interface{}) error {
+func LoadReader(reader io.Reader, overrides map[string]any) error {
 	return doLoad(config.Source(reader), config.Static(overrides))
 }
 
-func LoadMap(m map[string]interface{}) error {
+func LoadMap(m map[string]any) error {
 	return doLoad(config.Static(m))
 }
 
@@ -82,7 +82,7 @@ func Global() *Wrapper {
 
 // Get populates out with the configuration at the given key.
 // Populate out with default values before calling this function to ensure sane defaults if there are any.
-func Get(key string, out interface{}) error {
+func Get(key string, out any) error {
 	return conf.Get(key, out)
 }
 
@@ -91,11 +91,11 @@ func GetSection(section Section) error {
 	return conf.GetSection(section)
 }
 
-func WrapperFromReader(reader io.Reader, overrides map[string]interface{}) (*Wrapper, error) {
+func WrapperFromReader(reader io.Reader, overrides map[string]any) (*Wrapper, error) {
 	return newWrapper(config.Source(reader), config.Static(overrides))
 }
 
-func WrapperFromMap(m map[string]interface{}) (*Wrapper, error) {
+func WrapperFromMap(m map[string]any) (*Wrapper, error) {
 	return newWrapper(config.Static(m))
 }
 
@@ -113,7 +113,7 @@ type Wrapper struct {
 	mu       sync.RWMutex
 }
 
-func (w *Wrapper) Get(key string, out interface{}) error {
+func (w *Wrapper) Get(key string, out any) error {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -76,10 +76,10 @@ func TestLoad(t *testing.T) {
 }
 
 func TestOverride(t *testing.T) {
-	overrides := map[string]interface{}{
-		"server": map[string]interface{}{
+	overrides := map[string]any{
+		"server": map[string]any{
 			"listenAddr": ":6666",
-			"tls": map[string]interface{}{
+			"tls": map[string]any{
 				"certificate": "newCert",
 			},
 		},
@@ -153,16 +153,16 @@ func TestCerbosConfig(t *testing.T) {
 
 func TestStrictParsing(t *testing.T) {
 	testCases := []struct {
-		conf    map[string]interface{}
+		conf    map[string]any
 		name    string
 		wantErr bool
 	}{
 		{
 			name: "valid config",
-			conf: map[string]interface{}{
-				"server": map[string]interface{}{
+			conf: map[string]any{
+				"server": map[string]any{
 					"listenAddr": ":6666",
-					"tls": map[string]interface{}{
+					"tls": map[string]any{
 						"certificate": "newCert",
 					},
 				},
@@ -170,10 +170,10 @@ func TestStrictParsing(t *testing.T) {
 		},
 		{
 			name: "undeclared field",
-			conf: map[string]interface{}{
-				"server": map[string]interface{}{
+			conf: map[string]any{
+				"server": map[string]any{
 					"listenAddr": ":6666",
-					"tls": map[string]interface{}{
+					"tls": map[string]any{
 						"certificate": "newCert",
 					},
 					"wibble": "wobble",
@@ -183,10 +183,10 @@ func TestStrictParsing(t *testing.T) {
 		},
 		{
 			name: "wrong case for field",
-			conf: map[string]interface{}{
-				"server": map[string]interface{}{
+			conf: map[string]any{
+				"server": map[string]any{
 					"listenaddr": ":6666",
-					"tls": map[string]interface{}{
+					"tls": map[string]any{
 						"certificate": "newCert",
 					},
 				},

--- a/internal/engine/evaluator.go
+++ b/internal/engine/evaluator.go
@@ -241,9 +241,9 @@ func (ppe *principalPolicyEvaluator) Evaluate(ctx context.Context, tctx tracer.C
 	return result, nil
 }
 
-func evaluateVariables(tctx tracer.Context, variables map[string]*runtimev1.Expr, input *enginev1.CheckInput) (map[string]interface{}, error) {
+func evaluateVariables(tctx tracer.Context, variables map[string]*runtimev1.Expr, input *enginev1.CheckInput) (map[string]any, error) {
 	var errs error
-	evalVars := make(map[string]interface{}, len(variables))
+	evalVars := make(map[string]any, len(variables))
 	for varName, varExpr := range variables {
 		vctx := tctx.StartVariable(varName, varExpr.Original)
 		val, err := evaluateCELExpr(varExpr.Checked, evalVars, input)
@@ -260,7 +260,7 @@ func evaluateVariables(tctx tracer.Context, variables map[string]*runtimev1.Expr
 	return evalVars, errs
 }
 
-func satisfiesCondition(tctx tracer.Context, cond *runtimev1.Condition, variables map[string]interface{}, input *enginev1.CheckInput) (bool, error) {
+func satisfiesCondition(tctx tracer.Context, cond *runtimev1.Condition, variables map[string]any, input *enginev1.CheckInput) (bool, error) {
 	if cond == nil {
 		tctx.ComputedBoolResult(true, nil, "")
 		return true, nil
@@ -339,7 +339,7 @@ func satisfiesCondition(tctx tracer.Context, cond *runtimev1.Condition, variable
 	}
 }
 
-func evaluateBoolCELExpr(expr *exprpb.CheckedExpr, variables map[string]interface{}, input *enginev1.CheckInput) (bool, error) {
+func evaluateBoolCELExpr(expr *exprpb.CheckedExpr, variables map[string]any, input *enginev1.CheckInput) (bool, error) {
 	val, err := evaluateCELExpr(expr, variables, input)
 	if err != nil {
 		return false, err
@@ -353,12 +353,12 @@ func evaluateBoolCELExpr(expr *exprpb.CheckedExpr, variables map[string]interfac
 	return boolVal, nil
 }
 
-func evaluateCELExpr(expr *exprpb.CheckedExpr, variables map[string]interface{}, input *enginev1.CheckInput) (interface{}, error) {
+func evaluateCELExpr(expr *exprpb.CheckedExpr, variables map[string]any, input *enginev1.CheckInput) (any, error) {
 	if expr == nil {
 		return nil, nil
 	}
 
-	result, _, err := conditions.Eval(conditions.StdEnv, cel.CheckedExprToAst(expr), map[string]interface{}{
+	result, _, err := conditions.Eval(conditions.StdEnv, cel.CheckedExprToAst(expr), map[string]any{
 		conditions.CELRequestIdent:    input,
 		conditions.CELResourceAbbrev:  input.Resource,
 		conditions.CELPrincipalAbbrev: input.Principal,

--- a/internal/engine/evaluator_test.go
+++ b/internal/engine/evaluator_test.go
@@ -148,7 +148,7 @@ func TestPartialEvaluationWithGlobalVars(t *testing.T) {
 	))
 	is.NoError(err)
 
-	pvars, _ := cel.PartialVars(map[string]interface{}{
+	pvars, _ := cel.PartialVars(map[string]any{
 		"gbLoc": "en_GB",
 		"gb_us": []string{"GB", "US"},
 		"ca":    "ca",

--- a/internal/engine/planner.go
+++ b/internal/engine/planner.go
@@ -413,7 +413,7 @@ func evaluateCELExprPartially(expr *exprpb.CheckedExpr, input *enginev1.Resource
 		return nil, nil, err
 	}
 	ast := cel.ParsedExprToAst(&exprpb.ParsedExpr{Expr: e})
-	knownVars := make(map[string]interface{})
+	knownVars := make(map[string]any)
 	env := conditions.StdPartialEnv
 	if len(input.Resource.GetAttr()) > 0 {
 		var ds []*exprpb.Decl

--- a/internal/engine/tracer/context.go
+++ b/internal/engine/tracer/context.go
@@ -30,7 +30,7 @@ type Context interface {
 	Activated()
 	AppliedEffect(effect effectv1.Effect, message string)
 	ComputedBoolResult(result bool, err error, message string)
-	ComputedResult(result interface{})
+	ComputedResult(result any)
 	Failed(err error, message string)
 	Skipped(err error, message string)
 }
@@ -163,14 +163,14 @@ func (c *context) ComputedBoolResult(result bool, err error, message string) {
 	})
 }
 
-func (c *context) ComputedResult(result interface{}) {
+func (c *context) ComputedResult(result any) {
 	c.addTrace(&enginev1.Trace_Event{
 		Status: enginev1.Trace_Event_STATUS_ACTIVATED,
 		Result: protobufValue(result),
 	})
 }
 
-func protobufValue(goValue interface{}) *structpb.Value {
+func protobufValue(goValue any) *structpb.Value {
 	data, err := json.Marshal(goValue)
 	if err != nil {
 		return structpb.NewStringValue("<failed to marshal value to JSON>")
@@ -251,7 +251,7 @@ func (noopContext) AppliedEffect(effect effectv1.Effect, message string) {}
 
 func (noopContext) ComputedBoolResult(result bool, err error, message string) {}
 
-func (noopContext) ComputedResult(result interface{}) {}
+func (noopContext) ComputedResult(result any) {}
 
 func (noopContext) Failed(err error, message string) {}
 

--- a/internal/namer/namer.go
+++ b/internal/namer/namer.go
@@ -39,7 +39,7 @@ func (m ModuleID) Value() (driver.Value, error) {
 	return m.hash, nil
 }
 
-func (m *ModuleID) Scan(src interface{}) error {
+func (m *ModuleID) Scan(src any) error {
 	switch v := src.(type) {
 	case uint64:
 		m.hash = v

--- a/internal/outputcolor/level.go
+++ b/internal/outputcolor/level.go
@@ -73,7 +73,7 @@ func scan(ctx *kong.DecodeContext) (*Level, error) {
 	return pointer(Basic), nil
 }
 
-func parse(v interface{}) (*Level, error) {
+func parse(v any) (*Level, error) {
 	s, ok := v.(string)
 	if !ok {
 		return nil, fmt.Errorf("invalid flag value (expected string, got %T)", v)

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -30,11 +30,11 @@ type Printer struct {
 	stderr io.Writer
 }
 
-func (p *Printer) Println(args ...interface{}) {
+func (p *Printer) Println(args ...any) {
 	fmt.Fprintln(p.stdout, args...)
 }
 
-func (p *Printer) Printf(format string, args ...interface{}) {
+func (p *Printer) Printf(format string, args ...any) {
 	fmt.Fprintf(p.stdout, format, args...)
 }
 
@@ -64,7 +64,7 @@ func (p *Printer) coloredJSON(data string, colorLevel outputcolor.Level) error {
 	return formatter.Format(p.stdout, styles.SolarizedDark256, iterator)
 }
 
-func (p *Printer) PrintJSON(val interface{}, colorLevel outputcolor.Level) error {
+func (p *Printer) PrintJSON(val any, colorLevel outputcolor.Level) error {
 	var data bytes.Buffer
 	var enc *json.Encoder
 	if colorLevel.Enabled() {

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -280,10 +280,10 @@ func mkCache(size int) gcache.Cache {
 	gauge := metrics.MakeCacheGauge(cacheKind)
 	return gcache.New(size).
 		ARC().
-		AddedFunc(func(_, _ interface{}) {
+		AddedFunc(func(_, _ any) {
 			gauge.Add(1)
 		}).
-		EvictedFunc(func(_, _ interface{}) {
+		EvictedFunc(func(_, _ any) {
 			gauge.Add(-1)
 		}).Build()
 }

--- a/internal/server/codec.go
+++ b/internal/server/codec.go
@@ -30,7 +30,7 @@ func (c Codec) Name() string {
 	return name
 }
 
-func (c Codec) Marshal(v interface{}) ([]byte, error) {
+func (c Codec) Marshal(v any) ([]byte, error) {
 	if b, err := c.vtcodec.Marshal(v); err == nil {
 		return b, nil
 	}
@@ -42,7 +42,7 @@ func (c Codec) Marshal(v interface{}) ([]byte, error) {
 	return proto.Marshal(vv)
 }
 
-func (c Codec) Unmarshal(data []byte, v interface{}) error {
+func (c Codec) Unmarshal(data []byte, v any) error {
 	if err := c.vtcodec.Unmarshal(data, v); err == nil {
 		return nil
 	}

--- a/internal/server/conf_test.go
+++ b/internal/server/conf_test.go
@@ -16,14 +16,14 @@ import (
 func TestConfigValidate(t *testing.T) {
 	testCases := []struct {
 		name        string
-		conf        map[string]interface{}
+		conf        map[string]any
 		wantLoadErr bool
 		wantErr     bool
 	}{
 		{
 			name: "valid config",
-			conf: map[string]interface{}{
-				"server": map[string]interface{}{
+			conf: map[string]any{
+				"server": map[string]any{
 					"httpListenAddr": ":6666",
 					"grpcListenAddr": ":6667",
 				},
@@ -31,8 +31,8 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			name: "invalid httpListenAddr",
-			conf: map[string]interface{}{
-				"server": map[string]interface{}{
+			conf: map[string]any{
+				"server": map[string]any{
 					"httpListenAddr": "wibble",
 					"grpcListenAddr": ":6667",
 				},
@@ -41,8 +41,8 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			name: "invalid grpcListenAddr",
-			conf: map[string]interface{}{
-				"server": map[string]interface{}{
+			conf: map[string]any{
+				"server": map[string]any{
 					"httpListenAddr": ":6666",
 					"grpcListenAddr": "wibble",
 				},
@@ -51,11 +51,11 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			name: "unencodedAdminPasswordHash",
-			conf: map[string]interface{}{
-				"server": map[string]interface{}{
-					"adminAPI": map[string]interface{}{
+			conf: map[string]any{
+				"server": map[string]any{
+					"adminAPI": map[string]any{
 						"enabled": true,
-						"adminCredentials": map[string]interface{}{
+						"adminCredentials": map[string]any{
 							"username":     defaultAdminUsername,
 							"passwordHash": defaultRawAdminPasswordHash,
 						},
@@ -98,7 +98,7 @@ func TestAdminAPICredentials(t *testing.T) {
 
 	testCases := []struct {
 		name           string
-		conf           map[string]interface{}
+		conf           map[string]any
 		unsafe         bool
 		wantUsername   string
 		wantPasswdHash []byte
@@ -106,9 +106,9 @@ func TestAdminAPICredentials(t *testing.T) {
 	}{
 		{
 			name: "defaults",
-			conf: map[string]interface{}{
-				"server": map[string]interface{}{
-					"adminAPI": map[string]interface{}{
+			conf: map[string]any{
+				"server": map[string]any{
+					"adminAPI": map[string]any{
 						"enabled": true,
 					},
 				},
@@ -119,11 +119,11 @@ func TestAdminAPICredentials(t *testing.T) {
 		},
 		{
 			name: "userProvidedNonDefault",
-			conf: map[string]interface{}{
-				"server": map[string]interface{}{
-					"adminAPI": map[string]interface{}{
+			conf: map[string]any{
+				"server": map[string]any{
+					"adminAPI": map[string]any{
 						"enabled": true,
-						"adminCredentials": map[string]interface{}{
+						"adminCredentials": map[string]any{
 							"username":     nonDefaultUsername,
 							"passwordHash": nonDefaultPasswordHashEncoded,
 						},
@@ -135,11 +135,11 @@ func TestAdminAPICredentials(t *testing.T) {
 		},
 		{
 			name: "userProvidedDefaultUsername",
-			conf: map[string]interface{}{
-				"server": map[string]interface{}{
-					"adminAPI": map[string]interface{}{
+			conf: map[string]any{
+				"server": map[string]any{
+					"adminAPI": map[string]any{
 						"enabled": true,
-						"adminCredentials": map[string]interface{}{
+						"adminCredentials": map[string]any{
 							"username":     defaultAdminUsername,
 							"passwordHash": nonDefaultPasswordHashEncoded,
 						},
@@ -152,11 +152,11 @@ func TestAdminAPICredentials(t *testing.T) {
 		},
 		{
 			name: "userProvidedDefaultPasswordHash",
-			conf: map[string]interface{}{
-				"server": map[string]interface{}{
-					"adminAPI": map[string]interface{}{
+			conf: map[string]any{
+				"server": map[string]any{
+					"adminAPI": map[string]any{
 						"enabled": true,
-						"adminCredentials": map[string]interface{}{
+						"adminCredentials": map[string]any{
 							"username":     nonDefaultUsername,
 							"passwordHash": defaultAdminPasswordHash,
 						},

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -33,13 +33,13 @@ const (
 	unknownSvc            = "Unknown service"
 )
 
-func XForwardedHostUnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+func XForwardedHostUnaryServerInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return handler(ctx, req)
 	}
 
-	headers := make(map[string]interface{}, 2) //nolint:gomnd
+	headers := make(map[string]any, 2) //nolint:gomnd
 
 	xfh, ok := md["x-forwarded-host"]
 	if ok {
@@ -71,7 +71,7 @@ func loggingDecider(fullMethodName string, _ error) bool {
 
 // payloadLoggingDecider decides whether to log request payloads.
 func payloadLoggingDecider(conf *Conf) grpc_logging.ServerPayloadLoggingDecider {
-	return func(ctx context.Context, fullMethodName string, servingObject interface{}) bool {
+	return func(ctx context.Context, fullMethodName string, servingObject any) bool {
 		return conf.LogRequestPayloads && strings.HasPrefix(fullMethodName, "/cerbos.svc.v1")
 	}
 }
@@ -151,7 +151,7 @@ func withCORS(conf *Conf, handler http.Handler) http.Handler {
 	return c.Handler(handler)
 }
 
-func handleUnknownServices(_ interface{}, stream grpc.ServerStream) error {
+func handleUnknownServices(_ any, stream grpc.ServerStream) error {
 	errFn := func(msg string) error {
 		return status.Errorf(codes.Unimplemented, msg)
 	}

--- a/internal/storage/conf.go
+++ b/internal/storage/conf.go
@@ -29,13 +29,13 @@ func (c *Conf) Key() string {
 	return ConfKey
 }
 
-func (c *Conf) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *Conf) UnmarshalYAML(unmarshal func(any) error) error {
 	// We want to avoid defining all the storage driver configuration structs as fields of the Conf
 	// struct to maintain the "plugin" nature of those drivers (and avoid circular package references).
 	// However, the strict YAML parser throws an error if it sees undefined fields. This is a slightly
 	// inefficient workaround to get over that issue.
 
-	var confMap map[string]interface{}
+	var confMap map[string]any
 	if err := unmarshal(&confMap); err != nil {
 		return fmt.Errorf("failed to unmarshal storage config: %w", err)
 	}

--- a/internal/storage/db/internal/db.go
+++ b/internal/storage/db/internal/db.go
@@ -234,7 +234,7 @@ func (s *dbStorage) AddOrUpdate(ctx context.Context, policies ...policy.Wrapper)
 				}
 
 				// insert the new dependency records
-				depRows := make([]interface{}, len(dependencies))
+				depRows := make([]any, len(dependencies))
 				for ix, d := range dependencies {
 					depRows[ix] = PolicyDependency{PolicyID: p.ID, DependencyID: d}
 				}
@@ -258,7 +258,7 @@ func (s *dbStorage) AddOrUpdate(ctx context.Context, policies ...policy.Wrapper)
 				}
 
 				// insert the new ancestry records
-				ancRows := make([]interface{}, len(ancestors))
+				ancRows := make([]any, len(ancestors))
 				for ix, a := range ancestors {
 					ancRows[ix] = PolicyAncestor{PolicyID: p.ID, AncestorID: a}
 				}
@@ -470,7 +470,7 @@ func (s *dbStorage) Delete(ctx context.Context, ids ...namer.ModuleID) error {
 		return nil
 	}
 
-	idList := make([]interface{}, len(ids))
+	idList := make([]any, len(ids))
 	events := make([]storage.Event, len(ids))
 
 	for i, id := range ids {

--- a/internal/storage/db/internal/funcs.go
+++ b/internal/storage/db/internal/funcs.go
@@ -10,7 +10,7 @@ import (
 	"github.com/doug-martin/goqu/v9/exp"
 )
 
-func ConcatWithSepFunc(dialect string) func(string, ...interface{}) exp.Expression {
+func ConcatWithSepFunc(dialect string) func(string, ...any) exp.Expression {
 	switch dialect {
 	case "mysql", "mysql8", "sqlserver":
 		return mysqlConcatWithSep
@@ -19,8 +19,8 @@ func ConcatWithSepFunc(dialect string) func(string, ...interface{}) exp.Expressi
 	}
 }
 
-func mysqlConcatWithSep(sep string, args ...interface{}) exp.Expression {
-	a := make([]interface{}, len(args)+1)
+func mysqlConcatWithSep(sep string, args ...any) exp.Expression {
+	a := make([]any, len(args)+1)
 	a[0] = sep
 	for i, arg := range args {
 		a[i+1] = arg
@@ -30,7 +30,7 @@ func mysqlConcatWithSep(sep string, args ...interface{}) exp.Expression {
 }
 
 //nolint:gomnd
-func ansiConcatWithSep(sep string, args ...interface{}) exp.Expression {
+func ansiConcatWithSep(sep string, args ...any) exp.Expression {
 	n := len(args)
 	switch n {
 	case 0:
@@ -39,7 +39,7 @@ func ansiConcatWithSep(sep string, args ...interface{}) exp.Expression {
 		return goqu.L("? || ?", args[0], sep)
 	default:
 		f := strings.Repeat("? || ? || ", n-1) + "?"
-		a := make([]interface{}, (2*n)-1)
+		a := make([]any, (2*n)-1)
 		for i := 0; i < n-1; i++ {
 			a[i*2] = args[i]
 			a[(i*2)+1] = sep

--- a/internal/storage/db/internal/funcs_test.go
+++ b/internal/storage/db/internal/funcs_test.go
@@ -25,7 +25,7 @@ import (
 func TestConcatWithSep(t *testing.T) {
 	testCases := []struct {
 		want map[string]string
-		args []interface{}
+		args []any
 	}{
 		{
 			want: map[string]string{
@@ -36,7 +36,7 @@ func TestConcatWithSep(t *testing.T) {
 			},
 		},
 		{
-			args: []interface{}{"a"},
+			args: []any{"a"},
 			want: map[string]string{
 				"sqlserver": "SELECT CONCAT_WS('.', 'a') FROM \"table\"",
 				"mysql":     "SELECT CONCAT_WS('.', 'a') FROM `table`",
@@ -45,7 +45,7 @@ func TestConcatWithSep(t *testing.T) {
 			},
 		},
 		{
-			args: []interface{}{"a", "b"},
+			args: []any{"a", "b"},
 			want: map[string]string{
 				"sqlserver": "SELECT CONCAT_WS('.', 'a', 'b') FROM \"table\"",
 				"mysql":     "SELECT CONCAT_WS('.', 'a', 'b') FROM `table`",
@@ -54,7 +54,7 @@ func TestConcatWithSep(t *testing.T) {
 			},
 		},
 		{
-			args: []interface{}{"a", "b", "c"},
+			args: []any{"a", "b", "c"},
 			want: map[string]string{
 				"sqlserver": `SELECT CONCAT_WS('.', 'a', 'b', 'c') FROM "table"`,
 				"mysql":     "SELECT CONCAT_WS('.', 'a', 'b', 'c') FROM `table`",
@@ -63,7 +63,7 @@ func TestConcatWithSep(t *testing.T) {
 			},
 		},
 		{
-			args: []interface{}{goqu.C("a"), goqu.C("b"), "c", "d"},
+			args: []any{goqu.C("a"), goqu.C("b"), "c", "d"},
 			want: map[string]string{
 				"sqlserver": `SELECT CONCAT_WS('.', "a", "b", 'c', 'd') FROM "table"`,
 				"mysql":     "SELECT CONCAT_WS('.', `a`, `b`, 'c', 'd') FROM `table`",

--- a/internal/storage/db/internal/model.go
+++ b/internal/storage/db/internal/model.go
@@ -71,7 +71,7 @@ func (pdw PolicyDefWrapper) Value() (driver.Value, error) {
 	return pdw.Policy.MarshalVT()
 }
 
-func (pdw *PolicyDefWrapper) Scan(src interface{}) error {
+func (pdw *PolicyDefWrapper) Scan(src any) error {
 	var source []byte
 	switch t := src.(type) {
 	case nil:

--- a/internal/storage/index/index.go
+++ b/internal/storage/index/index.go
@@ -439,7 +439,7 @@ func (idx *index) RepoStats(_ context.Context) storage.RepoStats {
 func (idx *index) Reload(ctx context.Context) ([]storage.Event, error) {
 	log := ctxzap.Extract(ctx)
 	log.Info("Initiated a store reload")
-	ievts, err, shared := idx.sfGroup.Do("reload", func() (interface{}, error) {
+	ievts, err, shared := idx.sfGroup.Do("reload", func() (any, error) {
 		idxIface, err := Build(ctx, idx.fsys, idx.buildOpts...)
 		if err != nil {
 			log.Error("Failed to build index while re-indexing")

--- a/internal/storage/reload.go
+++ b/internal/storage/reload.go
@@ -15,7 +15,7 @@ import (
 var sfGroup singleflight.Group
 
 func Reload(ctx context.Context, rs ReloadableStore) error {
-	_, err, shared := sfGroup.Do("admin_reload", func() (interface{}, error) {
+	_, err, shared := sfGroup.Do("admin_reload", func() (any, error) {
 		if err := rs.Reload(ctx); err != nil {
 			return nil, fmt.Errorf("failed to reload the store: %w", err)
 		}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -15,10 +15,10 @@ import (
 )
 
 func TestDriverInstantiation(t *testing.T) {
-	conf := map[string]interface{}{
-		"storage": map[string]interface{}{
+	conf := map[string]any{
+		"storage": map[string]any{
 			"driver": "disk",
-			"disk": map[string]interface{}{
+			"disk": map[string]any{
 				"directory": t.TempDir(),
 			},
 		},

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -34,7 +34,7 @@ func (ipe InvalidPolicyError) Unwrap() error {
 	return ipe.Err
 }
 
-func NewInvalidPolicyError(err error, msg string, args ...interface{}) InvalidPolicyError {
+func NewInvalidPolicyError(err error, msg string, args ...any) InvalidPolicyError {
 	return InvalidPolicyError{Message: fmt.Sprintf(msg, args...), Err: err}
 }
 
@@ -52,7 +52,7 @@ func (ise InvalidSchemaError) Unwrap() error {
 	return ise.Err
 }
 
-func NewInvalidSchemaError(err error, msg string, args ...interface{}) InvalidSchemaError {
+func NewInvalidSchemaError(err error, msg string, args ...any) InvalidSchemaError {
 	return InvalidSchemaError{Message: fmt.Sprintf(msg, args...), Err: err}
 }
 

--- a/internal/svc/helpers.go
+++ b/internal/svc/helpers.go
@@ -19,7 +19,7 @@ const (
 	playgroundIDTagKey = "playground_id"
 )
 
-func ExtractRequestFields(fullMethod string, req interface{}) map[string]interface{} {
+func ExtractRequestFields(fullMethod string, req any) map[string]any {
 	if req == nil {
 		return nil
 	}
@@ -31,7 +31,7 @@ func ExtractRequestFields(fullMethod string, req interface{}) map[string]interfa
 			return nil
 		}
 
-		return map[string]interface{}{
+		return map[string]any{
 			metaTagKey: map[string]string{requestIDTagKey: crsReq.RequestId},
 		}
 
@@ -41,7 +41,7 @@ func ExtractRequestFields(fullMethod string, req interface{}) map[string]interfa
 			return nil
 		}
 
-		return map[string]interface{}{
+		return map[string]any{
 			metaTagKey: map[string]string{requestIDTagKey: crbReq.RequestId},
 		}
 
@@ -51,7 +51,7 @@ func ExtractRequestFields(fullMethod string, req interface{}) map[string]interfa
 			return nil
 		}
 
-		return map[string]interface{}{
+		return map[string]any{
 			metaTagKey: map[string]string{playgroundIDTagKey: pgReq.PlaygroundId},
 		}
 
@@ -61,7 +61,7 @@ func ExtractRequestFields(fullMethod string, req interface{}) map[string]interfa
 			return nil
 		}
 
-		return map[string]interface{}{
+		return map[string]any{
 			metaTagKey: map[string]string{playgroundIDTagKey: pgReq.PlaygroundId},
 		}
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -243,7 +243,7 @@ func mkProps(ping *telemetryv1.Ping) (analytics.Properties, error) {
 		return nil, fmt.Errorf("failed to marshal ping: %w", err)
 	}
 
-	var props map[string]interface{}
+	var props map[string]any
 	if err := json.Unmarshal(pingBytes, &props); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal ping: %w", err)
 	}

--- a/internal/test/template.go
+++ b/internal/test/template.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cerbos/cerbos/internal/policy"
 )
 
-func RenderTemplate(tb testing.TB, path string, data interface{}) []byte {
+func RenderTemplate(tb testing.TB, path string, data any) []byte {
 	tb.Helper()
 
 	tmpl, err := template.New(filepath.Base(path)).Funcs(TemplateFuncs()).ParseFiles(path)
@@ -35,7 +35,7 @@ func RenderTemplate(tb testing.TB, path string, data interface{}) []byte {
 }
 
 func TemplateFuncs() template.FuncMap {
-	funcs := make(map[string]interface{})
+	funcs := make(map[string]any)
 	for n, f := range sprig.FuncMap() {
 		funcs[n] = f
 	}

--- a/internal/util/app.go
+++ b/internal/util/app.go
@@ -19,10 +19,20 @@ var (
 func AppVersion() string {
 	var sb strings.Builder
 	_, _ = sb.WriteString(Version)
-	_, _ = sb.WriteString(fmt.Sprintf("\nBuilt on %s from %s\n", BuildDate, Commit))
+	_, _ = sb.WriteString(fmt.Sprintf("\nBuild timestamp: %s\n", BuildDate))
+	_, _ = sb.WriteString(fmt.Sprintf("Build commit: %s\n", Commit))
 
-	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Sum != "" {
-		_, _ = sb.WriteString(fmt.Sprintf("Module version: %s, Module checksum: %s\n", info.Main.Version, info.Main.Sum))
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if info.Main.Sum != "" {
+			_, _ = sb.WriteString(fmt.Sprintf("Module version: %s, Module checksum: %s\n", info.Main.Version, info.Main.Sum))
+		}
+
+		_, _ = sb.WriteString(fmt.Sprintf("Go version: %s\n", info.GoVersion))
+		for _, bs := range info.Settings {
+			if strings.HasPrefix(bs.Key, "vcs") {
+				_, _ = sb.WriteString(fmt.Sprintf("%s: %s\n", bs.Key, bs.Value))
+			}
+		}
 	}
 
 	return sb.String()

--- a/internal/util/hash.go
+++ b/internal/util/hash.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 )
 
-var hashPool = &sync.Pool{New: func() interface{} { return xxhash.New() }}
+var hashPool = &sync.Pool{New: func() any { return xxhash.New() }}
 
 type Hashable interface {
 	HashPB(hash.Hash, map[string]struct{})

--- a/internal/util/hash_test.go
+++ b/internal/util/hash_test.go
@@ -20,8 +20,8 @@ import (
 var dummy uint64
 
 var (
-	strPool = &sync.Pool{New: func() interface{} { return xxhashv2.New() }}
-	pbPool  = &sync.Pool{New: func() interface{} { return xxhashv2.New() }}
+	strPool = &sync.Pool{New: func() any { return xxhashv2.New() }}
+	pbPool  = &sync.Pool{New: func() any { return xxhashv2.New() }}
 )
 
 func TestXXHashV2(t *testing.T) {

--- a/internal/util/pb.go
+++ b/internal/util/pb.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func ToStructPB(v interface{}) (*structpb.Value, error) {
+func ToStructPB(v any) (*structpb.Value, error) {
 	val, err := structpb.NewValue(v)
 	if err == nil {
 		return val, nil
@@ -23,7 +23,7 @@ func ToStructPB(v interface{}) (*structpb.Value, error) {
 	vv := reflect.ValueOf(v)
 	switch vv.Kind() {
 	case reflect.Array, reflect.Slice:
-		arr := make([]interface{}, vv.Len())
+		arr := make([]any, vv.Len())
 		for i := 0; i < vv.Len(); i++ {
 			el := vv.Index(i)
 			// TODO (cell) Recurse
@@ -33,7 +33,7 @@ func ToStructPB(v interface{}) (*structpb.Value, error) {
 		return structpb.NewValue(arr)
 	case reflect.Map:
 		if vv.Type().Key().Kind() == reflect.String {
-			m := make(map[string]interface{})
+			m := make(map[string]any)
 
 			iter := vv.MapRange()
 			for iter.Next() {


### PR DESCRIPTION
Upgrade to some of the Go 1.18 features 

- Use the `any` alias for `interface{}`
- In the version output, display build information added by the compiler