### PR TITLE
feat: Support for filtering decision logs

### DIFF
--- a/docs/modules/configuration/pages/audit.adoc
+++ b/docs/modules/configuration/pages/audit.adoc
@@ -16,7 +16,15 @@ audit:
   decisionLogsEnabled: true # Log policy decisions
   excludeMetadataKeys: ['authorization'] # Excludes given gRPC request metadata keys from audit logs.(Takes precedence over includeMetadataKeys)
   includeMetadataKeys: ['content-type'] # Includes given gRPC request metadata keys in audit logs.
+  decisionLogFilters: # DecisionLogFilters define the filters to apply while producing decision logs.
+    checkResources: # CheckResources defines the filters that apply to CheckResources calls.
+      ignoreAllowAll: false # IgnoreAllowAll ignores responses that don't contain an EFFECT_DENY.
+    planResources: # PlanResources defines the filters that apply to PlanResources calls.
+      ignoreAll: false # IgnoreAll prevents any plan responses from being logged. Takes precedence over other filters.
+      ignoreAlwaysAllow: false # IgnoreAlwaysAllow ignores ALWAYS_ALLOWED plans.
   backend: local # Audit backend to use.
+  file: # Configuration for the file audit backend
+    path: /path/to/file.log # Path to the log file to use as output. The special values stdout and stderr can be used to write to stdout or stderr respectively.
   local: # Configuration for the local audit backend
     storagePath: /path/to/dir # Path to store the data
     retentionPeriod: 168h # Records older than this will be automatically deleted

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -1,6 +1,12 @@
 audit:
   accessLogsEnabled: false # AccessLogsEnabled defines whether access logging is enabled.
   backend: local # Backend states which backend to use for Audits.
+  decisionLogFilters: # DecisionLogFilters define the filters to apply while producing decision logs.
+    checkResources: # CheckResources defines the filters that apply to CheckResources calls.
+      ignoreAllowAll: false # IgnoreAllowAll ignores responses that don't contain an EFFECT_DENY.
+    planResources: # PlanResources defines the filters that apply to PlanResources calls.
+      ignoreAll: false # IgnoreAll prevents any plan responses from being logged. Takes precedence over other filters.
+      ignoreAlwaysAllow: false # IgnoreAlwaysAllow ignores ALWAYS_ALLOWED plans.
   decisionLogsEnabled: false # DecisionLogsEnabled defines whether logging of policy decisions is enabled.
   enabled: false # Enabled defines whether audit logging is enabled.
   excludeMetadataKeys: ['authorization'] # ExcludeMetadataKeys defines which gRPC request metadata keys should be excluded from the audit logs. Takes precedence over includeMetadataKeys.

--- a/hack/dev/conf.secure.yaml
+++ b/hack/dev/conf.secure.yaml
@@ -22,7 +22,8 @@ auxData:
 
 audit:
   enabled: true
-  backend: "file"
+  backend: "local"
+  decisionLogsEnabled: false
   local:
     storagePath: /tmp/cerbos_auditlog
     advanced:

--- a/hack/dev/plan.hurl
+++ b/hack/dev/plan.hurl
@@ -9,7 +9,7 @@ jsonpath "$.action" == "approve"
 jsonpath "$.resourceKind" == "leave_request"
 jsonpath "$.policyVersion" == "20210210"
 jsonpath "$.filter" != null
-jsonpath "$.meta.filterDebug" == "(request.resource.attr.status == \"PENDING_APPROVAL\")"
+jsonpath "$.meta.filterDebug" == "(eq request.resource.attr.status \"PENDING_APPROVAL\")"
 
 
 # Plan resources request 1 (deprecated endpoint)
@@ -23,7 +23,7 @@ jsonpath "$.action" == "approve"
 jsonpath "$.resourceKind" == "leave_request"
 jsonpath "$.policyVersion" == "20210210"
 jsonpath "$.filter" != null
