### PR TITLE
fix: Transform membership test in empty list to false

### DIFF
--- a/internal/test/testdata/query_planner_filter/case_12.yaml
+++ b/internal/test/testdata/query_planner_filter/case_12.yaml
@@ -1,0 +1,15 @@
+---
+description: membership test in empty array
+input:
+  kind: KIND_CONDITIONAL
+  condition:
+    expression:
+      operator: in
+      operands:
+        - variable: request.resource.attr.accountId
+        - value: []
+wantFilter:
+  kind: KIND_ALWAYS_DENIED
+wantString: "(false)"
+
+

--- a/internal/test/testdata/query_planner_filter/case_13.yaml
+++ b/internal/test/testdata/query_planner_filter/case_13.yaml
@@ -1,0 +1,21 @@
+---
+description: membership test
+input:
+  kind: KIND_CONDITIONAL
+  condition:
+    expression:
+      operator: in
+      operands:
+        - variable: request.resource.attr.accountId
+        - value: ["accountId1"]
+wantFilter:
+  kind: KIND_CONDITIONAL
+  condition:
+    expression:
+      operator: in
+      operands:
+        - variable: request.resource.attr.accountId
+        - value: ["accountId1"]
+wantString: "(in request.resource.attr.accountId [\"accountId1\"])"
+
+

--- a/internal/test/testdata/query_planner_filter/case_14.yaml
+++ b/internal/test/testdata/query_planner_filter/case_14.yaml
@@ -1,0 +1,29 @@
+---
+description: OR membership test in empty array with expression
+input:
+  kind: KIND_CONDITIONAL
+  condition:
+    expression:
+      operator: or
+      operands:
+        - expression:
+            operator: in
+            operands:
+              - variable: request.resource.attr.accountId
+              - value: []
+        - expression:
+            operator: eq
+            operands:
+              - variable: R.attr.department
+              - value: "marketing"
+wantFilter:
+  kind: KIND_CONDITIONAL
+  condition:
+    expression:
+      operator: eq
+      operands:
+        - variable: request.resource.attr.department
+        - value: "marketing"
+wantString: "(eq request.resource.attr.department \"marketing\")"
+
+


### PR DESCRIPTION
Signed-off-by: Dennis Buduev <dennis@cerbos.dev>

#### Description

Optimises the AST produced by Resource Planner API. 

In the case of a membership test `in` in an empty array, the expression has to be replaced with the `false` value, which can be further optimised.

Fixes #1058 

#### Checklist 

- [x] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
