### PR TITLE
docs: Update audit examples

### DIFF
--- a/docs/modules/configuration/pages/audit.adoc
+++ b/docs/modules/configuration/pages/audit.adoc
@@ -32,6 +32,8 @@ The only required setting for the `local` backend is the `storagePath` field whi
 ----
 audit: 
   enabled: true 
+  accessLogsEnabled: true 
+  decisionLogsEnabled: true 
   backend: local 
   local: 
     storagePath: /path/to/dir 
@@ -57,6 +59,8 @@ NOTE: This backend cannot be queried using the Admin API, `cerbosctl audit` or `
 ----
 audit: 
   enabled: true 
+  accessLogsEnabled: true 
+  decisionLogsEnabled: true 
   backend: file
   file: 
     path: /path/to/audit.log

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -1,7 +1,7 @@
 audit:
-  accessLogsEnabled: true # AccessLogsEnabled defines whether access logging is enabled.
+  accessLogsEnabled: false # AccessLogsEnabled defines whether access logging is enabled.
   backend: local # Backend states which backend to use for Audits.
-  decisionLogsEnabled: true # DecisionLogsEnabled defines whether logging of policy decisions is enabled.
+  decisionLogsEnabled: false # DecisionLogsEnabled defines whether logging of policy decisions is enabled.
   enabled: false # Enabled defines whether audit logging is enabled.
   file:
     path: /path/to/file.log # Path to the log file to use as output. The special values stdout and stderr can be used to write to stdout or stderr respectively.

--- a/internal/audit/conf.go
+++ b/internal/audit/conf.go
@@ -25,9 +25,9 @@ type confHolder struct {
 	// Enabled defines whether audit logging is enabled.
 	Enabled bool `yaml:"enabled" conf:",example=false"`
 	// AccessLogsEnabled defines whether access logging is enabled.
-	AccessLogsEnabled bool `yaml:"accessLogsEnabled" conf:",example=true"`
+	AccessLogsEnabled bool `yaml:"accessLogsEnabled" conf:",example=false"`
 	// DecisionLogsEnabled defines whether logging of policy decisions is enabled.
-	DecisionLogsEnabled bool `yaml:"decisionLogsEnabled" conf:",example=true"`
+	DecisionLogsEnabled bool `yaml:"decisionLogsEnabled" conf:",example=false"`
 }
 
 func (c *Conf) UnmarshalYAML(unmarshal func(any) error) error {


### PR DESCRIPTION
Due to a change in how config is unmarshaled, the defaults are not
correctly being set. Until that issue is fixed, we need to update the
examples to instruct the users that they should explicitly set the
`accessLogsEnabled` and `decisionLogsEnabled` settings.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
