### PR TITLE
enhancement(helm): Upgrade to HPA v2 API

### DIFF
--- a/deploy/charts/cerbos/templates/hpa.yaml
+++ b/deploy/charts/cerbos/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "cerbos.fullname" . }}
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/deploy/charts/cerbos/values-audit-log.yaml
+++ b/deploy/charts/cerbos/values-audit-log.yaml
@@ -1,4 +1,4 @@
-# Illustrates how to deploy Cerbos with an SQLite3 backend and audit logs. 
+# Illustrates how to deploy Cerbos with an SQLite3 backend and audit logs.
 
 cerbos:
   config:
@@ -6,19 +6,19 @@ cerbos:
     storage:
       driver: "sqlite3"
       sqlite3:
-        dsn: "file:/data/cerbos.sqlite?mode=rwc&_fk=true"  
+        dsn: "file:/data/cerbos.sqlite?mode=rwc&_fk=true"
     # Configure audit logging
     audit:
       enabled: true
       accessLogsEnabled: true
       decisionLogsEnabled: true
       backend: local
-      local: 
+      local:
         storagePath: /audit/cerbos
 
-# Create volumes to hold the SQLite3 database and the audit log. 
+# Create volumes to hold the SQLite3 database and the audit log.
 # Note that this example uses emptyDir volumes that lose data when the pod or node is killed.
-# Use persistent volumes in production to preserve the data between pod restarts. 
+# Use persistent volumes in production to preserve the data between pod restarts.
 
 volumes:
   - name: cerbos-policies
@@ -31,3 +31,10 @@ volumeMounts:
     mountPath: /data
   - name: cerbos-auditlog
     mountPath: /audit
+
+# Optional: Autoscale the Cerbos deployment using CPU and memory utilization.
+autoscaling:
+  enabled: true
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+


### PR DESCRIPTION
The beta versions of `HorizontalPodAutoScaler` v2 will be dropped in
Kubernetes 1.26 and some distributions such as GKE are warning about it
now.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
