### PR TITLE
fix: Apply defaults when loading audit config

### DIFF
--- a/hack/dev/conf.insecure.yaml
+++ b/hack/dev/conf.insecure.yaml
@@ -19,9 +19,11 @@ auxData:
 
 audit:
   enabled: true
-  backend: "local"
+  backend: "file"
   local:
     storagePath: /tmp/cerbos_auditlog
+  file:
+    path: stdout
 
 tracing:
   sampleProbability: 1.0

--- a/hack/dev/conf.secure.yaml
+++ b/hack/dev/conf.secure.yaml
@@ -22,13 +22,13 @@ auxData:
 
 audit:
   enabled: true
-  accessLogsEnabled: true
-  decisionLogsEnabled: true
-  backend: "local"
+  backend: "file"
   local:
     storagePath: /tmp/cerbos_auditlog
     advanced:
       flushInterval: 5s
+  file:
+    path: stdout
 
 tracing:
   sampleProbability: 1.0

--- a/hack/dev/plan.hurl
+++ b/hack/dev/plan.hurl
@@ -80,22 +80,28 @@ jsonpath "$.message" == "Bad request: missing principal attribute \"vip\""
 POST {{protocol}}://{{host}}:{{port}}/api/plan/resources
 Content-Type: application/json
 file,requests/plan_resources/req4.json;
-HTTP/* 400
+HTTP/* 200
 [Asserts]
 header "Content-Type" == "application/json"
-jsonpath "$.code" == 3
-jsonpath "$.message" == "Bad request: no matching policies"
+jsonpath "$.action" == "view"
+jsonpath "$.resourceKind" == "album:object"
+jsonpath "$.policyVersion" == "nonexistent"
+jsonpath "$.filter.kind" == "KIND_ALWAYS_DENIED"
+jsonpath "$.meta.filterDebug" == "NO_MATCH"
 
 
 # Plan resources request 4 (deprecated endpoint)
 POST {{protocol}}://{{host}}:{{port}}/api/x/plan/resources
 Content-Type: application/json
 file,requests/plan_resources/req4.json;
-HTTP/* 400
+HTTP/* 200
 [Asserts]
 header "Content-Type" == "application/json"
-jsonpath "$.code" == 3
-jsonpath "$.message" == "Bad request: no matching policies"
+jsonpath "$.action" == "view"
+jsonpath "$.resourceKind" == "album:object"
+jsonpath "$.policyVersion" == "nonexistent"
+jsonpath "$.filter.kind" == "KIND_ALWAYS_DENIED"
+jsonpath "$.meta.filterDebug" == "NO_MATCH"
 
 
 # Plan resources request 5 (scoped policies)

--- a/hack/dev/requests/plan_resources/req1.json
+++ b/hack/dev/requests/plan_resources/req1.json
@@ -9,6 +9,7 @@
       "manager"
     ],
     "attr": {
+      "reader": false,
       "department": "marketing",
       "managed_geographies": "GB",
       "geography": "GB",

--- a/hack/dev/requests/plan_resources/req2.json
+++ b/hack/dev/requests/plan_resources/req2.json
@@ -5,6 +5,9 @@
   "principal":  {
     "id":  "harry",
     "policyVersion":  "20210210",
+    "attr": {
+      "reader": false
+    },
     "roles":  [
       "employee"
     ]

--- a/internal/audit/conf.go
+++ b/internal/audit/conf.go
@@ -57,7 +57,7 @@ func (c *Conf) UnmarshalYAML(unmarshal func(any) error) error {
 		return fmt.Errorf("failed to marshal audit config [%v]: %w", confMap, err)
 	}
 
-	c.confHolder = confHolder{}
+	c.confHolder = confHolder{AccessLogsEnabled: true, DecisionLogsEnabled: true}
 	return yaml.Unmarshal(yamlBytes, &c.confHolder)
 }
 

--- a/internal/audit/conf_test.go
+++ b/internal/audit/conf_test.go
@@ -12,24 +12,54 @@ import (
 	"github.com/cerbos/cerbos/internal/config"
 )
 
-func TestLenientConfigLoad(t *testing.T) {
-	conf := map[string]any{
-		"audit": map[string]any{
-			"enabled": true,
-			"backend": "local",
-			"local": map[string]any{
-				"storagePath": t.TempDir(),
+func TestConfigLoad(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		conf := map[string]any{
+			"audit": map[string]any{
+				"enabled": true,
+				"backend": "local",
+				"local": map[string]any{
+					"storagePath": t.TempDir(),
+				},
+				"wibble": "wobble",
 			},
-			"wibble": "wobble",
-		},
-	}
+		}
 
-	require.NoError(t, config.LoadMap(conf))
+		require.NoError(t, config.LoadMap(conf))
 
-	c := &audit.Conf{}
-	err := config.GetSection(c)
+		c := &audit.Conf{}
+		err := config.GetSection(c)
 
-	require.NoError(t, err)
-	require.True(t, c.Enabled)
-	require.Equal(t, "local", c.Backend)
+		require.NoError(t, err)
+		require.True(t, c.Enabled)
+		require.True(t, c.AccessLogsEnabled)
+		require.True(t, c.DecisionLogsEnabled)
+		require.Equal(t, "local", c.Backend)
+	})
+
+	t.Run("overrides", func(t *testing.T) {
+		conf := map[string]any{
+			"audit": map[string]any{
+				"enabled":             true,
+				"accessLogsEnabled":   false,
+				"decisionLogsEnabled": false,
+				"backend":             "file",
+				"file": map[string]any{
+					"path": "stdout",
+				},
+				"wibble": "wobble",
+			},
+		}
+
+		require.NoError(t, config.LoadMap(conf))
+
+		c := &audit.Conf{}
+		err := config.GetSection(c)
+
+		require.NoError(t, err)
+		require.True(t, c.Enabled)
+		require.False(t, c.AccessLogsEnabled)
+		require.False(t, c.DecisionLogsEnabled)
+		require.Equal(t, "file", c.Backend)
+	})
 }


### PR DESCRIPTION
Audit conf needs to be parsed leniently (to ignore unknown fields) because it can have different backend configurations. Because of this, the `SetDefaults` method does not get called correctly -- resulting in the defaults for `accessLogsEnabled` and `decisionLogsEnabled` not being set.

This patch sets the defaults before unmarshaling to fix the above problem.