### PR TITLE
chore(ci): Update changelog grouping

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -161,13 +161,24 @@ changelog:
   sort: asc
   groups:
     - title: Features
-      regexp: '^feat.+'
+      regexp: |
+        \bfeat(\(.+?\))?\!?:.+
       order: 5
     - title: Enhancements
-      regexp: '^enhancement.+'
+      regexp: |
+        \benhancement(\(.+?\))?\!?:.+
       order: 10
     - title: Bug fixes
-      regexp: '^fix.+'
+      regexp: |
+        \bfix(\(.+?\))?\!?:.+
       order: 15
-    - title: Others
+    - title: Documentation
+      regexp: |
+        \bdocs(\(.+?\))?\!?:.+
       order: 20
+    - title: Chores
+      regexp: |
+        \bchore(\(.+?\))?\!?:.+
+      order: 25
+    - title: Others
+      order: 30


### PR DESCRIPTION
Fixes the Gorelease changelog grouping.
Goreleaser uses the output from `git log` where each line begins with the commit hash and the regexes need to be updated to take that into consideration.

Fixes #887 

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
