### PR TITLE
chore(test): Update Minio config in tests

### DIFF
--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -29,7 +29,7 @@ stop_kind() {
 run_tests() {
     (
         cd "$SCRIPT_DIR"
-        telepresence connect --no-report -- go test -v -failfast -p=2 --tags="tests e2e" "$@"
+        telepresence connect --no-report -- go test -v -failfast -p=1 --tags="tests e2e" "$@"
     )
 }
 
@@ -41,5 +41,5 @@ if [[ "$#" -gt "0" ]]; then
     # E.g. e2e/run.sh ./mysql/... -args -run-id=xxxxx -no-cleanup
     run_tests "$@"
 else
-    run_tests ./... -args -no-cleanup="$E2E_NO_CLEANUP"
+    run_tests ./... -args -no-cleanup="$E2E_NO_CLEANUP" -command-timeout=4m
 fi


### PR DESCRIPTION
The blob store tests have started failing because the new release of
Minio container is checking the data directory for IO-DIRECT access.
Switching to the default `/data` directory seems to fix this issue.

In addition, the healthcheck should be using the readiness probe instead
of the liveness probe because sometimes the server is not yet ready to
accept connections even if it is up.

Also reduces the parallelism in E2E test runs because lately they have
been failing -- possibly due to resource contention.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
