### PR TITLE
fix: Kafka async publish fails when the API request returns

### DIFF
--- a/docs/modules/configuration/pages/audit.adoc
+++ b/docs/modules/configuration/pages/audit.adoc
@@ -139,9 +139,10 @@ audit:
     ack: all # Ack mode for producing messages. Valid values are "none", "leader" or "all" (default). Idempotency is disabled when mode is not "all".
     brokers: ['localhost:9092'] # Required. Brokers list to seed the Kafka client.
     clientID: cerbos # ClientID reported in Kafka connections.
+    closeTimeout: 30s # CloseTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
     encoding: json # Encoding format. Valid values are "json" (default) or "protobuf".
-    flushTimeout: 30s # FlushTimeout sets how often messages are flushed to the remote Kafka server.
     maxBufferedRecords: 1000 # MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.
     produceSync: false # ProduceSync forces the client to produce messages to Kafka synchronously. This can have a significant impact on performance.
+    publishTimeout: 5s # PublishTimeout sets how long to attempt to publish a message before giving up.
     topic: cerbos.audit.log # Required. Topic to write audit entries to.
 ----

--- a/docs/modules/configuration/pages/audit.adoc
+++ b/docs/modules/configuration/pages/audit.adoc
@@ -32,10 +32,11 @@ audit:
     ack: all # Ack mode for producing messages. Valid values are "none", "leader" or "all" (default). Idempotency is disabled when mode is not "all".
     brokers: ['localhost:9092'] # Required. Brokers list to seed the Kafka client.
     clientID: cerbos # ClientID reported in Kafka connections.
+    closeTimeout: 30s # CloseTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
     encoding: json # Encoding format. Valid values are "json" (default) or "protobuf".
-    flushTimeout: 30s # FlushTimeout sets how often messages are flushed to the remote Kafka server.
     maxBufferedRecords: 1000 # MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.
     produceSync: false # ProduceSync forces the client to produce messages to Kafka synchronously. This can have a significant impact on performance.
+    publishTimeout: 5s # PublishTimeout sets how long to attempt to publish a message before giving up.
     topic: cerbos.audit.log # Required. Topic to write audit entries to.
 ----
 

--- a/docs/modules/configuration/pages/audit.adoc
+++ b/docs/modules/configuration/pages/audit.adoc
@@ -36,7 +36,7 @@ audit:
     encoding: json # Encoding format. Valid values are "json" (default) or "protobuf".
     maxBufferedRecords: 1000 # MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.
     produceSync: false # ProduceSync forces the client to produce messages to Kafka synchronously. This can have a significant impact on performance.
-    publishTimeout: 5s # PublishTimeout sets how long to attempt to publish a message before giving up.
+    produceTimeout: 5s # ProduceTimeout sets how long to attempt to publish a message before giving up.
     topic: cerbos.audit.log # Required. Topic to write audit entries to.
 ----
 
@@ -143,6 +143,6 @@ audit:
     encoding: json # Encoding format. Valid values are "json" (default) or "protobuf".
     maxBufferedRecords: 1000 # MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.
     produceSync: false # ProduceSync forces the client to produce messages to Kafka synchronously. This can have a significant impact on performance.
-    publishTimeout: 5s # PublishTimeout sets how long to attempt to publish a message before giving up.
+    produceTimeout: 5s # ProduceTimeout sets how long to attempt to publish a message before giving up.
     topic: cerbos.audit.log # Required. Topic to write audit entries to.
 ----

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -17,10 +17,11 @@ audit:
     ack: all # Ack mode for producing messages. Valid values are "none", "leader" or "all" (default). Idempotency is disabled when mode is not "all".
     brokers: ['localhost:9092'] # Required. Brokers list to seed the Kafka client.
     clientID: cerbos # ClientID reported in Kafka connections.
-    flushTimeout: 30s # CloseTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
+    closeTimeout: 30s # CloseTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
     encoding: json # Encoding format. Valid values are "json" (default) or "protobuf".
     maxBufferedRecords: 1000 # MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.
     produceSync: false # ProduceSync forces the client to produce messages to Kafka synchronously. This can have a significant impact on performance.
+    publishTimeout: 5s # PublishTimeout sets how long to attempt to publish a message before giving up.
     topic: cerbos.audit.log # Required. Topic to write audit entries to.
   local:
     advanced: 

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -17,8 +17,8 @@ audit:
     ack: all # Ack mode for producing messages. Valid values are "none", "leader" or "all" (default). Idempotency is disabled when mode is not "all".
     brokers: ['localhost:9092'] # Required. Brokers list to seed the Kafka client.
     clientID: cerbos # ClientID reported in Kafka connections.
