### PR TITLE
chore(ci): Set output via environment file rather than stdout

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -20,8 +20,10 @@ jobs:
             code:
               - '!(docs/**)'
             docs:
+              - .github/workflows/pr-test.yaml
               - 'docs/**'
             protos:
+              - .github/workflows/pr-test.yaml
               - '**/*.proto'
 
   generate:
@@ -226,7 +228,7 @@ jobs:
 
       - name: Find latest release
         id: latest-release
-        run: gh release view --json tagName --jq '"::set-output name=tag::\(.tagName)"'
+        run: gh release view --json tagName --jq '"tag=\(.tagName)"' >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/