### PR TITLE
enhancement: Support auto-propagation for traces

### DIFF
--- a/docs/modules/configuration/pages/tracing.adoc
+++ b/docs/modules/configuration/pages/tracing.adoc
@@ -11,18 +11,6 @@ The system to export the trace data must be specified using the `exporter` setti
 ****
 link:https://opentelemetry.io[OpenTelemetry] is the evolving standard for observability. Cerbos supports OpenTelemetry with a few caveats due to limitations in the current Go implementation of OpenTelemetry. 
 
-* Traces must be in one of `W3C Trace Context` or `B3` propagation formats in order for distributed tracing to work. You must configure this using `tracing.propagationFormat` configuration key (see below). The default is `w3c-tracecontext`.
-+
-In Go applications, the propagation format can be set using one of the following code snippets. For other languages, refer to the relevant OpenTelemetry library documentation.
-+
-[source,go]
-----
-// W3C Trace Context
-otel.SetTextMapPropagator(propagation.TraceContext{})
-
-// B3 
-otel.SetTextMapPropagator(b3.New(b3.WithInjectEncoding(b3.B3MultipleHeader | b3.B3SingleHeader)))
-----
 
 * gRPC clients should use the link:https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/propagators/opencensus[OpenCensus binary propagation format] for distributed traces.
 
