### PR TITLE
chore(docs): Fix confdocs panic when no struct tag is provided

### DIFF
--- a/hack/tools/confdocs/confdocs.go
+++ b/hack/tools/confdocs/confdocs.go
@@ -368,6 +368,10 @@ func indentf(out io.Writer, n int, format string, args ...any) error {
 }
 
 func parseTag(tag string) (*TagInfo, error) {
+	if tag == "" {
+		return nil, errTagNotExists
+	}
+
 	t, err := structtag.Parse(tag[1 : len(tag)-1])
 	if err != nil {
 		return nil, fmt.Errorf("structtag failed to parse tags: %w", err)


### PR DESCRIPTION
Signed-off-by: Oğuzhan Durgun <oguzhandurgun95@gmail.com>

#### Description

I have realized - thanks to #1017 (Thanks @rcrowe!) - `confdocs` doesn't have a check for empty struct tags, hence it is panicking. 


