### PR TITLE
enhancement: Enable auth on API explorer page

### DIFF
--- a/schema/assets/ui.html
+++ b/schema/assets/ui.html
@@ -1,17 +1,17 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="utf-8"> 
+    <meta charset="utf-8">
     <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
   </head>
   <body>
-    <rapi-doc 
-      spec-url="/schema/swagger.json" 
-      render-style="view" 
-      schema-style="table" 
-      allow-authentication="false" 
+    <rapi-doc
+      spec-url="/schema/swagger.json"
+      render-style="view"
+      schema-style="table"
+      allow-authentication="true"
       allow-server-selection="false"
-      show-header="false" 
+      show-header="false"
       schema-description-expanded="true"
       theme="dark"></rapi-doc>
   </body>


### PR DESCRIPTION
Allow users to try out the Admin API with credentials.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