@@ -37,7 +25,6 @@ otel.SetTextMapPropagator(b3.New(b3.WithInjectEncoding(b3.B3MultipleHeader | b3.
 ----
 tracing:
   sampleProbability: 0.5
-  propagationFormat: b3
   exporter: jaeger
   jaeger: 
     serviceName: cerbos 

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,9 @@ require (
 	github.com/tidwall/sjson v1.2.4
 	go.elastic.co/ecszap v1.0.1
 	go.opencensus.io v0.23.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.32.0
+	go.opentelemetry.io/contrib/propagators/autoprop v0.0.0-20220603191935-427146bc07f1
+	go.opentelemetry.io/contrib/propagators/b3 v1.7.0
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/bridge/opencensus v0.30.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.7.0
@@ -131,6 +134,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
@@ -218,6 +222,9 @@ require (
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
+	go.opentelemetry.io/contrib/propagators/aws v1.7.0 // indirect
+	go.opentelemetry.io/contrib/propagators/jaeger v1.7.0 // indirect
+	go.opentelemetry.io/contrib/propagators/ot v1.7.0 // indirect
 	go.opentelemetry.io/otel/metric v0.30.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v0.30.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -586,6 +586,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
+github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fergusstrange/embedded-postgres v1.15.0 h1:9H5c8Xzp+8nXuEpXKkUPpSyhj7PNZ2QmO/FIus8VYp0=
 github.com/fergusstrange/embedded-postgres v1.15.0/go.mod h1:VqymgzpNsdJspJeISq4+jpqWL1FOrqIzt9o78W5ekkw=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
@@ -1613,6 +1615,18 @@ go.opentelemetry.io/contrib v0.20.0/go.mod h1:G/EtFaa6qaN7+LxqfIAT3GiZa7Wv5DTBUz
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0/go.mod h1:oVGt1LRbBOBq1A5BQLlUg9UaU/54aiHw8cgjV3aWZ/E=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.28.0/go.mod h1:vEhqr0m4eTc+DWxfsXoXue2GBgV2uUwVznkGIHW/e5w=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0/go.mod h1:2AboqHi0CiIZU0qwhtUfCYD1GeUzvvIXWNkhDt7ZMG4=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.32.0 h1:mac9BKRqwaX6zxHPDe3pvmWpwuuIM0vuXv2juCnQevE=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.32.0/go.mod h1:5eCOqeGphOyz6TsY3ZDNjE33SM/TFAK3RGuCL2naTgY=
+go.opentelemetry.io/contrib/propagators/autoprop v0.0.0-20220603191935-427146bc07f1 h1:Xe0m4KIkEvLefnOA8MGdL5T9n7CjlpwObZUogte87yQ=
+go.opentelemetry.io/contrib/propagators/autoprop v0.0.0-20220603191935-427146bc07f1/go.mod h1:bZh9hrevMnml/lSGrnChXbzOUxFNUAYc24XoEXUG15A=
+go.opentelemetry.io/contrib/propagators/aws v1.7.0 h1:hzLtX+K4YhsrBabA35uBYxCENb5rS/9Z9X8MToTlA3k=
+go.opentelemetry.io/contrib/propagators/aws v1.7.0/go.mod h1:h/ql5T6e1XLRFplWNNdzLHp8eb0dkBu+xYOCYxerh0Q=
+go.opentelemetry.io/contrib/propagators/b3 v1.7.0 h1:oRAenUhj+GFttfIp3gj7HYVzBhPOHgq/dWPDSmLCXSY=
+go.opentelemetry.io/contrib/propagators/b3 v1.7.0/go.mod h1:gXx7AhL4xXCF42gpm9dQvdohoDa2qeyEx4eIIxqK+h4=
+go.opentelemetry.io/contrib/propagators/jaeger v1.7.0 h1:x2mXKtONfOJFfNFSx4QXFx1fms6bKIPVvWvgdiaPdRI=
+go.opentelemetry.io/contrib/propagators/jaeger v1.7.0/go.mod h1:kt2lNImfxV6dETRsDCENd6jU6G0mPRS+P0qlNuvtkTE=
+go.opentelemetry.io/contrib/propagators/ot v1.7.0 h1:KPPToDRxyY/HI3qD4RqwWRbaQ65RIpF8uKWDqWkFHDA=
+go.opentelemetry.io/contrib/propagators/ot v1.7.0/go.mod h1:5qxBZR730yb71uXc3bazxt2Si8o8LQK3iJTnSLca/BU=
 go.opentelemetry.io/otel v0.20.0/go.mod h1:Y3ugLH2oa81t5QO+Lty+zXf8zC9L26ax4Nzoxm/dooo=
 go.opentelemetry.io/otel v1.3.0/go.mod h1:PWIKzi6JCp7sM0k9yZ43VX+T345uNbAkDKwHVjb2PTs=
 go.opentelemetry.io/otel v1.7.0 h1:Z2lA3Tdch0iDcrhJXDIlC94XE+bxok1F9B+4Lz/lGsM=

--- a/internal/observability/tracing/conf.go
+++ b/internal/observability/tracing/conf.go
@@ -22,7 +22,7 @@ var (
 type Conf struct {
 	// Jaeger configures the Jaeger exporter.
 	Jaeger *JaegerConf `yaml:"jaeger"`
-	// [Deprecated] PropagationFormat is the trace propagation format to use. Valid values are w3c-tracecontext or b3.
+	// [Deprecated] PropagationFormat is no longer used. Traces in trace-context, baggage, or b3 formats are automatically detected and propagated.
 	PropagationFormat string `yaml:"propagationFormat" conf:",ignore"`
 	// Exporter is the type of trace exporter to use.
 	Exporter string `yaml:"exporter" conf:",example=jaeger"`

--- a/internal/observability/tracing/conf.go
+++ b/internal/observability/tracing/conf.go
@@ -9,10 +9,8 @@ import (
 )
 
 const (
-	confKey                    = "tracing"
-	jaegerExporter             = "jaeger"
-	propagationW3CTraceContext = "w3c-tracecontext"
-	propagationB3              = "b3"
+	confKey        = "tracing"
+	jaegerExporter = "jaeger"
 )
 
 var (
@@ -24,7 +22,7 @@ var (
 type Conf struct {
 	// Jaeger configures the Jaeger exporter.
 	Jaeger *JaegerConf `yaml:"jaeger"`
-	// PropagationFormat is the trace propagation format to use. Valid values are w3c-tracecontext or b3.
+	// [Deprecated] PropagationFormat is the trace propagation format to use. Valid values are w3c-tracecontext or b3.
 	PropagationFormat string `yaml:"propagationFormat" conf:",ignore"`
 	// Exporter is the type of trace exporter to use.
 	Exporter string `yaml:"exporter" conf:",example=jaeger"`
@@ -45,15 +43,7 @@ func (c *Conf) Key() string {
 	return confKey
 }
 
-func (c *Conf) SetDefaults() {
-	c.PropagationFormat = propagationW3CTraceContext
-}
-
 func (c *Conf) Validate() error {
-	if c.PropagationFormat != propagationW3CTraceContext && c.PropagationFormat != propagationB3 {
-		return fmt.Errorf("unsupported propagation format %q: valid values are %q or %q", c.PropagationFormat, propagationW3CTraceContext, propagationB3)
-	}
-
 	switch c.Exporter {
 	case "":
 		return nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -463,10 +463,10 @@ func (s *Server) startHTTPServer(ctx context.Context, l net.Listener, grpcSrv *g
 	// handle gRPC requests that come over http
 	cerbosMux.MatcherFunc(func(r *http.Request, _ *mux.RouteMatch) bool {
 		return r.ProtoMajor == 2 && strings.Contains(r.Header.Get("Content-Type"), "application/grpc")
-	}).Handler(tracing.HTTPHandler(grpcSrv))
+	}).Handler(tracing.HTTPHandler(grpcSrv, "grpc"))
 
-	cerbosMux.PathPrefix(adminEndpoint).Handler(tracing.HTTPHandler(prettyJSON(gwmux)))
-	cerbosMux.PathPrefix(apiEndpoint).Handler(tracing.HTTPHandler(prettyJSON(gwmux)))
+	cerbosMux.PathPrefix(adminEndpoint).Handler(tracing.HTTPHandler(prettyJSON(gwmux), adminEndpoint))
+	cerbosMux.PathPrefix(apiEndpoint).Handler(tracing.HTTPHandler(prettyJSON(gwmux), apiEndpoint))
 	cerbosMux.Path(healthEndpoint).Handler(prettyJSON(gwmux))
 	cerbosMux.Path(schemaEndpoint).HandlerFunc(schema.ServeSvcSwagger)
 


### PR DESCRIPTION
Allows the HTTP server to automatically detect and handle traces
propagated using different formats. Supports trace-context, baggage and
b3 by default. Can be overridden using the OTEL_PROPAGATORS environment
variable.

Fixes #967

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
