### PR TITLE
enhancement: Report audit close error

### DIFF
--- a/internal/audit/file/log.go
+++ b/internal/audit/file/log.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cerbos/cerbos/internal/audit"
 	"github.com/cerbos/cerbos/internal/config"
 	"go.elastic.co/ecszap"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -98,9 +99,11 @@ func (l *Log) WriteDecisionLogEntry(_ context.Context, record audit.DecisionLogE
 	return nil
 }
 
-func (l *Log) Close() {
-	_ = l.accessLog.Sync()
-	_ = l.decisionLog.Sync()
+func (l *Log) Close() error {
+	return multierr.Combine(
+		l.accessLog.Sync(),
+		l.decisionLog.Sync(),
+	)
 }
 
 type protoMsg struct {

--- a/internal/audit/file/log_test.go
+++ b/internal/audit/file/log_test.go
@@ -31,7 +31,9 @@ func TestLog(t *testing.T) {
 	log, err := file.NewLog(&file.Conf{Path: output}, decisionFilter)
 	require.NoError(t, err)
 
-	t.Cleanup(log.Close)
+	t.Cleanup(func() {
+		log.Close()
+	})
 
 	require.Equal(t, file.Backend, log.Backend())
 	require.True(t, log.Enabled())

--- a/internal/audit/local/badgerdb.go
+++ b/internal/audit/local/badgerdb.go
@@ -366,12 +366,14 @@ func (l *Log) getByID(ctx context.Context, prefix []byte, id audit.ID, c collect
 	c.done(err)
 }
 
-func (l *Log) Close() {
+func (l *Log) Close() error {
+	var err error
 	l.stopOnce.Do(func() {
 		close(l.stopChan)
 		l.wg.Wait()
-		l.db.Close()
+		err = l.db.Close()
 	})
+	return err
 }
 
 func genKey(prefix []byte, id audit.IDBytes) []byte {

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"sync"
 	"time"
 
@@ -28,9 +29,9 @@ type Info interface {
 
 type Log interface {
 	Info
+	io.Closer
 	WriteAccessLogEntry(context.Context, AccessLogEntryMaker) error
 	WriteDecisionLogEntry(context.Context, DecisionLogEntryMaker) error
-	Close()
 }
 
 type QueryableLog interface {
@@ -141,10 +142,11 @@ func (lw *logWrapper) WriteDecisionLogEntry(ctx context.Context, entry DecisionL
 	return lw.backend.WriteDecisionLogEntry(ctx, entry)
 }
 
-func (lw *logWrapper) Close() {
+func (lw *logWrapper) Close() error {
 	if lw.backend != nil {
-		lw.backend.Close()
+		return lw.backend.Close()
 	}
+	return nil
 }
 
 type queryableLogWrapper struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -265,7 +265,9 @@ func (s *Server) Start(ctx context.Context, param Param) error {
 		}
 
 		log.Debug("Shutting down the audit log")
-		param.AuditLog.Close()
+		if err := param.AuditLog.Close(); err != nil {
+			log.Error("Failed to cleanly close audit log", zap.Error(err))
+		}
 
 		log.Info("Shutdown complete")
 		return nil


### PR DESCRIPTION
#### Description

As part of implementing [Kafka](https://github.com/cerbos/cerbos/pull/1499) I wanted to see when messages were failing to be flushed; async publishing and failing to flush can mean lost messages.

So as not to grow that PR & keep it focused, I've split this PR off.

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [ ] ~PR is linked to the corresponding issue~
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
