### PR TITLE
docs(backport): Document limits on `resources` and `actions` (#930)

### DIFF
--- a/docs/modules/api/pages/index.adoc
+++ b/docs/modules/api/pages/index.adoc
@@ -103,13 +103,13 @@ This is the main API entrypoint for checking permissions for a set of resources.
 <4> Principal policy scope. Optional. See xref:policies:scoped_policies.adoc[].
 <5> The roles attached to this principal by the identity provider.
 <6> Free-form context data about this principal. Policy rule conditions are evaluated based on these values.
-<7> List of resources the principal is attempting to access.
+<7> List of resources the principal is attempting to access. Up to 20 resources may be provided in a single request.
 <8> ID of the resource.
 <9> Resource kind. This is used to determine the resource policy that applies to this resource.
 <10> Resource policy version. Optional. The server falls back to the xref:configuration:engine.adoc[configured default version] if this is not specified. 
 <11> Resource policy scope. Optional. See xref:policies:scoped_policies.adoc[].
 <12> Free-form context data about this resource. Policy rule conditions are evaluated based on these values.
-<13> List of actions being performed on the resource.
+<13> List of actions being performed on the resource. Up to 10 actions per resource may be provided.
 <14> Optional section for providing auxiliary data.
 <15> JWT to use as an auxiliary data source. 
 <16> ID of the keyset to use to verify the JWT. Optional if only a single xref:configuration:auxdata.adoc[keyset is configured].
@@ -227,7 +227,7 @@ Checks permissions for a set of homogeneous resources.
 }
 ----
 <1> Request ID can be anything that uniquely identifies a request.
-<2> Actions being performed on the resource instances. Required.
+<2> Actions being performed on the resource instances. Required. Up to 10 actions may be provided in a single request.
 <3> Resource policy version. Optional. The server falls back to the xref:configuration:engine.adoc[configured default version] if this is not specified.
 <4> Resource kind. Required. This value is used to determine the resource policy to evaluate. 
 <5> Resource scope. Optional. See xref:policies:scoped_policies.adoc[].


### PR DESCRIPTION
Backport of #930 