### PR TITLE
chore(test): Update E2E setup script

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,7 +35,8 @@ jobs:
       - name: Install Helmfile and Telepresence
         run: |
           mkdir bin
-          curl -fL https://github.com/roboll/helmfile/releases/download/v0.143.0/helmfile_linux_amd64 -o bin/helmfile
+          curl -fL https://github.com/helmfile/helmfile/releases/download/v0.145.2/helmfile_0.145.2_linux_amd64.tar.gz -o bin/helmfile.tar.gz
+          tar -xf bin/helmfile.tar.gz -C bin
           chmod +x bin/helmfile
           curl -fL https://app.getambassador.io/download/tel2/linux/amd64/latest/telepresence -o bin/telepresence
           chmod +x bin/telepresence

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -29,12 +29,13 @@ stop_kind() {
 run_tests() {
     (
         cd "$SCRIPT_DIR"
+        telepresence helm install
         telepresence connect --no-report -- go test -v -failfast -p=1 --tags="tests e2e" "$@"
     )
 }
 
 check_prerequisites
-start_kind 
+start_kind
 trap stop_kind EXIT
 
 if [[ "$#" -gt "0" ]]; then


### PR DESCRIPTION
Telepresence now requires the traffic manager to be installed manually
by the user.

- Update E2E script to install Telepresence traffic manager
- Update workflow to use latest Helmfile release

Fixes #913

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
