### PR TITLE
docs: Add clarification about who provides parentRoles

### DIFF
--- a/docs/modules/policies/pages/derived_roles.adoc
+++ b/docs/modules/policies/pages/derived_roles.adoc
@@ -2,7 +2,7 @@ include::ROOT:partial$attributes.adoc[]
 
 = Derived roles
 
-Traditional RBAC roles are usually broad groupings with no context awareness. Derived roles are a way of augmenting those broad roles with contextual data to provide more fine-grained control at runtime. For example, a person with the broad `manager` role can be augmented to `manager_of_scranton_branch` by taking into account the geographic location (or another factor) and giving that derived role bearer extra privileges on resources that belong to the Scranton branch.
+Traditional RBAC roles are usually broad groupings with no context awareness. They are static and they are provided by the Identity Provider(IDP), not by Cerbos. Cerbos provides derived roles as a way of augmenting those broad roles with contextual data to provide more fine-grained control at runtime. For example, a person with the broad `manager` role can be augmented to `manager_of_scranton_branch` by taking into account the geographic location (or another factor) and giving that derived role bearer extra privileges on resources that belong to the Scranton branch.
 
 NOTE: Derived roles are dynamically determined at runtime by matching the principal's `roles` sent in the xref:api:index.adoc#check-resources[API request] to the `parentRoles` specified in the derived roles definitions. Don't use the derived role names as `roles` in the API request as Cerbos only expects that field to contain "normal" roles.    
 


### PR DESCRIPTION
I suggest to making more clear that parent roles are provided by the identity provider. It would be interesting to have some white papers links on the subject. Some libraries do this, such as alibaba (https://antv.vision/en/docs/specification/reference), but I couldn´t find any free white paper that talks about static roles and derived roles.

Signed-off-by: albcunha <albcunha@users.noreply.github.com>

#### Description

<!-- Thank you for contributing Cerbos! Please describe the changes made in this PR here and provide any other useful information for reviewers. Make sure that you included some automated tests (e.g unit tests) to verify your changes.  If there is a requirement for user input for testing, please include the instructions as well. -->

Fixes #<!-- Link the relevant issue here -->

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [ ] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [ ] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
