### PR TITLE
enhancement: Expand aliases in PlanResources output

### DIFF
--- a/internal/conditions/cel.go
+++ b/internal/conditions/cel.go
@@ -5,6 +5,7 @@ package conditions
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker/decls"
@@ -100,6 +101,26 @@ func ResourceAttributeNames(s string) []string {
 		fmt.Sprintf("%s.%s.%s", CELResourceAbbrev, CELAttrField, s),     // R.attr.<s>
 		fmt.Sprintf("%s.%s.%s", Fqn(CELResourceField), CELAttrField, s), // request.resource.attr.<s>
 	}
+}
+
+func ExpandAbbrev(s string) string {
+	prefix, rest, ok := strings.Cut(s, ".")
+
+	expanded := prefix
+	switch prefix {
+	case CELPrincipalAbbrev:
+		expanded = Fqn(CELPrincipalField)
+	case CELResourceAbbrev:
+		expanded = Fqn(CELResourceField)
+	case CELVariablesAbbrev:
+		expanded = CELVariablesIdent
+	}
+
+	if ok {
+		return fmt.Sprintf("%s.%s", expanded, rest)
+	}
+
+	return expanded
 }
 
 func newCELQueryPlanEnvOptions() []cel.EnvOption {

--- a/internal/conditions/cel_test.go
+++ b/internal/conditions/cel_test.go
@@ -14,3 +14,46 @@ func TestResourceAttributeNames(t *testing.T) {
 	fqns := ResourceAttributeNames(name)
 	require.Equal(t, []string{"R.attr.a", "request.resource.attr.a"}, fqns)
 }
+
+func TestExpandAbbrev(t *testing.T) {
+	testCases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "R",
+			want:  "request.resource",
+		},
+		{
+			input: "P",
+			want:  "request.principal",
+		},
+		{
+			input: "V",
+			want:  "variables",
+		},
+		{
+			input: "R.attr.department",
+			want:  "request.resource.attr.department",
+		},
+		{
+			input: "P.attr.department",
+			want:  "request.principal.attr.department",
+		},
+		{
+			input: "V.is_admin",
+			want:  "variables.is_admin",
+		},
+		{
+			input: "request.principal.attr.department",
+			want:  "request.principal.attr.department",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			have := ExpandAbbrev(tc.input)
+			require.Equal(t, tc.want, have)
+		})
+	}
+}

--- a/internal/test/testdata/query_planner/suite/harry.yaml
+++ b/internal/test/testdata/query_planner/suite/harry.yaml
@@ -17,7 +17,7 @@ tests:
         expression:
           operator: eq
           operands:
-            - variable: R.attr.owner
+            - variable: request.resource.attr.owner
             - value: harry
   - action: view:refer-derived-role
     resource:

--- a/internal/test/testdata/query_planner/suite/macro_user.yaml
+++ b/internal/test/testdata/query_planner/suite/macro_user.yaml
@@ -25,7 +25,7 @@ tests:
             - expression:
                 operator: map
                 operands:
-                  - variable: R.attr.geos
+                  - variable: request.resource.attr.geos
                   - expression:
                       operator: lambda
                       operands:
@@ -48,7 +48,7 @@ tests:
             - expression:
                 operator: filter
                 operands:
-                  - variable: R.attr.geos
+                  - variable: request.resource.attr.geos
                   - expression:
                       operator: lambda
                       operands:
@@ -68,7 +68,7 @@ tests:
         expression:
           operator: all
           operands:
-            - variable: R.attr.geos
+            - variable: request.resource.attr.geos
             - expression:
                 operator: lambda
                 operands:
@@ -88,7 +88,7 @@ tests:
         expression:
           operator: exists
           operands:
-            - variable: R.attr.geos
+            - variable: request.resource.attr.geos
             - expression:
                 operator: lambda
                 operands:
@@ -108,7 +108,7 @@ tests:
         expression:
           operator: exists_one
           operands:
-            - variable: R.attr.geos
+            - variable: request.resource.attr.geos
             - expression:
                 operator: lambda
                 operands:
@@ -128,7 +128,7 @@ tests:
         expression:
           operator: all
           operands:
-            - variable: R.attr.geos
+            - variable: request.resource.attr.geos
             - expression:
                 operator: lambda
                 operands:
@@ -161,7 +161,7 @@ tests:
         expression:
           operator: all
           operands:
-            - variable: R.attr.sessions
+            - variable: request.resource.attr.sessions
             - expression:
                 operator: lambda
                 operands:

--- a/internal/test/testdata/query_planner/suite/maggie.yaml
+++ b/internal/test/testdata/query_planner/suite/maggie.yaml
@@ -41,12 +41,12 @@ tests:
                             - expression:
                                   operator: eq
                                   operands:
-                                      - variable: R.attr.status
+                                      - variable: request.resource.attr.status
                                       - value: "PENDING_APPROVAL"
                             - expression:
                                   operator: ne
                                   operands:
-                                      - variable: R.attr.owner
+                                      - variable: request.resource.attr.owner
                                       - value: "maggie"
 
     - action: "report:deny-deny"
@@ -62,11 +62,11 @@ tests:
               - expression:
                   operator: not
                   operands:
-                    - variable: R.attr.deleted
+                    - variable: request.resource.attr.deleted
               - expression:
                   operator: not
                   operands:
