### PR TITLE
fix: Rewrite log level change without Go 1.19 features

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cerbos/cerbos
 
-go 1.19
+go 1.18
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2


### PR DESCRIPTION
`atomic.Bool` is only available in Go 1.19 and users on older versions
of Go won't be able to download the SDK because of that. Since
`atomic.Bool` is not crucial for a correct implementation, we can revert
it this time.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
