### PR TITLE
chore(helm): Allow configuring a custom nodePort in helm chart values

### DIFF
--- a/deploy/charts/cerbos/templates/service.yaml
+++ b/deploy/charts/cerbos/templates/service.yaml
@@ -7,13 +7,19 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.httpPort }}
+    - port: {{ .Values.service.http.port }}
       targetPort: http
       protocol: TCP
       name: http
-    - port: {{ .Values.service.grpcPort }}
+      {{ if eq .Values.service.type "NodePort" -}}
+      nodePort: {{ .Values.service.http.nodePort }}
+      {{- end }}
+    - port: {{ .Values.service.grpc.port }}
       targetPort: grpc
       protocol: TCP
       name: grpc
+      {{ if eq .Values.service.type "NodePort" -}}
+      nodePort: {{ .Values.service.grpc.nodePort }}
+      {{- end }}
   selector:
     {{- include "cerbos.selectorLabels" . | nindent 4 }}

--- a/deploy/charts/cerbos/templates/service.yaml
+++ b/deploy/charts/cerbos/templates/service.yaml
@@ -7,19 +7,19 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.http.port }}
+    - port: {{ .Values.service.httpPort }}
       targetPort: http
       protocol: TCP
       name: http
       {{ if eq .Values.service.type "NodePort" -}}
-      nodePort: {{ .Values.service.http.nodePort }}
+      nodePort: {{ .Values.service.httpNodePort }}
       {{- end }}
-    - port: {{ .Values.service.grpc.port }}
+    - port: {{ .Values.service.grpcPort }}
       targetPort: grpc
       protocol: TCP
       name: grpc
       {{ if eq .Values.service.type "NodePort" -}}
-      nodePort: {{ .Values.service.grpc.nodePort }}
+      nodePort: {{ .Values.service.grpcNodePort }}
       {{- end }}
   selector:
     {{- include "cerbos.selectorLabels" . | nindent 4 }}

--- a/deploy/charts/cerbos/values.yaml
+++ b/deploy/charts/cerbos/values.yaml
@@ -85,8 +85,12 @@ envFrom: []
 # Cerbos service settings.
 service:
   type: ClusterIP
-  httpPort: 3592
-  grpcPort: 3593
+  http:
+    port: 3592
+    nodePort: 103592
+  grpc:
+    port: 3593
+    nodePort: 103593
 
 # Cerbos deployment settings.
 cerbos:

--- a/deploy/charts/cerbos/values.yaml
+++ b/deploy/charts/cerbos/values.yaml
@@ -85,12 +85,10 @@ envFrom: []
 # Cerbos service settings.
 service:
   type: ClusterIP
-  http:
-    port: 3592
-    nodePort: 103592
-  grpc:
-    port: 3593
-    nodePort: 103593
+  httpPort: 3592
+  grpcPort: 3593
+  httpNodePort: 13592
+  grpcNodePort: 13593
 
 # Cerbos deployment settings.
 cerbos:


### PR DESCRIPTION
#### Description

Add nodePort values in default values.yaml file to allow users to configure a custom NodePort

Fixes #1249 

#### Checklist 

- [x] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
