### PR TITLE
docs(backport): Fix typo in 04_testing-policies.adoc (#1477)

### DIFF
--- a/docs/modules/ROOT/pages/tutorial/04_testing-policies.adoc
+++ b/docs/modules/ROOT/pages/tutorial/04_testing-policies.adoc
@@ -8,7 +8,7 @@ Cerbos allows you to write xref:policies:compile.adoc[tests for policies] and ru
 
 A test suite defines a number of resources and principals and the expected result of actions for any combination of them.
 
-To define a test suite, create a `tests` folder alongside your policy folder. In this folder, any number of tests can be fined as YAML but the file must end with `_test`.
+To define a test suite, create a `tests` folder alongside your policy folder. In this folder, any number of tests can be defined as YAML but the file must end with `_test`.
 
 As an example, the `contact` policy states that a `user` can create, read and update a contact, but only an `admin` can delete them - therefore you can create a test suite for this like the below:
 


### PR DESCRIPTION
Update 04_testing-policies.adoc

Minor typo fix.

Backport of #1477 