+    flushTimeout: 30s # CloseTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
     encoding: json # Encoding format. Valid values are "json" (default) or "protobuf".
-    flushTimeout: 30s # FlushTimeout sets how often messages are flushed to the remote Kafka server.
     maxBufferedRecords: 1000 # MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.
     produceSync: false # ProduceSync forces the client to produce messages to Kafka synchronously. This can have a significant impact on performance.
     topic: cerbos.audit.log # Required. Topic to write audit entries to.

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -21,7 +21,7 @@ audit:
     encoding: json # Encoding format. Valid values are "json" (default) or "protobuf".
     maxBufferedRecords: 1000 # MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.
     produceSync: false # ProduceSync forces the client to produce messages to Kafka synchronously. This can have a significant impact on performance.
-    publishTimeout: 5s # PublishTimeout sets how long to attempt to publish a message before giving up.
+    produceTimeout: 5s # ProduceTimeout sets how long to attempt to publish a message before giving up.
     topic: cerbos.audit.log # Required. Topic to write audit entries to.
   local:
     advanced: 

--- a/internal/audit/kafka/conf.go
+++ b/internal/audit/kafka/conf.go
@@ -19,7 +19,7 @@ const (
 	defaultAcknowledgement    = AckAll
 	defaultEncoding           = EncodingJSON
 	defaultCloseTimeout       = 30 * time.Second
-	defaultPublishTimeout     = 5 * time.Second
+	defaultProduceTimeout     = 5 * time.Second
 	defaultClientID           = "cerbos"
 	defaultMaxBufferedRecords = 250
 )
