### PR TITLE
fix: Transform maps to lists in comprehension expressions

### DIFF
--- a/internal/engine/ast.go
+++ b/internal/engine/ast.go
@@ -297,6 +297,7 @@ func mkListExpr(elems []*exprpb.Expr) *exprpb.Expr {
 		},
 	}
 }
+
 func mkExprOpExpr(op string, args ...*enginev1.PlanResourcesFilter_Expression_Operand) *enginev1.PlanResourcesFilter_Expression_Operand_Expression {
 	return &enginev1.PlanResourcesFilter_Expression_Operand_Expression{
 		Expression: &enginev1.PlanResourcesFilter_Expression{Operator: op, Operands: args},
@@ -452,7 +453,7 @@ func buildExprImpl(cur *exprpb.Expr, acc *enginev1.PlanResourcesFilter_Expressio
 		}
 		acc.Node = mkExprOpExpr(Struct, operands...)
 	case *exprpb.Expr_ComprehensionExpr:
-		lambdaAst, err := BuildLambdaAST(expr.ComprehensionExpr)
+		lambdaAst, err := buildLambdaAST(expr.ComprehensionExpr)
 		if err != nil {
 			return err
 		}

--- a/internal/engine/lambda.go
+++ b/internal/engine/lambda.go
@@ -1,0 +1,56 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package engine
+
+import (
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"fmt"
+	"github.com/google/cel-go/common/operators"
+)
+
+type LambdaAST struct {
+	Operator   string
+	IterRange  *exprpb.Expr
+	IterVar    string
+	LambdaExpr *exprpb.Expr
+}
+
+func BuildLambdaAST(e *exprpb.Expr_Comprehension) (*LambdaAST, error) {
+	obj := &LambdaAST{
+		IterVar:   e.IterVar,
+		IterRange: e.IterRange,
+	}
+	var step *exprpb.Expr_CallExpr
+	var ok bool
+	if step, ok = e.LoopStep.ExprKind.(*exprpb.Expr_CallExpr); !ok {
+		return nil, fmt.Errorf("expected loop-step expression type CallExpr, got: %T", e.LoopStep.ExprKind)
+	}
+	switch step.CallExpr.Function {
+	case operators.LogicalAnd:
+		obj.Operator = All
+		obj.LambdaExpr = step.CallExpr.Args[1]
+	case operators.LogicalOr:
+		obj.Operator = Exists
+		obj.LambdaExpr = step.CallExpr.Args[1]
+	case operators.Add:
+		obj.Operator = Map
+		if elements := step.CallExpr.Args[1].GetListExpr().GetElements(); len(elements) > 0 {
+			obj.LambdaExpr = elements[0]
+		}
+	case operators.Conditional:
+		switch e.AccuInit.ExprKind.(type) {
+		case *exprpb.Expr_ListExpr:
+			obj.Operator = Filter
+		case *exprpb.Expr_ConstExpr:
+			obj.Operator = ExistsOne
+		default:
+			return nil, fmt.Errorf("expected loop-accu-init expression type ConstExpr or ListExpr, got: %T", e.AccuInit.ExprKind)
+		}
+		obj.LambdaExpr = step.CallExpr.Args[0]
+	default:
+		return nil, fmt.Errorf("unexpected loop-step function: %q", step.CallExpr.Function)
+	}
+
+	return obj, nil
+}

--- a/internal/engine/lambda.go
+++ b/internal/engine/lambda.go
@@ -4,16 +4,17 @@
 package engine
 
 import (
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	"fmt"
+
 	"github.com/google/cel-go/common/operators"
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 type LambdaAST struct {
-	Operator   string
 	IterRange  *exprpb.Expr
-	IterVar    string
 	LambdaExpr *exprpb.Expr
+	Operator   string
+	IterVar    string
 }
 
 func BuildLambdaAST(e *exprpb.Expr_Comprehension) (*LambdaAST, error) {

--- a/internal/engine/lambda.go
+++ b/internal/engine/lambda.go
@@ -17,7 +17,7 @@ type lambdaAST struct {
 	iterVar    string
 }
 
-func BuildLambdaAST(e *exprpb.Expr_Comprehension) (*lambdaAST, error) {
+func buildLambdaAST(e *exprpb.Expr_Comprehension) (*lambdaAST, error) {
 	obj := &lambdaAST{
 		iterVar:   e.IterVar,
 		iterRange: e.IterRange,

--- a/internal/engine/testdata/ast_build_expr.yaml
+++ b/internal/engine/testdata/ast_build_expr.yaml
@@ -212,3 +212,22 @@
           operands:
             - variable: x
             - variable: z
+
+"{x: 1, z: 2}.all(t, t > 0)":
+  expression:
+    operator: all
+    operands:
+      - expression:
+          operator: list
+          operands:
+            - variable: x
+            - variable: z
+      - expression:
+          operator: lambda
+          operands:
+            - expression:
+                operator: gt
+                operands:
+                  - variable: t
+                  - value: 0
+            - variable: t

--- a/internal/test/testdata/query_planner/policies/resource_policy_leave_request.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policy_leave_request.yaml
@@ -169,3 +169,15 @@ resourcePolicy:
       condition:
         match:
           expr: R.attr.teamId in P.attr.teams
+    - actions: ["map-exists"]
+      roles: ["employee"]
+      effect: EFFECT_ALLOW
+      condition:
+        match:
+          expr: P.attr.teams.exists(t, t == R.attr.teamId)
+    - actions: ["map-all"]
+      roles: ["employee"]
+      effect: EFFECT_ALLOW
+      condition:
+        match:
+          expr: P.attr.teams.all(t, t.startsWith(R.attr.teamId))

--- a/internal/test/testdata/query_planner/suite/harry.yaml
+++ b/internal/test/testdata/query_planner/suite/harry.yaml
@@ -66,3 +66,43 @@ tests:
           operands:
             - variable: request.resource.attr.teamId
             - value: ["team1", "team2"]
+  - action: map-exists
+    resource:
+      kind: leave_request
+      policyVersion: default
+    want:
+      kind: KIND_CONDITIONAL
+      condition:
+        expression:
+          operator: exists
+          operands:
+            - value: ["team1", "team2"]
+            - expression:
+                operator: lambda
+                operands:
+                  - expression:
+                      operator: eq
+                      operands:
+                        - variable: t
+                        - variable: request.resource.attr.teamId
+                  - variable: t
+  - action: map-all
+    resource:
+      kind: leave_request
+      policyVersion: default
+    want:
+      kind: KIND_CONDITIONAL
+      condition:
+        expression:
+          operator: all
+          operands:
+            - value: ["team1", "team2"]
+            - expression:
+                operator: lambda
+                operands:
+                  - expression:
+                      operator: startsWith
+                      operands:
+                        - variable: t
+                        - variable: request.resource.attr.teamId
+                  - variable: t


### PR DESCRIPTION
#### Description

Expressions like `exists`, `all`, and `exists_one` can be applied to maps, but only map keys are used in the expressions. The resource plan API hence can contain a list instead of a map in the produced AST. That makes the AST much easier to parse.

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
