### PR TITLE
enhancement: Allow specification of gRPC request metadata keys to be logged

### DIFF
--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -3,6 +3,8 @@ audit:
   backend: local # Backend states which backend to use for Audits.
   decisionLogsEnabled: false # DecisionLogsEnabled defines whether logging of policy decisions is enabled.
   enabled: false # Enabled defines whether audit logging is enabled.
+  excludeMetadataKeys: ['content-type'] # ExcludeMetadataKeys defines which grpc request metadata keys are going to be excluded from the logs. Takes precedence over IncludeKeys.
+  includeMetadataKeys: ['content-type'] # IncludeMetadataKeys defines which grpc request metadata keys are going to be included in the logs.
   file:
     path: /path/to/file.log # Path to the log file to use as output. The special values stdout and stderr can be used to write to stdout or stderr respectively.
   local:

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -3,7 +3,7 @@ audit:
   backend: local # Backend states which backend to use for Audits.
   decisionLogsEnabled: false # DecisionLogsEnabled defines whether logging of policy decisions is enabled.
   enabled: false # Enabled defines whether audit logging is enabled.
-  excludeMetadataKeys: ['content-type'] # ExcludeMetadataKeys defines which gRPC request metadata keys should be excluded from access logs. Takes precedence over includeMetadataKeys.
+  excludeMetadataKeys: ['authorization'] # ExcludeMetadataKeys defines which gRPC request metadata keys should be excluded from access logs. Takes precedence over includeMetadataKeys.
   includeMetadataKeys: ['content-type'] # IncludeMetadataKeys defines which gRPC request metadata keys should be included in access logs.
   file:
     path: /path/to/file.log # Path to the log file to use as output. The special values stdout and stderr can be used to write to stdout or stderr respectively.

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -3,8 +3,8 @@ audit:
   backend: local # Backend states which backend to use for Audits.
   decisionLogsEnabled: false # DecisionLogsEnabled defines whether logging of policy decisions is enabled.
   enabled: false # Enabled defines whether audit logging is enabled.
-  excludeMetadataKeys: ['content-type'] # ExcludeMetadataKeys defines which grpc request metadata keys are going to be excluded from the logs. Takes precedence over IncludeKeys.
-  includeMetadataKeys: ['content-type'] # IncludeMetadataKeys defines which grpc request metadata keys are going to be included in the logs.
+  excludeMetadataKeys: ['content-type'] # ExcludeMetadataKeys defines which gRPC request metadata keys should be excluded from access logs. Takes precedence over includeMetadataKeys.
+  includeMetadataKeys: ['content-type'] # IncludeMetadataKeys defines which gRPC request metadata keys should be included in access logs.
   file:
     path: /path/to/file.log # Path to the log file to use as output. The special values stdout and stderr can be used to write to stdout or stderr respectively.
   local:

--- a/internal/audit/conf.go
+++ b/internal/audit/conf.go
@@ -22,6 +22,10 @@ type Conf struct {
 type confHolder struct {
 	// Backend states which backend to use for Audits.
 	Backend string `yaml:"backend" conf:",example=local"`
+	// IncludeMetadataKeys defines which grpc request metadata keys are going to be included in the logs.
+	IncludeMetadataKeys []string `yaml:"includeMetadataKeys" conf:",example=['content-type']"`
+	// ExcludeMetadataKeys defines which grpc request metadata keys are going to be excluded from the logs. Takes precedence over IncludeKeys.
+	ExcludeMetadataKeys []string `yaml:"excludeMetadataKeys" conf:",example=['content-type']"`
 	// Enabled defines whether audit logging is enabled.
 	Enabled bool `yaml:"enabled" conf:",example=false"`
 	// AccessLogsEnabled defines whether access logging is enabled.

--- a/internal/audit/conf.go
+++ b/internal/audit/conf.go
@@ -22,9 +22,9 @@ type Conf struct {
 type confHolder struct {
 	// Backend states which backend to use for Audits.
 	Backend string `yaml:"backend" conf:",example=local"`
-	// IncludeMetadataKeys defines which grpc request metadata keys are going to be included in the logs.
+	// IncludeMetadataKeys defines which gRPC request metadata keys should be included in access logs.
 	IncludeMetadataKeys []string `yaml:"includeMetadataKeys" conf:",example=['content-type']"`
-	// ExcludeMetadataKeys defines which grpc request metadata keys are going to be excluded from the logs. Takes precedence over IncludeKeys.
+	// ExcludeMetadataKeys defines which gRPC request metadata keys should be excluded from access logs. Takes precedence over includeMetadataKeys.
 	ExcludeMetadataKeys []string `yaml:"excludeMetadataKeys" conf:",example=['content-type']"`
 	// Enabled defines whether audit logging is enabled.
 	Enabled bool `yaml:"enabled" conf:",example=false"`

--- a/internal/audit/conf.go
+++ b/internal/audit/conf.go
@@ -25,7 +25,7 @@ type confHolder struct {
 	// IncludeMetadataKeys defines which gRPC request metadata keys should be included in access logs.
 	IncludeMetadataKeys []string `yaml:"includeMetadataKeys" conf:",example=['content-type']"`
 	// ExcludeMetadataKeys defines which gRPC request metadata keys should be excluded from access logs. Takes precedence over includeMetadataKeys.
-	ExcludeMetadataKeys []string `yaml:"excludeMetadataKeys" conf:",example=['content-type']"`
+	ExcludeMetadataKeys []string `yaml:"excludeMetadataKeys" conf:",example=['authorization']"`
 	// Enabled defines whether audit logging is enabled.
 	Enabled bool `yaml:"enabled" conf:",example=false"`
 	// AccessLogsEnabled defines whether access logging is enabled.

--- a/internal/audit/interceptor_test.go
+++ b/internal/audit/interceptor_test.go
@@ -1,0 +1,44 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build tests
+// +build tests
+
+package audit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMkIncludeKeysMethod(t *testing.T) {
+	testCases := []struct {
+		key      string
+		expected bool
+	}{
+		{
+			key:      "a",
+			expected: false,
+		},
+		{
+			key:      "b",
+			expected: false,
+		},
+		{
+			key:      "c",
+			expected: true,
+		},
+	}
+
+	excludedMetadataKeys := []string{"a", "b"}
+	includedMetadataKeys := []string{"a", "c"}
+	includeKeys := mkIncludeKeysMethod(excludedMetadataKeys, includedMetadataKeys)
+
+	for _, tc := range testCases {
+		t.Run(tc.key, func(t *testing.T) {
+			actual := includeKeys(tc.key)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Adds `excludeMetadataKeys` and `includeMetadataKeys` to `audit` configuration.

```
audit:
  accessLogsEnabled: true
  excludeMetadataKeys: ['content-type', 'user-agent']
  includeMetadataKeys: ['content-type', 'user-agent']
```

Here is description of how it works:
- If both `excludeMetadataKeys` and `includeMetadataKeys` has a certain key, the key will *NOT* be logged.
- If only `excludeMetadataKeys` has a certain key, the key will *NOT* be logged.
- If only `includeMetadataKeys` has a certain key, the key will be logged.

resolves #1201