### PR TITLE
feat: Add file backend for audit logs

### DIFF
--- a/docs/modules/cli/pages/cerbosctl.adoc
+++ b/docs/modules/cli/pages/cerbosctl.adoc
@@ -62,6 +62,7 @@ Use "cerbosctl [command] --help" for more information about a command.
 ----
 
 
+[#audit]
 == `audit` 
 
 This command allows you to view the audit logs captured by the Cerbos server. xref:configuration:audit.adoc[Audit logging] must be enabled on the server to obtain the data through this command.
@@ -112,6 +113,7 @@ cerbosctl audit --kind=access --lookup=01F9Y5MFYTX7Y87A30CTJ2FB0S
 ----
 
 
+[#decisions]
 == `decisions`
 
 This command starts an interactive text user interface to view and analyze the decision records captured by the Cerbos server. It accepts the same xref:#audit-filters[filter flags] as the `audit` command.

--- a/docs/modules/configuration/pages/audit.adoc
+++ b/docs/modules/configuration/pages/audit.adoc
@@ -3,9 +3,7 @@ include::ROOT:partial$attributes.adoc[]
 = Audit block
 
 The `audit` block configures the audit logging settings for the Cerbos instance. Audit logs capture access records and decisions made by the engine along with the associated context data.
-
-
-Log storage is handled by different backends. In the free version, only the `local` backend is supported.
+ 
 
 NOTE: Audit logging has some overhead in terms of resource usage (disk IO, CPU and memory). This overhead is usually negligible unless Cerbos is running in a resource-constrained environment. If resources are scarce or if you are expecting heavy traffic, disabling audit logging might have a positive impact on performance. 
 
@@ -25,7 +23,9 @@ audit:
 
 == Local backend
 
-The `local` backend uses an embedded key-value store to save audit records. The default settings should be sufficient for many use cases. Advanced users can fine-tune these settings using the `advanced` section.
+The `local` backend uses an embedded key-value store to save audit records. Records are preserved for seven days by default and can be queried using the xref:api:admin_api.adoc[Admin API], the xref:cli:cerbosctl.adoc#audit[`cerbosctl audit`] command or the xref:cli:cerbosctl.adoc#decisions[`cerbosctl decisions`] text interface (TUI).
+
+The only required setting for the `local` backend is the `storagePath` field which specifies the path on disk where the logs should be stored.
 
 
 [source,yaml,linenums]
@@ -43,3 +43,26 @@ audit:
       gcInterval: 15m # How often the garbage collector runs to remove old entries from the log. 
 ----
 
+
+[#file]
+== File backend
+
+The `file` backend writes audit records as newline-delimited JSON to a file or stdout/stderr. With this backend you can use your existing log aggregation system (DataDog agent, Elastic agent, Fluentd, Graylog -- to name a few) to collect, process and archive the audit data from all Cerbos instances.
+
+
+NOTE: This backend cannot be queried using the Admin API, `cerbosctl audit` or `cerbosctl decisions`.
+
+
+[source,yaml,linenums]
+----
+audit: 
+  enabled: true 
+  backend: file
+  file: 
+    path: /path/to/audit.log
+----
+
+
+The `path` field can be set to special names `stdout` or `stderr` to log to stdout or stderr. Note that this would result in audit logs being mixed up with normal Cerbos operational logs. It is recommended to use an actual file for audit log output if your container orchestrator has support for collecting logs from files in addition to stdout/stderr.
+
+Audit log entries can be selected by setting a filter on `log.logger == "cerbos.audit"`. Access log entries have `log.kind == "access"` and decision log entries have `log.kind == "decision"`. 

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -3,6 +3,8 @@ audit:
   backend: local # Backend states which backend to use for Audits.
   decisionLogsEnabled: true # DecisionLogsEnabled defines whether logging of policy decisions is enabled.
   enabled: false # Enabled defines whether audit logging is enabled.
+  file:
+    path: /path/to/file.log # Path to the log file to use as output. The special values stdout and stderr can be used to write to stdout or stderr respectively.
   local:
     advanced: 
       bufferSize: 256 

--- a/internal/audit/file/conf.go
+++ b/internal/audit/file/conf.go
@@ -10,12 +10,9 @@ import (
 	"github.com/cerbos/cerbos/internal/audit"
 )
 
-const (
-	confKey   = audit.ConfKey + ".file"
-	stderrStr = "stderr"
-	stdoutStr = "stdout"
-)
+const confKey = audit.ConfKey + ".file"
 
+// Conf is optional configuration for file Audit.
 type Conf struct {
 	// Path to the log file to use as output. The special values stdout and stderr can be used to write to stdout or stderr respectively.
 	Path string `yaml:"path" conf:",example=/path/to/file.log"`
@@ -26,7 +23,7 @@ func (c *Conf) Key() string {
 }
 
 func (c *Conf) SetDefaults() {
-	c.Path = stdoutStr
+	c.Path = "stdout"
 }
 
 func (c *Conf) Validate() error {

--- a/internal/audit/file/conf.go
+++ b/internal/audit/file/conf.go
@@ -1,0 +1,38 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package file
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cerbos/cerbos/internal/audit"
+)
+
+const (
+	confKey   = audit.ConfKey + ".file"
+	stderrStr = "stderr"
+	stdoutStr = "stdout"
+)
+
+type Conf struct {
+	// Path to the log file to use as output. The special values stdout and stderr can be used to write to stdout or stderr respectively.
+	Path string `yaml:"path" conf:",example=/path/to/file.log"`
+}
+
+func (c *Conf) Key() string {
+	return confKey
+}
+
+func (c *Conf) SetDefaults() {
+	c.Path = stdoutStr
+}
+
+func (c *Conf) Validate() error {
+	if strings.TrimSpace(c.Path) == "" {
+		return fmt.Errorf("invalid path %q", c.Path)
+	}
+
+	return nil
+}

--- a/internal/audit/file/log.go
+++ b/internal/audit/file/log.go
@@ -1,0 +1,196 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package file
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/cerbos/cerbos/internal/audit"
+	"github.com/cerbos/cerbos/internal/config"
+	"go.elastic.co/ecszap"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func init() {
+	audit.RegisterBackend("file", func(_ context.Context, confW *config.Wrapper) (audit.Log, error) {
+		conf := new(Conf)
+		if err := confW.GetSection(conf); err != nil {
+			return nil, fmt.Errorf("failed to read local audit log configuration: %w", err)
+		}
+
+		return NewLog(conf)
+	})
+}
+
+type Log struct {
+	accessLog   *zap.Logger
+	decisionLog *zap.Logger
+}
+
+func NewLog(conf *Conf) (*Log, error) {
+	// remove level, time and message because they are not useful in this context
+	encoderConf := ecszap.NewDefaultEncoderConfig().ToZapCoreEncoderConfig()
+	encoderConf.LevelKey = ""
+	encoderConf.TimeKey = ""
+	encoderConf.MessageKey = ""
+
+	zapConf := zap.NewProductionConfig()
+	zapConf.Sampling = nil
+	zapConf.DisableCaller = true
+	zapConf.DisableStacktrace = true
+	zapConf.EncoderConfig = encoderConf
+	zapConf.OutputPaths = []string{conf.Path}
+
+	logger, err := zapConf.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create logger: %w", err)
+	}
+
+	return &Log{
+		accessLog:   logger.Named("cerbos.audit").With(zap.String("log.kind", "access")),
+		decisionLog: logger.Named("cerbos.audit").With(zap.String("log.kind", "decision")),
+	}, nil
+}
+
+func (l *Log) WriteAccessLogEntry(_ context.Context, record audit.AccessLogEntryMaker) error {
+	rec, err := record()
+	if err != nil {
+		return err
+	}
+
+	l.accessLog.Info("", zap.Inline(protoMsg{msg: rec}))
+	return nil
+}
+
+func (l *Log) WriteDecisionLogEntry(_ context.Context, record audit.DecisionLogEntryMaker) error {
+	rec, err := record()
+	if err != nil {
+		return err
+	}
+
+	l.decisionLog.Info("", zap.Inline(protoMsg{msg: rec}))
+	return nil
+}
+
+func (l *Log) Close() {
+	_ = l.accessLog.Sync()
+	_ = l.decisionLog.Sync()
+}
+
+type protoMsg struct {
+	msg proto.Message
+}
+
+func (pm protoMsg) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if pm.msg == nil {
+		return nil
+	}
+
+	pm.msg.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		switch {
+		case fd.IsMap():
+			_ = enc.AddObject(fd.JSONName(), protoMap{m: v.Map(), valueFD: fd.MapValue()})
+		case fd.IsList():
+			_ = enc.AddArray(fd.JSONName(), protoList{l: v.List(), valueFD: fd})
+		default:
+			encodeSingular(enc, fd.JSONName(), fd, v)
+		}
+
+		return true
+	})
+
+	return nil
+}
+
+func encodeSingular(enc zapcore.ObjectEncoder, fieldName string, fd protoreflect.FieldDescriptor, v protoreflect.Value) {
+	switch fd.Kind() {
+	case protoreflect.BoolKind:
+		enc.AddBool(fieldName, v.Bool())
+	case protoreflect.EnumKind:
+		enumVal := fd.Enum().Values().ByNumber(v.Enum())
+		enc.AddString(fieldName, string(enumVal.Name()))
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Int64Kind, protoreflect.Sint64Kind:
+		enc.AddInt64(fieldName, v.Int())
+	case protoreflect.Uint32Kind, protoreflect.Uint64Kind, protoreflect.Sfixed32Kind, protoreflect.Fixed32Kind, protoreflect.Sfixed64Kind, protoreflect.Fixed64Kind:
+		enc.AddUint64(fieldName, v.Uint())
+	case protoreflect.FloatKind, protoreflect.DoubleKind:
+		enc.AddFloat64(fieldName, v.Float())
+	case protoreflect.StringKind:
+		enc.AddString(fieldName, v.String())
+	case protoreflect.BytesKind:
+		enc.AddBinary(fieldName, v.Bytes())
+	case protoreflect.MessageKind:
+		msg := v.Message()
+		// output timestamps as readable timestamps instead of constituent components (seconds and nanoseconds)
+		if msg.Descriptor().FullName() == "google.protobuf.Timestamp" {
+			if tsVal, err := protojson.Marshal(msg.Interface()); err == nil {
+				enc.AddByteString(fieldName, bytes.Trim(tsVal, `"`))
+				return
+			}
+		}
+		_ = enc.AddObject(fieldName, protoMsg{msg: msg.Interface()})
+	default:
+		// do nothing
+	}
+}
+
+type protoMap struct {
+	m       protoreflect.Map
+	valueFD protoreflect.FieldDescriptor
+}
+
+func (pm protoMap) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if pm.m == nil {
+		return nil
+	}
+
+	pm.m.Range(func(mk protoreflect.MapKey, v protoreflect.Value) bool {
+		encodeSingular(enc, mk.String(), pm.valueFD, v)
+		return true
+	})
+
+	return nil
+}
+
+type protoList struct {
+	l       protoreflect.List
+	valueFD protoreflect.FieldDescriptor
+}
+
+func (pl protoList) MarshalLogArray(enc zapcore.ArrayEncoder) error {
+	if pl.l == nil {
+		return nil
+	}
+
+	for i := 0; i < pl.l.Len(); i++ {
+		v := pl.l.Get(i)
+
+		switch pl.valueFD.Kind() {
+		case protoreflect.BoolKind:
+			enc.AppendBool(v.Bool())
+		case protoreflect.EnumKind:
+			enc.AppendInt32(int32(v.Enum()))
+		case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Int64Kind, protoreflect.Sint64Kind:
+			enc.AppendInt64(v.Int())
+		case protoreflect.Uint32Kind, protoreflect.Uint64Kind, protoreflect.Sfixed32Kind, protoreflect.Fixed32Kind, protoreflect.Sfixed64Kind, protoreflect.Fixed64Kind:
+			enc.AppendUint64(v.Uint())
+		case protoreflect.FloatKind, protoreflect.DoubleKind:
+			enc.AppendFloat64(v.Float())
+		case protoreflect.StringKind:
+			enc.AppendString(v.String())
+		case protoreflect.MessageKind:
+			_ = enc.AppendObject(protoMsg{msg: v.Message().Interface()})
+		default:
+			// do nothing
+		}
+	}
+
+	return nil
+}

