### PR TITLE
chore(ci): Remove docs preview generation

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -186,14 +186,6 @@ jobs:
         uses: ./.github/actions/antora-docs
         id: docs
 
-      - name: Deploy preview
-        uses: netlify/actions/cli@master
-        with:
-          args: deploy
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-
 
   golangci:
     needs: changes


### PR DESCRIPTION
Netlify preview deploys don't work within a workflow because the command
tries to open a browser to authenticate even when the credentials are
provided in the environment.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