-                    - variable: R.attr.hidden
+                    - variable: request.resource.attr.hidden
 
     - action: "report:deny"
       resource:
@@ -78,7 +78,7 @@ tests:
           expression:
             operator: not
             operands:
-              - variable: R.attr.deleted
+              - variable: request.resource.attr.deleted
 
     - action: "approve:true-in-both-or-and-conditions"
       resource:
@@ -93,12 +93,12 @@ tests:
               - expression:
                   operator: eq
                   operands:
-                    - variable: R.attr.status
+                    - variable: request.resource.attr.status
                     - value: "PENDING_APPROVAL"
               - expression:
                   operator: ne
                   operands:
-                    - variable: R.attr.owner
+                    - variable: request.resource.attr.owner
                     - value: "maggie"
 
     - action: "approve:allow-allow-deny"
@@ -117,7 +117,7 @@ tests:
                     - expression:
                         operator: eq
                         operands:
-                          - variable: R.attr.owner
+                          - variable: request.resource.attr.owner
                           - value: "maggie"
               - expression:
                   operator: or
@@ -125,12 +125,12 @@ tests:
                     - expression:
                         operator: eq
                         operands:
-                          - variable: R.attr.status
+                          - variable: request.resource.attr.status
                           - value: "PENDING_APPROVAL"
                     - expression:
                         operator: eq
                         operands:
-                          - variable: R.attr.geography
+                          - variable: request.resource.attr.geography
                           - value: "US"
     - action: "approve:allow-allow"
       resource:
@@ -145,12 +145,12 @@ tests:
               - expression:
                   operator: eq
                   operands:
-                    - variable: R.attr.status
+                    - variable: request.resource.attr.status
                     - value: "PENDING_APPROVAL"
               - expression:
                   operator: eq
                   operands:
-                    - variable: R.attr.geography
+                    - variable: request.resource.attr.geography
                     - value: "US"
 
     - action: "approve:allow-deny"
@@ -169,12 +169,12 @@ tests:
                   - expression:
                       operator: eq
                       operands:
-                        - variable: R.attr.owner
+                        - variable: request.resource.attr.owner
                         - value: "maggie"
               - expression:
                   operator: eq
                   operands:
-                    - variable: R.attr.status
+                    - variable: request.resource.attr.status
                     - value: "PENDING_APPROVAL"
 
     - action: "approve:false-in-and-condition"
@@ -200,7 +200,7 @@ tests:
                     - expression:
                         operator: in
                         operands:
-                          - variable: R.attr.team
+                          - variable: request.resource.attr.team
                           - value: ["A", "B"]
               - expression:
                   operator: not
@@ -208,7 +208,7 @@ tests:
                     - expression:
                         operator: lt
                         operands:
-                          - variable: R.attr.GPA
+                          - variable: request.resource.attr.GPA
                           - value: 4.7
 
     - action: "approve:with-jwt"
@@ -221,7 +221,7 @@ tests:
           expression:
             operator: eq
             operands:
-              - variable: R.attr.groupID
+              - variable: request.resource.attr.groupID
               - value: 42
     - action: "approve:refer-derived-role"
       resource:
@@ -238,12 +238,12 @@ tests:
               - expression:
                   operator: eq
                   operands:
-                    - variable: R.attr.status
+                    - variable: request.resource.attr.status
                     - value: "PENDING_APPROVAL"
               - expression:
                   operator: ne
                   operands:
-                    - variable: R.attr.owner
+                    - variable: request.resource.attr.owner
                     - value: "maggie"
     - action: "approve"
       resource:
@@ -260,12 +260,12 @@ tests:
               - expression:
                   operator: eq
                   operands:
-                    - variable: R.attr.status
+                    - variable: request.resource.attr.status
                     - value: "PENDING_APPROVAL"
               - expression:
                   operator: ne
                   operands:
-                    - variable: R.attr.owner
+                    - variable: request.resource.attr.owner
                     - value: "maggie"
     - action: "approve"
       resource:
@@ -280,5 +280,5 @@ tests:
           expression:
             operator: eq
             operands:
-              - variable: R.attr.status
+              - variable: request.resource.attr.status
               - value: "PENDING_APPROVAL"

--- a/internal/test/testdata/server/plan_resources/plan_case_01_acme.hr.uk.yaml
+++ b/internal/test/testdata/server/plan_resources/plan_case_01_acme.hr.uk.yaml
@@ -37,7 +37,7 @@ planResources:
         "expression": {
           "operator": "eq",
           "operands": [
-            { "variable": "R.attr.owner" },
+            { "variable": "request.resource.attr.owner" },
             { "value": "harry"}
           ]
         }

--- a/internal/test/testdata/server/plan_resources/plan_case_02_acme.hr.yaml
+++ b/internal/test/testdata/server/plan_resources/plan_case_02_acme.hr.yaml
@@ -37,7 +37,7 @@ planResources:
         "expression": {
           "operator": "eq",
           "operands": [
-            { "variable": "R.attr.owner" },
+            { "variable": "request.resource.attr.owner" },
             { "value": "harry"}
           ]
         }


### PR DESCRIPTION
Expands aliases like `R` into their full form (`request.resource`) so
that regardless of the expression used in the policy, the PlanResources
output is always predictable.

Also implements some simple optimisations like converting `X && true`
into `X` or `X || false` into `false`.

Fixes #962
Fixes #874

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
