### PR TITLE
chore: Stable string representation for query filter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/spf13/afero v1.9.2
 	github.com/stretchr/testify v1.8.0
 	github.com/tidwall/gjson v1.14.3
+	github.com/tidwall/pretty v1.2.0
 	github.com/tidwall/sjson v1.2.5
 	go.elastic.co/ecszap v1.0.1
 	go.opencensus.io v0.23.0
@@ -221,7 +222,6 @@ require (
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/internal/engine/ast.go
+++ b/internal/engine/ast.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/google/cel-go/common/operators"
+	"github.com/tidwall/pretty"
 	"go.uber.org/multierr"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -736,7 +737,7 @@ func filterExprOpToString(b *strings.Builder, cond *enginev1.PlanResourcesFilter
 		if val, err := protojson.Marshal(t.Value); err != nil {
 			b.WriteString("<ERROR>")
 		} else {
-			b.Write(val)
+			b.Write(pretty.UglyInPlace(val))
 		}
 	case *enginev1.PlanResourcesFilter_Expression_Operand_Variable:
 		b.WriteString(t.Variable)


### PR DESCRIPTION
When generating the string representation of the query plan filter, we
use the `protojson` package to marshal some of the CEL protobufs.
Unfortunately, the output of `protojson` is not guaranteed to be stable
and the library intentionally adds random whitespaces to the output.

This PR strips non-essential whitespace from the JSON bytes to make the
output usable in tests.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
