### PR TITLE
feat: Add Cerbos version to response headers

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	svcv1 "github.com/cerbos/cerbos/api/genpb/cerbos/svc/v1"
+	"github.com/cerbos/cerbos/internal/util"
 )
 
 const (
@@ -197,4 +198,9 @@ func handleRoutingError(ctx context.Context, mux *runtime.ServeMux, marshaler ru
 	}
 
 	runtime.DefaultRoutingErrorHandler(ctx, mux, marshaler, w, r, httpStatus)
+}
+
+func cerbosVersionUnaryServerInterceptor(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	_ = grpc.SetHeader(ctx, metadata.Pairs("cerbos-version", util.Version))
+	return handler(ctx, req)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -443,6 +443,7 @@ func (s *Server) mkGRPCServer(log *zap.Logger, auditLog audit.Log) (*grpc.Server
 			),
 			grpc_zap.PayloadUnaryServerInterceptor(payloadLog, payloadLoggingDecider(s.conf)),
 			auditInterceptor,
+			cerbosVersionUnaryServerInterceptor,
 		),
 		grpc.StatsHandler(&ocgrpc.ServerHandler{}),
 		grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionAge: s.conf.Advanced.GRPC.MaxConnectionAge}),


### PR DESCRIPTION
This PR adds `cerbos-version` to the gRPC response headers (which comes through as `Grpc-Metadata-Cerbos-Version` in the HTTP response headers).