### PR TITLE
docs: Remove unstable warning from Linux packages

### DIFF
--- a/docs/modules/ROOT/pages/installation/binary.adoc
+++ b/docs/modules/ROOT/pages/installation/binary.adoc
@@ -7,7 +7,7 @@ Cerbos binaries are available for multiple operating systems and architectures. 
 [caption=]
 [%header,cols=".^1,.^1,3m",grid=rows]
 |===
-|OS | Arch | Bundle 
+|OS | Arch | Bundle
 |Linux | x86-64 | {app-name}_{app-version}_Linux_x86_64.tar.gz
 |Linux | arm64 | {app-name}_{app-version}_Linux_arm64.tar.gz
 |MacOS | universal | {app-name}_{app-version}_Darwin_all.tar.gz
@@ -27,14 +27,12 @@ chmod +x {app-name}
 [id="linux-packages"]
 == Linux Packages
 
-NOTE: Linux packages are currently an experimental feature and should be considered unstable.
-
 Cerbos DEB and RPM packages can be installed on any Linux distribution that supports one of those package formats. You can download the appropriate package for your system from the link:{app-github-releases-page}[releases page].
 
 IMPORTANT: Cerbos packages are currently only designed to work with systems where `systemd` is the init system. If you use a different init system, consider installing cerbos from the tarballs instead.
 
 
-The packages install the `cerbos` and `cerbosctl` binaries to `/usr/local/bin` and create a systemd service to automatically start the Cerbos server. The default configuration is setup to look for policies in `/var/cerbos/policies` but you can change this by editing `/etc/cerbos/yaml` and reloading the service with `sudo systemctl restart cerbos`. 
+The packages install the `cerbos` and `cerbosctl` binaries to `/usr/local/bin` and create a systemd service to automatically start the Cerbos server. The default configuration is setup to look for policies in `/var/cerbos/policies` but you can change this by editing `/etc/cerbos/yaml` and reloading the service with `sudo systemctl restart cerbos`.
 
 
 [source,sh]


### PR DESCRIPTION
Signed-off-by: Charith Ellawala <charith@cerbos.dev>
