### PR TITLE
chore(ci): Fix data race in store test

### DIFF
--- a/internal/storage/git/store_test.go
+++ b/internal/storage/git/store_test.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -147,8 +146,6 @@ func TestUpdateStore(t *testing.T) {
 	}
 
 	numPolicySets := 10
-	rng := rand.New(rand.NewSource(time.Now().Unix())) //nolint:gosec
-	var mu sync.Mutex
 
 	t.Run("no changes", func(t *testing.T) {
 		param := setupUpdateStoreTest(t, numPolicySets)
@@ -172,10 +169,7 @@ func TestUpdateStore(t *testing.T) {
 		}, nil)
 
 		checkEvents := storage.TestSubscription(param.store)
-		mu.Lock()
-		n := rng.Intn(numPolicySets)
-		mu.Unlock()
-		pset := genPolicySet(n)
+		pset := genPolicySet(rand.Intn(numPolicySets)) //nolint:gosec
 
 		require.NoError(t, commitToGitRepo(param.sourceGitDir, "Modify policy", func(_ *git.Worktree) error {
 			for _, p := range pset {
@@ -210,10 +204,7 @@ func TestUpdateStore(t *testing.T) {
 		}, nil)
 
 		checkEvents := storage.TestSubscription(param.store)
-		mu.Lock()
-		n := rng.Intn(numPolicySets)
-		mu.Unlock()
-		pset := genPolicySet(n)
+		pset := genPolicySet(rand.Intn(numPolicySets)) //nolint:gosec
 
 		wantEvents := make([]storage.Event, len(pset))
 		psetEventIdx := make(map[string]int, len(pset))
@@ -322,10 +313,7 @@ func TestUpdateStore(t *testing.T) {
 		}, nil)
 
 		checkEvents := storage.TestSubscription(param.store)
-		mu.Lock()
-		n := rng.Intn(numPolicySets)
-		mu.Unlock()
-		pset := genPolicySet(n)
+		pset := genPolicySet(rand.Intn(numPolicySets)) //nolint:gosec
 
 		require.NoError(t, commitToGitRepo(param.sourceGitDir, "Delete policy", func(wt *git.Worktree) error {
 			for file := range pset {
@@ -376,10 +364,7 @@ func TestUpdateStore(t *testing.T) {
 		}, nil)
 
 		checkEvents := storage.TestSubscription(param.store)
-		mu.Lock()
-		n := rng.Intn(numPolicySets)
-		mu.Unlock()
-		pset := genPolicySet(n)
+		pset := genPolicySet(rand.Intn(numPolicySets)) //nolint:gosec
 
 		require.NoError(t, commitToGitRepo(param.sourceGitDir, "Rename policy", func(wt *git.Worktree) error {
 			for file := range pset {
@@ -425,10 +410,7 @@ func TestUpdateStore(t *testing.T) {
 		}, nil)
 
 		checkEvents := storage.TestSubscription(param.store)
-		mu.Lock()
-		n := rng.Intn(numPolicySets)
-		mu.Unlock()
-		pset := genPolicySet(n)
+		pset := genPolicySet(rand.Intn(numPolicySets)) //nolint:gosec
 
 		require.NoError(t, commitToGitRepo(param.sourceGitDir, "Move policy out", func(wt *git.Worktree) error {
 			for file := range pset {


### PR DESCRIPTION
resolves #1500 

Quote from `math/rand.go`;
> // Random numbers are generated by a [Source], usually wrapped in a [Rand].
> // Both types should be used by a single goroutine at a time: sharing among
> // multiple goroutines requires some kind of synchronization.
> //
> // Top-level functions, such as [Float64] and [Int],
> // are safe for concurrent use by multiple goroutines.

Since we already made the decision to not use top-level functions in the git store test package, I thought the natural step forward would be to use some kind of synchronization as the docs suggest.