### PR TITLE
enhancement: Output detailed index build errors when the number of errors is low

### DIFF
--- a/cmd/cerbos/compile/compile.go
+++ b/cmd/cerbos/compile/compile.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/fatih/color"
 	"github.com/pterm/pterm"
+	"go.uber.org/zap"
 
 	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
 	internalcompile "github.com/cerbos/cerbos/cmd/cerbos/compile/internal/compilation"
@@ -75,7 +76,7 @@ func (c *Cmd) Run(k *kong.Kong) error {
 
 	p := printer.New(k.Stdout, k.Stderr)
 
-	idx, err := index.Build(ctx, os.DirFS(c.Dir))
+	idx, err := index.Build(ctx, os.DirFS(c.Dir), index.WithBuildFailureLogLevel(zap.DebugLevel))
 	if err != nil {
 		idxErr := new(index.BuildError)
 		if errors.As(err, &idxErr) {

--- a/internal/storage/index/index.go
+++ b/internal/storage/index/index.go
@@ -65,7 +65,7 @@ type index struct {
 	schemaLoader *SchemaLoader
 	sfGroup      singleflight.Group
 	stats        storage.RepoStats
-	buildOpts    []BuildOpt
+	buildOpts    buildOptions
 	mu           sync.RWMutex
 }
 
@@ -422,7 +422,7 @@ func (idx *index) Reload(ctx context.Context) ([]storage.Event, error) {
 	log := ctxzap.Extract(ctx)
 	log.Info("Initiated a store reload")
 	ievts, err, shared := idx.sfGroup.Do("reload", func() (any, error) {
-		idxIface, err := Build(ctx, idx.fsys, idx.buildOpts...)
+		idxIface, err := build(ctx, idx.fsys, idx.buildOpts)
 		if err != nil {
 			log.Error("Failed to build index while re-indexing")
 			return nil, err


### PR DESCRIPTION
Fixes #441 

When no more than 5 errors occur during index build, or when debug logging is enabled, the full error details will now be printed instead of just the summary.

e.g. when starting server the output is now
```
2022-06-21T10:59:32.594+0100    ERROR   cerbos.index    Index build failed      {"missing": [{"importingFile":"policy.yaml","desc":"Import 'wat' not found"}]}
cerbos: error: failed to create store: failed to build index: missing imports=1, missing scopes=0, duplicate definitions=0, load failures=0
```

or if more than 5 errors occur

```
2022-06-21T11:38:49.002+0100    ERROR   cerbos.index    Index build failed      {"error": "too many errors; run `cerbos compile` to see a full list"}
cerbos: error: failed to create store: failed to build index: missing imports=3, missing scopes=0, duplicate definitions=0, load failures=3
```