### PR TITLE
enhancement: Export traces via OTLP to a collector

### DIFF
--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -132,5 +132,8 @@ tracing:
   jaeger: # Jaeger configures the Jaeger exporter.
     agentEndpoint: "localhost:6831" # AgentEndpoint is the Jaeger agent endpoint to report to.
     collectorEndpoint: "http://localhost:14268/api/traces" # CollectorEndpoint is the Jaeger collector endpoint to report to.
-    serviceName: cerbos # ServiceName is the name of the service to report to Jaeger.
+    serviceName: cerbos # [Deprecated] Use top level ServiceName config. ServiceName is the name of the service to report to Jaeger.
+  otlp: # OTLP configures the OpenTelemetry exporter.
+    collectorEndpoint: "otel:4317" # CollectorEndpoint is the Open Telemetry collector endpoint to export to.
   sampleProbability: 0.1 # SampleProbability is the probability of sampling expressed as a number between 0 and 1.
+  serviceName: cerbos # ServiceName is the name of the service reported to the exporter.

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/bridge/opencensus v0.30.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.7.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.3.0
 	go.opentelemetry.io/otel/sdk v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0
 	go.uber.org/automaxprocs v1.5.1
@@ -157,6 +158,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.3.0 // indirect
 	github.com/googleapis/go-type-adapters v1.0.0 // indirect
 	github.com/gookit/color v1.5.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
