### PR TITLE
docs(backport): Fix git storage driver configuration example

### DIFF
--- a/docs/modules/configuration/pages/storage.adoc
+++ b/docs/modules/configuration/pages/storage.adoc
@@ -139,7 +139,7 @@ storage:
   driver: "git" 
   git: 
     protocol: ssh 
-    url: ssh://github.com:cerbos/policy-test.git
+    url: github.com:cerbos/policy-test.git
     branch: main
     subDir: policies
     checkoutDir: ${HOME}/tmp/cerbos/work 


### PR DESCRIPTION
Backport of #1211 

Error:
```
2022-09-13T11:59:54.678+0300    ERROR   cerbos.git.store        Failed to initialize git store  {"dir": "...", "error": "failed to clone from ssh://github.com:cerbos/policy-test.git to ...: parse \"ssh://github.com:cerbos/policy-test.git\": invalid port \":cerbos\" after host"}
```