@@ -38,12 +38,12 @@ type Conf struct {
 	Brokers []string `yaml:"brokers" conf:"required,example=['localhost:9092']"`
 	// CloseTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
 	CloseTimeout time.Duration `yaml:"closeTimeout" conf:",example=30s"`
-	// PublishTimeout sets how long to attempt to publish a message before giving up.
-	PublishTimeout time.Duration `yaml:"publishTimeout" conf:",example=5s"`
 	// MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.
 	MaxBufferedRecords int `yaml:"maxBufferedRecords" conf:",example=1000"`
 	// ProduceSync forces the client to produce messages to Kafka synchronously. This can have a significant impact on performance.
 	ProduceSync bool `yaml:"produceSync" conf:",example=false"`
+	// ProduceTimeout sets how long to attempt to publish a message before giving up.
+	ProduceTimeout time.Duration `yaml:"produceTimeout" conf:",example=5s"`
 }
 
 func (c *Conf) Key() string {
@@ -54,7 +54,7 @@ func (c *Conf) SetDefaults() {
 	c.Ack = defaultAcknowledgement
 	c.Encoding = defaultEncoding
 	c.CloseTimeout = defaultCloseTimeout
-	c.PublishTimeout = defaultPublishTimeout
+	c.ProduceTimeout = defaultProduceTimeout
 	c.ClientID = defaultClientID
 	c.MaxBufferedRecords = defaultMaxBufferedRecords
 }
@@ -78,8 +78,8 @@ func (c *Conf) Validate() error {
 		return errors.New("invalid close timeout")
 	}
 
-	if c.PublishTimeout <= 0 {
-		return errors.New("invalid publish timeout")
+	if c.ProduceTimeout <= 0 {
+		return errors.New("invalid produce timeout")
 	}
 
 	if strings.TrimSpace(c.ClientID) == "" {

--- a/internal/audit/kafka/conf.go
+++ b/internal/audit/kafka/conf.go
@@ -35,8 +35,8 @@ type Conf struct {
 	ClientID string `yaml:"clientID" conf:",example=cerbos"`
 	// Brokers list to seed the Kafka client.
 	Brokers []string `yaml:"brokers" conf:"required,example=['localhost:9092']"`
-	// FlushTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
-	FlushTimeout time.Duration `yaml:"flushTimeout" conf:",example=30s"`
+	// CloseTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
+	CloseTimeout time.Duration `yaml:"flushTimeout" conf:",example=30s"`
 	// MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.
 	MaxBufferedRecords int `yaml:"maxBufferedRecords" conf:",example=1000"`
 	// ProduceSync forces the client to produce messages to Kafka synchronously. This can have a significant impact on performance.
@@ -50,7 +50,7 @@ func (c *Conf) Key() string {
 func (c *Conf) SetDefaults() {
 	c.Ack = defaultAcknowledgement
 	c.Encoding = defaultEncoding
-	c.FlushTimeout = defaultFlushTimeout
+	c.CloseTimeout = defaultFlushTimeout
 	c.ClientID = defaultClientID
 	c.MaxBufferedRecords = defaultMaxBufferedRecords
 }
@@ -70,8 +70,8 @@ func (c *Conf) Validate() error {
 		return fmt.Errorf("invalid encoding format: %s", c.Encoding)
 	}
 
-	if c.FlushTimeout <= 0 {
-		return errors.New("invalid flush timeout")
+	if c.CloseTimeout <= 0 {
+		return errors.New("invalid close timeout")
 	}
 
 	if strings.TrimSpace(c.ClientID) == "" {

--- a/internal/audit/kafka/conf.go
+++ b/internal/audit/kafka/conf.go
@@ -35,7 +35,7 @@ type Conf struct {
 	ClientID string `yaml:"clientID" conf:",example=cerbos"`
 	// Brokers list to seed the Kafka client.
 	Brokers []string `yaml:"brokers" conf:"required,example=['localhost:9092']"`
-	// FlushTimeout sets how often messages are flushed to the remote Kafka server.
+	// FlushTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
 	FlushTimeout time.Duration `yaml:"flushTimeout" conf:",example=30s"`
 	// MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.
 	MaxBufferedRecords int `yaml:"maxBufferedRecords" conf:",example=1000"`

--- a/internal/audit/kafka/publisher.go
+++ b/internal/audit/kafka/publisher.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"github.com/cerbos/cerbos/internal/observability/logging"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/plugin/kzap"
 	"go.uber.org/zap"
@@ -170,7 +170,7 @@ func (p *Publisher) write(ctx context.Context, msg *kgo.Record) error {
 	p.Client.Produce(ctx, msg, func(r *kgo.Record, err error) {
 		if err != nil {
 			// TODO: Handle via interceptor
-			ctxzap.Extract(ctx).Warn("failed to write audit log entry", zap.Error(err))
+			logging.FromContext(ctx).Warn("failed to write audit log entry", zap.Error(err))
 		}
 	})
 	return nil

--- a/internal/audit/kafka/publisher.go
+++ b/internal/audit/kafka/publisher.go
@@ -68,7 +68,7 @@ type Publisher struct {
 	decisionFilter audit.DecisionLogEntryFilter
 	marshaller     recordMarshaller
 	sync           bool
-	flushTimeout   time.Duration
+	closeTimeout   time.Duration
 }
 
 func NewPublisher(conf *Conf, decisionFilter audit.DecisionLogEntryFilter) (*Publisher, error) {
@@ -104,12 +104,12 @@ func NewPublisher(conf *Conf, decisionFilter audit.DecisionLogEntryFilter) (*Pub
 		decisionFilter: decisionFilter,
 		marshaller:     newMarshaller(conf.Encoding),
 		sync:           conf.ProduceSync,
-		flushTimeout:   conf.FlushTimeout,
+		closeTimeout:   conf.CloseTimeout,
 	}, nil
 }
 
 func (p *Publisher) Close() error {
-	flushCtx, flushCancel := context.WithTimeout(context.Background(), p.flushTimeout)
+	flushCtx, flushCancel := context.WithTimeout(context.Background(), p.closeTimeout)
 	defer flushCancel()
 	if err := p.Client.Flush(flushCtx); err != nil {
 		return err


### PR DESCRIPTION
#### Description

Attempts to fix this failure to publish async message to Kafka by ignoring the parent context cancelling within the async Kafka publishing.

```
{"log.level":"warn","@timestamp":"2023-03-30T20:57:20.147Z","log.logger":"cerbos.grpc","message":"failed to write audit log entry","grpc.start_time":"2023-03-30T20:57:20Z","system":"grpc","span.kind":"server","grpc.service":"cerbos.svc.v1.CerbosService","grpc.method":"CheckResources","cerbos":{"call_id":"01GWT4Z20J4ZJK0H74RQGXPJ36"},"peer.address":"@","error":"context canceled"}
```

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [ ] ~PR is linked to the corresponding issue~
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
