### PR TITLE
chore: Update Otel semconv version

### DIFF
--- a/internal/observability/tracing/tracing.go
+++ b/internal/observability/tracing/tracing.go
@@ -19,7 +19,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/jaeger"
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 


### PR DESCRIPTION
The new version of Otel added by #885 uses a new version of the semantic
conventions (v1.10.0). We currently import v1.7.0 of semconv and that clashes with
the newer version -- preventing the server from starting up.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
