### PR TITLE
enhancement: Deduplicate operands to and/or operations

### DIFF
--- a/internal/test/testdata/server/plan_resources/plan_case_00.yaml
+++ b/internal/test/testdata/server/plan_resources/plan_case_00.yaml
@@ -38,22 +38,14 @@ planResources:
           operator: and
           operands:
             - expression:
-                operator: and
+                operator: eq
                 operands:
-                  - expression:
-                      operator: eq
-                      operands:
-                        - variable: request.resource.attr.geography
-                        - value: GB
-                  - expression:
-                      operator: eq
-                      operands:
-                        - variable: request.resource.attr.geography
-                        - value: GB
+                  - variable: request.resource.attr.geography
+                  - value: GB
             - expression:
                 operator: eq
                 operands:
                   - variable: request.resource.attr.status
                   - value: PENDING_APPROVAL
     meta:
-      filter_debug: "(and (and (eq request.resource.attr.geography \"GB\") (eq request.resource.attr.geography \"GB\")) (eq request.resource.attr.status \"PENDING_APPROVAL\"))"
+      filter_debug: "(and (eq request.resource.attr.geography \"GB\") (eq request.resource.attr.status \"PENDING_APPROVAL\"))"

--- a/internal/test/testdata/server/playground/proxy/pgp_rqp_case_00.yaml
+++ b/internal/test/testdata/server/playground/proxy/pgp_rqp_case_00.yaml
@@ -74,33 +74,13 @@ playgroundProxy:
             "operands": [
               {
                 "expression": {
-                  "operator": "and",
+                  "operator": "eq",
                   "operands": [
                     {
-                      "expression": {
-                        "operator": "eq",
-                        "operands": [
-                          {
-                            "variable": "request.resource.attr.geography"
-                          },
-                          {
-                            "value": "GB"
-                          }
-                        ]
-                      }
+                      "variable": "request.resource.attr.geography"
                     },
                     {
-                      "expression": {
-                        "operator": "eq",
-                        "operands": [
-                          {
-                            "variable": "request.resource.attr.geography"
-                          },
-                          {
-                            "value": "GB"
-                          }
-                        ]
-                      }
+                      "value": "GB"
                     }
                   ]
                 }
@@ -123,7 +103,7 @@ playgroundProxy:
         }
       },
       "meta": {
-        "filter_debug": "(and (and (eq request.resource.attr.geography \"GB\") (eq request.resource.attr.geography \"GB\")) (eq request.resource.attr.status \"PENDING_APPROVAL\"))"
+        "filter_debug": "(and (eq request.resource.attr.geography \"GB\") (eq request.resource.attr.status \"PENDING_APPROVAL\"))"
       }
     }
   }


### PR DESCRIPTION
I noticed a couple of test cases with redundant `(and x x)` clauses, thought it might be nice to optimise those out.