### PR TITLE
fix: Evict policies that are changed in-place

### DIFF
--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -36,6 +36,7 @@ auxData:
           refreshInterval: 1h # RefreshInterval is the refresh interval for the keyset.
           url: https://domain.tld/.well-known/keys.jwks # Required. URL is the JWKS URL to fetch the keyset from.
 compile:
+  cacheDuration: 60s # CacheDuration is the duration to cache an entry.
   cacheSize: 1024 # CacheSize is the number of compiled policies to cache in memory.
 engine:
   defaultPolicyVersion: "default" # DefaultPolicyVersion defines what version to assume if the request does not specify one.

--- a/internal/compile/conf.go
+++ b/internal/compile/conf.go
@@ -3,6 +3,13 @@
 
 package compile
 
+import (
+	"errors"
+	"time"
+
+	"go.uber.org/multierr"
+)
+
 const (
 	confKey          = "compile"
 	defaultCacheSize = 1024
@@ -12,6 +19,8 @@ const (
 type Conf struct {
 	// CacheSize is the number of compiled policies to cache in memory.
 	CacheSize uint `yaml:"cacheSize" conf:",example=1024"`
+	// CacheDuration is the duration to cache an entry.
+	CacheDuration time.Duration `yaml:"cacheDuration" conf:",example=60s"`
 }
 
 func (c *Conf) Key() string {
@@ -20,6 +29,18 @@ func (c *Conf) Key() string {
 
 func (c *Conf) SetDefaults() {
 	c.CacheSize = defaultCacheSize
+}
+
+func (c *Conf) Validate() (outErr error) {
+	if c.CacheSize < 1 {
+		outErr = multierr.Append(outErr, errors.New("compile.cacheSize must be greater than 0"))
+	}
+
+	if c.CacheDuration < 0 {
+		outErr = multierr.Append(outErr, errors.New("compile.cacheDuration must be positive"))
+	}
+
+	return outErr
 }
 
 // DefaultConf creates a config with defaults.

--- a/internal/storage/git/store.go
+++ b/internal/storage/git/store.go
@@ -405,11 +405,13 @@ func (s *Store) updateIndex(ctx context.Context) error {
 		if fromPath != toPath || fromType != toType {
 			switch fromType {
 			case util.FileTypePolicy:
+				s.log.Debugf("Removing policy %s", fromPath)
 				if err := s.applyIndexUpdate(c.From, storage.EventDeletePolicy); err != nil {
 					return err
 				}
 
 			case util.FileTypeSchema:
+				s.log.Debugf("Removing schema %s", fromPath)
 				s.NotifySubscribers(storage.NewSchemaEvent(storage.EventDeleteSchema, fromPath))
 
 			default:
@@ -419,11 +421,13 @@ func (s *Store) updateIndex(ctx context.Context) error {
 
 		switch toType {
 		case util.FileTypePolicy:
+			s.log.Debugf("Add/update policy %s", toPath)
 			if err := s.applyIndexUpdate(c.To, storage.EventAddOrUpdatePolicy); err != nil {
 				return err
 			}
 
 		case util.FileTypeSchema:
+			s.log.Debugf("Add/update schema %s", toPath)
 			s.NotifySubscribers(storage.NewSchemaEvent(storage.EventAddOrUpdateSchema, toPath))
 
 		default:

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -170,9 +170,10 @@ const (
 
 // Event is an event detected by the storage layer.
 type Event struct {
-	SchemaFile string
-	Kind       EventKind
-	PolicyID   namer.ModuleID
+	OldPolicyID *namer.ModuleID
+	SchemaFile  string
+	Kind        EventKind
+	PolicyID    namer.ModuleID
 }
 
 func (evt Event) String() string {


### PR DESCRIPTION
If a user edits a policy file in place and changes its identifiers
(name, version) then the old policy does not get evicted from the
compile cache and is still usable until Cerbos is restarted or the store
is reloaded using the Admin API.

This PR also adds a configuration field to set the expiry time of
compiled policies. The default is no expiry, which is the current
behaviour.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
