### PR TITLE
chore(test): Exercise audit log filtering in E2E tests

### DIFF
--- a/e2e/git/helmfile.yaml
+++ b/e2e/git/helmfile.yaml
@@ -77,7 +77,7 @@ releases:
                 maxResourcesPerRequest: 5
               adminAPI:
                 enabled: true
-                adminCredentials: 
+                adminCredentials:
                   username: cerbos
                   passwordHash: JDJ5JDEwJC5BYjQyY2RJNG5QR2NWMmJPdnNtQU93c09RYVA0eFFGdHBrbmFEeXh1NnlIVTE1cHJNY05PCgo=
             auxData:
@@ -89,8 +89,14 @@ releases:
               enabled: true
               accessLogsEnabled: true
               decisionLogsEnabled: true
+              decisionLogFilters:
+                checkResources:
+                  ignoreAllowAll: true
+                planResources:
+                  ignoreAll: true
+              excludeMetadataKeys: ["authorization"]
               backend: local
-              local: 
+              local:
                 storagePath: /audit/cerbos
             storage:
               driver: "git"

--- a/hack/dev/conf.secure.yaml
+++ b/hack/dev/conf.secure.yaml
@@ -22,8 +22,7 @@ auxData:
 
 audit:
   enabled: true
-  backend: "local"
-  decisionLogsEnabled: false
+  backend: "file"
   local:
     storagePath: /tmp/cerbos_auditlog
     advanced:


### PR DESCRIPTION
Exercise the recently added audit log filtering options in one of the
E2E test runs.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
