### PR TITLE
enhancement: Add support for reading archive files for the disk driver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@ assets/ filter=lfs diff=lfs merge=lfs -text
 **/*.svg filter=lfs diff=lfs merge=lfs -text
 **/*.gif filter=lfs diff=lfs merge=lfs -text
 **/*.zip filter=lfs diff=lfs merge=lfs -text
+**/*.tar filter=lfs diff=lfs merge=lfs -text
+**/*.tgz filter=lfs diff=lfs merge=lfs -text

--- a/cmd/cerbos/compile/compile.go
+++ b/cmd/cerbos/compile/compile.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage/disk"
 	"github.com/cerbos/cerbos/internal/storage/index"
+	"github.com/cerbos/cerbos/internal/util"
 	"github.com/cerbos/cerbos/internal/verify"
 )
 
@@ -76,7 +77,7 @@ func (c *Cmd) Run(k *kong.Kong) error {
 
 	p := printer.New(k.Stdout, k.Stderr)
 
-	idx, err := index.Build(ctx, os.DirFS(c.Dir), index.WithBuildFailureLogLevel(zap.DebugLevel))
+	idx, err := index.Build(ctx, util.OpenDirectoryFS(c.Dir), index.WithBuildFailureLogLevel(zap.DebugLevel))
 	if err != nil {
 		idxErr := new(index.BuildError)
 		if errors.As(err, &idxErr) {
@@ -137,10 +138,10 @@ func (c *Cmd) Run(k *kong.Kong) error {
 
 func (c *Cmd) testsDir() fs.FS {
 	if c.Tests == "" {
-		return os.DirFS(c.Dir)
+		return util.OpenDirectoryFS(c.Dir)
 	}
 
-	return os.DirFS(c.Tests)
+	return util.OpenDirectoryFS(c.Tests)
 }
 
 func (c *Cmd) Help() string {

--- a/cmd/cerbosctl/put/internal/files/find.go
+++ b/cmd/cerbosctl/put/internal/files/find.go
@@ -4,7 +4,6 @@
 package files
 
 import (
-	"archive/zip"
 	"fmt"
 	"io/fs"
 	"os"
@@ -32,16 +31,6 @@ func find(path string, recursive bool, fileType util.IndexedFileType, callback c
 	}
 
 	switch {
-	case util.IsZip(path):
-		zipFile, err := zip.OpenReader(path)
-		if err != nil {
-			return fmt.Errorf("failed to open zip file %s: %w", path, err)
-		}
-		defer zipFile.Close()
-
-		if err := doFind(zipFile, fileType, recursive, callback); err != nil {
-			return fmt.Errorf("failed to find files %s: %w", path, err)
-		}
 	case fileInfo.IsDir():
 		if err := doFind(os.DirFS(path), fileType, recursive, callback); err != nil {
 			return fmt.Errorf("failed to find files %s: %w", path, err)

--- a/cmd/cerbosctl/put/internal/files/find.go
+++ b/cmd/cerbosctl/put/internal/files/find.go
@@ -31,8 +31,8 @@ func find(path string, recursive bool, fileType util.IndexedFileType, callback c
 	}
 
 	switch {
-	case fileInfo.IsDir():
-		if err := doFind(os.DirFS(path), fileType, recursive, callback); err != nil {
+	case fileInfo.IsDir() || util.IsArchiveFile(path):
+		if err := doFind(util.OpenDirectoryFS(path), fileType, recursive, callback); err != nil {
 			return fmt.Errorf("failed to find files %s: %w", path, err)
 		}
 	default:

--- a/cmd/cerbosctl/put/internal/files/find.go
+++ b/cmd/cerbosctl/put/internal/files/find.go
@@ -32,14 +32,18 @@ func find(path string, recursive bool, fileType util.IndexedFileType, callback c
 
 	switch {
 	case fileInfo.IsDir() || util.IsArchiveFile(path):
-		if err := doFind(util.OpenDirectoryFS(path), fileType, recursive, callback); err != nil {
+		fsys, err := util.OpenDirectoryFS(path)
+		if err != nil {
+			return err
+		}
+		if err := doFind(fsys, fileType, recursive, callback); err != nil {
 			return fmt.Errorf("failed to find files %s: %w", path, err)
 		}
 	default:
 		fis := foundInFs{
 			path: filepath.Base(path),
 			id:   filepath.Base(path),
-			fsys: util.OpenDirectoryFS(filepath.Dir(path)),
+			fsys: os.DirFS(filepath.Dir(path)),
 		}
 
 		if id, ok := util.RelativeSchemaPath(path); fileType == util.FileTypeSchema && ok {

--- a/cmd/cerbosctl/put/internal/files/find.go
+++ b/cmd/cerbosctl/put/internal/files/find.go
@@ -50,7 +50,7 @@ func find(path string, recursive bool, fileType util.IndexedFileType, callback c
 		fis := foundInFs{
 			path: filepath.Base(path),
 			id:   filepath.Base(path),
-			fsys: os.DirFS(filepath.Dir(path)),
+			fsys: util.OpenDirectoryFS(filepath.Dir(path)),
 		}
 
 		if id, ok := util.RelativeSchemaPath(path); fileType == util.FileTypeSchema && ok {

--- a/docs/modules/configuration/pages/storage.adoc
+++ b/docs/modules/configuration/pages/storage.adoc
@@ -32,6 +32,21 @@ storage:
 
 CAUTION: On some platforms the automatic change detection feature can be inefficient and resource-intensive if the watched directory contains many files or gets updated frequently.
 
+=== Archive Files
+
+Alternatively, you can opt to archive and/or compress your policies directory into a Zip (`.zip`), Tar (`.tar`) or Gzip file (`.tgz` or `.tar.gz`). You can then specify the file in your config like so:
+
+.Archived fileset using a Zip file
+[source,yaml,linenums]
+----
+storage:
+  driver: disk
+  disk:
+    directory: /etc/cerbos/policies.zip
+----
+
+NOTE: Change detection will be disabled when using archive files.
+
 [id="blob-driver"]
 == Blob driver
 

--- a/docs/modules/configuration/pages/storage.adoc
+++ b/docs/modules/configuration/pages/storage.adoc
@@ -34,7 +34,9 @@ CAUTION: On some platforms the automatic change detection feature can be ineffic
 
 === Archive Files
 
-Alternatively, you can opt to archive and/or compress your policies directory into a Zip (`.zip`), Tar (`.tar`) or Gzip file (`.tgz` or `.tar.gz`). You can then specify the file in your config like so:
+Alternatively, you can opt to archive and/or compress your policies directory into a Zip (`.zip`), Tar (`.tar`) or Gzip file (`.tgz` or `.tar.gz`). The archive is assumed to be laid out like a standard policy directory. It must contain no non-policy YAML files.
+
+You specify the file in your config like so:
 
 .Archived fileset using a Zip file
 [source,yaml,linenums]

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/lestrrat-go/jwx/v2 v2.0.8
 	github.com/mattn/go-isatty v0.0.17
 	github.com/minio/minio-go/v7 v7.0.49
+	github.com/nlepage/go-tarfs v1.1.0
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/ory/dockertest/v3 v3.9.1

--- a/go.sum
+++ b/go.sum
@@ -1785,6 +1785,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba/go.mod h1:ncO5VaFWh0Nrt+4KT4mOZboaczBZcLuHrG+/sUeP8gI=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nlepage/go-tarfs v1.1.0 h1:bsACOiZMB/zFjYG/sE01070i9Fl26MnRpw0L6WuyfVs=
+github.com/nlepage/go-tarfs v1.1.0/go.mod h1:IhxRcLhLkawBetnwu/JNuoPkq/6cclAllhgEa6SmzS8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -168,6 +168,7 @@ func WithStoreIdentifier(p *policyv1.Policy, storeIdentifier string) *policyv1.P
 		p.Metadata = &policyv1.Metadata{}
 	}
 
+	//nolint:staticcheck
 	p.Metadata.StoreIdentifer = storeIdentifier // TODO: Remove this after deprecated StoreIdentifer no longer exists
 	p.Metadata.StoreIdentifier = storeIdentifier
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -168,7 +168,7 @@ func WithStoreIdentifier(p *policyv1.Policy, storeIdentifier string) *policyv1.P
 		p.Metadata = &policyv1.Metadata{}
 	}
 
-	
+	//nolint:staticcheck
 	p.Metadata.StoreIdentifer = storeIdentifier // TODO: Remove this after deprecated StoreIdentifer no longer exists
 	p.Metadata.StoreIdentifier = storeIdentifier
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -168,7 +168,6 @@ func WithStoreIdentifier(p *policyv1.Policy, storeIdentifier string) *policyv1.P
 		p.Metadata = &policyv1.Metadata{}
 	}
 
-	
 	p.Metadata.StoreIdentifer = storeIdentifier // TODO: Remove this after deprecated StoreIdentifer no longer exists
 	p.Metadata.StoreIdentifier = storeIdentifier
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -168,7 +168,7 @@ func WithStoreIdentifier(p *policyv1.Policy, storeIdentifier string) *policyv1.P
 		p.Metadata = &policyv1.Metadata{}
 	}
 
-	//nolint:staticcheck
+	
 	p.Metadata.StoreIdentifer = storeIdentifier // TODO: Remove this after deprecated StoreIdentifer no longer exists
 	p.Metadata.StoreIdentifier = storeIdentifier
 

--- a/internal/storage/disk/disk.go
+++ b/internal/storage/disk/disk.go
@@ -49,7 +49,13 @@ func NewStore(ctx context.Context, conf *Conf) (*Store, error) {
 	}
 
 	zap.S().Named("disk.store").Infof("Initializing disk store from %s", dir)
-	idx, err := index.Build(ctx, util.OpenDirectoryFS(dir))
+
+	fsys, err := util.OpenDirectoryFS(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	idx, err := index.Build(ctx, fsys)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/disk/disk.go
+++ b/internal/storage/disk/disk.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 
 	"github.com/cerbos/cerbos/internal/config"
@@ -15,6 +14,7 @@ import (
 	"github.com/cerbos/cerbos/internal/policy"
 	"github.com/cerbos/cerbos/internal/storage"
 	"github.com/cerbos/cerbos/internal/storage/index"
+	"github.com/cerbos/cerbos/internal/util"
 	"go.uber.org/zap"
 )
 
@@ -49,7 +49,7 @@ func NewStore(ctx context.Context, conf *Conf) (*Store, error) {
 	}
 
 	zap.S().Named("disk.store").Infof("Initializing disk store from %s", dir)
-	idx, err := index.Build(ctx, os.DirFS(dir))
+	idx, err := index.Build(ctx, util.OpenDirectoryFS(dir))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/disk/disk.go
+++ b/internal/storage/disk/disk.go
@@ -65,7 +65,7 @@ func NewStore(ctx context.Context, conf *Conf) (*Store, error) {
 		idx:                 idx,
 		SubscriptionManager: storage.NewSubscriptionManager(ctx),
 	}
-	if conf.WatchForChanges {
+	if conf.WatchForChanges && !util.IsArchiveFile(dir) {
 		if err := watchDir(ctx, dir, s.idx, s.SubscriptionManager, defaultCooldownPeriod); err != nil {
 			return nil, err
 		}

--- a/internal/storage/index/builder_test.go
+++ b/internal/storage/index/builder_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"io"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -31,7 +30,7 @@ import (
 func TestBuildIndexWithDisk(t *testing.T) {
 	dir := test.PathToDir(t, "store")
 
-	idx, err := Build(context.Background(), os.DirFS(dir))
+	idx, err := Build(context.Background(), util.OpenDirectoryFS(dir))
 	require.NoError(t, err)
 	require.NotNil(t, idx)
 

--- a/internal/storage/index/builder_test.go
+++ b/internal/storage/index/builder_test.go
@@ -30,7 +30,10 @@ import (
 func TestBuildIndexWithDisk(t *testing.T) {
 	dir := test.PathToDir(t, "store")
 
-	idx, err := Build(context.Background(), util.OpenDirectoryFS(dir))
+	fsys, err := util.OpenDirectoryFS(dir)
+	require.NoError(t, err)
+
+	idx, err := Build(context.Background(), fsys)
 	require.NoError(t, err)
 	require.NotNil(t, idx)
 

--- a/internal/storage/index/index_test.go
+++ b/internal/storage/index/index_test.go
@@ -21,11 +21,6 @@ import (
 )
 
 func TestIndexLoadPolicy(t *testing.T) {
-	base := test.PathToDir(t, "store")
-	fsys := os.DirFS(base)
-	idx, err := index.Build(context.Background(), fsys)
-	require.NoError(t, err)
-
 	policyFiles := []string{
 		"derived_roles/common_roles.yaml",
 		"derived_roles/derived_roles_01.yaml",
@@ -46,7 +41,13 @@ func TestIndexLoadPolicy(t *testing.T) {
 		"resource_policies/policy_06.yaml",
 	}
 
-	t.Run("load policy", func(t *testing.T) {
+	testLoadPolicy := func(t *testing.T, path string) {
+		t.Helper()
+
+		base := test.PathToDir(t, path)
+		idx, err := index.Build(context.Background(), util.OpenDirectoryFS(base))
+		require.NoError(t, err)
+
 		t.Run("should load the policies", func(t *testing.T) {
 			policies, err := idx.LoadPolicy(context.Background(), policyFiles...)
 			require.NoError(t, err)
@@ -79,6 +80,19 @@ func TestIndexLoadPolicy(t *testing.T) {
 				require.Equal(t, wrapperspb.UInt64(util.HashPB(p, policy.IgnoreHashFields)), p.Metadata.Hash)
 			}
 		})
+	}
+
+	t.Run("load policy", func(t *testing.T) {
+		testLoadPolicy(t, "store")
+	})
+	t.Run("load policy zip", func(t *testing.T) {
+		testLoadPolicy(t, "store_archive/policies.zip")
+	})
+	t.Run("load policy tar", func(t *testing.T) {
+		testLoadPolicy(t, "store_archive/policies.tar")
+	})
+	t.Run("load policy gzip", func(t *testing.T) {
+		testLoadPolicy(t, "store_archive/policies.tgz")
 	})
 }
 

--- a/internal/storage/index/index_test.go
+++ b/internal/storage/index/index_test.go
@@ -45,7 +45,9 @@ func TestIndexLoadPolicy(t *testing.T) {
 		t.Helper()
 
 		base := test.PathToDir(t, path)
-		idx, err := index.Build(context.Background(), util.OpenDirectoryFS(base))
+		fsys, err := util.OpenDirectoryFS(base)
+		require.NoError(t, err)
+		idx, err := index.Build(context.Background(), fsys)
 		require.NoError(t, err)
 
 		t.Run("should load the policies", func(t *testing.T) {

--- a/internal/test/testdata/store_archive/policies.tar
+++ b/internal/test/testdata/store_archive/policies.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c06cbca64541c5df699390546c3ed0991a4daf0858e040f0487c8b6831443cea
+size 41472

--- a/internal/test/testdata/store_archive/policies.tgz
+++ b/internal/test/testdata/store_archive/policies.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8da8c0bc2d1901fd9c4f2203113790565a7c3f9e33ee1847e673e0698d40e73
+size 2956

--- a/internal/test/testdata/store_archive/policies.zip
+++ b/internal/test/testdata/store_archive/policies.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:381c0da22603d01f43567b9a36a832ff00c80ff0719c3f99e4e0b634513ecdcc
+size 13428

--- a/internal/util/filesystem.go
+++ b/internal/util/filesystem.go
@@ -90,8 +90,8 @@ func getFsFromTar(r io.Reader) (fs.FS, error) {
 	return tfs, nil
 }
 
-// OpenDirectoryFS attempts to open a directory FS at the given location. It'll initially check if the target file is a zip,
-// and if so, will return a zip Reader (which implements fs.FS).
+// OpenDirectoryFS attempts to open a directory FS at the given location. It'll initially check if the target file is an archive,
+// and if so, will return the appropriate type which implements the fs.FS interface.
 func OpenDirectoryFS(path string) (fs.FS, error) {
 	// We don't use `switch filepath.Ext(path)` here because it only suffixes from the final `.`, so `.tar.gz` won't be
 	// correctly handled

--- a/internal/util/filesystem.go
+++ b/internal/util/filesystem.go
@@ -4,12 +4,17 @@
 package util
 
 import (
+	"archive/zip"
+	"compress/gzip"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/nlepage/go-tarfs"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -63,6 +68,59 @@ func IsHidden(fileName string) bool {
 
 func IsZip(fileName string) bool {
 	return strings.HasSuffix(fileName, ".zip")
+}
+
+func IsTar(fileName string) bool {
+	return strings.HasSuffix(fileName, ".tar")
+}
+
+func IsGzip(fileName string) bool {
+	return strings.HasSuffix(fileName, ".tar.gz") || strings.HasSuffix(fileName, ".tgz")
+}
+
+func getFsFromTar(r io.Reader) fs.FS {
+	tfs, err := tarfs.New(r)
+	if err != nil {
+		panic(fmt.Errorf("failed to open tar file: %w", err))
+	}
+	return tfs
+}
+
+// OpenDirectoryFS attempts to open a directory FS at the given location. It'll initially check if the target file is a zip,
+// and if so, will return a zip Reader (which implements fs.FS).
+func OpenDirectoryFS(path string) fs.FS {
+	switch {
+	case IsZip(path):
+		zr, err := zip.OpenReader(path)
+		if err != nil {
+			panic(fmt.Errorf("failed to open zip file: %w", err))
+		}
+		return zr
+	case IsTar(path):
+		f, err := os.Open(path)
+		if err != nil {
+			panic(fmt.Errorf("failed to open tar file: %w", err))
+		}
+		defer f.Close()
+
+		return getFsFromTar(f)
+	case IsGzip(path):
+		f, err := os.Open(path)
+		if err != nil {
+			panic(fmt.Errorf("failed to open gzip file: %w", err))
+		}
+		defer f.Close()
+
+		gzr, err := gzip.NewReader(f)
+		if err != nil {
+			panic(fmt.Errorf("failed to open gzip file: %w", err))
+		}
+		defer gzr.Close()
+
+		return getFsFromTar(gzr)
+	}
+
+	return os.DirFS(path)
 }
 
 // LoadFromJSONOrYAML reads a JSON or YAML encoded protobuf from the given path.

--- a/internal/util/filesystem.go
+++ b/internal/util/filesystem.go
@@ -96,13 +96,13 @@ func OpenDirectoryFS(path string) fs.FS {
 	// We don't use `switch filepath.Ext(path)` here because it only suffixes from the final `.`, so `.tar.gz` won't be
 	// correctly handled
 	switch {
-	case strings.HasSuffix(path, ".zip"):
+	case IsZip(path):
 		zr, err := zip.OpenReader(path)
 		if err != nil {
 			panic(fmt.Errorf("failed to open zip file: %w", err))
 		}
 		return zr
-	case strings.HasSuffix(path, ".tar"):
+	case IsTar(path):
 		f, err := os.Open(path)
 		if err != nil {
 			panic(fmt.Errorf("failed to open tar file: %w", err))
@@ -110,7 +110,7 @@ func OpenDirectoryFS(path string) fs.FS {
 		defer f.Close()
 
 		return getFsFromTar(f)
-	case strings.HasSuffix(path, ".tar.gz") || strings.HasSuffix(path, ".tgz"):
+	case IsGzip(path):
 		f, err := os.Open(path)
 		if err != nil {
 			panic(fmt.Errorf("failed to open gzip file: %w", err))

--- a/internal/util/filesystem.go
+++ b/internal/util/filesystem.go
@@ -66,6 +66,22 @@ func IsHidden(fileName string) bool {
 	}
 }
 
+func IsZip(fileName string) bool {
+	return strings.HasSuffix(fileName, ".zip")
+}
+
+func IsTar(fileName string) bool {
+	return strings.HasSuffix(fileName, ".tar")
+}
+
+func IsGzip(fileName string) bool {
+	return strings.HasSuffix(fileName, ".tar.gz") || strings.HasSuffix(fileName, ".tgz")
+}
+
+func IsArchiveFile(fileName string) bool {
+	return IsZip(fileName) || IsTar(fileName) || IsGzip(fileName)
+}
+
 func getFsFromTar(r io.Reader) fs.FS {
 	tfs, err := tarfs.New(r)
 	if err != nil {

--- a/internal/util/filesystem_test.go
+++ b/internal/util/filesystem_test.go
@@ -147,3 +147,25 @@ func TestRelativeSchemaPath(t *testing.T) {
 		})
 	}
 }
+
+func TestIsArchiveFile(t *testing.T) {
+	tests := []struct {
+		fileName string
+		want     bool
+	}{
+		{"foo.zip", true},
+		{"foo.tar", true},
+		{"foo.tgz", true},
+		{"foo.tar.gz", true},
+		// Unsupported files
+		{"foo/", false},
+		{"foo.yaml", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.fileName, func(t *testing.T) {
+			if got := util.IsArchiveFile(tt.fileName); got != tt.want {
+				t.Errorf("IsArchiveFile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds function to attempt retrieval of an `fs.FS` instance from `tar`, `zip` and `gzip` files if they have the matching extensions, otherwise defaults to `os.DirFS`.

TODO
- [x] Swop out for existing os.DirFS() calls where appropriate
- [x] Tidy file extension parsing
- [x] Fix [dirwatch](https://github.com/Sambigeara/cerbos/blob/e20b91705e28d41bb120b10102ef6b28d2779d94/internal/storage/disk/dirwatch.go#L51-L53)
- [x] Docs