### PR TITLE
chore: Refactor private/verify package

### DIFF
--- a/internal/verify/test_fixture.go
+++ b/internal/verify/test_fixture.go
@@ -116,7 +116,7 @@ func loadFixtureElement(fsys fs.FS, path string, pb validatableMessage) error {
 	return pb.Validate()
 }
 
-func (tf *testFixture) runTestSuite(ctx context.Context, eng InputChecker, shouldRun func(string) bool, file string, suite *policyv1.TestSuite, trace bool) *policyv1.TestResults_Suite {
+func (tf *testFixture) runTestSuite(ctx context.Context, eng Checker, shouldRun func(string) bool, file string, suite *policyv1.TestSuite, trace bool) *policyv1.TestResults_Suite {
 	suiteResult := &policyv1.TestResults_Suite{
 		File:    file,
 		Name:    suite.Name,
@@ -149,7 +149,7 @@ func (tf *testFixture) runTestSuite(ctx context.Context, eng InputChecker, shoul
 	return suiteResult
 }
 
-func runTest(ctx context.Context, eng InputChecker, test *policyv1.Test, action string, shouldRun func(string) bool, suite *policyv1.TestSuite, trace bool) *policyv1.TestResults_Details {
+func runTest(ctx context.Context, eng Checker, test *policyv1.Test, action string, shouldRun func(string) bool, suite *policyv1.TestSuite, trace bool) *policyv1.TestResults_Details {
 	details := &policyv1.TestResults_Details{}
 
 	if test.Skip || !shouldRun(fmt.Sprintf("%s/%s", suite.Name, test.Name.String())) {
@@ -201,7 +201,7 @@ func runTest(ctx context.Context, eng InputChecker, test *policyv1.Test, action 
 	return details
 }
 
-func performCheck(ctx context.Context, eng InputChecker, inputs []*enginev1.CheckInput, trace bool, nowFunc func() time.Time) ([]*enginev1.CheckOutput, []*enginev1.Trace, error) {
+func performCheck(ctx context.Context, eng Checker, inputs []*enginev1.CheckInput, trace bool, nowFunc func() time.Time) ([]*enginev1.CheckOutput, []*enginev1.Trace, error) {
 	if !trace {
 		output, err := eng.Check(ctx, inputs, engine.WithNowFunc(nowFunc))
 		return output, nil, err

--- a/internal/verify/test_fixture.go
+++ b/internal/verify/test_fixture.go
@@ -116,7 +116,7 @@ func loadFixtureElement(fsys fs.FS, path string, pb validatableMessage) error {
 	return pb.Validate()
 }
 
-func (tf *testFixture) runTestSuite(ctx context.Context, eng *engine.Engine, shouldRun func(string) bool, file string, suite *policyv1.TestSuite, trace bool) *policyv1.TestResults_Suite {
+func (tf *testFixture) runTestSuite(ctx context.Context, eng InputChecker, shouldRun func(string) bool, file string, suite *policyv1.TestSuite, trace bool) *policyv1.TestResults_Suite {
 	suiteResult := &policyv1.TestResults_Suite{
 		File:    file,
 		Name:    suite.Name,
@@ -149,7 +149,7 @@ func (tf *testFixture) runTestSuite(ctx context.Context, eng *engine.Engine, sho
 	return suiteResult
 }
 
-func runTest(ctx context.Context, eng *engine.Engine, test *policyv1.Test, action string, shouldRun func(string) bool, suite *policyv1.TestSuite, trace bool) *policyv1.TestResults_Details {
+func runTest(ctx context.Context, eng InputChecker, test *policyv1.Test, action string, shouldRun func(string) bool, suite *policyv1.TestSuite, trace bool) *policyv1.TestResults_Details {
 	details := &policyv1.TestResults_Details{}
 
 	if test.Skip || !shouldRun(fmt.Sprintf("%s/%s", suite.Name, test.Name.String())) {
@@ -201,7 +201,7 @@ func runTest(ctx context.Context, eng *engine.Engine, test *policyv1.Test, actio
 	return details
 }
 
-func performCheck(ctx context.Context, eng *engine.Engine, inputs []*enginev1.CheckInput, trace bool, nowFunc func() time.Time) ([]*enginev1.CheckOutput, []*enginev1.Trace, error) {
+func performCheck(ctx context.Context, eng InputChecker, inputs []*enginev1.CheckInput, trace bool, nowFunc func() time.Time) ([]*enginev1.CheckOutput, []*enginev1.Trace, error) {
 	if !trace {
 		output, err := eng.Check(ctx, inputs, engine.WithNowFunc(nowFunc))
 		return output, nil, err

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -25,12 +25,12 @@ type Config struct {
 
 var ErrTestFixtureNotFound = errors.New("test fixture not found")
 
-type InputChecker interface {
+type Checker interface {
 	Check(ctx context.Context, inputs []*enginev1.CheckInput, opts ...engine.CheckOpt) ([]*enginev1.CheckOutput, error)
 }
 
 // Verify runs the test suites from the provided directory.
-func Verify(ctx context.Context, fsys fs.FS, eng InputChecker, conf Config) (*policyv1.TestResults, error) {
+func Verify(ctx context.Context, fsys fs.FS, eng Checker, conf Config) (*policyv1.TestResults, error) {
 	var shouldRun func(string) bool
 
 	if conf.Run == "" {

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"sort"
 
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
 	"github.com/cerbos/cerbos/internal/engine"
 	"github.com/cerbos/cerbos/internal/util"
@@ -24,8 +25,12 @@ type Config struct {
 
 var ErrTestFixtureNotFound = errors.New("test fixture not found")
 
+type InputChecker interface {
+	Check(ctx context.Context, inputs []*enginev1.CheckInput, opts ...engine.CheckOpt) ([]*enginev1.CheckOutput, error)
+}
+
 // Verify runs the test suites from the provided directory.
-func Verify(ctx context.Context, fsys fs.FS, eng *engine.Engine, conf Config) (*policyv1.TestResults, error) {
+func Verify(ctx context.Context, fsys fs.FS, eng InputChecker, conf Config) (*policyv1.TestResults, error) {
 	var shouldRun func(string) bool
 
 	if conf.Run == "" {

--- a/private/verify/verify.go
+++ b/private/verify/verify.go
@@ -69,6 +69,6 @@ func WithCustomChecker(ctx context.Context, fsys fs.FS, eng simpleInputChecker) 
 
 type inputCheckFunc func(ctx context.Context, inputs []*enginev1.CheckInput) ([]*enginev1.CheckOutput, error)
 
-func (receiver inputCheckFunc) Check(ctx context.Context, inputs []*enginev1.CheckInput, _opts ...engine.CheckOpt) ([]*enginev1.CheckOutput, error) {
-	return receiver(ctx, inputs)
+func (f inputCheckFunc) Check(ctx context.Context, inputs []*enginev1.CheckInput, _opts ...engine.CheckOpt) ([]*enginev1.CheckOutput, error) {
+	return f(ctx, inputs)
 }

--- a/private/verify/verify.go
+++ b/private/verify/verify.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cerbos/cerbos/internal/verify"
 	"github.com/cerbos/cerbos/private/compile"
 
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	"go.uber.org/zap"
 )
 
@@ -51,4 +52,23 @@ func Files(ctx context.Context, fsys fs.FS) (*policyv1.TestResults, error) {
 	}
 
 	return results, nil
+}
+
+type simpleInputChecker interface {
+	Check(ctx context.Context, inputs []*enginev1.CheckInput) ([]*enginev1.CheckOutput, error)
+}
+
+func WithCustomChecker(ctx context.Context, fsys fs.FS, eng simpleInputChecker) (*policyv1.TestResults, error) {
+	results, err := verify.Verify(ctx, fsys, inputCheckFunc(eng.Check), verify.Config{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to run tests: %w", err)
+	}
+
+	return results, nil
+}
+
+type inputCheckFunc func(ctx context.Context, inputs []*enginev1.CheckInput) ([]*enginev1.CheckOutput, error)
+
+func (receiver inputCheckFunc) Check(ctx context.Context, inputs []*enginev1.CheckInput, _opts ...engine.CheckOpt) ([]*enginev1.CheckOutput, error) {
+	return receiver(ctx, inputs)
 }

--- a/private/verify/verify.go
+++ b/private/verify/verify.go
@@ -59,7 +59,7 @@ type simpleChecker interface {
 }
 
 func WithCustomChecker(ctx context.Context, fsys fs.FS, eng simpleChecker) (*policyv1.TestResults, error) {
-	results, err := verify.Verify(ctx, fsys, inputCheckFunc(eng.Check), verify.Config{})
+	results, err := verify.Verify(ctx, fsys, checkFunc(eng.Check), verify.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to run tests: %w", err)
 	}
@@ -67,8 +67,8 @@ func WithCustomChecker(ctx context.Context, fsys fs.FS, eng simpleChecker) (*pol
 	return results, nil
 }
 
-type inputCheckFunc func(ctx context.Context, inputs []*enginev1.CheckInput) ([]*enginev1.CheckOutput, error)
+type checkFunc func(ctx context.Context, inputs []*enginev1.CheckInput) ([]*enginev1.CheckOutput, error)
 
-func (f inputCheckFunc) Check(ctx context.Context, inputs []*enginev1.CheckInput, _opts ...engine.CheckOpt) ([]*enginev1.CheckOutput, error) {
+func (f checkFunc) Check(ctx context.Context, inputs []*enginev1.CheckInput, _opts ...engine.CheckOpt) ([]*enginev1.CheckOutput, error) {
 	return f(ctx, inputs)
 }

--- a/private/verify/verify.go
+++ b/private/verify/verify.go
@@ -54,11 +54,11 @@ func Files(ctx context.Context, fsys fs.FS) (*policyv1.TestResults, error) {
 	return results, nil
 }
 
-type simpleInputChecker interface {
+type simpleChecker interface {
 	Check(ctx context.Context, inputs []*enginev1.CheckInput) ([]*enginev1.CheckOutput, error)
 }
 
-func WithCustomChecker(ctx context.Context, fsys fs.FS, eng simpleInputChecker) (*policyv1.TestResults, error) {
+func WithCustomChecker(ctx context.Context, fsys fs.FS, eng simpleChecker) (*policyv1.TestResults, error) {
 	results, err := verify.Verify(ctx, fsys, inputCheckFunc(eng.Check), verify.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to run tests: %w", err)


### PR DESCRIPTION
Allow passing engine implementation to the private verifier.

Signed-off-by: Dennis Buduev <dennis@cerbos.dev>