--- a/internal/audit/file/log_test.go
+++ b/internal/audit/file/log_test.go
@@ -1,0 +1,130 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package file_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	auditv1 "github.com/cerbos/cerbos/api/genpb/cerbos/audit/v1"
+	effectv1 "github.com/cerbos/cerbos/api/genpb/cerbos/effect/v1"
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
+	"github.com/cerbos/cerbos/internal/audit"
+	"github.com/cerbos/cerbos/internal/audit/file"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const numRecords = 100_000
+
+func TestLog(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "audit.log")
+	startDate := time.Now()
+
+	log, err := file.NewLog(&file.Conf{Path: output})
+	require.NoError(t, err)
+
+	t.Cleanup(log.Close)
+
+	ch := make(chan int, 100)
+	g, ctx := errgroup.WithContext(context.Background())
+
+	for i := 0; i < 10; i++ {
+		g.Go(func() error {
+			for x := range ch {
+				ts := startDate.Add(time.Duration(x) * time.Second)
+				id, err := audit.NewIDForTime(ts)
+				if err != nil {
+					return err
+				}
+
+				if err := log.WriteAccessLogEntry(ctx, mkAccessLogEntry(t, id, x, ts)); err != nil {
+					return err
+				}
+
+				if err := log.WriteDecisionLogEntry(ctx, mkDecisionLogEntry(t, id, x, ts)); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	}
+
+	g.Go(func() error {
+		defer close(ch)
+
+		for i := 0; i < numRecords; i++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
+			ch <- i
+		}
+
+		return nil
+	})
+
+	require.NoError(t, g.Wait())
+
+	stat, err := os.Stat(output)
+	require.NoError(t, err, "Failed to stat %s", output)
+	require.True(t, stat.Size() > 0, "Audit log is empty")
+}
+
+func mkAccessLogEntry(t *testing.T, id audit.ID, i int, ts time.Time) audit.AccessLogEntryMaker {
+	t.Helper()
+
+	return func() (*auditv1.AccessLogEntry, error) {
+		return &auditv1.AccessLogEntry{
+			CallId:    string(id),
+			Timestamp: timestamppb.New(ts),
+			Peer: &auditv1.Peer{
+				Address: "1.1.1.1",
+			},
+			Metadata: map[string]*auditv1.MetaValues{"Num": {Values: []string{strconv.Itoa(i)}}},
+			Method:   "/cerbos.svc.v1.CerbosService/Check",
+		}, nil
+	}
+}
+
+func mkDecisionLogEntry(t *testing.T, id audit.ID, i int, ts time.Time) audit.DecisionLogEntryMaker {
+	t.Helper()
+
+	return func() (*auditv1.DecisionLogEntry, error) {
+		return &auditv1.DecisionLogEntry{
+			CallId:    string(id),
+			Timestamp: timestamppb.New(ts),
+			Inputs: []*enginev1.CheckInput{
+				{
+					RequestId: strconv.Itoa(i),
+					Resource: &enginev1.Resource{
+						Kind: "test:kind",
+						Id:   "test",
+					},
+					Principal: &enginev1.Principal{
+						Id:    "test",
+						Roles: []string{"a", "b"},
+					},
+					Actions: []string{"a1", "a2"},
+				},
+			},
+			Outputs: []*enginev1.CheckOutput{
+				{
+					RequestId:  strconv.Itoa(i),
+					ResourceId: "test",
+					Actions: map[string]*enginev1.CheckOutput_ActionEffect{
+						"a1": {Effect: effectv1.Effect_EFFECT_ALLOW, Policy: "resource.test.v1"},
+						"a2": {Effect: effectv1.Effect_EFFECT_ALLOW, Policy: "resource.test.v1"},
+					},
+				},
+			},
+		}, nil
+	}
+}

--- a/internal/audit/log_test.go
+++ b/internal/audit/log_test.go
@@ -6,7 +6,6 @@ package audit_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -37,61 +36,7 @@ func TestNopLog(t *testing.T) {
 		require.False(t, recordMakerCalled)
 	})
 