-jsonpath "$.meta.filterDebug" == "(request.resource.attr.status == \"PENDING_APPROVAL\")"
+jsonpath "$.meta.filterDebug" == "(eq request.resource.attr.status \"PENDING_APPROVAL\")"
 
 
 # Plan resources request 2
@@ -58,22 +58,28 @@ jsonpath "$.meta.filterDebug" == "(true)"
 POST {{protocol}}://{{host}}:{{port}}/api/plan/resources
 Content-Type: application/json
 file,requests/plan_resources/req3.json;
-HTTP/* 400
+HTTP/* 200
 [Asserts]
 header "Content-Type" == "application/json"
-jsonpath "$.code" == 3
-jsonpath "$.message" == "Bad request: missing principal attribute \"vip\""
+jsonpath "$.action" == "view-as-vip"
+jsonpath "$.resourceKind" == "album:object"
+jsonpath "$.policyVersion" == "default"
+jsonpath "$.filter.kind" == "KIND_CONDITIONAL"
+jsonpath "$.meta.filterDebug" == "(eq request.resource.attr.owner \"1\")"
 
 
 # Plan resources request 3 (deprecated endpoint)
 POST {{protocol}}://{{host}}:{{port}}/api/x/plan/resources
 Content-Type: application/json
 file,requests/plan_resources/req3.json;
-HTTP/* 400
+HTTP/* 200
 [Asserts]
 header "Content-Type" == "application/json"
-jsonpath "$.code" == 3
-jsonpath "$.message" == "Bad request: missing principal attribute \"vip\""
+jsonpath "$.action" == "view-as-vip"
+jsonpath "$.resourceKind" == "album:object"
+jsonpath "$.policyVersion" == "default"
+jsonpath "$.filter.kind" == "KIND_CONDITIONAL"
+jsonpath "$.meta.filterDebug" == "(eq request.resource.attr.owner \"1\")"
 
 
 # Plan resources request 4
@@ -114,7 +120,7 @@ header "Content-Type" == "application/json"
 jsonpath "$.action" == "delete"
 jsonpath "$.resourceKind" == "leave_request"
 jsonpath "$.filter.kind" == "KIND_CONDITIONAL"
-jsonpath "$.meta.filterDebug" == "((R.attr.owner == \"john\") AND (true))"
+jsonpath "$.meta.filterDebug" == "(eq request.resource.attr.owner \"john\")"
 jsonpath "$.meta.matchedScope" == "acme.hr.uk"
 
 
@@ -128,5 +134,5 @@ header "Content-Type" == "application/json"
 jsonpath "$.action" == "delete"
 jsonpath "$.resourceKind" == "leave_request"
 jsonpath "$.filter.kind" == "KIND_CONDITIONAL"
-jsonpath "$.meta.filterDebug" == "((R.attr.owner == \"john\") AND (true))"
+jsonpath "$.meta.filterDebug" == "(eq request.resource.attr.owner \"john\")"
 jsonpath "$.meta.matchedScope" == "acme.hr.uk"

--- a/hack/scripts/cover.sh
+++ b/hack/scripts/cover.sh
@@ -12,6 +12,12 @@ trap 'rm -rf "$COVERFILE"' EXIT
 (
     cd "${SCRIPT_DIR}/../.."
     go test -tags=tests -coverprofile="$COVERFILE" -count=1 $@
-    go tool cover -html="$COVERFILE"
+
+    # go install github.com/nikandfor/cover@latest
+    if command -v cover &> /dev/null; then
+        cover -p "$COVERFILE"
+    else
+        go tool cover -html="$COVERFILE"
+    fi
 )
 

--- a/internal/audit/conf.go
+++ b/internal/audit/conf.go
@@ -32,6 +32,27 @@ type confHolder struct {
 	AccessLogsEnabled bool `yaml:"accessLogsEnabled" conf:",example=false"`
 	// DecisionLogsEnabled defines whether logging of policy decisions is enabled.
 	DecisionLogsEnabled bool `yaml:"decisionLogsEnabled" conf:",example=false"`
+	// DecisionLogFilters define the filters to apply while producing decision logs.
+	DecisionLogFilters DecisionLogFilters `yaml:"decisionLogFilters"`
+}
+
+type DecisionLogFilters struct {
+	// CheckResources defines the filters that apply to CheckResources calls.
+	CheckResources CheckResourcesFilter `yaml:"checkResources"`
+	// PlanResources defines the filters that apply to PlanResources calls.
+	PlanResources PlanResourcesFilter `yaml:"planResources"`
+}
+
+type CheckResourcesFilter struct {
+	// IgnoreAllowAll ignores responses that don't contain an EFFECT_DENY.
+	IgnoreAllowAll bool `yaml:"ignoreAllowAll" conf:",example=false"`
+}
+
+type PlanResourcesFilter struct {
+	// IgnoreAll prevents any plan responses from being logged. Takes precedence over other filters.
+	IgnoreAll bool `yaml:"ignoreAll" conf:",example=false"`
+	// IgnoreAlwaysAllow ignores ALWAYS_ALLOWED plans.
+	IgnoreAlwaysAllow bool `yaml:"ignoreAlwaysAllow" conf:",example=false"`
 }
 
 func (c *Conf) UnmarshalYAML(unmarshal func(any) error) error {

--- a/internal/audit/decision_filter.go
+++ b/internal/audit/decision_filter.go
@@ -1,0 +1,116 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package audit
+
+import (
+	"fmt"
+
+	auditv1 "github.com/cerbos/cerbos/api/genpb/cerbos/audit/v1"
+	effectv1 "github.com/cerbos/cerbos/api/genpb/cerbos/effect/v1"
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
+)
+
+type DecisionLogEntryFilter func(*auditv1.DecisionLogEntry) *auditv1.DecisionLogEntry
+
+func NewDecisionLogEntryFilter() (DecisionLogEntryFilter, error) {
+	conf, err := GetConf()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read audit config: %w", err)
+	}
+
+	return NewDecisionLogEntryFilterFromConf(conf), nil
+}
+
+func NewDecisionLogEntryFilterFromConf(conf *Conf) DecisionLogEntryFilter {
+	filters := conf.DecisionLogFilters
+	haveFilters := filters.CheckResources.IgnoreAllowAll ||
+		filters.PlanResources.IgnoreAll ||
+		filters.PlanResources.IgnoreAlwaysAllow
+
+	if !haveFilters {
+		return func(entry *auditv1.DecisionLogEntry) *auditv1.DecisionLogEntry {
+			return entry
+		}
+	}
+
+	filterCheckResources := buildCheckResourcesFilter(filters.CheckResources)
+	filterPlanResources := buildPlanResourcesFilter(filters.PlanResources)
+
+	return func(entry *auditv1.DecisionLogEntry) *auditv1.DecisionLogEntry {
+		if entry == nil {
+			return nil
+		}
+
+		switch mt := entry.Method.(type) {
+		case *auditv1.DecisionLogEntry_CheckResources_:
+			if cr := filterCheckResources(mt.CheckResources); cr != nil {
+				entry.Method = &auditv1.DecisionLogEntry_CheckResources_{
+					CheckResources: cr,
+				}
+				return entry
+			}
+			return nil
+		case *auditv1.DecisionLogEntry_PlanResources_:
+			if pr := filterPlanResources(mt.PlanResources); pr != nil {
+				entry.Method = &auditv1.DecisionLogEntry_PlanResources_{
+					PlanResources: pr,
+				}
+				return entry
+			}
+			return nil
+		default:
+			return entry
+		}
+	}
+}
+
+func buildCheckResourcesFilter(f CheckResourcesFilter) func(*auditv1.DecisionLogEntry_CheckResources) *auditv1.DecisionLogEntry_CheckResources {
+	if !f.IgnoreAllowAll {
+		return func(cr *auditv1.DecisionLogEntry_CheckResources) *auditv1.DecisionLogEntry_CheckResources {
+			return cr
+		}
+	}
+
+	return func(cr *auditv1.DecisionLogEntry_CheckResources) *auditv1.DecisionLogEntry_CheckResources {
+		if cr == nil {
+			return nil
+		}
+
+		for _, o := range cr.Outputs {
+			for _, e := range o.Actions {
+				if e.Effect == effectv1.Effect_EFFECT_DENY {
+					return cr
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func buildPlanResourcesFilter(f PlanResourcesFilter) func(*auditv1.DecisionLogEntry_PlanResources) *auditv1.DecisionLogEntry_PlanResources {
+	if f.IgnoreAll {
+		return func(_ *auditv1.DecisionLogEntry_PlanResources) *auditv1.DecisionLogEntry_PlanResources {
+			return nil
+		}
+	}
+
+	if f.IgnoreAlwaysAllow {
+		return func(pr *auditv1.DecisionLogEntry_PlanResources) *auditv1.DecisionLogEntry_PlanResources {
+			if pr == nil || pr.Output == nil || pr.Output.Filter == nil {
+				return nil
+			}
+
+			if pr.Output.Filter.Kind == enginev1.PlanResourcesFilter_KIND_ALWAYS_ALLOWED {
+				return nil
+			}
+
+			return pr
+		}
+	}
+
+	return func(pr *auditv1.DecisionLogEntry_PlanResources) *auditv1.DecisionLogEntry_PlanResources {
+		return pr
+	}
+}

--- a/internal/audit/decision_filter_test.go
+++ b/internal/audit/decision_filter_test.go
@@ -1,0 +1,174 @@
+// Copyright 2021-2022 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package audit
+
+import (
+	"testing"
+
+	auditv1 "github.com/cerbos/cerbos/api/genpb/cerbos/audit/v1"
+	effectv1 "github.com/cerbos/cerbos/api/genpb/cerbos/effect/v1"
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestDecisionLogEntryFilter(t *testing.T) {
+	testCases := []struct {
+		name    string
+		filters DecisionLogFilters
+		input   *auditv1.DecisionLogEntry
+		want    *auditv1.DecisionLogEntry
+	}{
+		{
+			name:    "CheckResources/NoFilter",
+			filters: DecisionLogFilters{},
+			input:   mkCheckResourcesLogEntry(false),
+			want:    mkCheckResourcesLogEntry(false),
+		},
+		{
+			name: "CheckResources/OnlyDenyResponses/NoDenies",
+			filters: DecisionLogFilters{
+				CheckResources: CheckResourcesFilter{
+					IgnoreAllowAll: true,
+				},
+			},
+			input: mkCheckResourcesLogEntry(false),
+		},
+		{
+			name: "CheckResources/OnlyDenyResponses/SomeDenies",
+			filters: DecisionLogFilters{
+				CheckResources: CheckResourcesFilter{
+					IgnoreAllowAll: true,
+				},
+			},
+			input: mkCheckResourcesLogEntry(true),
+			want:  mkCheckResourcesLogEntry(true),
+		},
+		{
+			name:    "PlanResources/NoFilter",
+			filters: DecisionLogFilters{},
+			input:   mkPlanResourcesLogEntry(enginev1.PlanResourcesFilter_KIND_ALWAYS_ALLOWED),
+			want:    mkPlanResourcesLogEntry(enginev1.PlanResourcesFilter_KIND_ALWAYS_ALLOWED),
+		},
+		{
+			name: "PlanResources/IgnoreAll",
+			filters: DecisionLogFilters{
+				PlanResources: PlanResourcesFilter{
+					IgnoreAll: true,
+				},
+			},
+			input: mkPlanResourcesLogEntry(enginev1.PlanResourcesFilter_KIND_CONDITIONAL),
+		},
+		{
+			name: "PlanResources/IgnoreAlwaysAllow/AlwaysAllowed",
+			filters: DecisionLogFilters{
+				PlanResources: PlanResourcesFilter{
+					IgnoreAlwaysAllow: true,
+				},
+			},
+			input: mkPlanResourcesLogEntry(enginev1.PlanResourcesFilter_KIND_ALWAYS_ALLOWED),
+		},
+		{
+			name: "PlanResources/IgnoreAlwaysAllow/AlwaysDenied",
+			filters: DecisionLogFilters{
+				PlanResources: PlanResourcesFilter{
+					IgnoreAlwaysAllow: true,
+				},
+			},
+			input: mkPlanResourcesLogEntry(enginev1.PlanResourcesFilter_KIND_ALWAYS_DENIED),
+			want:  mkPlanResourcesLogEntry(enginev1.PlanResourcesFilter_KIND_ALWAYS_DENIED),
+		},
+		{
+			name: "PlanResources/IgnoreAlwaysAllow/Conditional",
+			filters: DecisionLogFilters{
+				PlanResources: PlanResourcesFilter{
+					IgnoreAlwaysAllow: true,
+				},
+			},
+			input: mkPlanResourcesLogEntry(enginev1.PlanResourcesFilter_KIND_CONDITIONAL),
+			want:  mkPlanResourcesLogEntry(enginev1.PlanResourcesFilter_KIND_CONDITIONAL),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			f := NewDecisionLogEntryFilterFromConf(&Conf{
+				confHolder: confHolder{DecisionLogFilters: tc.filters},
+			})
+
+			have := f(tc.input)
+			require.Empty(t, cmp.Diff(tc.want, have, protocmp.Transform()))
+		})
+	}
+}
+
+func mkCheckResourcesLogEntry(includeDeny bool) *auditv1.DecisionLogEntry {
+	outputs := []*enginev1.CheckOutput{
+		{
+			RequestId:  "test",
+			ResourceId: "test",
+			Actions: map[string]*enginev1.CheckOutput_ActionEffect{
+				"a1": {Effect: effectv1.Effect_EFFECT_ALLOW, Policy: "resource.test.v1"},
+				"a2": {Effect: effectv1.Effect_EFFECT_ALLOW, Policy: "resource.test.v1"},
+			},
+		},
+	}
+
+	if includeDeny {
+		outputs[0].Actions["a2"].Effect = effectv1.Effect_EFFECT_DENY
+	}
+
+	return &auditv1.DecisionLogEntry{
+		CallId: "foo",
+		Method: &auditv1.DecisionLogEntry_CheckResources_{
+			CheckResources: &auditv1.DecisionLogEntry_CheckResources{
+				Inputs: []*enginev1.CheckInput{
+					{
+						RequestId: "test",
+						Resource: &enginev1.Resource{
+							Kind: "test:kind",
+							Id:   "test",
+						},
+						Principal: &enginev1.Principal{
+							Id:    "test",
+							Roles: []string{"a", "b"},
+						},
+						Actions: []string{"a1", "a2"},
+					},
+				},
+				Outputs: outputs,
+			},
+		},
+	}
+}
+
+func mkPlanResourcesLogEntry(kind enginev1.PlanResourcesFilter_Kind) *auditv1.DecisionLogEntry {
+	return &auditv1.DecisionLogEntry{
+		CallId: "foo",
+		Method: &auditv1.DecisionLogEntry_PlanResources_{
+			PlanResources: &auditv1.DecisionLogEntry_PlanResources{
+				Input: &enginev1.PlanResourcesInput{
+					RequestId: "test",
+					Action:    "view",
+					Principal: &enginev1.Principal{
+						Id: "george",
+					},
+					Resource: &enginev1.PlanResourcesInput_Resource{
+						Kind: "leave_request",
+					},
+				},
+				Output: &enginev1.PlanResourcesOutput{
+					RequestId: "test",
+					Action:    "view",
+					Kind:      "leave_request",
+					Filter: &enginev1.PlanResourcesFilter{
+						Kind: kind,
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/audit/file/log_test.go
+++ b/internal/audit/file/log_test.go
@@ -27,7 +27,8 @@ func TestLog(t *testing.T) {
 	output := filepath.Join(t.TempDir(), "audit.log")
 	startDate := time.Now()
 
-	log, err := file.NewLog(&file.Conf{Path: output})
+	decisionFilter := audit.NewDecisionLogEntryFilterFromConf(&audit.Conf{})
+	log, err := file.NewLog(&file.Conf{Path: output}, decisionFilter)
 	require.NoError(t, err)
 
 	t.Cleanup(log.Close)

--- a/internal/audit/local/badgerdb_test.go
+++ b/internal/audit/local/badgerdb_test.go
@@ -44,7 +44,8 @@ func TestBadgerLog(t *testing.T) {
 	startDate, err := time.Parse(time.RFC3339, "2021-01-01T10:00:00Z")
 	require.NoError(t, err)
 
-	db, err := local.NewLog(conf)
+	decisionFilter := audit.NewDecisionLogEntryFilterFromConf(&audit.Conf{})
+	db, err := local.NewLog(conf, decisionFilter)
 	require.NoError(t, err)
 
 	require.Equal(t, local.Backend, db.Backend())
@@ -54,7 +55,7 @@ func TestBadgerLog(t *testing.T) {
 	db.Close()
 
 	// re-open the db
-	db, err = local.NewLog(conf)
+	db, err = local.NewLog(conf, decisionFilter)
 	require.NoError(t, err)
 
 	defer db.Close()

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -58,7 +58,7 @@ type DecisionLogIterator interface {
 }
 
 // Constructor for backends.
-type Constructor func(context.Context, *config.Wrapper) (Log, error)
+type Constructor func(context.Context, *config.Wrapper, DecisionLogEntryFilter) (Log, error)
 
 // RegisterBackend registers an audit log backend.
 func RegisterBackend(name string, cons Constructor) {
@@ -90,7 +90,8 @@ func NewLogFromConf(ctx context.Context, confW *config.Wrapper) (Log, error) {
 		return nil, fmt.Errorf("unknown backend [%s]", conf.Backend)
 	}
 
-	backend, err := cons(ctx, confW)
+	decisionFilter := NewDecisionLogEntryFilterFromConf(conf)
+	backend, err := cons(ctx, confW, decisionFilter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create backend: %w", err)
 	}

--- a/internal/audit/metadata_test.go
+++ b/internal/audit/metadata_test.go
@@ -16,11 +16,11 @@ import (
 
 func TestMetadataExtractor(t *testing.T) {
 	testCases := []struct {
+		input       map[string]string
+		want        map[string]*auditv1.MetaValues
 		name        string
 		includeKeys []string
 		excludeKeys []string
-		input       map[string]string
-		want        map[string]*auditv1.MetaValues
 	}{
 		{
 			name:  "NoIncludeOrExclude",

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -189,7 +189,8 @@ func mkEngine(tb testing.TB, p param) (*Engine, context.CancelFunc) {
 		}
 		conf.SetDefaults()
 
-		auditLog, err = local.NewLog(conf)
+		decisionFilter := audit.NewDecisionLogEntryFilterFromConf(&audit.Conf{})
+		auditLog, err = local.NewLog(conf, decisionFilter)
 		require.NoError(tb, err)
 	} else {
 		auditLog = audit.NewNopLog()


### PR DESCRIPTION
Adds ability to filter out some decision log entries from the audit log
to reduce noise.

- Ignore `CheckResources` reponses that have all `ALLOW` results
- Ignore all `PlanResources` responses
- Ignore `PlanResources` responses that are `ALWAYS_ALLOWED`

The implementation is intentionally asymmetric because the assumption
here is that `DENY` responses are inherently interesting and should not
be filtered out. Therefore, there are no options to log only `ALLOW`
responses.

Fixes #1380

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
