### PR TITLE
enhancement: Audit error metric

### DIFF
--- a/internal/audit/kafka/publisher.go
+++ b/internal/audit/kafka/publisher.go
@@ -41,8 +41,9 @@ const (
 type Kind []byte
 
 var (
-	KindAccess   Kind = []byte("access")
-	KindDecision Kind = []byte("decision")
+	// reallocate once ahead of time to avoid allocations in the hot path.
+	KindAccess   Kind = []byte(audit.KindAccess)
+	KindDecision Kind = []byte(audit.KindDecision)
 )
 
 func init() {

--- a/internal/audit/kafka/publisher.go
+++ b/internal/audit/kafka/publisher.go
@@ -10,8 +10,11 @@ import (
 	"time"
 
 	"github.com/cerbos/cerbos/internal/observability/logging"
+	"github.com/cerbos/cerbos/internal/observability/metrics"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/plugin/kzap"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -179,10 +182,25 @@ func (p *Publisher) write(ctx context.Context, msg *kgo.Record) error {
 	defer produceCancel()
 
 	p.Client.Produce(produceCtx, msg, func(r *kgo.Record, err error) {
-		if err != nil {
-			// TODO: Handle via interceptor
-			logging.FromContext(ctx).Warn("failed to write audit log entry", zap.Error(err))
+		if err == nil {
+			return
 		}
+
+		// TODO: Currently have to duplicate logWrapper as it does not support async audit publishing.
+		logging.FromContext(ctx).Warn("failed to write audit log entry", zap.Error(err))
+
+		// Due to async nature of this callback, we need to pull the `kind` out of the header
+		var kind string
+		for _, h := range r.Headers {
+			if h.Key == HeaderKeyKind {
+				kind = string(h.Value)
+				break
+			}
+		}
+		_ = stats.RecordWithTags(ctx,
+			[]tag.Mutator{tag.Upsert(metrics.KeyAuditKind, kind)},
+			metrics.AuditErrorCount.M(1),
+		)
 	})
 	return nil
 }

--- a/internal/observability/metrics/metrics.go
+++ b/internal/observability/metrics/metrics.go
@@ -32,6 +32,7 @@ func init() {
 }
 
 var (
+	KeyAuditKind            = tag.MustNewKey("kind")
 	KeyCacheKind            = tag.MustNewKey("kind")
 	KeyCacheResult          = tag.MustNewKey("result")
 	KeyCompileStatus        = tag.MustNewKey("status")
@@ -42,6 +43,18 @@ var (
 )
 
 var (
+	AuditErrorCount = stats.Int64(
+		"cerbos.dev/audit/error_count",
+		"Number of errors encountered while writing audit log entry",
+		stats.UnitDimensionless,
+	)
+
+	AuditErrorCountView = &view.View{
+		Measure:     AuditErrorCount,
+		TagKeys:     []tag.Key{KeyAuditKind},
+		Aggregation: view.Count(),
+	}
+
 	CacheAccessCount = stats.Int64(
 		"cerbos.dev/cache/access_count",
 		"Counter of cache access",
@@ -162,6 +175,7 @@ var (
 )
 
 var DefaultCerbosViews = []*view.View{
+	AuditErrorCountView,
 	CacheAccessCountView,
 	CacheMaxSizeView,
 	CompileDurationView,


### PR DESCRIPTION
#### Description

After introducing Kafka as an audit backend, there's a greater chance that errors occur when writing audit log entries. In order to monitor the health we require various metrics to be exposed, this PR focus on audit write errors for access & decision logs.

#### Checklist 

- [x] The PR title has the correct prefix 
- [ ] ~PR is linked to the corresponding issue~
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
