### PR TITLE
chore(ci): Update README of the E2E tests to reflect the change of the helmfile repository

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,7 +7,7 @@ This is still a WIP.
 - [kind](https://kind.sigs.k8s.io)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 - [Helm](https://helm.sh)
-- [Helmfile](https://github.com/roboll/helmfile)
+- [Helmfile](https://github.com/helmfile/helmfile)
 - [Telepresence](https://www.telepresence.io/docs/latest/install/)
 
 ## Running tests


### PR DESCRIPTION
Signed-off-by: Oğuzhan Durgun <oguzhandurgun95@gmail.com>

#### Description

The repository for the `helmfile` project is changed from https://github.com/roboll/helmfile to https://github.com/helmfile/helmfile. This PR changes the URL in `e2e/README.md` to reflect this change.

There is still a reference to the old repository in `.github/workflows/e2e.yaml:36`, but since the new repository does not have a release yet we will have to wait for it. Created an issue (#913) for this. 
