### PR TITLE
docs: update 02_resource-definition.adoc

### DIFF
--- a/docs/modules/ROOT/pages/tutorial/02_resource-definition.adoc
+++ b/docs/modules/ROOT/pages/tutorial/02_resource-definition.adoc
@@ -2,6 +2,7 @@ include::partial$attributes.adoc[]
 
 = Policy authoring
 
+// THIS URL is not working at the moment
 NOTE: The policies for this section can be found link:{app-github-url}/tree/docs/main/docs/modules/ROOT/examples/tutorial/03-resource-definition/cerbos[on Github].
 
 == Authentication roles


### PR DESCRIPTION
The link at the beginning of the tutorial is pointing to a 404 website.

Signed-off-by: adrianwix <37629556+adrianwix@users.noreply.github.com>

#### Description

<!-- Thank you for contributing Cerbos! Please describe the changes made in this PR here and provide any other useful information for reviewers. Make sure that you included some automated tests (e.g unit tests) to verify your changes.  If there is a requirement for user input for testing, please include the instructions as well. -->

Fixes #<!-- Link the relevant issue here -->

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [ ] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [ ] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
