### PR TITLE
fix: Return correct error code when store is invalid

### DIFF
--- a/internal/compile/manager.go
+++ b/internal/compile/manager.go
@@ -5,6 +5,7 @@ package compile
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -301,4 +302,8 @@ func (pce PolicyCompilationErr) Error() string {
 
 func (pce PolicyCompilationErr) Unwrap() error {
 	return pce.underlying
+}
+
+func (pce PolicyCompilationErr) Is(target error) bool {
+	return errors.As(target, &PolicyCompilationErr{})
 }

--- a/internal/svc/cerbos_svc.go
+++ b/internal/svc/cerbos_svc.go
@@ -135,7 +135,7 @@ func (cs *CerbosService) CheckResourceSet(ctx context.Context, req *requestv1.Ch
 	outputs, err := cs.eng.Check(logging.ToContext(ctx, log), inputs)
 	if err != nil {
 		log.Error("Policy check failed", zap.Error(err))
-		if errors.As(err, &compile.PolicyCompilationErr{}) {
+		if errors.Is(err, compile.PolicyCompilationErr{}) {
 			return nil, status.Errorf(codes.FailedPrecondition, "Check failed due to invalid policy")
 		}
 		return nil, status.Errorf(codes.Internal, "Policy check failed")
@@ -183,6 +183,9 @@ func (cs *CerbosService) CheckResourceBatch(ctx context.Context, req *requestv1.
 	outputs, err := cs.eng.Check(logging.ToContext(ctx, log), inputs)
 	if err != nil {
 		log.Error("Policy check failed", zap.Error(err))
+		if errors.Is(err, compile.PolicyCompilationErr{}) {
+			return nil, status.Errorf(codes.FailedPrecondition, "Check failed due to invalid policy")
+		}
 		return nil, status.Errorf(codes.Internal, "Policy check failed")
 	}
 
@@ -240,6 +243,9 @@ func (cs *CerbosService) CheckResources(ctx context.Context, req *requestv1.Chec
 	outputs, err := cs.eng.Check(logging.ToContext(ctx, log), inputs)
 	if err != nil {
 		log.Error("Policy check failed", zap.Error(err))
+		if errors.Is(err, compile.PolicyCompilationErr{}) {
+			return nil, status.Errorf(codes.FailedPrecondition, "Check failed due to invalid policy")
+		}
 		return nil, status.Errorf(codes.Internal, "Policy check failed")
 	}
 

--- a/internal/svc/cerbos_svc.go
+++ b/internal/svc/cerbos_svc.go
@@ -68,6 +68,9 @@ func (cs *CerbosService) PlanResources(ctx context.Context, request *requestv1.P
 	output, err := cs.eng.PlanResources(logging.ToContext(ctx, log), input)
 	if err != nil {
 		log.Error("Resources query plan request failed", zap.Error(err))
+		if errors.Is(err, compile.PolicyCompilationErr{}) {
+			return nil, status.Errorf(codes.FailedPrecondition, "Resources query plan failed due to invalid policy")
+		}
 		return nil, status.Errorf(codes.Internal, "Resources query plan request failed")
 	}
 


### PR DESCRIPTION
Instead of returning `Internal` error, return `FailedPrecondition` when
the requested policy has a compilation error. We already had this special case handled in the `CheckResourceSet` RPC but, for some reason, it had been omitted in the other RPCs.

Fixes #1590

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
