### PR TITLE
chore(release): Prepare release 0.19.1

### DIFF
--- a/deploy/charts/cerbos/Chart.yaml
+++ b/deploy/charts/cerbos/Chart.yaml
@@ -16,5 +16,5 @@ keywords:
   - policies
   - rbac
   - security
-version: "0.19.0"
-appVersion: "0.19.0"
+version: "0.19.1"
+appVersion: "0.19.1"

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -20,7 +20,7 @@ urls:
 asciidoc:
   attributes:
     app-name: "cerbos"
-    app-version: "0.19.0@"
+    app-version: "0.19.1@"
     experimental: true
     page-pagination: true
   extensions:

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,7 +1,7 @@
 ---
 name: cerbos
 title: Cerbos
-version: "0.19.0"
+version: "0.19.1"
 nav:
   - modules/ROOT/nav.adoc
   - modules/api/nav.adoc

--- a/docs/modules/releases/nav.adoc
+++ b/docs/modules/releases/nav.adoc
@@ -1,4 +1,5 @@
 .Release Notes
+* xref:v0.19.1.adoc[v0.19.1]
 * xref:v0.19.0.adoc[v0.19.0]
 * xref:v0.18.0.adoc[v0.18.0]
 * xref:v0.17.0.adoc[v0.17.0]

--- a/docs/modules/releases/pages/v0.19.1.adoc
+++ b/docs/modules/releases/pages/v0.19.1.adoc
@@ -1,0 +1,17 @@
+include::ROOT:partial$attributes.adoc[]
+
+[#v0.19.1]
+= Cerbos v0.19.1
+
+This is a minor patch release to update the Go client SDK with ability to set scopes on resources and principals. See xref:v0.19.0.adoc[v0.19.0 release notes] for full set of changes available in this release.
+
+== Highlights
+
+
+== Changelog
+
+
+=== Bug Fixes
+
+* Allow setting scope on SDK requests (link:https://github.com/cerbos/cerbos/pull/1151[#1151])
+


### PR DESCRIPTION
Release 0.19.1 with the fix for setting scopes using the Go SDK.