### PR TITLE
feat: Support different compression algorithms for kafka audit

### DIFF
--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -18,6 +18,7 @@ audit:
     brokers: ['localhost:9092'] # Required. Brokers list to seed the Kafka client.
     clientID: cerbos # ClientID reported in Kafka connections.
     closeTimeout: 30s # CloseTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
+    compression: ['zstd' # Compression sets the compression algorithm to use in order of priority. Valid values are "none", "gzip", "snappy","lz4", "zstd". Default is ["snappy", "none"].
     encoding: json # Encoding format. Valid values are "json" (default) or "protobuf".
     maxBufferedRecords: 1000 # MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.
     produceSync: false # ProduceSync forces the client to produce messages to Kafka synchronously. This can have a significant impact on performance.

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -18,7 +18,7 @@ audit:
     brokers: ['localhost:9092'] # Required. Brokers list to seed the Kafka client.
     clientID: cerbos # ClientID reported in Kafka connections.
     closeTimeout: 30s # CloseTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
-    compression: ['zstd' # Compression sets the compression algorithm to use in order of priority. Valid values are "none", "gzip", "snappy","lz4", "zstd". Default is ["snappy", "none"].
+    compression: ['snappy'] # Compression sets the compression algorithm to use in order of priority. Valid values are "none", "gzip", "snappy","lz4", "zstd". Default is ["snappy", "none"].
     encoding: json # Encoding format. Valid values are "json" (default) or "protobuf".
     maxBufferedRecords: 1000 # MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.
     produceSync: false # ProduceSync forces the client to produce messages to Kafka synchronously. This can have a significant impact on performance.

--- a/internal/audit/kafka/conf.go
+++ b/internal/audit/kafka/conf.go
@@ -35,6 +35,8 @@ type Conf struct {
 	ClientID string `yaml:"clientID" conf:",example=cerbos"`
 	// Brokers list to seed the Kafka client.
 	Brokers []string `yaml:"brokers" conf:"required,example=['localhost:9092']"`
+	// Compression sets the compression algorithm to use in order of priority. Valid values are "none", "gzip", "snappy","lz4", "zstd". Default is ["snappy", "none"].
+	Compression []string `yaml:"compression" conf:",example=['zstd', 'snappy', 'none']"`
 	// CloseTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
 	CloseTimeout time.Duration `yaml:"closeTimeout" conf:",example=30s"`
 	// MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.
@@ -53,6 +55,7 @@ func (c *Conf) SetDefaults() {
 	c.CloseTimeout = defaultCloseTimeout
 	c.ClientID = defaultClientID
 	c.MaxBufferedRecords = defaultMaxBufferedRecords
+	c.Compression = []string{CompressionSnappy, CompressionNone}
 }
 
 func (c *Conf) Validate() error {
@@ -82,6 +85,11 @@ func (c *Conf) Validate() error {
 		return errors.New("empty brokers")
 	}
 
+	_, err := formatCompression(c.Compression)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -96,4 +104,27 @@ func formatAck(ack string) (kgo.Acks, error) {
 	default:
 		return kgo.NoAck(), fmt.Errorf("invalid ack value: %s", ack)
 	}
+}
+
+func formatCompression(compression []string) ([]kgo.CompressionCodec, error) {
+	codecs := make([]kgo.CompressionCodec, 0, len(compression))
+
+	for _, c := range compression {
+		switch c {
+		case CompressionNone:
+			codecs = append(codecs, kgo.NoCompression())
+		case CompressionGzip:
+			codecs = append(codecs, kgo.GzipCompression())
+		case CompressionSnappy:
+			codecs = append(codecs, kgo.SnappyCompression())
+		case CompressionLZ4:
+			codecs = append(codecs, kgo.Lz4Compression())
+		case CompressionZstd:
+			codecs = append(codecs, kgo.ZstdCompression())
+		default:
+			return nil, fmt.Errorf("invalid compression algorithm: %s", compression)
+		}
+	}
+
+	return codecs, nil
 }

--- a/internal/audit/kafka/conf.go
+++ b/internal/audit/kafka/conf.go
@@ -36,7 +36,7 @@ type Conf struct {
 	// Brokers list to seed the Kafka client.
 	Brokers []string `yaml:"brokers" conf:"required,example=['localhost:9092']"`
 	// Compression sets the compression algorithm to use in order of priority. Valid values are "none", "gzip", "snappy","lz4", "zstd". Default is ["snappy", "none"].
-	Compression []string `yaml:"compression" conf:",example=['zstd', 'snappy', 'none']"`
+	Compression []string `yaml:"compression" conf:",example=['snappy']"`
 	// CloseTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
 	CloseTimeout time.Duration `yaml:"closeTimeout" conf:",example=30s"`
 	// MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.

--- a/internal/audit/kafka/publisher.go
+++ b/internal/audit/kafka/publisher.go
@@ -32,6 +32,12 @@ const (
 
 	HeaderKeyEncoding = "cerbos.audit.encoding"
 	HeaderKeyKind     = "cerbos.audit.kind"
+
+	CompressionNone   = "none"
+	CompressionGzip   = "gzip"
+	CompressionSnappy = "snappy"
+	CompressionLZ4    = "lz4"
+	CompressionZstd   = "zstd"
 )
 
 type Encoding string
@@ -97,6 +103,13 @@ func NewPublisher(conf *Conf, decisionFilter audit.DecisionLogEntryFilter) (*Pub
 	if conf.Ack != AckAll {
 		clientOpts = append(clientOpts, kgo.DisableIdempotentWrite())
 	}
+
+	compression, err := formatCompression(conf.Compression)
+	if err != nil {
+		return nil, err
+	}
+
+	clientOpts = append(clientOpts, kgo.ProducerBatchCompression(compression...))
 
 	client, err := kgo.NewClient(clientOpts...)
 	if err != nil {


### PR DESCRIPTION
#### Description

<!-- Thank you for contributing Cerbos! Please describe the changes made in this PR here and provide any other useful information for reviewers. Make sure that you included some automated tests (e.g unit tests) to verify your changes.  If there is a requirement for user input for testing, please include the instructions as well. -->

Adds support for different compression modes for kafka. We have a use case to use zstd and currently the franz-go package defaults to `snappy, none` (in priority order). 

Fixes #<!-- Link the relevant issue here -->

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
