### PR TITLE
enhancement: Group compile requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ compile:
 	@ go build ./... && go test -tags="tests e2e" -run=ignore  ./... > /dev/null
 
 .PHONY: pre-commit
-pre-commit: lint-helm build test-race
+pre-commit: lint-helm generate lint test-all
 
 .PHONY: build
 build: generate lint test package

--- a/internal/audit/interceptor.go
+++ b/internal/audit/interceptor.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	auditv1 "github.com/cerbos/cerbos/api/genpb/cerbos/audit/v1"
+	"github.com/cerbos/cerbos/internal/observability/tracing"
 )
 
 type (
@@ -50,6 +51,9 @@ func NewUnaryInterceptor(log Log, exclude ExcludeMethod) (grpc.UnaryServerInterc
 		resp, err := handler(NewContextWithCallID(ctx, callID), req)
 
 		if logErr := log.WriteAccessLogEntry(ctx, func() (*auditv1.AccessLogEntry, error) {
+			ctx, span := tracing.StartSpan(ctx, "audit.WriteAccessLog")
+			defer span.End()
+
 			entry := &auditv1.AccessLogEntry{
 				CallId:     string(callID),
 				Timestamp:  timestamppb.New(ts),

--- a/internal/compile/manager_test.go
+++ b/internal/compile/manager_test.go
@@ -236,8 +236,8 @@ func anyCtx(ctx context.Context) bool {
 }
 
 type MockStore struct {
-	mock.Mock
 	subscriber storage.Subscriber
+	mock.Mock
 }
 
 func (ms *MockStore) Driver() string {

--- a/internal/observability/tracing/attributes.go
+++ b/internal/observability/tracing/attributes.go
@@ -9,10 +9,16 @@ const (
 	requestIDKey     = attribute.Key("cerbos.request.id")
 	reqResourceIDKey = attribute.Key("cerbos.request.resource_id")
 	policyFQNKey     = attribute.Key("cerbos.policy.fqn")
+	policyNameKey    = attribute.Key("cerbos.policy.name")
+	policyScopeKey   = attribute.Key("cerbos.policy.scope")
+	policyVersionKey = attribute.Key("cerbos.policy.version")
 )
 
 var (
 	RequestID     = requestIDKey.String
 	ReqResourceID = reqResourceIDKey.String
 	PolicyFQN     = policyFQNKey.String
+	PolicyName    = policyNameKey.String
+	PolicyScope   = policyScopeKey.String
+	PolicyVersion = policyVersionKey.String
 )


### PR DESCRIPTION
Group simultaneous requests to compile a policy into a single call.

Also adds more trace spans to the engine to increase visibility.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
