### PR TITLE
chore(ci): Use latest Go version in builds

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.19.x
+          check-latest: true
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.19.x
+          check-latest: true
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -96,6 +97,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.19.x
+          check-latest: true
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -198,6 +200,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.19.x
+          check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.19.x
+          check-latest: true
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/snaphot.yaml
+++ b/.github/workflows/snaphot.yaml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.19.x
+          check-latest: true
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.19.x
+          check-latest: true
 
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Force the `setup-go` action to check whether the cached Go version is
the latest.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
