### PR TITLE
fix(sdk): Allow plaintext connections to any host 

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -17,7 +17,7 @@ import (
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/local"
+	"google.golang.org/grpc/credentials/insecure"
 
 	effectv1 "github.com/cerbos/cerbos/api/genpb/cerbos/effect/v1"
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
@@ -212,7 +212,7 @@ func mkDialOpts(conf *config) ([]grpc.DialOption, error) {
 	}
 
 	if conf.plaintext {
-		dialOpts = append(dialOpts, grpc.WithTransportCredentials(local.NewCredentials()))
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
 		tlsConf, err := mkTLSConfig(conf)
 		if err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,6 +1,8 @@
 // Copyright 2021-2022 Zenauth Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build tests
+
 package client_test
 
 import (
@@ -12,7 +14,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	"github.com/cerbos/cerbos/client"
 	"github.com/cerbos/cerbos/client/testutil"
 	"github.com/cerbos/cerbos/internal/test"
@@ -22,7 +23,6 @@ const (
 	adminUsername = "cerbos"
 	adminPassword = "cerbosAdmin"
 	jwt           = "eyJhbGciOiJFUzM4NCIsImtpZCI6IjE5TGZaYXRFZGc4M1lOYzVyMjNndU1KcXJuND0iLCJ0eXAiOiJKV1QifQ.eyJhdWQiOlsiY2VyYm9zLWp3dC10ZXN0cyJdLCJjdXN0b21BcnJheSI6WyJBIiwiQiIsIkMiXSwiY3VzdG9tSW50Ijo0MiwiY3VzdG9tTWFwIjp7IkEiOiJBQSIsIkIiOiJCQiIsIkMiOiJDQyJ9LCJjdXN0b21TdHJpbmciOiJmb29iYXIiLCJleHAiOjE5NDk5MzQwMzksImlzcyI6ImNlcmJvcy10ZXN0LXN1aXRlIn0.WN_tOScSpd_EI-P5EI1YlagxEgExSfBjAtcrgcF6lyWj1lGpR_GKx9goZEp2p_t5AVWXN_bjz_sMUmJdJa4cVd55Qm1miR-FKu6oNRHnSEWdMFmnArwPw-YDJWfylLFX"
-	timeout       = 15 * time.Second
 
 	readyTimeout      = 60 * time.Second
 	readyPollInterval = 50 * time.Millisecond
@@ -78,7 +78,7 @@ func TestClient(t *testing.T) {
 					c, err := client.New(port.addr, tc.opts...)
 					require.NoError(t, err)
 
-					t.Run(port.name, testGRPCClient(c.With(client.AuxDataJWT(jwt, ""))))
+					t.Run(port.name, client.TestGRPCClient(c.With(client.AuxDataJWT(jwt, ""))))
 				}
 			})
 
@@ -103,7 +103,7 @@ func TestClient(t *testing.T) {
 				c, err := client.New(s.GRPCAddr(), tc.opts...)
 				require.NoError(t, err)
 
-				t.Run("grpc", testGRPCClient(c.With(client.AuxDataJWT(jwt, ""))))
+				t.Run("grpc", client.TestGRPCClient(c.With(client.AuxDataJWT(jwt, ""))))
 			})
 		})
 	}
