### PR TITLE
fix: Transform maps to lists for membership test  

### DIFF
--- a/internal/engine/ast.go
+++ b/internal/engine/ast.go
@@ -240,6 +240,28 @@ func convert(expr *enginev1.PlanResourcesAst_Node, acc *enginev1.PlanResourcesFi
 	return nil
 }
 
+func mkConstStringExpr(s string) *exprpb.Expr {
+	return &exprpb.Expr{
+		ExprKind: &exprpb.Expr_ConstExpr{
+			ConstExpr: &exprpb.Constant{
+				ConstantKind: &exprpb.Constant_StringValue{
+					StringValue: s,
+				},
+			},
+		},
+	}
+}
+
+func mkListExpr(elems []*exprpb.Expr) *exprpb.Expr {
+	return &exprpb.Expr{
+		ExprKind: &exprpb.Expr_ListExpr{
+			ListExpr: &exprpb.Expr_CreateList{
+				Elements: elems,
+			},
+		},
+	}
+}
+
 func mkExprOpExpr(op string, args ...*enginev1.PlanResourcesFilter_Expression_Operand) *enginev1.PlanResourcesFilter_Expression_Operand_Expression {
 	return &enginev1.PlanResourcesFilter_Expression_Operand_Expression{
 		Expression: &enginev1.PlanResourcesFilter_Expression{Operator: op, Operands: args},
@@ -247,6 +269,10 @@ func mkExprOpExpr(op string, args ...*enginev1.PlanResourcesFilter_Expression_Op
 }
 
 func buildExpr(expr *exprpb.Expr, acc *enginev1.PlanResourcesFilter_Expression_Operand) error {
+	return buildExprImpl(expr, acc, nil)
+}
+
+func buildExprImpl(cur *exprpb.Expr, acc *enginev1.PlanResourcesFilter_Expression_Operand, parent *exprpb.Expr) error {
 	type (
 		Expr        = enginev1.PlanResourcesFilter_Expression
 		ExprOp      = enginev1.PlanResourcesFilter_Expression_Operand
@@ -254,7 +280,7 @@ func buildExpr(expr *exprpb.Expr, acc *enginev1.PlanResourcesFilter_Expression_O
 		ExprOpValue = enginev1.PlanResourcesFilter_Expression_Operand_Value
 		ExprOpVar   = enginev1.PlanResourcesFilter_Expression_Operand_Variable
 	)
-	switch expr := expr.ExprKind.(type) {
+	switch expr := cur.ExprKind.(type) {
 	case *exprpb.Expr_CallExpr:
 		fn, _ := opFromCLE(expr.CallExpr.Function)
 		var offset int
@@ -264,7 +290,7 @@ func buildExpr(expr *exprpb.Expr, acc *enginev1.PlanResourcesFilter_Expression_O
 		operands := make([]*ExprOp, len(expr.CallExpr.Args)+offset)
 		if expr.CallExpr.Target != nil {
 			operands[0] = new(ExprOp)
-			err := buildExpr(expr.CallExpr.Target, operands[0])
+			err := buildExprImpl(expr.CallExpr.Target, operands[0], cur)
 			if err != nil {
 				return err
 			}
@@ -272,7 +298,7 @@ func buildExpr(expr *exprpb.Expr, acc *enginev1.PlanResourcesFilter_Expression_O
 
 		for i, arg := range expr.CallExpr.Args {
 			operands[i+offset] = new(ExprOp)
-			err := buildExpr(arg, operands[i+offset])
+			err := buildExprImpl(arg, operands[i+offset], cur)
 			if err != nil {
 				return err
 			}
@@ -319,7 +345,7 @@ func buildExpr(expr *exprpb.Expr, acc *enginev1.PlanResourcesFilter_Expression_O
 			acc.Node = &ExprOpVar{Variable: sb.String()}
 		} else {
 			op := new(ExprOp)
-			err := buildExpr(expr.SelectExpr.Operand, op)
+			err := buildExprImpl(expr.SelectExpr.Operand, op, cur)
 			if err != nil {
 				return err
 			}
@@ -348,7 +374,7 @@ func buildExpr(expr *exprpb.Expr, acc *enginev1.PlanResourcesFilter_Expression_O
 			operands := make([]*ExprOp, len(x.Elements))
 			for i := range operands {
 				operands[i] = new(ExprOp)
-				err := buildExpr(x.Elements[i], operands[i])
+				err := buildExprImpl(x.Elements[i], operands[i], cur)
 				if err != nil {
 					return err
 				}
@@ -357,19 +383,43 @@ func buildExpr(expr *exprpb.Expr, acc *enginev1.PlanResourcesFilter_Expression_O
 		}
 	case *exprpb.Expr_StructExpr:
 		x := expr.StructExpr
+		if c := parent.GetCallExpr(); c != nil {
+			// convert struct to a list, if it is a key membership test operation
+			const argsCount = 2
+			const rhsIndex = 1 // right-hand side arg index
+			if c.Function == operators.In && len(c.Args) == argsCount && c.Args[rhsIndex] == cur {
+				elems := make([]*exprpb.Expr, 0, len(x.Entries))
+				var el *exprpb.Expr
+				for _, entry := range x.Entries {
+					switch e := entry.KeyKind.(type) {
+					case *exprpb.Expr_CreateStruct_Entry_MapKey:
+						el = e.MapKey
+					case *exprpb.Expr_CreateStruct_Entry_FieldKey:
+						el = mkConstStringExpr(e.FieldKey)
+					}
+					elems = append(elems, el)
+				}
+				list := mkListExpr(elems)
+				err := buildExprImpl(list, acc, parent)
+				if err != nil {
+					return err
+				}
+				return nil
+			}
+		}
 		operands := make([]*ExprOp, len(x.Entries))
 		for i, entry := range x.Entries {
 			k, v := new(ExprOp), new(ExprOp)
 			switch entry := entry.KeyKind.(type) {
 			case *exprpb.Expr_CreateStruct_Entry_MapKey:
-				err := buildExpr(entry.MapKey, k)
+				err := buildExprImpl(entry.MapKey, k, cur)
 				if err != nil {
 					return err
 				}
 			case *exprpb.Expr_CreateStruct_Entry_FieldKey:
 				k.Node = &ExprOpValue{Value: structpb.NewStringValue(entry.FieldKey)}
 			}
-			err := buildExpr(entry.Value, v)
+			err := buildExprImpl(entry.Value, v, cur)
 			if err != nil {
 				return err
 			}
@@ -412,7 +462,7 @@ func buildExpr(expr *exprpb.Expr, acc *enginev1.PlanResourcesFilter_Expression_O
 			return fmt.Errorf("unexpected loop-step function: %q", step.CallExpr.Function)
 		}
 		lambda := new(ExprOp)
-		err := buildExpr(le, lambda)
+		err := buildExprImpl(le, lambda, cur)
 		if err != nil {
 			return err
 		}
@@ -422,7 +472,7 @@ func buildExpr(expr *exprpb.Expr, acc *enginev1.PlanResourcesFilter_Expression_O
 		}
 
 		op := new(ExprOp)
-		err = buildExpr(x.IterRange, op)
+		err = buildExprImpl(x.IterRange, op, cur)
 		if err != nil {
 			return err
 		}
@@ -430,7 +480,7 @@ func buildExpr(expr *exprpb.Expr, acc *enginev1.PlanResourcesFilter_Expression_O
 		acc.Node = mkExprOpExpr(operator, op,
 			&ExprOp{Node: mkExprOpExpr(Lambda, lambda, &ExprOp{Node: &ExprOpVar{Variable: x.IterVar}})})
 	default:
-		return fmt.Errorf("buildExpr: unsupported expression: %v", expr)
+		return fmt.Errorf("buildExprImpl: unsupported expression: %v", expr)
 	}
 
 	return nil

--- a/internal/engine/ast.go
+++ b/internal/engine/ast.go
@@ -385,9 +385,9 @@ func buildExprImpl(cur *exprpb.Expr, acc *enginev1.PlanResourcesFilter_Expressio
 		x := expr.StructExpr
 		if c := parent.GetCallExpr(); c != nil {
 			// convert struct to a list, if it is a key membership test operation
-			const argsCount = 2
+			const nArgs = 2
 			const rhsIndex = 1 // right-hand side arg index
-			if c.Function == operators.In && len(c.Args) == argsCount && c.Args[rhsIndex] == cur {
+			if c.Function == operators.In && len(c.Args) == nArgs && c.Args[rhsIndex] == cur {
 				elems := make([]*exprpb.Expr, 0, len(x.Entries))
 				var el *exprpb.Expr
 				for _, entry := range x.Entries {

--- a/internal/engine/ast_test.go
+++ b/internal/engine/ast_test.go
@@ -18,6 +18,7 @@ import (
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	"github.com/cerbos/cerbos/internal/conditions"
 	"github.com/cerbos/cerbos/internal/util"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 //go:embed testdata/ast_build_expr.yaml
@@ -39,7 +40,7 @@ func getExpectedExpressions(t *testing.T) map[string]*exOp {
 		b, err := v.MarshalJSON()
 		require.NoError(t, err)
 		err = util.ReadJSONOrYAML(bytes.NewReader(b), expected)
-		require.NoError(t, err)
+		require.NoError(t, err, string(b))
 		res[k] = expected
 	}
 
@@ -62,7 +63,7 @@ func Test_buildExpr(t *testing.T) {
 			err := buildExpr(parse(k), acc)
 			is.NoError(err)
 
-			is.Empty(cmp.Diff(want, acc, protocmp.Transform()))
+			is.Empty(cmp.Diff(want, acc, protocmp.Transform()), "unexpected expression: %s", protojson.Format(acc))
 		})
 	}
 }

--- a/internal/engine/testdata/ast_build_expr.yaml
+++ b/internal/engine/testdata/ast_build_expr.yaml
@@ -194,3 +194,21 @@
     operands:
       - variable: a
       - variable: b
+
+"a in {\"x\": 1, \"z\": 2}":
+  expression:
+    operator: in
+    operands:
+      - variable: a
+      - value: ["x", "z"]
+
+"a in {x: 1, z: 2}":
+  expression:
+    operator: in
+    operands:
+      - variable: a
+      - expression:
+          operator: list
+          operands:
+            - variable: x
+            - variable: z

--- a/internal/test/testdata/query_planner/policies/resource_policy_leave_request.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policy_leave_request.yaml
@@ -163,3 +163,9 @@ resourcePolicy:
       condition:
         match:
           expr: "42"
+    - actions: ["map-membership"]
+      roles: ["employee"]
+      effect: EFFECT_ALLOW
+      condition:
+        match:
+          expr: R.attr.teamId in P.attr.teams

--- a/internal/test/testdata/query_planner/suite/harry.yaml
+++ b/internal/test/testdata/query_planner/suite/harry.yaml
@@ -6,6 +6,10 @@ principal:
   roles:
     - employee
     - user
+  attr:
+    teams:
+      team1: employee
+      team2: user
 tests:
   - action: view
     resource:
@@ -50,3 +54,15 @@ tests:
       policyVersion: default
     want:
       kind: KIND_ALWAYS_DENIED
+  - action: map-membership
+    resource:
+      kind: leave_request
+      policyVersion: default
+    want:
+      kind: KIND_CONDITIONAL
+      condition:
+        expression:
+          operator: in
+          operands:
+            - variable: request.resource.attr.teamId
+            - value: ["team1", "team2"]


### PR DESCRIPTION
#### Description

Membership test operation `in` can be used to test if a key exists in a map. 
The produced AST currently contains the entire struct, which is confusing. It is expected the map to be converted to a list of keys.

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
