### PR TITLE
fix: Ignore test files when updating index from git

### DIFF
--- a/internal/storage/git/store.go
+++ b/internal/storage/git/store.go
@@ -438,6 +438,11 @@ func (s *Store) applyIndexUpdate(ce object.ChangeEntry, eventKind storage.EventK
 		return nil
 	}
 
+	if util.IsSupportedTestFile(ce.Name) {
+		s.log.Infow("Ignoring test file", "path", ce.Name)
+		return nil
+	}
+
 	idxFn := s.idx.Delete
 	entry := index.Entry{File: ce.Name}
 


### PR DESCRIPTION
Fixes #984 

The git store currently only ignores test files on the initial load - index updates attempt to read tests as policies, causing an unmarshalling error.

This PR ignores test files in index updates as well.