### PR TITLE
chore: Make Otel resource schemaless

### DIFF
--- a/internal/observability/tracing/tracing.go
+++ b/internal/observability/tracing/tracing.go
@@ -104,7 +104,6 @@ func configureOtel(ctx context.Context, svcName *string, exporter tracesdk.SpanE
 	}
 
 	res, err := resource.New(context.Background(),
-		resource.WithSchemaURL(semconv.SchemaURL),
 		resource.WithAttributes(semconv.ServiceNameKey.String(*svcName)),
 		resource.WithProcessPID(),
 		resource.WithHost(),


### PR DESCRIPTION
In order to avoid schema conflicts every time Otel is upgraded, drop the
schema version from the resource definition. Since we are only using the
`ServiceName` attribute which ought to be stable by this point (but one
can never tell with Otel :shrug:), omitting the version should be fine.

https://pkg.go.dev/go.opentelemetry.io/otel/sdk@v1.14.0/resource#Merge

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
