### PR TITLE
fix: Purge compile cache on store reload

### DIFF
--- a/internal/storage/db/internal/db.go
+++ b/internal/storage/db/internal/db.go
@@ -30,6 +30,7 @@ import (
 type DBStorage interface {
 	storage.Subscribable
 	storage.Instrumented
+	storage.Reloadable
 	AddOrUpdate(ctx context.Context, policies ...policy.Wrapper) error
 	GetCompilationUnits(ctx context.Context, ids ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error)
 	GetDependents(ctx context.Context, ids ...namer.ModuleID) (map[namer.ModuleID][]namer.ModuleID, error)
@@ -579,4 +580,9 @@ func (s *dbStorage) RepoStats(ctx context.Context) storage.RepoStats {
 		ScanValContext(ctx, &stats.SchemaCount)
 
 	return stats
+}
+
+func (s *dbStorage) Reload(context.Context) error {
+	s.NotifySubscribers(storage.NewReloadEvent())
+	return nil
 }

--- a/internal/storage/db/store.go
+++ b/internal/storage/db/store.go
@@ -4,19 +4,7 @@
 package db
 
 import (
-	"context"
 	"errors"
-
-	"github.com/cerbos/cerbos/internal/namer"
-	"github.com/cerbos/cerbos/internal/policy"
 )
 
 var ErrNoResults = errors.New("no results")
-
-type Store interface {
-	AddOrUpdate(context.Context, ...policy.Wrapper) error
-	Delete(context.Context, ...namer.ModuleID) error
-	GetCompilationUnits(context.Context, ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error)
-	ListPolicyIDs(context.Context) ([]string, error)
-	ListSchemaIDs(context.Context) ([]string, error)
-}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -163,6 +163,7 @@ const (
 	EventDeletePolicy
 	EventAddOrUpdateSchema
 	EventDeleteSchema
+	EventReload
 	EventNop
 )
 
@@ -187,6 +188,8 @@ func (evt Event) String() string {
 	case EventDeleteSchema:
 		kind = "DELETE SCHEMA"
 		id = evt.SchemaFile
+	case EventReload:
+		kind = "RELOAD"
 	case EventNop:
 		kind = "NOP"
 	default:
@@ -204,6 +207,11 @@ func NewPolicyEvent(kind EventKind, policyID namer.ModuleID) Event {
 // NewSchemaEvent creates a new storage event for a schema.
 func NewSchemaEvent(kind EventKind, schemaFile string) Event {
 	return Event{Kind: kind, SchemaFile: schemaFile}
+}
+
+// NewReloadEvent creates a new reload event.
+func NewReloadEvent() Event {
+	return Event{Kind: EventReload}
 }
 
 type RepoStats struct {


### PR DESCRIPTION
Purges the compile cache when the store is reloaded using the Admin API.
Previously, the cache was only updated when there were new or deleted
files. If an existing file had changed, that wasn't detected.

This change also makes the database stores reloadable.

Fixes #1215

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
