### PR TITLE
chore(ci): Use token with Buf setup action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,8 @@
 name: "CodeQL"
-
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
-
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 jobs:
   analyze:
     name: Analyze
@@ -61,3 +57,14 @@ jobs:
       uses: github/codeql-action/analyze@v2
       with:
         category: "/language:${{matrix.language}}"
+
+
+    - name: Notify Slack
+      if: failure()
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      uses: voxmedia/github-action-slack-notify-build@v2
+      with:
+        channel_id: C02TMGNNL4V
+        status: FAILED
+        color: danger

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -221,6 +221,8 @@ jobs:
 
       - name: Setup Buf
         uses: bufbuild/buf-setup-action@v1.11.0
+        with:
+          github_token: ${{ github.token }}
 
       - name: Lint protos
         uses: bufbuild/buf-lint-action@v1.0.3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,6 +67,8 @@ jobs:
 
       - name: Setup Buf
         uses: bufbuild/buf-setup-action@v1.11.0
+        with:
+          github_token: ${{ github.token }}
 
       - name: Push to BSR
         uses: bufbuild/buf-push-action@v1.1.1

--- a/.github/workflows/snaphot.yaml
+++ b/.github/workflows/snaphot.yaml
@@ -104,6 +104,8 @@ jobs:
 
       - name: Setup Buf
         uses: bufbuild/buf-setup-action@v1.11.0
+        with:
+          github_token: ${{ github.token }}
 
       - name: Push to BSR
         uses: bufbuild/buf-push-action@v1.1.1


### PR DESCRIPTION
The `buf-setup-action` step can sometimes fail if the GitHub token is
not supplied. https://github.com/bufbuild/buf-setup-action#github-token

Also changes the CodeQL workflow to run just on Mondays because it takes too
long to run on every PR.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
