### PR TITLE
feat: Optimise a query plan of a membership test in a single-item list

### DIFF
--- a/internal/engine/ast.go
+++ b/internal/engine/ast.go
@@ -577,8 +577,18 @@ func normaliseFilterExprOpExpr(expr *enginev1.PlanResourcesFilter_Expression_Ope
 	const nArgsInOp = 2
 	if expr.Expression.Operator == In && len(expr.Expression.Operands) == nArgsInOp {
 		if v := expr.Expression.Operands[nArgsInOp-1].GetValue(); v != nil {
-			if len(v.GetListValue().GetValues()) == 0 {
+			values := v.GetListValue().GetValues()
+			n := len(values)
+			if n == 0 {
 				return falseExprOpValue
+			} else if n == 1 {
+				// replace `a in [x]` with `a eq x`
+				expr.Expression.Operator = Equals
+				expr.Expression.Operands[nArgsInOp-1] = &enginev1.PlanResourcesFilter_Expression_Operand{
+					Node: &enginev1.PlanResourcesFilter_Expression_Operand_Value{
+						Value: values[0],
+					},
+				}
 			}
 		}
 	}

--- a/internal/test/testdata/query_planner_filter/case_15.yaml
+++ b/internal/test/testdata/query_planner_filter/case_15.yaml
@@ -1,5 +1,5 @@
 ---
-description: membership test
+description: membership test in a single-item array
 input:
   kind: KIND_CONDITIONAL
   condition:
@@ -7,15 +7,15 @@ input:
       operator: in
       operands:
         - variable: request.resource.attr.accountId
-        - value: ["accountId1", "accountId2"]
+        - value: ["abc123"]
 wantFilter:
   kind: KIND_CONDITIONAL
   condition:
     expression:
-      operator: in
+      operator: eq
       operands:
         - variable: request.resource.attr.accountId
-        - value: ["accountId1", "accountId2"]
-wantString: "(in request.resource.attr.accountId [\"accountId1\",\"accountId2\"])"
+        - value: "abc123"
+wantString: "(eq request.resource.attr.accountId \"abc123\")"
 
 


### PR DESCRIPTION
Adds optimisation for a query plan by replacing a membership test `in` with an equality check if the list contains a single item.  ` a in [x]` is replaced with `a == x`.

This supports the workaround for issue #1263.

Signed-off-by: Dennis Buduev <dennis@cerbos.dev>
