### PR TITLE
chore(ci): Use pull request title to apply labels

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -32,13 +32,11 @@ jobs:
         with:
           types: |
             chore
-            ci
             docs
             enhancement
             feat
             fix
             revert
-            test
           requireScope: false
           subjectPattern: '^[A-Z].+$'
           subjectPatternError: |

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -7,6 +7,21 @@ on:
       - edited
       - synchronize
 jobs:
+  label:
+    name: Apply PR labels
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Apply PR labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run:
+          hack/scripts/apply-pr-labels.sh "${{ github.event.number }}" "${{ github.event.pull_request.title }}"
+
   validate:
     name: Validate PR title
     runs-on: ubuntu-latest

--- a/hack/scripts/apply-pr-labels.sh
+++ b/hack/scripts/apply-pr-labels.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021-2022 Zenauth Ltd.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+pull_request_number="$1"
+pull_request_title="$2"
+
+add_label() {
+  local label="$1"
+  gh pr edit "$pull_request_number" --add-label "$label"
+}
+
+conventional_commits_pattern="^([^(:!]+)([(]([^)]+)[)])?!?: "
+
+if [[ "$pull_request_title" =~ $conventional_commits_pattern ]]; then
+  type="${BASH_REMATCH[1]}"
+  scope="${BASH_REMATCH[3]}"
+else
+  echo "Pull request title doesn't match Conventional Commits specification" >&2
+  exit 1
+fi
+
+case "$type" in
+  chore)
+    add_label chore
+    ;;
+
+  docs)
+    add_label documentation
+    ;;
+
+  enhancement)
+    add_label enhancement
+    ;;
+
+  feat)
+    add_label feature
+    ;;
+
+  fix)
+    add_label bug
+    ;;
+esac
+
+case "$scope" in
+  ci)
+    add_label ci
+    ;;
+
+  release)
+    add_label release
+    ;;
+
+  test)
+    add_label testing
+    ;;
+esac


### PR DESCRIPTION
Fixes #773 

This PR adds a job to CI to apply label(s) to the PR depending on the Conventional Commits prefix in the title.

To avoid erroneously removing manually-applied labels, it doesn't attempt to remove labels, so if the prefix changes it might be necessary to manually remove outdated labels. I didn't feel like it was worth the extra complexity to attempt to remove labels because I don't think it's common for the prefix to swap between types.

I also removed `ci` and `test` from the allowed types, because we tend to use `chore(ci)` and `chore(test)` instead.