### PR TITLE
chore(ci): Enable LFS for snapshot build

### DIFF
--- a/.github/workflows/snaphot.yaml
+++ b/.github/workflows/snaphot.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          lfs: true
 
       - name: Set up QEMU
         id: qemu


### PR DESCRIPTION
The tests introduced in #1343 require LFS objects.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