@@ -140,321 +140,6 @@ func loadPolicies(t *testing.T, ac client.AdminClient) {
 
 	require.NoError(t, err)
 	require.NoError(t, ac.AddOrUpdatePolicy(context.Background(), ps))
-}
-
-func testGRPCClient(c client.Client) func(*testing.T) {
-	return func(t *testing.T) {
-		t.Run("CheckResourceSet", func(t *testing.T) {
-			ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
-			defer cancelFunc()
-
-			have, err := c.CheckResourceSet(
-				ctx,
-				client.NewPrincipal("john").
-					WithRoles("employee").
-					WithPolicyVersion("20210210").
-					WithAttributes(map[string]any{
-						"department": "marketing",
-						"geography":  "GB",
-						"team":       "design",
-					}),
-				client.NewResourceSet("leave_request").
-					WithPolicyVersion("20210210").
-					AddResourceInstance("XX125", map[string]any{
-						"department": "marketing",
-						"geography":  "GB",
-						"id":         "XX125",
-						"owner":      "john",
-						"team":       "design",
-					}),
-				"view:public", "approve", "defer")
-
-			require.NoError(t, err)
-			require.True(t, have.IsAllowed("XX125", "view:public"))
-			require.False(t, have.IsAllowed("XX125", "approve"))
-			require.True(t, have.IsAllowed("XX125", "defer"))
-		})
-
-		t.Run("CheckResourceBatch", func(t *testing.T) {
-			ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
-			defer cancelFunc()
-
-			have, err := c.CheckResourceBatch(
-				ctx,
-				client.NewPrincipal("john").
-					WithRoles("employee").
-					WithPolicyVersion("20210210").
-					WithAttributes(map[string]any{
-						"department": "marketing",
-						"geography":  "GB",
-						"team":       "design",
-					}),
-				client.NewResourceBatch().
-					Add(client.
-						NewResource("leave_request", "XX125").
-						WithPolicyVersion("20210210").
-						WithAttributes(map[string]any{
-							"department": "marketing",
-							"geography":  "GB",
-							"id":         "XX125",
-							"owner":      "john",
-							"team":       "design",
-						}), "view:public", "defer").
-					Add(client.
-						NewResource("leave_request", "XX125").
-						WithPolicyVersion("20210210").
-						WithAttributes(map[string]any{
-							"department": "marketing",
-							"geography":  "GB",
-							"id":         "XX125",
-							"owner":      "john",
-							"team":       "design",
-						}), "approve").
-					Add(client.
-						NewResource("leave_request", "XX225").
-						WithPolicyVersion("20210210").
-						WithAttributes(map[string]any{
-							"department": "engineering",
-							"geography":  "GB",
-							"id":         "XX225",
-							"owner":      "mary",
-							"team":       "frontend",
-						}), "approve"),
-			)
-
-			require.NoError(t, err)
-			require.True(t, have.IsAllowed("XX125", "view:public"))
-			require.False(t, have.IsAllowed("XX125", "approve"))
-			require.True(t, have.IsAllowed("XX125", "defer"))
-			require.False(t, have.IsAllowed("XX225", "approve"))
-		})
-
-		t.Run("CheckResources", func(t *testing.T) {
-			principal := client.NewPrincipal("john").
-				WithRoles("employee").
-				WithPolicyVersion("20210210").
-				WithAttributes(map[string]any{
-					"department": "marketing",
-					"geography":  "GB",
-					"team":       "design",
-				})
-
-			resources := client.NewResourceBatch().
-				Add(client.
-					NewResource("leave_request", "XX125").
-					WithPolicyVersion("20210210").
-					WithAttributes(map[string]any{
-						"department": "marketing",
-						"geography":  "GB",
-						"id":         "XX125",
-						"owner":      "john",
-						"team":       "design",
-					}), "view:public", "defer").
-				Add(client.
-					NewResource("leave_request", "XX125").
-					WithPolicyVersion("20210210").
-					WithAttributes(map[string]any{
-						"department": "marketing",
-						"geography":  "GB",
-						"id":         "XX125",
-						"owner":      "john",
-						"team":       "design",
-					}), "approve").
-				Add(client.
-					NewResource("leave_request", "XX225").
-					WithPolicyVersion("20210210").
-					WithAttributes(map[string]any{
-						"department": "engineering",
-						"geography":  "GB",
-						"id":         "XX225",
-						"owner":      "mary",
-						"team":       "frontend",
-					}), "approve")
-
-			check := func(t *testing.T, have *client.CheckResourcesResponse, err error) {
-				t.Helper()
-				require.NoError(t, err)
-
-				haveXX125 := have.GetResource("XX125", client.MatchResourceKind("leave_request"))
-				require.NoError(t, haveXX125.Err())
-				require.True(t, haveXX125.IsAllowed("view:public"))
-				require.False(t, haveXX125.IsAllowed("approve"))
-				require.True(t, haveXX125.IsAllowed("defer"))
-
-				haveXX225 := have.GetResource("XX225")
-				require.NoError(t, haveXX225.Err())
-				require.False(t, haveXX225.IsAllowed("approve"))
-			}
-
-			t.Run("Direct", func(t *testing.T) {
-				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
-				defer cancelFunc()
-
-				have, err := c.CheckResources(ctx, principal, resources)
-				check(t, have, err)
-			})
-
-			t.Run("WithPrincipal", func(t *testing.T) {
-				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
-				defer cancelFunc()
-
-				have, err := c.WithPrincipal(principal).CheckResources(ctx, resources)
-				check(t, have, err)
-			})
-		})
-
-		t.Run("CheckResourcesScoped", func(t *testing.T) {
-			principal := client.NewPrincipal("john").
-				WithRoles("employee").
-				WithScope("acme.hr").
-				WithAttributes(map[string]any{
-					"department": "marketing",
-					"geography":  "GB",
-					"team":       "design",
-					"ip_address": "10.20.5.5",
-				})
-
-			resources := client.NewResourceBatch().
-				Add(client.
-					NewResource("leave_request", "XX125").
-					WithScope("acme.hr.uk").
-					WithAttributes(map[string]any{
-						"department": "marketing",
-						"geography":  "GB",
-						"id":         "XX125",
-						"owner":      "john",
-						"team":       "design",
-					}), "view:public", "delete", "create").
-				Add(client.
-					NewResource("leave_request", "XX225").
-					WithScope("acme.hr").
-					WithAttributes(map[string]any{
-						"department": "marketing",
-						"geography":  "GB",
-						"id":         "XX225",
-						"owner":      "john",
-						"team":       "design",
-					}), "view:public", "delete", "create")
-
-			check := func(t *testing.T, have *client.CheckResourcesResponse, err error) {
-				t.Helper()
-				require.NoError(t, err)
-
-				haveXX125 := have.GetResource("XX125", client.MatchResourceKind("leave_request"))
-				require.NoError(t, haveXX125.Err())
-				require.True(t, haveXX125.IsAllowed("view:public"))
-				require.True(t, haveXX125.IsAllowed("delete"))
-				require.True(t, haveXX125.IsAllowed("create"))
-				require.Equal(t, "acme.hr.uk", haveXX125.Resource.Scope)
-
-				haveXX225 := have.GetResource("XX225", client.MatchResourceKind("leave_request"))
-				require.NoError(t, haveXX225.Err())
-				require.True(t, haveXX225.IsAllowed("view:public"))
-				require.False(t, haveXX225.IsAllowed("delete"))
-				require.True(t, haveXX225.IsAllowed("create"))
-				require.Equal(t, "acme.hr", haveXX225.Resource.Scope)
-			}
-
-			t.Run("Direct", func(t *testing.T) {
-				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
-				defer cancelFunc()
-
-				have, err := c.CheckResources(ctx, principal, resources)
-				check(t, have, err)
-			})
-
-			t.Run("WithPrincipal", func(t *testing.T) {
-				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
-				defer cancelFunc()
-
-				have, err := c.WithPrincipal(principal).CheckResources(ctx, resources)
-				check(t, have, err)
-			})
-		})
-
-		t.Run("IsAllowed", func(t *testing.T) {
-			principal := client.NewPrincipal("john").
-				WithRoles("employee").
-				WithPolicyVersion("20210210").
-				WithAttributes(map[string]any{
-					"department": "marketing",
-					"geography":  "GB",
-					"team":       "design",
-				})
-
-			resource := client.NewResource("leave_request", "XX125").
-				WithPolicyVersion("20210210").
-				WithAttributes(map[string]any{
-					"department": "marketing",
-					"geography":  "GB",
-					"id":         "XX125",
-					"owner":      "john",
-					"team":       "design",
-				})
-
-			t.Run("Direct", func(t *testing.T) {
-				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
-				defer cancelFunc()
-
-				have, err := c.IsAllowed(ctx, principal, resource, "defer")
-				require.NoError(t, err)
-				require.True(t, have)
-			})
-
-			t.Run("WithPrincipal", func(t *testing.T) {
-				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
-				defer cancelFunc()
-
-				have, err := c.WithPrincipal(principal).IsAllowed(ctx, resource, "defer")
-				require.NoError(t, err)
-				require.True(t, have)
-			})
-		})
-
-		t.Run("ResourcesQueryPlan", func(t *testing.T) {
-			principal := client.NewPrincipal("maggie").
-				WithRoles("manager").
-				WithAttr("geography", "US").
-				WithAttr("managed_geographies", "US").
-				WithAttr("reader", false)
-
-			resource := client.NewResource("leave_request", "").
-				WithPolicyVersion("20210210").
-				WithAttr("geography", "US")
-
-			cc := c.With(client.IncludeMeta(true))
-
-			check := func(t *testing.T, have *client.PlanResourcesResponse, err error) {
-				t.Helper()
-				is := require.New(t)
-
-				is.NoError(err)
-				is.Equal(have.Filter.Kind, enginev1.PlanResourcesFilter_KIND_CONDITIONAL)
-				expression := have.Filter.Condition.GetExpression()
-				is.NotNil(expression)
-				is.Equal(expression.Operator, "eq")
-				is.Equal(expression.Operands[0].GetVariable(), "request.resource.attr.status")
-				is.Equal(expression.Operands[1].GetValue().GetStringValue(), "PENDING_APPROVAL")
-				t.Log(have.Meta.FilterDebug)
-			}
-
-			t.Run("Direct", func(t *testing.T) {
-				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
-				defer cancelFunc()
-
-				have, err := cc.PlanResources(ctx, principal, resource, "approve")
-				check(t, have, err)
-			})
-
-			t.Run("WithPrincipal", func(t *testing.T) {
-				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
-				defer cancelFunc()
-
-				have, err := cc.WithPrincipal(principal).PlanResources(ctx, resource, "approve")
-				check(t, have, err)
-			})
-		})
-	}
 }
 
 func serverIsReady(s *testutil.ServerInfo) func() bool {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -22,13 +22,13 @@ import (
 const (
 	adminUsername = "cerbos"
 	adminPassword = "cerbosAdmin"
-	jwt           = "eyJhbGciOiJFUzM4NCIsImtpZCI6IjE5TGZaYXRFZGc4M1lOYzVyMjNndU1KcXJuND0iLCJ0eXAiOiJKV1QifQ.eyJhdWQiOlsiY2VyYm9zLWp3dC10ZXN0cyJdLCJjdXN0b21BcnJheSI6WyJBIiwiQiIsIkMiXSwiY3VzdG9tSW50Ijo0MiwiY3VzdG9tTWFwIjp7IkEiOiJBQSIsIkIiOiJCQiIsIkMiOiJDQyJ9LCJjdXN0b21TdHJpbmciOiJmb29iYXIiLCJleHAiOjE5NDk5MzQwMzksImlzcyI6ImNlcmJvcy10ZXN0LXN1aXRlIn0.WN_tOScSpd_EI-P5EI1YlagxEgExSfBjAtcrgcF6lyWj1lGpR_GKx9goZEp2p_t5AVWXN_bjz_sMUmJdJa4cVd55Qm1miR-FKu6oNRHnSEWdMFmnArwPw-YDJWfylLFX"
 
 	readyTimeout      = 60 * time.Second
 	readyPollInterval = 50 * time.Millisecond
 )
 
 func TestClient(t *testing.T) {
+	jwt := client.GenerateToken(t, time.Now().Add(5*time.Minute))
 	testCases := []struct {
 		name string
 		tls  bool

--- a/client/tests.go
+++ b/client/tests.go
@@ -1,0 +1,341 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build tests || e2e
+
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
+	"github.com/stretchr/testify/require"
+)
+
+const timeout = 15 * time.Second
+
+func RunE2ETests(addr string, opts ...Opt) func(*testing.T) {
+	c, err := New(addr, opts...)
+	if err != nil {
+		panic(err)
+	}
+
+	return TestGRPCClient(c)
+}
+
+func TestGRPCClient(c Client) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Run("CheckResourceSet", func(t *testing.T) {
+			ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
+			defer cancelFunc()
+
+			have, err := c.CheckResourceSet(
+				ctx,
+				NewPrincipal("john").
+					WithRoles("employee").
+					WithPolicyVersion("20210210").
+					WithAttributes(map[string]any{
+						"department": "marketing",
+						"geography":  "GB",
+						"team":       "design",
+					}),
+				NewResourceSet("leave_request").
+					WithPolicyVersion("20210210").
+					AddResourceInstance("XX125", map[string]any{
+						"department": "marketing",
+						"geography":  "GB",
+						"id":         "XX125",
+						"owner":      "john",
+						"team":       "design",
+					}),
+				"view:public", "approve", "defer")
+
+			require.NoError(t, err)
+			require.True(t, have.IsAllowed("XX125", "view:public"))
+			require.False(t, have.IsAllowed("XX125", "approve"))
+			require.True(t, have.IsAllowed("XX125", "defer"))
+		})
+
+		t.Run("CheckResourceBatch", func(t *testing.T) {
+			ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
+			defer cancelFunc()
+
+			have, err := c.CheckResourceBatch(
+				ctx,
+				NewPrincipal("john").
+					WithRoles("employee").
+					WithPolicyVersion("20210210").
+					WithAttributes(map[string]any{
+						"department": "marketing",
+						"geography":  "GB",
+						"team":       "design",
+					}),
+				NewResourceBatch().
+					Add(
+						NewResource("leave_request", "XX125").
+							WithPolicyVersion("20210210").
+							WithAttributes(map[string]any{
+								"department": "marketing",
+								"geography":  "GB",
+								"id":         "XX125",
+								"owner":      "john",
+								"team":       "design",
+							}), "view:public", "defer").
+					Add(
+						NewResource("leave_request", "XX125").
+							WithPolicyVersion("20210210").
+							WithAttributes(map[string]any{
+								"department": "marketing",
+								"geography":  "GB",
+								"id":         "XX125",
+								"owner":      "john",
+								"team":       "design",
+							}), "approve").
+					Add(
+						NewResource("leave_request", "XX225").
+							WithPolicyVersion("20210210").
+							WithAttributes(map[string]any{
+								"department": "engineering",
+								"geography":  "GB",
+								"id":         "XX225",
+								"owner":      "mary",
+								"team":       "frontend",
+							}), "approve"),
+			)
+
+			require.NoError(t, err)
+			require.True(t, have.IsAllowed("XX125", "view:public"))
+			require.False(t, have.IsAllowed("XX125", "approve"))
+			require.True(t, have.IsAllowed("XX125", "defer"))
+			require.False(t, have.IsAllowed("XX225", "approve"))
+		})
+
+		t.Run("CheckResources", func(t *testing.T) {
+			principal := NewPrincipal("john").
+				WithRoles("employee").
+				WithPolicyVersion("20210210").
+				WithAttributes(map[string]any{
+					"department": "marketing",
+					"geography":  "GB",
+					"team":       "design",
+				})
+
+			resources := NewResourceBatch().
+				Add(
+					NewResource("leave_request", "XX125").
+						WithPolicyVersion("20210210").
+						WithAttributes(map[string]any{
+							"department": "marketing",
+							"geography":  "GB",
+							"id":         "XX125",
+							"owner":      "john",
+							"team":       "design",
+						}), "view:public", "defer").
+				Add(
+					NewResource("leave_request", "XX125").
+						WithPolicyVersion("20210210").
+						WithAttributes(map[string]any{
+							"department": "marketing",
+							"geography":  "GB",
+							"id":         "XX125",
+							"owner":      "john",
+							"team":       "design",
+						}), "approve").
+				Add(
+					NewResource("leave_request", "XX225").
+						WithPolicyVersion("20210210").
+						WithAttributes(map[string]any{
+							"department": "engineering",
+							"geography":  "GB",
+							"id":         "XX225",
+							"owner":      "mary",
+							"team":       "frontend",
+						}), "approve")
+
+			check := func(t *testing.T, have *CheckResourcesResponse, err error) {
+				t.Helper()
+				require.NoError(t, err)
+
+				haveXX125 := have.GetResource("XX125", MatchResourceKind("leave_request"))
+				require.NoError(t, haveXX125.Err())
+				require.True(t, haveXX125.IsAllowed("view:public"))
+				require.False(t, haveXX125.IsAllowed("approve"))
+				require.True(t, haveXX125.IsAllowed("defer"))
+
+				haveXX225 := have.GetResource("XX225")
+				require.NoError(t, haveXX225.Err())
+				require.False(t, haveXX225.IsAllowed("approve"))
+			}
+
+			t.Run("Direct", func(t *testing.T) {
+				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
+				defer cancelFunc()
+
+				have, err := c.CheckResources(ctx, principal, resources)
+				check(t, have, err)
+			})
+
+			t.Run("WithPrincipal", func(t *testing.T) {
+				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
+				defer cancelFunc()
+
+				have, err := c.WithPrincipal(principal).CheckResources(ctx, resources)
+				check(t, have, err)
+			})
+		})
+
+		t.Run("CheckResourcesScoped", func(t *testing.T) {
+			principal := NewPrincipal("john").
+				WithRoles("employee").
+				WithScope("acme.hr").
+				WithAttributes(map[string]any{
+					"department": "marketing",
+					"geography":  "GB",
+					"team":       "design",
+					"ip_address": "10.20.5.5",
+				})
+
+			resources := NewResourceBatch().
+				Add(
+					NewResource("leave_request", "XX125").
+						WithScope("acme.hr.uk").
+						WithAttributes(map[string]any{
+							"department": "marketing",
+							"geography":  "GB",
+							"id":         "XX125",
+							"owner":      "john",
+							"team":       "design",
+						}), "view:public", "delete", "create").
+				Add(
+					NewResource("leave_request", "XX225").
+						WithScope("acme.hr").
+						WithAttributes(map[string]any{
+							"department": "marketing",
+							"geography":  "GB",
+							"id":         "XX225",
+							"owner":      "john",
+							"team":       "design",
+						}), "view:public", "delete", "create")
+
+			check := func(t *testing.T, have *CheckResourcesResponse, err error) {
+				t.Helper()
+				require.NoError(t, err)
+
+				haveXX125 := have.GetResource("XX125", MatchResourceKind("leave_request"))
+				require.NoError(t, haveXX125.Err())
+				require.True(t, haveXX125.IsAllowed("view:public"))
+				require.True(t, haveXX125.IsAllowed("delete"))
+				require.True(t, haveXX125.IsAllowed("create"))
+				require.Equal(t, "acme.hr.uk", haveXX125.Resource.Scope)
+
+				haveXX225 := have.GetResource("XX225", MatchResourceKind("leave_request"))
+				require.NoError(t, haveXX225.Err())
+				require.True(t, haveXX225.IsAllowed("view:public"))
+				require.False(t, haveXX225.IsAllowed("delete"))
+				require.True(t, haveXX225.IsAllowed("create"))
+				require.Equal(t, "acme.hr", haveXX225.Resource.Scope)
+			}
+
+			t.Run("Direct", func(t *testing.T) {
+				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
+				defer cancelFunc()
+
+				have, err := c.CheckResources(ctx, principal, resources)
+				check(t, have, err)
+			})
+
+			t.Run("WithPrincipal", func(t *testing.T) {
+				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
+				defer cancelFunc()
+
+				have, err := c.WithPrincipal(principal).CheckResources(ctx, resources)
+				check(t, have, err)
+			})
+		})
+
+		t.Run("IsAllowed", func(t *testing.T) {
+			principal := NewPrincipal("john").
+				WithRoles("employee").
+				WithPolicyVersion("20210210").
+				WithAttributes(map[string]any{
+					"department": "marketing",
+					"geography":  "GB",
+					"team":       "design",
+				})
+
+			resource := NewResource("leave_request", "XX125").
+				WithPolicyVersion("20210210").
+				WithAttributes(map[string]any{
+					"department": "marketing",
+					"geography":  "GB",
+					"id":         "XX125",
+					"owner":      "john",
+					"team":       "design",
+				})
+
+			t.Run("Direct", func(t *testing.T) {
+				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
+				defer cancelFunc()
+
+				have, err := c.IsAllowed(ctx, principal, resource, "defer")
+				require.NoError(t, err)
+				require.True(t, have)
+			})
+
+			t.Run("WithPrincipal", func(t *testing.T) {
+				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
+				defer cancelFunc()
+
+				have, err := c.WithPrincipal(principal).IsAllowed(ctx, resource, "defer")
+				require.NoError(t, err)
+				require.True(t, have)
+			})
+		})
+
+		t.Run("ResourcesQueryPlan", func(t *testing.T) {
+			principal := NewPrincipal("maggie").
+				WithRoles("manager").
+				WithAttr("geography", "US").
+				WithAttr("managed_geographies", "US").
+				WithAttr("reader", false)
+
+			resource := NewResource("leave_request", "").
+				WithPolicyVersion("20210210").
+				WithAttr("geography", "US")
+
+			cc := c.With(IncludeMeta(true))
+
+			check := func(t *testing.T, have *PlanResourcesResponse, err error) {
+				t.Helper()
+				is := require.New(t)
+
+				is.NoError(err)
+				is.Equal(have.Filter.Kind, enginev1.PlanResourcesFilter_KIND_CONDITIONAL)
+				expression := have.Filter.Condition.GetExpression()
+				is.NotNil(expression)
+				is.Equal(expression.Operator, "eq")
+				is.Equal(expression.Operands[0].GetVariable(), "request.resource.attr.status")
+				is.Equal(expression.Operands[1].GetValue().GetStringValue(), "PENDING_APPROVAL")
+				t.Log(have.Meta.FilterDebug)
+			}
+
+			t.Run("Direct", func(t *testing.T) {
+				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
+				defer cancelFunc()
+
+				have, err := cc.PlanResources(ctx, principal, resource, "approve")
+				check(t, have, err)
+			})
+
+			t.Run("WithPrincipal", func(t *testing.T) {
+				ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
+				defer cancelFunc()
+
+				have, err := cc.WithPrincipal(principal).PlanResources(ctx, resource, "approve")
+				check(t, have, err)
+			})
+		})
+	}
+}

--- a/e2e/notls/helmfile.yaml
+++ b/e2e/notls/helmfile.yaml
@@ -1,0 +1,85 @@
+repositories:
+  - name: bitnami
+    url: https://charts.bitnami.com/bitnami
+
+helmDefaults:
+  cleanupOnFail: true
+  wait: true
+  recreatePods: true
+  force: true
+  createNamespace: true
+
+releases:
+  - name: cerbos
+    namespace: '{{ requiredEnv "E2E_NS" }}'
+    createNamespace: true
+    labels:
+      e2e-run: '{{ requiredEnv "E2E_RUN_ID" }}'
+      e2e-ctx: '{{ requiredEnv "E2E_CONTEXT_ID" }}'
+    chart: '{{ requiredEnv "E2E_SRC_ROOT" }}/deploy/charts/cerbos'
+    hooks:
+      - events: ["presync"]
+        showlogs: true
+        command: kubectl
+        args:
+          - create
+          - namespace
+          - '{{ requiredEnv "E2E_NS" }}'
+      - events: ["postuninstall"]
+        showlogs: true
+        command: kubectl
+        args:
+          - delete
+          - namespace
+          - '{{ requiredEnv "E2E_NS" }}'
+    values:
+      - nameOverride: '{{ requiredEnv "E2E_CONTEXT_ID" }}'
+      - image:
+          repository: '{{ env "E2E_CERBOS_IMG_REPO" | default "ghcr.io/cerbos/cerbos" }}'
+          tag: '{{ env "E2E_CERBOS_IMG_TAG" | default "dev" }}'
+      - volumes:
+        - name: cerbos-auditlog
+          emptyDir: {}
+        - name: cerbos-policies
+          emptyDir: {}
+      - volumeMounts:
+        - name: cerbos-auditlog
+          mountPath: /audit
+        - name: cerbos-policies
+          mountPath: /data
+      - cerbos:
+          logLevel: DEBUG
+          config:
+            server:
+              playgroundEnabled: true
+              requestLimits:
+                maxActionsPerResource: 5
+                maxResourcesPerRequest: 5
+              adminAPI:
+                enabled: true
+                adminCredentials:
+                  username: cerbos
+                  passwordHash: JDJ5JDEwJC5BYjQyY2RJNG5QR2NWMmJPdnNtQU93c09RYVA0eFFGdHBrbmFEeXh1NnlIVTE1cHJNY05PCgo=
+            auxData:
+              jwt:
+                disableVerification: true
+            schema:
+              enforcement: reject
+            audit:
+              enabled: true
+              accessLogsEnabled: true
+              decisionLogsEnabled: true
+              backend: local
+              local:
+                storagePath: /audit/cerbos
+            storage:
+              driver: "git"
+              git:
+                protocol: https
+                url: https://github.com/cerbos/cerbos.git
+                branch: main
+                subDir: internal/test/testdata/store
+                checkoutDir: /data
+                updatePollInterval: 60s
+            telemetry:
+              disabled: true

--- a/e2e/notls/notls_test.go
+++ b/e2e/notls/notls_test.go
@@ -1,0 +1,16 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build e2e
+
+package notls_test
+
+import (
+	"testing"
+
+	"github.com/cerbos/cerbos/internal/test/e2e"
+)
+
+func TestNoTLS(t *testing.T) {
+	e2e.RunSuites(t, e2e.WithContextID("notls"), e2e.WithImmutableStoreSuites(), e2e.WithTLSDisabled())
+}

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -29,7 +29,7 @@ stop_kind() {
 run_tests() {
     (
         cd "$SCRIPT_DIR"
-        telepresence helm install
+        telepresence helm install --upgrade
         telepresence connect --no-report -- go test -v -failfast -p=1 --tags="tests e2e" "$@"
     )
 }

--- a/internal/server/tests.go
+++ b/internal/server/tests.go
@@ -52,7 +52,7 @@ func (ac AuthCreds) GetRequestMetadata(ctx context.Context, in ...string) (map[s
 }
 
 func (AuthCreds) RequireTransportSecurity() bool {
-	return true
+	return false
 }
 
 func LoadTestCases(tb testing.TB, dirs ...string) *TestRunner {

--- a/internal/test/e2e/ctx.go
+++ b/internal/test/e2e/ctx.go
@@ -71,12 +71,13 @@ type Config struct {
 	NoCleanup      bool          `json:"no_cleanup"`
 }
 
-func NewCtx(t *testing.T, contextID string) Ctx {
-	return Ctx{ContextID: contextID, Config: conf, T: t}
+func NewCtx(t *testing.T, contextID string, noTLS bool) Ctx {
+	return Ctx{ContextID: contextID, Config: conf, T: t, NoTLS: noTLS}
 }
 
 type Ctx struct {
 	ContextID string
+	NoTLS     bool
 	*testing.T
 	Config
 }
@@ -122,7 +123,11 @@ func (c Ctx) GRPCAddr() string {
 }
 
 func (c Ctx) HTTPAddr() string {
-	return fmt.Sprintf("https://%s:%d", c.CerbosHost(), HTTPPort)
+	protocol := "https"
+	if c.NoTLS {
+		protocol = "http"
+	}
+	return fmt.Sprintf("%s://%s:%d", protocol, c.CerbosHost(), HTTPPort)
 }
 
 func (c Ctx) HealthURL() string {


### PR DESCRIPTION
The SDK client was configured to use local transport credentials when the `WithPlaintext` option was used. That prevents the client from connecting to any hosts other than localhost. This PR switches the credential type to `insecure`.

We didn't catch this before because the E2E tests always use TLS. This PR integrates the client tests into the E2E suite and introduces a new test that runs without TLS.