### PR TITLE
Updating documentation for Tests

### DIFF
--- a/docs/modules/policies/pages/compile.adoc
+++ b/docs/modules/policies/pages/compile.adoc
@@ -241,7 +241,7 @@ docker run -i -t \
 ----
 
 
-Machine readable output can be produced by passing `--format=json` flag to the command.
+Machine readable output can be produced by passing `--output=json` flag to the command.  `--output=list` is also an option, in addition to the default `--output=tree`.
 
 
 By default, all discovered tests are run. To run just some of the tests, provide a regular expression that matches the test using the `--run` flag.


### PR DESCRIPTION
#### Description

It appears that the documentation is out of date with regards to the format/output option for running tests.  The documentation currently describes the '--format' flag, while the actual command is now '--output'.

