### PR TITLE
docs(backport): Add recipe link to admin API demo (#1338)

### DIFF
--- a/docs/modules/recipes/nav.adoc
+++ b/docs/modules/recipes/nav.adoc
@@ -3,6 +3,7 @@
 ** xref:photo-share/index.adoc[Photo-share application]
 ** link:https://github.com/cerbos/demo-rest[Demo of securing a REST API with Cerbos]
 ** link:https://github.com/cerbos/demo-multitenant-saas[Modelling a multi-tenant SaaS with Cerbos]
+** link:https://github.com/cerbos/demo-admin-api[Admin API demo with Go and React]
 * Authentication Integration
 ** xref:authentication/auth0/index.adoc[Auth0]
 ** xref:authentication/fusionauth/index.adoc[FusionAuth]


### PR DESCRIPTION
Backport of #1338 

* Add recipe link to admin API demo

Signed-off-by: Sam Lock <sam@swlock.co.uk>
Co-authored-by: Charith Ellawala <charithe@users.noreply.github.com>