### PR TITLE
fix: Render the condition correctly in an Engine trace

### DIFF
--- a/internal/engine/tracer/context.go
+++ b/internal/engine/tracer/context.go
@@ -143,9 +143,13 @@ func (c *context) StartOutput(ruleName string) Context {
 }
 
 func (c *context) start(component *enginev1.Trace_Component) Context {
+	components := make([]*enginev1.Trace_Component, len(c.components)+1)
+	copy(components, c.components)
+	components[len(c.components)] = component
+
 	return &context{
 		sink:       c.sink,
-		components: append(c.components, component),
+		components: components,
 	}
 }
 

--- a/internal/test/testdata/verify_junit/cases/case_007.yaml.golden
+++ b/internal/test/testdata/verify_junit/cases/case_007.yaml.golden
@@ -36,14 +36,8 @@
       <failure type="RESULT_FAILED" message="Output expectation unsatisfied">
         <outputs>
           <output src="resource.company.vdefault#rule-001">
-            <expected><![CDATA[{
-  "principal":  "blah",
-  "resource":  "yy1"
-}]]></expected>
-            <actual><![CDATA[{
-  "principal":  "user",
-  "resource":  "xx1"
-}]]></actual>
+            <expected><![CDATA[{"principal":"blah","resource":"yy1"}]]></expected>
+            <actual><![CDATA[{"principal":"user","resource":"xx1"}]]></actual>
           </output>
         </outputs>
         <actual>EFFECT_ALLOW</actual>

--- a/internal/verify/junit/junit.go
+++ b/internal/verify/junit/junit.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
+	"github.com/tidwall/pretty"
 )
 
 const (
@@ -179,7 +180,7 @@ func renderValue(v proto.Message) string {
 		return "FAILED TO RENDER"
 	}
 
-	return string(vv)
+	return string(pretty.UglyInPlace(vv))
 }
 
 type TestSuites struct {

--- a/internal/verify/junit/junit.go
+++ b/internal/verify/junit/junit.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
 )
@@ -133,13 +134,13 @@ func processTestCases(s *policyv1.TestResults_Suite) ([]testCase, Summary, error
 								case *policyv1.TestResults_OutputFailure_Mismatched:
 									outputSet[i] = output{
 										Src:      o.Src,
-										Actual:   outputValue{Value: protojson.Format(t.Mismatched.Actual)},
-										Expected: outputValue{Value: protojson.Format(t.Mismatched.Expected)},
+										Actual:   outputValue{Value: renderValue(t.Mismatched.Actual)},
+										Expected: outputValue{Value: renderValue(t.Mismatched.Expected)},
 									}
 								case *policyv1.TestResults_OutputFailure_Missing:
 									outputSet[i] = output{
 										Src:      o.Src,
-										Expected: outputValue{Value: protojson.Format(t.Missing.Expected)},
+										Expected: outputValue{Value: renderValue(t.Missing.Expected)},
 									}
 								default:
 									outputSet[i] = output{
@@ -170,6 +171,15 @@ func processTestCases(s *policyv1.TestResults_Suite) ([]testCase, Summary, error
 	}
 
 	return testCases, summary, nil
+}
+
+func renderValue(v proto.Message) string {
+	vv, err := protojson.Marshal(v)
+	if err != nil {
+		return "FAILED TO RENDER"
+	}
+
+	return string(vv)
 }
 
 type TestSuites struct {


### PR DESCRIPTION
The engine trace sometimes displays the wrong condition in its ouput.
This is due to the underlying slice being reused inadvertantly.

Fixes #1635

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
