### PR TITLE
fix: Handle other data types while optimizing IN expression

### DIFF
--- a/internal/test/testdata/query_planner/policies/resource_policy_top.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policy_top.yaml
@@ -1,0 +1,16 @@
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  resource: top
+  version: default
+  rules:
+    - actions:
+        - VIEW
+      roles:
+        - customer-user
+      condition:
+        match:
+          any:
+            of:
+              - expr: R.attr.custAnal in P.attr.custAllowedValues
+              - expr: R.attr.salhAnal in P.attr.salhAllowedValues
+      effect: EFFECT_DENY

--- a/internal/test/testdata/query_planner/suite/wrong_attr_data_type.yaml
+++ b/internal/test/testdata/query_planner/suite/wrong_attr_data_type.yaml
@@ -1,0 +1,34 @@
+---
+description: Wrong attribute data type
+principal:
+    id: adam
+    policyVersion: default
+    roles:
+        - customer-user
+    attr:
+      custAllowedValues: "VALUE1"
+      salhAllowedValues: "VALUE2"
+tests:
+    - action: "VIEW"
+      resource:
+        kind: top
+        policyVersion: default
+      want:
+        kind: KIND_CONDITIONAL
+        condition:
+          expression:
+            operator: not
+            operands:
+              - expression:
+                  operator: or
+                  operands:
+                    - expression:
+                        operator: eq
+                        operands:
+                          - variable: request.resource.attr.custAnal
+                          - value: VALUE1
+                    - expression:
+                        operator: eq
+                        operands:
+                          - variable: request.resource.attr.salhAnal
+                          - value: VALUE2

--- a/internal/test/testdata/query_planner_filter/case_16.yaml
+++ b/internal/test/testdata/query_planner_filter/case_16.yaml
@@ -1,13 +1,13 @@
 ---
-description: membership test in a single-item array
+description: membership test in a single-item map
 input:
   kind: KIND_CONDITIONAL
   condition:
     expression:
       operator: in
       operands:
-        - variable: R.attr.accountId
-        - value: ["abc123"]
+        - variable: request.resource.attr.accountId
+        - value: {"abc123": "def456"}
 wantFilter:
   kind: KIND_CONDITIONAL
   condition:

--- a/internal/test/testdata/query_planner_filter/case_17.yaml
+++ b/internal/test/testdata/query_planner_filter/case_17.yaml
@@ -1,0 +1,15 @@
+---
+description: membership test in an empty map
+input:
+  kind: KIND_CONDITIONAL
+  condition:
+    expression:
+      operator: in
+      operands:
+        - variable: request.resource.attr.accountId
+        - value: {}
+wantFilter:
+  kind: KIND_ALWAYS_DENIED
+wantString: "(false)"
+
+

--- a/internal/test/testdata/query_planner_filter/case_18.yaml
+++ b/internal/test/testdata/query_planner_filter/case_18.yaml
@@ -1,0 +1,35 @@
+---
+description: Using IN with a value that is not a container
+input:
+  kind: KIND_CONDITIONAL
+  condition:
+    expression:
+      operator: or
+      operands:
+        - expression:
+            operator: in
+            operands:
+              - variable: R.attr.accountId
+              - value: "test"
+        - expression:
+            operator: in
+            operands:
+              - variable: R.attr.rank
+              - value: 1
+wantFilter:
+  kind: KIND_CONDITIONAL
+  condition:
+    expression:
+      operator: or
+      operands:
+        - expression:
+            operator: eq
+            operands:
+              - variable: request.resource.attr.accountId
+              - value: "test"
+        - expression:
+            operator: eq
+            operands:
+              - variable: request.resource.attr.rank
+              - value: 1
+wantString: "(or (eq request.resource.attr.accountId \"test\") (eq request.resource.attr.rank 1))"


### PR DESCRIPTION
When the query planner is trying to optimize an `IN` expression, it is
wrongly assuming that the operand can only be a list. This leads to the
planner completely ignoring IN expressions that don't have a list as an
operand.

This fix changes the logic to handle both lists and maps, which are valid
operand types to `IN`. Other non-container types cause the `IN` operator
to automatically convert itself to an `EQ`.

Fixes #1333

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
