### PR TITLE
fix: Treat non-boolean expression results as `false`

### DIFF
--- a/internal/engine/evaluator.go
+++ b/internal/engine/evaluator.go
@@ -362,7 +362,7 @@ func (ep evalParams) evaluateBoolCELExpr(expr *exprpb.CheckedExpr, variables map
 
 	boolVal, ok := val.(bool)
 	if !ok {
-		return false, fmt.Errorf("unexpected result: wanted bool, got %T", val)
+		return false, nil
 	}
 
 	return boolVal, nil

--- a/internal/test/testdata/cel_eval/null_attr_allof.yaml
+++ b/internal/test/testdata/cel_eval/null_attr_allof.yaml
@@ -1,0 +1,21 @@
+---
+condition:
+  all:
+    of:
+      - expr: P.attr.x
+      - expr: R.attr.department == "marketing"
+input: {
+  "requestId": "test",
+  "actions": ["*"],
+  "principal": {
+    "id": "john",
+    "roles": ["employee"]
+  },
+  "resource": {
+    "kind": "leave_request",
+    "attr": {
+      "department": "marketing"
+    }
+  }
+}
+want: false

--- a/internal/test/testdata/cel_eval/null_attr_anyof.yaml
+++ b/internal/test/testdata/cel_eval/null_attr_anyof.yaml
@@ -1,0 +1,21 @@
+---
+condition:
+  any:
+    of:
+      - expr: P.attr.x
+      - expr: R.attr.department == "marketing"
+input: {
+  "requestId": "test",
+  "actions": ["*"],
+  "principal": {
+    "id": "john",
+    "roles": ["employee"]
+  },
+  "resource": {
+    "kind": "leave_request",
+    "attr": {
+      "department": "marketing"
+    }
+  }
+}
+want: true

--- a/internal/test/testdata/cel_eval/null_attr_noneof.yaml
+++ b/internal/test/testdata/cel_eval/null_attr_noneof.yaml
@@ -1,0 +1,21 @@
+---
+condition:
+  none:
+    of:
+      - expr: P.attr.x
+      - expr: R.attr.department == "engineering"
+input: {
+  "requestId": "test",
+  "actions": ["*"],
+  "principal": {
+    "id": "john",
+    "roles": ["employee"]
+  },
+  "resource": {
+    "kind": "leave_request",
+    "attr": {
+      "department": "marketing"
+    }
+  }
+}
+want: true


### PR DESCRIPTION
When evaluating `any`, `all` or `none` blocks, if one of the expressions
returns a non-boolean result, the whole block is marked as having
failed. We can be a bit more lenient here and treat non-boolean values
as `false`. Note that this treats _all_ values as `false` and does not
make the distinction of treating certain values as `true`. Users are
responsible for converting any non-boolean values into boolean values
themselves.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
