### PR TITLE
chore(ci): Improve caching

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -1,0 +1,80 @@
+name: Set up Go
+
+description: Install Go and cache dependencies
+
+inputs:
+  cross_compiling:
+    description: true if cross-compiling (which generates a much larger build cache that we only want to use on snapshot builds)
+    required: false
+    default: "false"
+
+  write_deps_cache:
+    description: true to save dependencies cache at the end of the workflow
+    required: false
+    default: "false"
+
+  write_build_cache:
+    description: true to save build cache at the end of the workflow
+    required: false
+    default: "false"
+
+outputs:
+  cache_hit:
+    description: true if an exact match was found for both the dependency and build cache keys
+    value: ${{ (steps.cache_deps.outputs.cache-hit == 'true' || steps.restore_deps.outputs.cache-hit == 'true') && (steps.cache_build.outputs.cache-hit == 'true' || steps.restore_build.outputs.cache-hit == 'true') }}
+
+runs:
+  using: composite
+
+  steps:
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.20.x
+        check-latest: true
+
+    - name: Cache dependencies
+      id: cache_deps
+      if: ${{ inputs.write_deps_cache == 'true' }}
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/cerbos/bin
+        key: ${{ runner.os }}-go-deps-${{ hashFiles('**/go.mod') }}
+        restore-keys: |
+          ${{ runner.os }}-go-deps-
+
+    - name: Restore cached dependencies
+      id: restore_deps
+      if: ${{ inputs.write_deps_cache != 'true' }}
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/cerbos/bin
+        key: ${{ runner.os }}-go-deps-${{ hashFiles('**/go.mod') }}
+        restore-keys: |
+          ${{ runner.os }}-go-deps-
+
+    - name: Cache build outputs
+      id: cache_build
+      if: ${{ inputs.write_build_cache == 'true' }}
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-build-${{ inputs.cross_compiling }}-${{ hashFiles('**/go.mod') }}
+        restore-keys: |
+          ${{ runner.os }}-go-build-${{ inputs.cross_compiling }}-
+
+    - name: Restore cached build outputs
+      id: restore_build
+      if: ${{ inputs.write_build_cache != 'true' }}
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-build-${{ inputs.cross_compiling }}-${{ hashFiles('**/go.mod') }}
+        restore-keys: |
+          ${{ runner.os }}-go-build-${{ inputs.cross_compiling }}-

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -1,0 +1,46 @@
+name: Cache dependencies
+
+on:
+  push:
+    branches:
+      - main
+  workflow_call:
+
+jobs:
+  changes:
+    name: Check for changes
+    runs-on: ubuntu-latest
+    outputs:
+      deps: ${{ steps.filter.outputs.deps }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Check for changes
+        id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            deps:
+              - .github/workflows/cache.yaml
+              - "**/go.mod"
+
+  cache:
+    name: Cache dependencies
+    needs: changes
+    if: ${{ needs.changes.outputs.deps == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Install Go and cache dependencies
+        id: setup
+        uses: ./.github/actions/setup-go
+        with:
+          write_deps_cache: true
+          write_build_cache: true
+
+      - name: Warm cache
+        if: ${{ steps.setup.outputs.cache_hit != 'true' }}
+        run: make warm-cache

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,26 +9,13 @@ jobs:
     name: Run E2E Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-          check-latest: true
-
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/.cache/cerbos/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+      - name: Install Go and restore cached dependencies
+        uses: ./.github/actions/setup-go
 
       - name: Install Helm
         uses: azure/setup-helm@v3.5

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -26,30 +26,20 @@ jobs:
               - .github/workflows/pr-test.yaml
               - '**/*.proto'
 
+  cache:
+    uses: ./.github/workflows/cache.yaml
+
   generate:
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     name: Generate
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-          check-latest: true
-
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/.cache/cerbos/bin
-          key: generate-${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            generate-${{ runner.os }}-go-
+      - name: Install Go and restore cached dependencies
+        uses: ./.github/actions/setup-go
 
       - name: Generate
         run: make generate
@@ -95,27 +85,13 @@ jobs:
     outputs:
       job-total: ${{ strategy.job-total }}
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-          check-latest: true
-
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           lfs: true
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/.cache/cerbos/bin
-          key: test-${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}-${{ strategy.job-index }}
-          restore-keys: |
-            test-${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}-
-            test-${{ runner.os }}-go-
+      - name: Install Go and restore cached dependencies
+        uses: ./.github/actions/setup-go
 
       - name: Download previous test times
         uses: actions/download-artifact@v3
@@ -146,21 +122,11 @@ jobs:
     name: Upload test times
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/.cache/cerbos/bin
-          key: test-${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}-0
+      - name: Install Go and restore cached dependencies
+        uses: ./.github/actions/setup-go
 
       - name: Download JUnit reports
         uses: actions/download-artifact@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,16 +9,15 @@ jobs:
     name: Release Binaries
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-          check-latest: true
-
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Install Go and restore cached dependencies
+        uses: ./.github/actions/setup-go
+        with:
+          cross_compiling: true
 
       - name: Set up QEMU
         id: qemu

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -11,12 +11,6 @@ jobs:
     name: Publish Dev Containers
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-          check-latest: true
-
       - name: Checkout code
         uses: actions/checkout@v3
         with:
@@ -41,15 +35,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/cache@v3
+      - name: Install Go and cache dependencies
+        uses: ./.github/actions/setup-go
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/.cache/cerbos/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cross_compiling: true
+          write_build_cache: true
 
       - name: Generate
         run: make generate

--- a/.github/workflows/test-matrix.yaml
+++ b/.github/workflows/test-matrix.yaml
@@ -11,23 +11,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/.cache/cerbos/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+      - name: Install Go and restore cached dependencies
+        uses: ./.github/actions/setup-go
 
       - name: Build
         uses: goreleaser/goreleaser-action@v3

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -9,24 +9,11 @@ jobs:
     name: Run Vulnerability Check
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-          check-latest: true
-
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/.cache/cerbos/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+      - name: Install Go and restore cached dependencies
+        uses: ./.github/actions/setup-go
 
       - name: Check vulnerabilities
         run: |

--- a/Makefile
+++ b/Makefile
@@ -144,3 +144,6 @@ install-cerbosctl:
 			exit -1; \
 		fi; \
 	fi; \
+
+.PHONY: warm-cache
+warm-cache: compile proto-gen-deps $(GOTESTSUM) $(MOCKERY) $(TESTSPLIT)


### PR DESCRIPTION
Since [branches don't share caches, except for the default branch](https://github.com/actions/cache#cache-scopes), we need to warm the cache on `main` branch pushes to avoid missing the cache on the first build of every PR.

Our caches are quite large, so to reduce eviction `pr-test` jobs now use common caches for dependencies and build outputs (generated by `make warm-cache`). The `snapshots` job re-uses the dependencies cache, but has a separate build cache which is much larger, thanks to cross-compiling.