### PR TITLE
fix: Introduce custom temp directory creation function with pathname length limit for uds

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -177,7 +177,7 @@ func apiTests(tpg testParamGen) func(*testing.T) {
 }
 
 // createTempDirForUDS is used to generate a temporary directory with a pathname length below a defined limit.
-// This is to prevent the randonly generated directory path length exceeding platform limits (~100-108 ish, platform specific).
+// This is to prevent the randonly generated directory path length exceeding platform limits (104-108 ish, platform specific).
 func createTempDirForUDS(t *testing.T) string {
 	t.Helper()
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -178,7 +178,7 @@ func apiTests(tpg testParamGen) func(*testing.T) {
 }
 
 // createTempDirForUDS is used to generate a temporary directory with a pathname length below a defined limit.
-// This is to prevent the randonly generated directory path length exceeding platform limits (104-108, platform specific).
+// This is to prevent the randomly generated directory path length exceeding platform limits (104-108, platform specific).
 func createTempDirForUDS(t *testing.T) string {
 	t.Helper()
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -34,7 +34,8 @@ import (
 	"github.com/cerbos/cerbos/internal/test"
 )
 
-const udsMaxSocketPathLength = 104 // NOTE(saml) AFAIK, this is the max allowable path length on macOS, which appears to be the shortest of common platforms
+// NOTE(saml) this is the max allowable path length on macOS, which appears to be the shortest of common platforms (at 104).
+const udsMaxSocketPathLength = 104
 
 type testParam struct {
 	store        storage.Store
@@ -177,7 +178,7 @@ func apiTests(tpg testParamGen) func(*testing.T) {
 }
 
 // createTempDirForUDS is used to generate a temporary directory with a pathname length below a defined limit.
-// This is to prevent the randonly generated directory path length exceeding platform limits (104-108 ish, platform specific).
+// This is to prevent the randonly generated directory path length exceeding platform limits (104-108, platform specific).
 func createTempDirForUDS(t *testing.T) string {
 	t.Helper()
 


### PR DESCRIPTION
Fixes #1540 

Unix domain socket addresses are limited in length (generally) to 104-108, platform specific (on `MacOS Monterey 12.4`, this appears to be 104). Sometimes, the generation of the temp directory pathname (via `t.TempDir()`) can exceed this limit, so when attempting to create a uds listener, it would fail with `invalid argument`.

This PR creates a helper function with more explicit control over the length of the output pathname.
