### PR TITLE
fix: Avoid short-circuit when expressions access non-existent attributes

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -17,7 +17,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
-	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
 	privatev1 "github.com/cerbos/cerbos/api/genpb/cerbos/private/v1"
 	schemav1 "github.com/cerbos/cerbos/api/genpb/cerbos/schema/v1"
 	"github.com/cerbos/cerbos/internal/audit"
@@ -200,39 +199,6 @@ func mkEngine(tb testing.TB, p param) (*Engine, context.CancelFunc) {
 	require.NoError(tb, err)
 
 	return eng, cancelFunc
-}
-
-func TestSatisfiesCondition(t *testing.T) {
-	testCases := test.LoadTestCases(t, "cel_eval")
-
-	for _, tcase := range testCases {
-		tcase := tcase
-		t.Run(tcase.Name, func(t *testing.T) {
-			tc := readCELTestCase(t, tcase.Input)
-			cond, err := compile.Condition(&policyv1.Condition{Condition: &policyv1.Condition_Match{Match: tc.Condition}})
-			require.NoError(t, err)
-
-			tctx := tracer.Start(newTestTraceSink(t))
-			retVal, err := satisfiesCondition(tctx.StartCondition(), cond, nil, tc.Input)
-
-			if tc.WantError {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			require.Equal(t, tc.Want, retVal)
-		})
-	}
-}
-
-func readCELTestCase(t *testing.T, data []byte) *privatev1.CelTestCase {
-	t.Helper()
-
-	tc := &privatev1.CelTestCase{}
-	require.NoError(t, util.ReadJSONOrYAML(bytes.NewReader(data), tc))
-
-	return tc
 }
 
 func readQPTestSuite(t *testing.T, data []byte) *privatev1.QueryPlannerTestSuite {

--- a/internal/engine/evaluator.go
+++ b/internal/engine/evaluator.go
@@ -345,6 +345,10 @@ func evaluateBoolCELExpr(expr *exprpb.CheckedExpr, variables map[string]any, inp
 		return false, err
 	}
 
+	if val == nil {
+		return false, nil
+	}
+
 	boolVal, ok := val.(bool)
 	if !ok {
 		return false, fmt.Errorf("unexpected result: wanted bool, got %T", val)

--- a/internal/test/testdata/cel_eval/missing_attr_allof.yaml
+++ b/internal/test/testdata/cel_eval/missing_attr_allof.yaml
@@ -1,0 +1,24 @@
+---
+condition:
+  all:
+    of:
+      - expr: P.attr.team == "team"
+      - expr: P.attr.department == "marketing"
+input: {
+  "requestId": "test",
+  "actions": ["*"],
+  "principal": {
+    "id": "john",
+    "roles": ["employee"],
+    "attr": {
+      "department": "marketing"
+    }
+  },
+  "resource": {
+    "kind": "leave_request",
+    "attr": {
+      "department": "marketing"
+    }
+  }
+}
+want: false

--- a/internal/test/testdata/cel_eval/missing_attr_anyof.yaml
+++ b/internal/test/testdata/cel_eval/missing_attr_anyof.yaml
@@ -1,0 +1,24 @@
+---
+condition:
+  any:
+    of:
+      - expr: P.attr.team == "team"
+      - expr: P.attr.department == "marketing"
+input: {
+  "requestId": "test",
+  "actions": ["*"],
+  "principal": {
+    "id": "john",
+    "roles": ["employee"],
+    "attr": {
+      "department": "marketing"
+    }
+  },
+  "resource": {
+    "kind": "leave_request",
+    "attr": {
+      "department": "marketing"
+    }
+  }
+}
+want: true

--- a/internal/test/testdata/cel_eval/missing_attr_noneof.yaml
+++ b/internal/test/testdata/cel_eval/missing_attr_noneof.yaml
@@ -1,0 +1,24 @@
+---
+condition:
+  none:
+    of:
+      - expr: P.attr.team == "team"
+      - expr: P.attr.department == "marketing"
+input: {
+  "requestId": "test",
+  "actions": ["*"],
+  "principal": {
+    "id": "john",
+    "roles": ["employee"],
+    "attr": {
+      "department": "marketing"
+    }
+  },
+  "resource": {
+    "kind": "leave_request",
+    "attr": {
+      "department": "marketing"
+    }
+  }
+}
+want: false

--- a/internal/test/testdata/server/playground/test/pgt_case_00.yaml
+++ b/internal/test/testdata/server/playground/test/pgt_case_00.yaml
@@ -85,8 +85,6 @@ playgroundTest:
                               ],
                               "event": {
                                 "status": "STATUS_ACTIVATED",
-                                "error": "unexpected result: wanted bool, got <nil>",
-                                "message": "Failed to evaluate expression",
                                 "result": false
                               }
                             },
@@ -107,8 +105,7 @@ playgroundTest:
                               ],
                               "event": {
                                 "status": "STATUS_SKIPPED",
-                                "error": "failed to evaluate `request.resource.attr.owner == request.principal.id`: unexpected result: wanted bool, got <nil>",
-                                "message": "Error evaluating condition"
+                                "message": "Condition not satisfied"
                               }
                             },
                             {


### PR DESCRIPTION
If a boolean expression arm in one of `any`, `all` or `none` blocks
uses a non-existent attribute, it returns a `nil` value. This cannot be
cast to a bool so we raise an error and short-circuit the evaluation of
the whole block. This patch fixes that issue.

Fixes #1055

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
