### PR TITLE
fix: Transform `_&&_`/`_||_` to `and`/`or` in ASTs

### DIFF
--- a/internal/engine/ast.go
+++ b/internal/engine/ast.go
@@ -79,6 +79,10 @@ func opFromCLE(fn string) (string, error) {
 		return Mod, nil
 	case operators.Index:
 		return Index, nil
+	case operators.LogicalAnd:
+		return And, nil
+	case operators.LogicalOr:
+		return Or, nil
 	case operators.LogicalNot:
 		return Not, nil
 	default:

--- a/internal/engine/testdata/ast_build_expr.yaml
+++ b/internal/engine/testdata/ast_build_expr.yaml
@@ -178,5 +178,19 @@
       - value: "1h"
 
 "now()":
- expression:
-   operator: now
+  expression:
+    operator: now
+
+"a && b":
+  expression:
+    operator: and
+    operands:
+      - variable: a
+      - variable: b
+
+"a || b":
+  expression:
+    operator: or
+    operands:
+      - variable: a
+      - variable: b


### PR DESCRIPTION
Fixes #1014 