### PR TITLE
fix: Mark /tmp as a container volume

### DIFF
--- a/Dockerfile.cerbos
+++ b/Dockerfile.cerbos
@@ -4,7 +4,7 @@ RUN apk add -U --no-cache ca-certificates && update-ca-certificates
 FROM scratch
 EXPOSE 3592 3593
 ENV CERBOS_CONFIG="__default__"
-VOLUME ["/policies"]
+VOLUME ["/policies", "/tmp", "/.cache"]
 ENTRYPOINT ["/cerbos"]
 CMD ["server"]
 HEALTHCHECK --interval=1m --timeout=3s CMD ["/cerbos", "healthcheck"]


### PR DESCRIPTION
Explicitly mark `/tmp` and `/.cache` as volumes so that the directories
are automatically created within the container.

Ideally `/tmp` should be a `tmpfs` mount and `/.cache` should be a
persistent mount, especially when the `bundle` driver is in use.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
