### PR TITLE
chore(ci): Increase snapshot build timeout

### DIFF
--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -10,7 +10,7 @@ jobs:
   publishContainers:
     name: Publish Dev Containers
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Snapshot build takes longer than 20 minutes in some cases.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
