### PR TITLE
fix: Handle principal-policy-only cases

### DIFF
--- a/cmd/cerbosctl/put_test.go
+++ b/cmd/cerbosctl/put_test.go
@@ -88,6 +88,7 @@ func testPutCmd(clientCtx *cmdclient.Context, globals *flagset.Globals) func(*te
 					"derived_roles.beta",
 					"derived_roles.buyer_derived_roles",
 					"derived_roles.package_roles",
+					"principal.daisy_duck.vdefault",
 					"principal.donald_duck.v20210210",
 					"principal.donald_duck.vdefault",
 					"principal.donald_duck.vdefault/acme",

--- a/internal/storage/blob/cloner_test.go
+++ b/internal/storage/blob/cloner_test.go
@@ -35,6 +35,7 @@ func TestCloneResult(t *testing.T) {
 		"principal_policies/policy_02.yaml",
 		"principal_policies/policy_02_acme.hr.yaml",
 		"principal_policies/policy_02_acme.yaml",
+		"principal_policies/policy_03.yaml",
 		"resource_policies/policy_01.yaml",
 		"resource_policies/policy_02.yaml",
 		"resource_policies/policy_03.yaml",

--- a/internal/storage/index/builder_test.go
+++ b/internal/storage/index/builder_test.go
@@ -42,7 +42,7 @@ func TestBuildIndexWithDisk(t *testing.T) {
 
 	t.Run("check_contents", func(t *testing.T) {
 		data := idxImpl.Inspect()
-		require.Len(t, data, 17)
+		require.Len(t, data, 18)
 
 		rp1 := filepath.Join("resource_policies", "policy_01.yaml")
 		rp2 := filepath.Join("resource_policies", "policy_02.yaml")
@@ -56,6 +56,7 @@ func TestBuildIndexWithDisk(t *testing.T) {
 		pp2 := filepath.Join("principal_policies", "policy_02.yaml")
 		pp3 := filepath.Join("principal_policies", "policy_02_acme.yaml")
 		pp4 := filepath.Join("principal_policies", "policy_02_acme.hr.yaml")
+		pp5 := filepath.Join("principal_policies", "policy_03.yaml")
 		drCommon := filepath.Join("derived_roles", "common_roles.yaml")
 		dr1 := filepath.Join("derived_roles", "derived_roles_01.yaml")
 		dr2 := filepath.Join("derived_roles", "derived_roles_02.yaml")
@@ -88,7 +89,7 @@ func TestBuildIndexWithDisk(t *testing.T) {
 		require.Contains(t, data[rp3].Dependencies, dr3)
 		require.Empty(t, data[rp3].References)
 
-		for _, pp := range []string{pp1, pp2, pp3, pp4} {
+		for _, pp := range []string{pp1, pp2, pp3, pp4, pp5} {
 			require.Contains(t, data, pp)
 			require.Empty(t, data[pp].Dependencies)
 			require.Empty(t, data[pp].References)

--- a/internal/test/testdata/engine/case_17.yaml
+++ b/internal/test/testdata/engine/case_17.yaml
@@ -1,0 +1,48 @@
+---
+description: "Only principal policy with no matching resource policy (#1397)"
+inputs: [
+  {
+    "requestId": "test",
+    "actions": [
+      "view",
+      "edit"
+    ],
+    "principal": {
+      "id": "daisy_duck",
+      "roles": [
+        "employee"
+      ],
+      "attr": {
+        "department": "finance",
+        "geography": "GB",
+      }
+    },
+    "resource": {
+      "kind": "expenses",
+      "id": "XX125",
+      "attr": {
+        "department": "marketing",
+        "geography": "GB",
+        "id": "XX125",
+        "owner": "john",
+        "team": "design",
+      }
+    }
+  }
+]
+wantOutputs: [
+  {
+    "requestId": "test",
+    "resourceId": "XX125",
+    "actions": {
+      "view": {
+        "effect": "EFFECT_ALLOW",
+        "policy": "principal.daisy_duck.vdefault"
+      },
+      "edit": {
+        "effect": "EFFECT_DENY",
+        "policy": "NO_MATCH"
+      }
+    }
+  }
+]

--- a/internal/test/testdata/store/principal_policies/policy_03.yaml
+++ b/internal/test/testdata/store/principal_policies/policy_03.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: "api.cerbos.dev/v1"
+principalPolicy:
+  principal: daisy_duck
+  version: default
+  rules:
+    - resource: "expenses"
+      actions:
+        - action: "view"
+          effect: EFFECT_ALLOW
+          name: expenses_admin


### PR DESCRIPTION
If there's only a principal policy and at least one of the actions does
not have a matching rule in the principal policy, everything gets denied
because we don't have a resource policy to fall back to. This PR fixes
that issue and preserves the valid decisions that came out of the
principal policy.

Fixes #1397

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
