### PR TITLE
docs: Add MacOS command variant for password generation

### DIFF
--- a/docs/modules/configuration/pages/server.adoc
+++ b/docs/modules/configuration/pages/server.adoc
@@ -111,6 +111,18 @@ Cerbos expects the password to be hashed with bcrypt and encoded with base64. Th
 echo "cerbosAdmin" | htpasswd -niBC 10 cerbos | cut -d ':' -f 2 | base64 -w0
 ----
 
+[NOTE]
+====
+On MacOS, the `base64` utility does not require the `-w0` argument.
+
+[source, sh]
+----
+echo "cerbosAdmin" | htpasswd -niBC 10 cerbos | cut -d ':' -f 2 | base64
+----
+
+====
+
+NOTE: The output of the above command for a given password value is not deterministic. It will vary between invocations or between different machines. This is because the `bcrypt` algorithm uses a salt (random noise) to make password cracking harder. 
 
 == Enable Playground
 

--- a/docs/modules/policies/pages/conditions.adoc
+++ b/docs/modules/policies/pages/conditions.adoc
@@ -181,6 +181,26 @@ NOTE: CEL has many builtin functions and operators. The fully up-to-date list ca
 
 == Durations
 
+[NOTE]
+====
+
+Duration values must be specified in one of the following units. Larger units like days, weeks or years are not supported because of ambiguity around their meaning due to factors such as daylight saving time transitions.
+
+[caption=]
+[%header,cols=".^1m,.^4",grid=rows]
+|===
+| Suffix | Unit 
+| ns     | Nanoseconds
+| us     | Microseconds
+| ms     | Milliseconds
+| s      | Seconds
+| m      | Minutes
+| h      | Hours
+|===
+
+
+====
+
 .Test data
 [source,json,linenums]
 ----


### PR DESCRIPTION
- MacOS `base64` command does not require the `--wrap` argument.
- Explain that `bcrypt` output is not deterministic.
- Add a note about supported duration units in conditions

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
