### PR TITLE
enhancement(helm): Annotations for deployment and service (#1363)

### DIFF
--- a/deploy/charts/cerbos/templates/_helpers.tpl
+++ b/deploy/charts/cerbos/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "cerbos.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -57,7 +60,7 @@ Determine the scheme based on whether the TLS secret is defined or not
 {{- if empty .Values.cerbos.tlsSecretName -}}
 http
 {{- else -}}
-https  
+https
 {{- end -}}
 {{- end }}
 

--- a/deploy/charts/cerbos/templates/deployment.yaml
+++ b/deploy/charts/cerbos/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "cerbos.fullname" . }}
   labels:
     {{- include "cerbos.labels" . | nindent 4 }}
+  {{- with .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -15,6 +19,9 @@ spec:
     metadata:
       labels:
         {{- include "cerbos.selectorLabels" . | nindent 8 }}
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- include "cerbos.podAnnotations" . | nindent 6 }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -28,7 +35,7 @@ spec:
       {{- end }}
       {{- with .Values.initContainers }}
       initContainers:
-        {{- toYaml . | nindent 8 }} 
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -70,7 +77,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: config 
+            - name: config
               mountPath: /config
               readOnly: true
             - name: work
@@ -91,7 +98,7 @@ spec:
           emptyDir: {}
       {{- with .Values.cerbos.tlsSecretName }}
         - name: certs
-          secret: 
+          secret:
             secretName: {{ . }}
       {{- end }}
       {{- with .Values.volumes }}

--- a/deploy/charts/cerbos/templates/service.yaml
+++ b/deploy/charts/cerbos/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "cerbos.fullname" . }}
   labels:
     {{- include "cerbos.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/charts/cerbos/values-jaeger-agent.yaml
+++ b/deploy/charts/cerbos/values-jaeger-agent.yaml
@@ -1,0 +1,48 @@
+# Illustrates how to deploy Cerbos with an auto-injected Jaeger agent.
+
+cerbos:
+  config:
+    # Configure the SQLite3 storage driver
+    storage:
+      driver: "sqlite3"
+      sqlite3:
+        dsn: "file:/data/cerbos.sqlite?mode=rwc&_fk=true"
+    # Configure tracing
+    tracing:
+      serviceName: cerbos
+      sampleProbability: 0.5
+      exporter: jaeger
+      jaeger:
+        agentEndpoint: "localhost:6831"
+
+
+# Annotate the deployment to inject the Jaeger agent.
+deployment:
+  annotations:
+    sidecar.jaegertracing.io/inject: "true"
+
+# Optional common labels for resources.
+commonLabels:
+  app.kubernetes.io/part-of: my-awesome-app
+
+# Optional annotations for the service.
+service:
+  annotations:
+    a8r.io/owner: my-awesome-team
+    a8r.io/uptime: dashboard.example.com/cerbos
+
+# Optional annotations for the Cerbos pod.
+podAnnotations:
+  a8r.io/owner: my-awesome-team
+
+# Create volumes to hold the SQLite3 database.
+# Note that this example uses emptyDir volumes that lose data when the pod or node is killed.
+# Use persistent volumes in production to preserve the data between pod restarts.
+volumes:
+  - name: cerbos-policies
+    emptyDir: {}
+
+volumeMounts:
+  - name: cerbos-policies
+    mountPath: /data
+

--- a/deploy/charts/cerbos/values.yaml
+++ b/deploy/charts/cerbos/values.yaml
@@ -31,6 +31,17 @@ serviceAccount:
 # Annotations to add to the pod.
 podAnnotations: {}
 
+# Common labels to add to the resources.
+commonLabels: {}
+
+# Annotations to add to the deployment.
+deployment:
+  annotations: {}
+
+# Annotations to add to the service.
+service:
+  annotations: {}
+
 # Security context for the whole pod.
 podSecurityContext: {}
   # fsGroup: 2000
@@ -108,5 +119,5 @@ cerbos:
   # Add Prometheus service discovery annotations to the pod.
   prometheusPodAnnotationsEnabled: true
   # Cerbos config file contents.
-  # Some server settings like server.httpListenAddr, server.grpcListenAddr, server.tls will be overwritten by the chart based on values provided above. 
+  # Some server settings like server.httpListenAddr, server.grpcListenAddr, server.tls will be overwritten by the chart based on values provided above.
   config: {}


### PR DESCRIPTION
Backport of #1363 to 0.23 branch

Allow users to define annotations for the deployment using `deployment.annotations` value key and annotations for the service using `service.annotations` value key.

Also adds `commonLabels` value key to help label all the resources created by the chart.

Fixes #1362

Signed-off-by: Charith Ellawala <charith@cerbos.dev>