-	t.Run("lastNAccessLogEntries", func(t *testing.T) {
-		it := log.LastNAccessLogEntries(context.Background(), 10)
-		require.NotNil(t, it)
-
-		rec, err := it.Next()
-		require.Nil(t, rec)
-		require.ErrorIs(t, err, audit.ErrIteratorClosed)
-	})
-
-	t.Run("lastNDecisionLogEntries", func(t *testing.T) {
-		it := log.LastNDecisionLogEntries(context.Background(), 10)
-		require.NotNil(t, it)
-
-		rec, err := it.Next()
-		require.Nil(t, rec)
-		require.ErrorIs(t, err, audit.ErrIteratorClosed)
-	})
-
-	t.Run("accessLogEntriesBetween", func(t *testing.T) {
-		it := log.AccessLogEntriesBetween(context.Background(), time.Now(), time.Now().Add(1*time.Hour))
-		require.NotNil(t, it)
-
-		rec, err := it.Next()
-		require.Nil(t, rec)
-		require.ErrorIs(t, err, audit.ErrIteratorClosed)
-	})
-
-	t.Run("decisionLogEntriesBetween", func(t *testing.T) {
-		it := log.DecisionLogEntriesBetween(context.Background(), time.Now(), time.Now().Add(1*time.Hour))
-		require.NotNil(t, it)
-
-		rec, err := it.Next()
-		require.Nil(t, rec)
-		require.ErrorIs(t, err, audit.ErrIteratorClosed)
-	})
-
-	t.Run("accessLogEntryByID", func(t *testing.T) {
-		it := log.AccessLogEntryByID(context.Background(), "01F9V33PSMJ3Z52CS6JPPWCYRZ")
-		require.NotNil(t, it)
-
-		rec, err := it.Next()
-		require.Nil(t, rec)
-		require.ErrorIs(t, err, audit.ErrIteratorClosed)
-	})
-
-	t.Run("decisionLogEntryByID", func(t *testing.T) {
-		it := log.DecisionLogEntryByID(context.Background(), "01F9V33PSMJ3Z52CS6JPPWCYRZ")
-		require.NotNil(t, it)
-
-		rec, err := it.Next()
-		require.Nil(t, rec)
-		require.ErrorIs(t, err, audit.ErrIteratorClosed)
-	})
-
-	t.Run("close", func(t *testing.T) {
+	t.Run("close", func(_ *testing.T) {
 		log.Close()
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -51,6 +51,8 @@ import (
 
 	// Import to register the Badger audit log backend.
 	_ "github.com/cerbos/cerbos/internal/audit/local"
+	// Import to register the file audit log backend.
+	_ "github.com/cerbos/cerbos/internal/audit/file"
 	"github.com/cerbos/cerbos/internal/auxdata"
 	"github.com/cerbos/cerbos/internal/compile"
 	"github.com/cerbos/cerbos/internal/engine"


### PR DESCRIPTION
Adds a new audit log backend named `file` which simply writes log entries to a file (or stdout/stderr). That file can then be picked up by log aggregators for archival and querying.

