### PR TITLE
docs: Add new JavaScript SDK

### DIFF
--- a/docs/modules/api/assets/images/javascript.svg
+++ b/docs/modules/api/assets/images/javascript.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a70a3d8d36ea6b0e614a04ec30d5a4fb2bf36d515492cb84050ded2b84d14393
+size 2325

--- a/docs/modules/api/pages/index.adoc
+++ b/docs/modules/api/pages/index.adoc
@@ -20,7 +20,7 @@ Alternatively, you can explore the API using the following methods as well:
 
 * link:https://pkg.go.dev/github.com/cerbos/cerbos/client[Go] image:go.svg[alt="Go",opts="interactive",width=40,height=40,link="https://pkg.go.dev/github.com/cerbos/cerbos/client"] 
 * link:https://github.com/cerbos/cerbos-sdk-java[Java] image:java.svg[alt="Java",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-java"]
-* link:https://github.com/cerbos/cerbos-sdk-node[NodeJS] image:nodejs.svg[alt="NodeJS",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-node"]
+* link:https://github.com/cerbos/cerbos-sdk-javascript[JavaScript] image:javascript.svg[alt="JavaScript",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-javascript"]
 * link:https://github.com/cerbos/cerbos-sdk-python[Python] image:python.svg[alt="Python",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-python"]
 * link:https://github.com/cerbos/cerbos-sdk-ruby[Ruby] image:ruby.svg[alt="Ruby",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-ruby"]
 * link:https://github.com/cerbos/cerbos-sdk-rust[Rust] image:rust.svg[alt="Rust",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-rust"]

--- a/docs/modules/api/pages/index.adoc
+++ b/docs/modules/api/pages/index.adoc
@@ -18,12 +18,12 @@ Alternatively, you can explore the API using the following methods as well:
 
 == Client SDKs
 
-* link:https://pkg.go.dev/github.com/cerbos/cerbos/client[Go] image:go.svg[alt="Go",opts="interactive",width=40,height=40,link="https://pkg.go.dev/github.com/cerbos/cerbos/client"] 
-* link:https://github.com/cerbos/cerbos-sdk-java[Java] image:java.svg[alt="Java",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-java"]
-* link:https://github.com/cerbos/cerbos-sdk-javascript[JavaScript] image:javascript.svg[alt="JavaScript",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-javascript"]
-* link:https://github.com/cerbos/cerbos-sdk-python[Python] image:python.svg[alt="Python",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-python"]
-* link:https://github.com/cerbos/cerbos-sdk-ruby[Ruby] image:ruby.svg[alt="Ruby",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-ruby"]
-* link:https://github.com/cerbos/cerbos-sdk-rust[Rust] image:rust.svg[alt="Rust",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-rust"]
+* image:go.svg[alt="Go",width=40,height=40,link="https://pkg.go.dev/github.com/cerbos/cerbos/client"]link:https://pkg.go.dev/github.com/cerbos/cerbos/client[&ensp;Go]
+* image:java.svg[alt="Java",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-java"]link:https://github.com/cerbos/cerbos-sdk-java[&ensp;Java]
+* image:javascript.svg[alt="JavaScript",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-javascript"]link:https://github.com/cerbos/cerbos-sdk-javascript[&ensp;JavaScript]
+* image:python.svg[alt="Python",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-python"]link:https://github.com/cerbos/cerbos-sdk-python[&ensp;Python]
+* image:ruby.svg[alt="Ruby",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-ruby"]link:https://github.com/cerbos/cerbos-sdk-ruby[&ensp;Ruby]
+* image:rust.svg[alt="Rust",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-rust"]link:https://github.com/cerbos/cerbos-sdk-rust[&ensp;Rust]
 
 Other languages coming soon
 


### PR DESCRIPTION
This PR replaces references to the old Node.js SDK with the new JavaScript one.

It also swaps the order of the logos and text so that they align neatly, and removes the `interactive` option from the SVGs so that the links work (when embedded as `<object>` elements with `interactive`, the surrounding `<a>` doesn't get cursor focus).

<img width="241" alt="Screenshot 2022-06-07 at 17 12 28" src="https://user-images.githubusercontent.com/785641/172430581-31599a22-27a3-4ed3-9fb7-3d667c08788f.png">
