### PR TITLE
enhancement: Add store polling metrics

### DIFF
--- a/internal/observability/metrics/metrics.go
+++ b/internal/observability/metrics/metrics.go
@@ -37,6 +37,9 @@ var (
 	KeyCompileStatus        = tag.MustNewKey("status")
 	KeyEngineDecisionStatus = tag.MustNewKey("status")
 	KeyEnginePlanStatus     = tag.MustNewKey("status")
+	KeyIndexCRUDKind        = tag.MustNewKey("kind")
+	KeyStoreDriver          = tag.MustNewKey("driver")
+	KeyStorePollStatus      = tag.MustNewKey("status")
 )
 
 var (
@@ -111,6 +114,18 @@ var (
 		Aggregation: defaultLatencyDistribution(),
 	}
 
+	IndexCRUDCount = stats.Int64(
+		"cerbos.dev/index/crud_count",
+		"Number of create/update/delete operations",
+		stats.UnitDimensionless,
+	)
+
+	IndexCRUDCountView = &view.View{
+		Measure:     IndexCRUDCount,
+		TagKeys:     []tag.Key{KeyIndexCRUDKind},
+		Aggregation: view.Count(),
+	}
+
 	IndexEntryCount = stats.Int64(
 		"cerbos.dev/index/entry_count",
 		"Number of entries in the index",
@@ -121,6 +136,18 @@ var (
 		Measure:     IndexEntryCount,
 		Aggregation: view.LastValue(),
 	}
+
+	StorePollCount = stats.Int64(
+		"cerbos.dev/store/poll_count",
+		"Number of times the store was polled for updates",
+		stats.UnitDimensionless,
+	)
+
+	StorePollCountView = &view.View{
+		Measure:     StorePollCount,
+		TagKeys:     []tag.Key{KeyStoreDriver, KeyStorePollStatus},
+		Aggregation: view.Count(),
+	}
 )
 
 var DefaultCerbosViews = []*view.View{
@@ -130,7 +157,9 @@ var DefaultCerbosViews = []*view.View{
 	EngineCheckLatencyView,
 	EngineCheckBatchSizeView,
 	EnginePlanLatencyView,
+	IndexCRUDCountView,
 	IndexEntryCountView,
+	StorePollCountView,
 }
 
 func defaultLatencyDistribution() *view.Aggregation {

--- a/internal/observability/metrics/metrics.go
+++ b/internal/observability/metrics/metrics.go
@@ -39,7 +39,6 @@ var (
 	KeyEnginePlanStatus     = tag.MustNewKey("status")
 	KeyIndexCRUDKind        = tag.MustNewKey("kind")
 	KeyStoreDriver          = tag.MustNewKey("driver")
-	KeyStorePollStatus      = tag.MustNewKey("status")
 )
 
 var (
@@ -139,13 +138,25 @@ var (
 
 	StorePollCount = stats.Int64(
 		"cerbos.dev/store/poll_count",
-		"Number of times the store was polled for updates",
+		"Number of times the remote store was polled for updates",
 		stats.UnitDimensionless,
 	)
 
 	StorePollCountView = &view.View{
 		Measure:     StorePollCount,
-		TagKeys:     []tag.Key{KeyStoreDriver, KeyStorePollStatus},
+		TagKeys:     []tag.Key{KeyStoreDriver},
+		Aggregation: view.Count(),
+	}
+
+	StoreSyncErrorCount = stats.Int64(
+		"cerbos.dev/store/sync_error_count",
+		"Number of errors encountered while syncing updates from the remote store",
+		stats.UnitDimensionless,
+	)
+
+	StoreSyncErrorCountView = &view.View{
+		Measure:     StoreSyncErrorCount,
+		TagKeys:     []tag.Key{KeyStoreDriver},
 		Aggregation: view.Count(),
 	}
 )
@@ -160,6 +171,7 @@ var DefaultCerbosViews = []*view.View{
 	IndexCRUDCountView,
 	IndexEntryCountView,
 	StorePollCountView,
+	StoreSyncErrorCountView,
 }
 
 func defaultLatencyDistribution() *view.Aggregation {

--- a/internal/storage/blob/store.go
+++ b/internal/storage/blob/store.go
@@ -296,15 +296,15 @@ func (s *Store) pollForUpdates(ctx context.Context) {
 			s.log.Info("Stopped polling for updates")
 			return
 		case <-ticker.C:
-			status := "success"
 			if err := s.updateIndex(ctx); err != nil {
-				status = "failure"
 				s.log.Errorw("Failed to check for updates", "error", err)
+				_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+					tag.Upsert(metrics.KeyStoreDriver, DriverName),
+				}, metrics.StoreSyncErrorCount.M(1))
 			}
 
 			_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
 				tag.Upsert(metrics.KeyStoreDriver, DriverName),
-				tag.Upsert(metrics.KeyStorePollStatus, status),
 			}, metrics.StorePollCount.M(1))
 		}
 	}

--- a/internal/storage/disk/dirwatch.go
+++ b/internal/storage/disk/dirwatch.go
@@ -13,9 +13,12 @@ import (
 	"time"
 
 	"github.com/rjeczalik/notify"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 	"go.uber.org/zap"
 
 	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
+	"github.com/cerbos/cerbos/internal/observability/metrics"
 	"github.com/cerbos/cerbos/internal/policy"
 	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage"
@@ -86,6 +89,10 @@ func (dw *dirWatch) handleEvents(ctx context.Context) {
 			dw.processEvent(evtInfo)
 		case <-ticker.C:
 			dw.triggerUpdate()
+			_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+				tag.Upsert(metrics.KeyStoreDriver, DriverName),
+				tag.Upsert(metrics.KeyStorePollStatus, "success"),
+			}, metrics.StorePollCount.M(1))
 		}
 	}
 }

--- a/internal/storage/git/store.go
+++ b/internal/storage/git/store.go
@@ -542,15 +542,15 @@ func (s *Store) pollForUpdates(ctx context.Context) {
 			s.log.Info("Stopped polling for updates")
 			return
 		case <-ticker.C:
-			status := "success"
 			if err := s.updateIndex(ctx); err != nil {
 				s.log.Errorw("Failed to check for updates", "error", err)
-				status = "failure"
+				_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+					tag.Upsert(metrics.KeyStoreDriver, DriverName),
+				}, metrics.StoreSyncErrorCount.M(1))
 			}
 
 			_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
 				tag.Upsert(metrics.KeyStoreDriver, DriverName),
-				tag.Upsert(metrics.KeyStorePollStatus, status),
 			}, metrics.StorePollCount.M(1))
 		}
 	}


### PR DESCRIPTION
Increments a counter each time a store is polled for updates and records
the success or failure status.

Also adds counters for CRUD operations.

Fixes #987

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
