### PR TITLE
chore: Upgrade Otel semconv version

### DIFF
--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -29,7 +29,7 @@ stop_kind() {
 run_tests() {
     (
         cd "$SCRIPT_DIR"
-        telepresence helm install --upgrade
+        telepresence helm upgrade
         telepresence connect --no-report -- go test -v -failfast -p=1 --tags="tests e2e" "$@"
     )
 }

--- a/internal/observability/tracing/tracing.go
+++ b/internal/observability/tracing/tracing.go
@@ -39,6 +39,10 @@ func Init(ctx context.Context) error {
 		return fmt.Errorf("failed to load tracing config: %w", err)
 	}
 
+	return InitFromConf(ctx, conf)
+}
+
+func InitFromConf(ctx context.Context, conf Conf) error {
 	switch conf.Exporter {
 	case jaegerExporter:
 		return configureJaeger(ctx)

--- a/internal/observability/tracing/tracing.go
+++ b/internal/observability/tracing/tracing.go
@@ -21,7 +21,8 @@ import (
 	otelprop "go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"go.opentelemetry.io/otel/semconv/v1.17.0/httpconv"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -182,7 +183,7 @@ func MarkFailed(span trace.Span, code int, err error) {
 		span.RecordError(err)
 	}
 
-	c, desc := semconv.SpanStatusFromHTTPStatusCode(code)
+	c, desc := httpconv.ServerStatus(code)
 	span.SetStatus(c, desc)
 }
 

--- a/internal/observability/tracing/tracing_test.go
+++ b/internal/observability/tracing/tracing_test.go
@@ -1,0 +1,27 @@
+// Copyright 2021-2023 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracing_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cerbos/cerbos/internal/observability/tracing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTracingInit(t *testing.T) {
+	// This test is for detecting whether the imported semconv version clashes with the semconv version of Otel libraries
+	conf := tracing.Conf{
+		SampleProbability: 1.0,
+		Jaeger: &tracing.JaegerConf{
+			AgentEndpoint: "localhost:6900",
+		},
+	}
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	t.Cleanup(cancelFn)
+
+	require.NoError(t, tracing.InitFromConf(ctx, conf))
+}


### PR DESCRIPTION
The semconv package from Otel has a secondary version encoded in the
package name. So, even if the library version is updated in go.mod, we
have to remember to manually update the import path too. If not, it
panics because apparently two different "versions" of semconv cannot
co-exist together :shrug:

Did I mention that Otel is the worst library I have ever worked with?

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