@@ -225,8 +227,11 @@ require (
 	go.opentelemetry.io/contrib/propagators/aws v1.7.0 // indirect
 	go.opentelemetry.io/contrib/propagators/jaeger v1.7.0 // indirect
 	go.opentelemetry.io/contrib/propagators/ot v1.7.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.3.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.3.0 // indirect
 	go.opentelemetry.io/otel/metric v0.30.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v0.30.0 // indirect
+	go.opentelemetry.io/proto/otlp v0.11.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -901,6 +901,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.3 h1:BGNSrTRW4rwfhJiFwvwF4XQ0Y72Jj9YEgxVrtovbD5o=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.3/go.mod h1:VHn7KgNsRriXa4mcgtkpR00OXyQY6g67JWMvn+R27A4=
@@ -1638,8 +1639,11 @@ go.opentelemetry.io/otel/bridge/opencensus v0.30.0/go.mod h1:jyERBSEU6EX7oR+Lyta
 go.opentelemetry.io/otel/exporters/jaeger v1.7.0 h1:wXgjiRldljksZkZrldGVe6XrG9u3kYDyQmkZwmm5dI0=
 go.opentelemetry.io/otel/exporters/jaeger v1.7.0/go.mod h1:PwQAOqBgqbLQRKlj466DuD2qyMjbtcPpfPfj+AqbSBs=
 go.opentelemetry.io/otel/exporters/otlp v0.20.0/go.mod h1:YIieizyaN77rtLJra0buKiNBOm9XQfkPEKBeuhoMwAM=
+go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.3.0 h1:R/OBkMoGgfy2fLhs2QhkCI1w4HLEQX92GCcJB6SSdNk=
 go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.3.0/go.mod h1:VpP4/RMn8bv8gNo9uK7/IMY4mtWLELsS+JIP0inH0h4=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.3.0 h1:giGm8w67Ja7amYNfYMdme7xSp2pIxThWopw8+QP51Yk=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.3.0/go.mod h1:hO1KLR7jcKaDDKDkvI9dP/FIhpmna5lkqPUQdEjFAM8=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.3.0 h1:VQbUHoJqytHHSJ1OZodPH9tvZZSVzUHjPHpkO85sT6k=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.3.0/go.mod h1:keUU7UfnwWTWpJ+FWnyqmogPa82nuU5VUANFq49hlMY=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.3.0/go.mod h1:QNX1aly8ehqqX1LEa6YniTU7VY9I6R3X/oPxhGdTceE=
 go.opentelemetry.io/otel/metric v0.20.0/go.mod h1:598I5tYlH1vzBjn+BTuhzTCSb/9debfNp6R3s7Pr1eU=
@@ -1659,6 +1663,7 @@ go.opentelemetry.io/otel/trace v1.3.0/go.mod h1:c/VDhno8888bvQYmbYLqe41/Ldmr/KKu
 go.opentelemetry.io/otel/trace v1.7.0 h1:O37Iogk1lEkMRXewVtZ1BBTVn5JEp8GrJvP92bJqC6o=
 go.opentelemetry.io/otel/trace v1.7.0/go.mod h1:fzLSB9nqR2eXzxPXb2JW9IKE+ScyXA48yyE4TNvoHqU=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
+go.opentelemetry.io/proto/otlp v0.11.0 h1:cLDgIBTf4lLOlztkhzAEdQsJ4Lj+i5Wc9k6Nn0K1VyU=
 go.opentelemetry.io/proto/otlp v0.11.0/go.mod h1:QpEjXPrNQzrFDZgoTo49dgHR9RYRSrg3NAKnUGl9YpQ=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/internal/observability/tracing/conf.go
+++ b/internal/observability/tracing/conf.go
@@ -24,8 +24,8 @@ var (
 
 // Conf is optional configuration for tracing.
 type Conf struct {
-	// ServiceName is the name of the service reproted to the exporter.
-	ServiceName *string
+	// ServiceName is the name of the service reported to the exporter.
+	ServiceName *string `yaml:"serviceName" conf:",example=cerbos"`
 	// Jaeger configures the Jaeger exporter.
 	Jaeger *JaegerConf `yaml:"jaeger"`
 	// OTLP configures the OpenTelemetry exporter.
@@ -48,7 +48,7 @@ type JaegerConf struct {
 }
 
 type OTLPConf struct {
-	// CollectorEndpoint is the Jaeger collector endpoint to report to.
+	// CollectorEndpoint is the Open Telemetry collector endpoint to export to.
 	CollectorEndpoint string `yaml:"collectorEndpoint" conf:",example=\"otel:4317\""`
 }
 

--- a/internal/observability/tracing/conf.go
+++ b/internal/observability/tracing/conf.go
@@ -24,6 +24,8 @@ var (
 
 // Conf is optional configuration for tracing.
 type Conf struct {
+	// ServiceName is the name of the service reproted to the exporter.
+	ServiceName *string
 	// Jaeger configures the Jaeger exporter.
 	Jaeger *JaegerConf `yaml:"jaeger"`
 	// OTLP configures the OpenTelemetry exporter.
@@ -37,7 +39,7 @@ type Conf struct {
 }
 
 type JaegerConf struct {
-	// ServiceName is the name of the service to report to Jaeger.
+	// [Deprecated] Use top level ServiceName config. ServiceName is the name of the service to report to Jaeger.
 	ServiceName string `yaml:"serviceName" conf:",example=cerbos"`
 	// AgentEndpoint is the Jaeger agent endpoint to report to.
 	AgentEndpoint string `yaml:"agentEndpoint" conf:",example=\"localhost:6831\""`
@@ -46,9 +48,6 @@ type JaegerConf struct {
 }
 
 type OTLPConf struct {
-	// ServiceName is the name of the service to report.
-	// TODO: Move ServiceName above exporter?
-	ServiceName string `yaml:"serviceName" conf:",example=cerbos"`
 	// CollectorEndpoint is the Jaeger collector endpoint to report to.
 	CollectorEndpoint string `yaml:"collectorEndpoint" conf:",example=\"otel:4317\""`
 }


### PR DESCRIPTION
#### Description

Currently, traces can only be exported in the Jaeger format, where as our collectors can only accept OTLP (gRPC or HTTP).

For the first PR I've kept the OTLP config simple by only supporting gRPC and no config to tune/enhance the exporter, such as gzip, load-balancing policy, batching or TLS.

**Issue:** #1018

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
