### PR TITLE
fix: Handle missing scopes in playground validate API

### DIFF
--- a/internal/svc/playground_svc.go
+++ b/internal/svc/playground_svc.go
@@ -328,6 +328,12 @@ func processLintErrors(ctx context.Context, errs *index.BuildError) *responsev1.
 		})
 	}
 
+	for _, ms := range errs.MissingScopes {
+		errors = append(errors, &responsev1.PlaygroundFailure_Error{
+			Error: fmt.Sprintf("Missing scope '%s'", ms),
+		})
+	}
+
 	for _, lf := range errs.LoadFailures {
 		errors = append(errors, &responsev1.PlaygroundFailure_Error{
 			File:  lf.File,

--- a/internal/test/testdata/server/playground/validate/pgv_invalid_case_02.yaml
+++ b/internal/test/testdata/server/playground/validate/pgv_invalid_case_02.yaml
@@ -1,0 +1,33 @@
+---
+description: Missing scope
+wantStatus:
+  httpStatusCode: 400
+  grpcStatusCode: 0
+playgroundValidate:
+  input: {
+    "playgroundId": "test",
+    "files": [
+      {
+        "fileName": "derived_roles/derived_roles_01.yaml",
+        "contents": "{{ fileString `store/derived_roles/derived_roles_01.yaml` | b64enc }}",
+      },
+      {
+        "fileName": "derived_roles/derived_roles_02.yaml",
+        "contents": "{{ fileString `store/derived_roles/derived_roles_02.yaml` | b64enc }}",
+      },
+      {
+        "fileName": "resource_policies/policy_05_acme.hr.uk.yaml",
+        "contents": "{{ fileString `store/resource_policies/policy_05_acme.hr.uk.yaml` | b64enc }}",
+      }
+    ]
+  }
+  wantResponse: {
+    "playgroundId": "test",
+    "failure": {
+      "errors": [
+        { "error": "Missing scope 'resource.leave_request.vdefault'" },
+        { "error": "Missing scope 'resource.leave_request.vdefault/acme'" },
+        { "error": "Missing scope 'resource.leave_request.vdefault/acme.hr'" }
+      ]
+    }
+  }


### PR DESCRIPTION
https://cerboscommunity.slack.com/archives/C028A53GAJE/p1655861307684469

There's a bug in the playground where an unhandled error occurs when there are missing scopes. This is because they aren't handled in the playground validate API, meaning the response omits the `errors` key from the `failure` object:

```json
{
  "playgroundId":"c39a499f-ce61-463c-a399-9be547563977",
  "failure": {}
}
```