### PR TITLE
chore(ci): Remove single commit validation

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -42,4 +42,3 @@ jobs:
           subjectPattern: '^[A-Z].+$'
           subjectPatternError: |
             Subject "{subject}" does not start with an uppercase letter
-          validateSingleCommit: true


### PR DESCRIPTION
GitHub no longer overwrites the squash commit title when there's only
one commit in a PR.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
