### PR TITLE
fix: Evict disabled policy from the cache

### DIFF
--- a/internal/compile/manager.go
+++ b/internal/compile/manager.go
@@ -133,6 +133,11 @@ func (c *Manager) recompile(evt storage.Event) error {
 	}
 
 	for modID, cu := range compileUnits {
+		if cu.MainPolicy() == nil || cu.MainPolicy().Disabled {
+			c.evict(cu.ModID)
+			c.log.Debugw("Evicted the disabled policy", "id", cu.ModID.String())
+			continue
+		}
 		if _, err := c.compile(cu); err != nil {
 			// log and remove the module that failed to compile.
 			c.log.Errorw("Failed to recompile", "id", modID, "error", err)


### PR DESCRIPTION
Disabling policies trigger a recompilation, and during recompilation, we see the following error in the logs;
```
Processing storage event        {"event": "ADD/UPDATE [17261342906893367968]"}
cerbos.compiler Failed to recompile     {"id": {}, "error": "missing policy definition {17261342906893367968}: invalid compilation unit"}
```