### PR TITLE
docs: Fix usage of CEL matches operator

### DIFF
--- a/docs/modules/policies/pages/conditions.adoc
+++ b/docs/modules/policies/pages/conditions.adoc
@@ -32,7 +32,7 @@ Every condition expression must evaluate to a boolean true/false value. You can 
 ----
 condition:
   match:
-    expr: matches(P.id, "^dev_.*")
+    expr: P.id.matches("^dev_.*")
 ----
 
 .``all`` operator: all expressions must evaluate to true (logical AND)
@@ -84,7 +84,7 @@ condition:
         - any:
             of: 
               - expr: R.attr.dev == true
-              - expr: matches(R.attr.id, "^[98][0-9]+")
+              - expr: R.attr.id.matches("^[98][0-9]+")
         - none:
             of:
               - expr: R.attr.qa == true
@@ -99,7 +99,7 @@ condition:
   match:
     expr: |-
       (R.attr.status == "DRAFT" && 
-        (R.attr.dev == true || matches(R.attr.id, "^[98][0-9]+")) &&
+        (R.attr.dev == true || R.attr.id.matches("^[98][0-9]+")) &&
         !(R.attr.qa == true || R.attr.canary == true))
 ----
 


### PR DESCRIPTION
#### Description

The global `matches(string, string)` operator is deprecated from the CEL spec in favor of member syntax `x.matches(string)`.