### PR TITLE
chore(ci): Add merge_group to GitHub workflow

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'v*'
+  merge_group:
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - synchronize
+  merge_group:
 jobs:
   label:
     name: Apply PR labels


### PR DESCRIPTION
I think this is why the queued PRs aren't being merged into `main` branch.