### PR TITLE
enhancement(helm): Volume mounts for Cerbos Cloud

### DIFF
--- a/deploy/charts/cerbos/templates/_helpers.tpl
+++ b/deploy/charts/cerbos/templates/_helpers.tpl
@@ -147,3 +147,12 @@ Merge the configurations to obtain the final configuration file
 {{ mustMergeOverwrite $defaultConf .Values.cerbos.config $derivedConf | toYaml }}
 {{- end }}
 
+{{/*
+Detect if bundle driver is used with default config
+*/}}
+{{- define "cerbos.defaultBundleDriverEnabled" -}}
+{{- $isBundleDriver := (eq (dig "config" "storage" "driver" "<not_defined>" .Values.cerbos) "bundle") -}}
+{{- $isDefaultTmp := (eq (dig "config" "storage" "bundle" "remote" "tempDir" "<not_defined>" .Values.cerbos) "<not_defined>") -}}
+{{- $isDefaultCache := (eq (dig "config" "storage" "bundle" "remote" "cacheDir" "<not_defined>" .Values.cerbos) "<not_defined>") -}}
+{{- if (and $isBundleDriver $isDefaultTmp $isDefaultCache) -}}yes{{- else -}}no{{- end -}}
+{{- end }}

--- a/deploy/charts/cerbos/templates/deployment.yaml
+++ b/deploy/charts/cerbos/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- $tlsDisabled := (eq (include "cerbos.tlsSecretName" .) "None") -}}
+{{- $defaultBundleDriverEnabled := (eq (include "cerbos.defaultBundleDriverEnabled" .) "yes") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -81,8 +82,15 @@ spec:
             - name: config
               mountPath: /config
               readOnly: true
+          {{- if $defaultBundleDriverEnabled }}
+            - name: bundletmp
+              mountPath: /tmp
+            - name: bundlecache
+              mountPath: /.cache
+          {{- else }}
             - name: work
               mountPath: /work
+          {{- end }}
           {{- if not $tlsDisabled }}
             - name: certs
               mountPath: /certs
@@ -95,8 +103,15 @@ spec:
         - name: config
           configMap:
             name: {{ include "cerbos.fullname" . }}
+      {{- if $defaultBundleDriverEnabled }}
+        - name: bundletmp
+          emptyDir: {}
+        - name: bundlecache
+          emptyDir: {}
+      {{- else }}
         - name: work
           emptyDir: {}
+      {{- end }}
       {{- if not $tlsDisabled }}
         - name: certs
           secret:

--- a/deploy/charts/cerbos/values-bundle-storage.yaml
+++ b/deploy/charts/cerbos/values-bundle-storage.yaml
@@ -1,0 +1,23 @@
+# Illustrates how to connect to Cerbos Cloud
+# Prerequisites:
+# - Sign-up to Cerbos Cloud and follow the instructions to create an API key
+# - Create a Kubernetes secret named `cerbos-cloud-credentials`:
+#      kubectl create secret generic cerbos-cloud-credentials \
+#         --from-literal=CERBOS_CLOUD_CLIENT_ID=<YOUR_CLIENT_ID> \
+#         --from-literal=CERBOS_CLOUD_CLIENT_SECRET=<YOUR_CLIENT_SECRET> \
+#         --from-literal=CERBOS_CLOUD_SECRET_KEY=<YOUR_SECRET_KEY>
+
+cerbos:
+  config:
+    # Configure the bundle storage driver
+    storage:
+      driver: "bundle"
+      bundle:
+        remote:
+          bundleLabel: "YOUR_LABEL" # Alternatively, add `CERBOS_CLOUD_BUNDLE=<YOUR_LABEL>` to the secret you created above.
+
+# Create environment variables from the secret.
+envFrom:
+  - secretRef:
+      name: cerbos-cloud-credentials
+


### PR DESCRIPTION
If the user is using the default settings, automatically mount
`emptyDir` volumes for temp and cache directories.

Also adds an example values file for connecting to Cerbos Cloud.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
