### PR TITLE
chore: Remove the cerbos prefix from output keys

### DIFF
--- a/internal/namer/namer.go
+++ b/internal/namer/namer.go
@@ -231,7 +231,7 @@ func RuleFQN(rpsMeta any, scope, ruleName string) string {
 		panic(fmt.Errorf("unknown runnable policy set meta type %T", m))
 	}
 
-	return fmt.Sprintf("%s#%s", policyFqn, ruleName)
+	return fmt.Sprintf("%s#%s", PolicyKeyFromFQN(policyFqn), ruleName)
 }
 
 type PolicyCoords struct {

--- a/internal/test/testdata/server/checks/check_resources/cr_case_06.yaml
+++ b/internal/test/testdata/server/checks/check_resources/cr_case_06.yaml
@@ -76,11 +76,11 @@ checkResources:
         },
         "outputs": [
           {
-            "src": "cerbos.resource.equipment_request.vdefault/acme#rule-001",
+            "src": "resource.equipment_request.vdefault/acme#rule-001",
             "val": "create_allowed:john"
           },
           {
-            "src": "cerbos.resource.equipment_request.vdefault#public-view",
+            "src": "resource.equipment_request.vdefault#public-view",
             "val": {
               "id": "john",
               "keys": "XX125",
@@ -96,7 +96,7 @@ checkResources:
             }
           },
           {
-            "src": "cerbos.resource.equipment_request.vdefault#rule-002",
+            "src": "resource.equipment_request.vdefault#rule-002",
             "val": "approval_status:john:DRAFT"
           }
         ]
@@ -113,7 +113,7 @@ checkResources:
         },
         "outputs": [
           {
-            "src": "cerbos.resource.equipment_request.vdefault#public-view",
+            "src": "resource.equipment_request.vdefault#public-view",
             "val": {
               "id": "john",
               "keys": "YY125",
@@ -129,7 +129,7 @@ checkResources:
             }
           },
           {
-            "src": "cerbos.resource.equipment_request.vdefault#rule-002",
+            "src": "resource.equipment_request.vdefault#rule-002",
             "val": "approval_status:john:DRAFT"
           }
         ]

--- a/internal/test/testdata/server/checks/check_resources/cr_case_07.yaml
+++ b/internal/test/testdata/server/checks/check_resources/cr_case_07.yaml
@@ -54,11 +54,11 @@ checkResources:
         },
         "outputs": [
           {
-            "src": "cerbos.principal.terry_tibbs.vdefault#equipment_request_rule-001",
+            "src": "principal.terry_tibbs.vdefault#equipment_request_rule-001",
             "val": ["foo", ["bar", true]]
           },
           {
-            "src": "cerbos.resource.equipment_request.vdefault#public-view",
+            "src": "resource.equipment_request.vdefault#public-view",
             "val": {
               "id": "terry_tibbs",
               "keys": "YY125",
@@ -74,7 +74,7 @@ checkResources:
             }
           },
           {
-            "src": "cerbos.resource.equipment_request.vdefault#rule-002",
+            "src": "resource.equipment_request.vdefault#rule-002",
             "val": "approval_status:terry_tibbs:DRAFT"
           },
         ]


### PR DESCRIPTION
When we output metadata, we don't use the `cerbos.` prefix for the
policy name. To keep things consistent, the rule names in the policy
output should also drop the prefix.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
