### PR TITLE
fix(ci): Fix confdocs panicking when no comment for a struct provided

### DIFF
--- a/hack/tools/confdocs/confdocs.go
+++ b/hack/tools/confdocs/confdocs.go
@@ -408,6 +408,9 @@ func parseTag(tag string) (*TagInfo, error) {
 }
 
 func parseDescMarker(cg *ast.CommentGroup) (string, bool) {
+	if cg == nil {
+		return "", false
+	}
 	for _, c := range cg.List {
 		submatches := descRegex.FindAllStringSubmatch(c.Text, -1)
 		if submatches != nil && submatches[0] != nil {


### PR DESCRIPTION
Signed-off-by: Oğuzhan Durgun <oguzhandurgun95@gmail.com>

#### Description

Fixes #908