### PR TITLE
fix: Respect `WithRootDir` option in `(Index).ListSchemaIDs`

### DIFF
--- a/internal/storage/index/index_test.go
+++ b/internal/storage/index/index_test.go
@@ -65,6 +65,24 @@ func TestIndexLoadPolicy(t *testing.T) {
 	})
 }
 
+func TestIndexListSchemaIDs(t *testing.T) {
+	ctx := context.Background()
+	fsys := os.DirFS(test.PathToDir(t, "."))
+
+	idx, err := index.Build(ctx, fsys, index.WithRootDir("store"))
+	require.NoError(t, err)
+
+	ids, err := idx.ListSchemaIDs(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{
+		"leave_request.json",
+		"principal.json",
+		"purchase_order.json",
+		"salary_record.json",
+	}, ids)
+}
+
 // mkListOfFiles generates a list of policy files under the given filesystem and returns the list.
 func mkListOfFiles(t *testing.T, dir, base string) []string {
 	t.Helper()

--- a/internal/storage/index/schema.go
+++ b/internal/storage/index/schema.go
@@ -5,6 +5,7 @@ package index
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/fs"
 	"path/filepath"
@@ -25,6 +26,28 @@ func NewSchemaLoader(fsys fs.FS, rootDir string) *SchemaLoader {
 	}
 
 	return &SchemaLoader{fsys: schemaFS}
+}
+
+func (sl *SchemaLoader) ListIDs(_ context.Context) ([]string, error) {
+	var schemaIds []string
+	err := fs.WalkDir(sl.fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		schemaIds = append(schemaIds, path)
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk schemas directory: %w", err)
+	}
+
+	return schemaIds, nil
 }
 
 func (sl *SchemaLoader) Load(_ context.Context, id string) (io.ReadCloser, error) {


### PR DESCRIPTION
The `ListSchemaIDs` method currently assumes that schemas are located in `./_schemas`, but the index's filesystem is not rooted at the policies directory.

This PR refactors the method to delegate to the `SchemaLoader`, which is aware of the policies directory set by `WithRootDir`.