### PR TITLE
chore(ci): Downgrade telepresence

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,10 +21,10 @@ jobs:
       - name: Install Helmfile and Telepresence
         run: |
           mkdir bin
-          curl -fL https://github.com/helmfile/helmfile/releases/download/v0.153.1/helmfile_0.153.1_linux_amd64.tar.gz -o bin/helmfile.tar.gz
+          curl -fL https://github.com/helmfile/helmfile/releases/download/v0.154.0/helmfile_0.154.0_linux_amd64.tar.gz -o bin/helmfile.tar.gz
           tar -xf bin/helmfile.tar.gz -C bin
           chmod +x bin/helmfile
-          curl -fL https://app.getambassador.io/download/tel2/linux/amd64/latest/telepresence -o bin/telepresence
+          curl -fL https://ambassador-labs.gateway.scarf.sh/telepresenceio/telepresence/releases/download/v2.13.2/telepresence-linux-amd64 -o bin/telepresence
           chmod +x bin/telepresence
           echo "$(pwd)/bin" >> $GITHUB_PATH
           mkdir -p ~/.config/telepresence
@@ -33,6 +33,7 @@ jobs:
             helm: 60s
             trafficManagerAPI: 30s
           EOF
+          go install github.com/stern/stern@latest
 
       - name: Initialize Helmfile
         run: helmfile init --force

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -42,5 +42,5 @@ if [[ "$#" -gt "0" ]]; then
     # E.g. e2e/run.sh ./mysql/... -args -run-id=xxxxx -no-cleanup
     run_tests "$@"
 else
-    run_tests ./... -args -no-cleanup="$E2E_NO_CLEANUP" -command-timeout=4m
+    run_tests ./... -args -no-cleanup="$E2E_NO_CLEANUP" -command-timeout=5m
 fi


### PR DESCRIPTION
The latest spate of E2E failures with random timeouts seem to be related
to the new release of Telepresence. This PR pins the version of
Telepresence to the last-known good version.

This PR also includes a change to dump pod logs on test failure to help
with debugging.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
