### PR TITLE
chore: Group changelog items

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -159,9 +159,15 @@ release:
 
 changelog:
   sort: asc
-  filters:
-    exclude:
-      - '^ci:'
-      - '^chore'
-      - '^docs:'
-      - '^test:'
+  groups:
+    - title: Features
+      regexp: '^feat.+'
+      order: 5
+    - title: Enhancements
+      regexp: '^enhancement.+'
+      order: 10
+    - title: Bug fixes
+      regexp: '^fix.+'
+      order: 15
+    - title: Others
+      order: 20


### PR DESCRIPTION
Group the commits by their type in the changelog shown in the GitHub
releases page.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
