### PR TITLE
docs(backport): Add new JavaScript SDK (#986)

### DIFF
--- a/docs/modules/api/assets/images/javascript.svg
+++ b/docs/modules/api/assets/images/javascript.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a70a3d8d36ea6b0e614a04ec30d5a4fb2bf36d515492cb84050ded2b84d14393
+size 2325

--- a/docs/modules/api/pages/index.adoc
+++ b/docs/modules/api/pages/index.adoc
@@ -18,12 +18,12 @@ Alternatively, you can explore the API using the following methods as well:
 
 == Client SDKs
 
-* link:https://pkg.go.dev/github.com/cerbos/cerbos/client[Go] image:go.svg[alt="Go",opts="interactive",width=40,height=40,link="https://pkg.go.dev/github.com/cerbos/cerbos/client"] 
-* link:https://github.com/cerbos/cerbos-sdk-java[Java] image:java.svg[alt="Java",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-java"]
-* link:https://github.com/cerbos/cerbos-sdk-node[NodeJS] image:nodejs.svg[alt="NodeJS",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-node"]
-* link:https://github.com/cerbos/cerbos-sdk-python[Python] image:python.svg[alt="Python",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-python"]
-* link:https://github.com/cerbos/cerbos-sdk-ruby[Ruby] image:ruby.svg[alt="Ruby",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-ruby"]
-* link:https://github.com/cerbos/cerbos-sdk-rust[Rust] image:rust.svg[alt="Rust",opts="interactive",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-rust"]
+* image:go.svg[alt="Go",width=40,height=40,link="https://pkg.go.dev/github.com/cerbos/cerbos/client"]link:https://pkg.go.dev/github.com/cerbos/cerbos/client[&ensp;Go]
+* image:java.svg[alt="Java",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-java"]link:https://github.com/cerbos/cerbos-sdk-java[&ensp;Java]
+* image:javascript.svg[alt="JavaScript",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-javascript"]link:https://github.com/cerbos/cerbos-sdk-javascript[&ensp;JavaScript]
+* image:python.svg[alt="Python",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-python"]link:https://github.com/cerbos/cerbos-sdk-python[&ensp;Python]
+* image:ruby.svg[alt="Ruby",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-ruby"]link:https://github.com/cerbos/cerbos-sdk-ruby[&ensp;Ruby]
+* image:rust.svg[alt="Rust",width=40,height=40,link="https://github.com/cerbos/cerbos-sdk-rust"]link:https://github.com/cerbos/cerbos-sdk-rust[&ensp;Rust]
 
 Other languages coming soon
 


### PR DESCRIPTION
Backports #986 to add the new JavaScript SDK to the v0.17 docs.