### PR TITLE
fix: Update hasIntersection function to support partial eval

### DIFF
--- a/internal/conditions/cerbos_lib.go
+++ b/internal/conditions/cerbos_lib.go
@@ -76,6 +76,7 @@ func (clib cerbosLib) CompileOptions() []cel.EnvOption {
 				[]*cel.Type{genericListType, genericListType},
 				cel.BoolType,
 				cel.BinaryBinding(fn),
+				cel.OverloadIsNonStrict(),
 			),
 			cel.MemberOverload(
 				fmt.Sprintf("%s_member_overload", name),
@@ -291,11 +292,17 @@ func convertToMap(b traits.Lister) map[ref.Val]struct{} {
 func hasIntersection(lhs, rhs ref.Val) ref.Val {
 	a, ok := lhs.(traits.Lister)
 	if !ok {
+		if types.IsUnknown(lhs) {
+			return lhs
+		}
 		return types.ValOrErr(a, "no such overload")
 	}
 
 	b, ok := rhs.(traits.Lister)
 	if !ok {
+		if types.IsUnknown(rhs) {
+			return rhs
+		}
 		return types.ValOrErr(b, "no such overload")
 	}
 

--- a/internal/engine/ast.go
+++ b/internal/engine/ast.go
@@ -467,7 +467,7 @@ func buildExprImpl(cur *exprpb.Expr, acc *enginev1.PlanResourcesFilter_Expressio
 			return err
 		}
 		if _, ok := lambda.Node.(*ExprOpExpr); !ok {
-			return fmt.Errorf("expect expression, got %T", lambda.Node)
+			return fmt.Errorf("expected expression, got %T", lambda.Node)
 		}
 		op := new(ExprOp)
 		err = buildExprImpl(iterRange, op, cur)

--- a/internal/test/testdata/query_planner/policies/resource_policy_report_with_map.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policy_report_with_map.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: "api.cerbos.dev/v1"
+resourcePolicy:
+  version: "default"
+  resource: "report_with_map"
+  rules:
+    - actions:
+        - write
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: hasIntersection(R.attr.workspaces, P.attr.workspaces.filter(w, w.role=="MANAGER").map(w, w.name))
+    - actions:
+        - write-rev
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: hasIntersection(P.attr.workspaces.filter(w, w.role=="MANAGER").map(w, w.name), R.attr.workspaces)
+    - actions:
+        - write-member
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: R.attr.workspaces.hasIntersection(P.attr.workspaces.filter(w, w.role=="MANAGER").map(w, w.name))
+    - actions:
+        - handle
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: P.attr.workspaces.filter(w, w.role=="MANAGER").all(w, w.name.startsWith("workspace"))

--- a/internal/test/testdata/query_planner/policies/resource_policy_report_with_map.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policy_report_with_map.yaml
@@ -29,6 +29,14 @@ resourcePolicy:
         match:
           expr: R.attr.workspaces.hasIntersection(P.attr.workspaces.filter(w, w.role=="MANAGER").map(w, w.name))
     - actions:
+        - write-member-rev
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: P.attr.workspaces.filter(w, w.role=="MANAGER").map(w, w.name).hasIntersection(R.attr.workspaces)
+    - actions:
         - handle
       effect: EFFECT_ALLOW
       roles:

--- a/internal/test/testdata/query_planner/suite/report_with_map.yaml
+++ b/internal/test/testdata/query_planner/suite/report_with_map.yaml
@@ -55,6 +55,18 @@ tests:
           operands:
             - value: ["workspaceA"]
             - variable: request.resource.attr.workspaces
+  - action: write-member-rev
+    resource:
+      kind: report_with_map
+      policyVersion: default
+    want:
+      kind: KIND_CONDITIONAL
+      condition:
+        expression:
+          operator: hasIntersection
+          operands:
+            - value: ["workspaceA"]
+            - variable: request.resource.attr.workspaces
   - action: handle
     resource:
       kind: report_with_map

--- a/internal/test/testdata/query_planner/suite/report_with_map.yaml
+++ b/internal/test/testdata/query_planner/suite/report_with_map.yaml
@@ -1,0 +1,63 @@
+---
+description: Report with map tests
+principal: {
+  "id": "123",
+  "roles": [
+    "USER"
+  ],
+  "attr": {
+    "workspaces": [
+      {
+        "name": "workspaceA",
+        "role": "MANAGER"
+      },
+      {
+        "name": "workspaceB",
+        "role": "MEMBER"
+      }
+    ]
+  }
+}
+tests:
+  - action: write
+    resource:
+      kind: report_with_map
+      policyVersion: default
+    want:
+      kind: KIND_CONDITIONAL
+      condition:
+        expression:
+          operator: hasIntersection
+          operands:
+            - variable: request.resource.attr.workspaces
+            - value: ["workspaceA"]
+  - action: write-member
+    resource:
+      kind: report_with_map
+      policyVersion: default
+    want:
+      kind: KIND_CONDITIONAL
+      condition:
+        expression:
+          operator: hasIntersection
+          operands:
+            - variable: request.resource.attr.workspaces
+            - value: ["workspaceA"]
+  - action: write-rev # swapped hasIntersection args
+    resource:
+      kind: report_with_map
+      policyVersion: default
+    want:
+      kind: KIND_CONDITIONAL
+      condition:
+        expression:
+          operator: hasIntersection
+          operands:
+            - value: ["workspaceA"]
+            - variable: request.resource.attr.workspaces
+  - action: handle
+    resource:
+      kind: report_with_map
+      policyVersion: default
+    want:
+      kind: KIND_ALWAYS_ALLOWED


### PR DESCRIPTION
Fixes #1276 

For the query planner the`hasIntersection` function needs to support partial evaluation.

I am going to update other functions in a separate PR(s).

Signed-off-by: Dennis Buduev <dennis@cerbos.dev>