### PR TITLE
chore: Ignore OpenTelemetry error message about sampler

### DIFF
--- a/internal/observability/tracing/tracing.go
+++ b/internal/observability/tracing/tracing.go
@@ -115,6 +115,12 @@ func configureOtel(ctx context.Context, svcName *string, exporter tracesdk.SpanE
 	)
 
 	otel.SetErrorHandler(otelErrHandler(func(err error) {
+		// this is a harmless error message that occurs because Otel doesn't recognise
+		// the OpenCensus sampler. We can remove this check when OpenCensus is replaced.
+		if strings.Contains(err.Error(), "unsupported sampler:") {
+			return
+		}
+
 		zap.L().Named("otel").Warn("OpenTelemetry error", zap.Error(err))
 	}))
 


### PR DESCRIPTION
Because OpenTelemetry doesn't recognise the OpenCensus sampler, it
produces a log message like the following on Cerbos startup:

```
"message":"OpenTelemetry error","error":"starting span \"ExportMetrics\": unsupported sampler: 0xc8b760"
```

This patch discards this particular error from the logs because it's
harmless and unavoidable until OpenCensus is completely replaced.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
