### PR TITLE
chore(e2e): Add E2E test with tracing enabled

### DIFF
--- a/e2e/jaeger/helmfile.yaml
+++ b/e2e/jaeger/helmfile.yaml
@@ -1,0 +1,126 @@
+repositories:
+  - name: jaegertracing
+    url: https://jaegertracing.github.io/helm-charts 
+
+helmDefaults:
+  cleanupOnFail: true
+  wait: true
+  recreatePods: true
+  force: true
+  createNamespace: true
+
+releases:
+  - name: jaeger
+    namespace: '{{ requiredEnv "E2E_NS" }}'
+    createNamespace: true
+    labels:
+      e2e-run: '{{ requiredEnv "E2E_RUN_ID" }}'
+      e2e-ctx: '{{ requiredEnv "E2E_CONTEXT_ID" }}'
+    chart: jaegertracing/jaeger
+    hooks:
+      - events: ["presync"]
+        showlogs: true
+        command: kubectl
+        args:
+          - create
+          - namespace
+          - '{{ requiredEnv "E2E_NS" }}'
+      - events: ["postuninstall"]
+        showlogs: true
+        command: kubectl
+        args:
+          - delete
+          - namespace
+          - '{{ requiredEnv "E2E_NS" }}'
+    values:
+      - nameOverride: '{{ requiredEnv "E2E_CONTEXT_ID" }}'
+      - provisionDataStore:
+          cassandra: false
+      - storage:
+          type: none
+      - agent:
+          enabled: true
+      - allInOne:
+          enabled: false
+      - collector:
+          enabled: false
+      - query:
+          enabled: false
+
+  - name: cerbos
+    namespace: '{{ requiredEnv "E2E_NS" }}'
+    createNamespace: true
+    labels:
+      e2e-run: '{{ requiredEnv "E2E_RUN_ID" }}'
+      e2e-ctx: '{{ requiredEnv "E2E_CONTEXT_ID" }}'
+    chart: '{{ requiredEnv "E2E_SRC_ROOT" }}/deploy/charts/cerbos'
+    hooks:
+      - events: ["presync"]
+        showlogs: true
+        command: kubectl
+        args:
+          - create
+          - secret
+          - tls
+          - 'cerbos-certs-{{ requiredEnv "E2E_CONTEXT_ID" }}'
+          - '--cert={{ requiredEnv "E2E_SRC_ROOT" }}/internal/test/testdata/server/tls.crt'
+          - '--key={{ requiredEnv "E2E_SRC_ROOT" }}/internal/test/testdata/server/tls.key'
+          - '--namespace={{ requiredEnv "E2E_NS" }}'
+      - events: ["postuninstall"]
+        showlogs: true
+        command: kubectl
+        args:
+          - delete
+          - secret
+          - 'cerbos-certs-{{ requiredEnv "E2E_CONTEXT_ID" }}'
+          - '--namespace={{ requiredEnv "E2E_NS" }}'
+    values:
+      - nameOverride: '{{ requiredEnv "E2E_CONTEXT_ID" }}'
+      - image:
+          repository: '{{ env "E2E_CERBOS_IMG_REPO" | default "ghcr.io/cerbos/cerbos" }}'
+          tag: '{{ env "E2E_CERBOS_IMG_TAG" | default "dev" }}'
+      - volumes:
+        - name: cerbos-auditlog
+          emptyDir: {}
+        - name: cerbos-policies
+          emptyDir: {}
+      - volumeMounts:
+        - name: cerbos-auditlog
+          mountPath: /audit
+        - name: cerbos-policies
+          mountPath: /data
+      - cerbos:
+          tlsSecretName: 'cerbos-certs-{{ requiredEnv "E2E_CONTEXT_ID" }}'
+          logLevel: DEBUG
+          config:
+            server:
+              playgroundEnabled: true
+              adminAPI:
+                enabled: true
+                adminCredentials:
+                  username: cerbos
+                  passwordHash: JDJ5JDEwJC5BYjQyY2RJNG5QR2NWMmJPdnNtQU93c09RYVA0eFFGdHBrbmFEeXh1NnlIVTE1cHJNY05PCgo=
+            auxData:
+              jwt:
+                disableVerification: true
+            schema:
+              enforcement: reject
+            audit:
+              enabled: true
+              accessLogsEnabled: true
+              decisionLogsEnabled: true
+              backend: local
+              local:
+                storagePath: /audit/cerbos
+            storage:
+              driver: "sqlite3"
+              sqlite3:
+                dsn: "file:/data/cerbos.sqlite?mode=rwc&_fk=true"
+            tracing:
+              sampleProbability: 1.0
+              exporter: jaeger
+              jaeger:
+                agentEndpoint: 'jaeger-agent.{{ requiredEnv "E2E_NS" }}.svc.cluster.local:6831'
+                serviceName: "cerbos"
+            telemetry:
+              disabled: true

--- a/e2e/jaeger/jaeger_test.go
+++ b/e2e/jaeger/jaeger_test.go
@@ -1,0 +1,16 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build e2e
+
+package jaeger_test
+
+import (
+	"testing"
+
+	"github.com/cerbos/cerbos/internal/test/e2e"
+)
+
+func TestJaeger(t *testing.T) {
+	e2e.RunSuites(t, e2e.WithContextID("jaeger"), e2e.WithMutableStoreSuites())
+}


### PR DESCRIPTION
The issue in #905 wasn't caught early because tracing is initialised in
`main` that is not covered by unit tests. The E2E tests didn't catch it
either because tracing was disabled. This PR adds an E2E test that runs
with Jaeger tracing enabled so that we can catch similar issues in the
future.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
