### PR TITLE
feat: Introduce environment-specific global variables

### DIFF
--- a/cmd/cerbos/repl/internal/repl.go
+++ b/cmd/cerbos/repl/internal/repl.go
@@ -323,6 +323,18 @@ func (r *REPL) setSpecialVar(name, value string) error {
 		r.evalPolicyVariables()
 		r.output.PrintResult(name, r.vars[conditions.CELVariablesIdent])
 
+	case conditions.CELGlobalsIdent, conditions.CELGlobalsAbbrev:
+		var globals map[string]any
+		if err := json.Unmarshal([]byte(value), &globals); err != nil {
+			return fmt.Errorf("failed to unmarshal JSON as %q: %w", name, err)
+		}
+
+		globalsVal := r.toRefVal(globals)
+		r.vars[conditions.CELGlobalsIdent] = globalsVal
+		r.vars[conditions.CELGlobalsAbbrev] = globalsVal
+		r.evalPolicyVariables()
+		r.output.PrintResult(name, r.vars[conditions.CELGlobalsIdent])
+
 	default:
 		return fmt.Errorf("setting %q is unsupported", name)
 	}

--- a/cmd/cerbos/repl/internal/repl_test.go
+++ b/cmd/cerbos/repl/internal/repl_test.go
@@ -274,6 +274,29 @@ func TestREPL(t *testing.T) {
 			},
 		},
 		{
+			name: "set_globals_variable",
+			directives: []DirectiveTest{
+				{
+					Directive: `:let G = {"foo":"bar"}`,
+					Check: func(t *testing.T, m *mockOutput) {
+						t.Helper()
+						require.Equal(t, "G", m.resultName)
+
+						want := map[string]any{"foo": "bar"}
+						require.Equal(t, want, m.resultVal.Value())
+					},
+				},
+				{
+					Directive: `globals.foo`,
+					Check: func(t *testing.T, m *mockOutput) {
+						t.Helper()
+						require.Equal(t, lastResultVar, m.resultName)
+						require.Equal(t, "bar", m.resultVal.Value())
+					},
+				},
+			},
+		},
+		{
 			name: "load_derived_roles",
 			directives: []DirectiveTest{
 				{

--- a/cmd/cerbosctl/put_test.go
+++ b/cmd/cerbosctl/put_test.go
@@ -98,6 +98,7 @@ func testPutCmd(clientCtx *cmdclient.Context, globals *flagset.Globals) func(*te
 					"resource.album_object.vdefault",
 					"resource.equipment_request.vdefault",
 					"resource.equipment_request.vdefault/acme",
+					"resource.global.vdefault",
 					"resource.leave_request.v20210210",
 					"resource.leave_request.vdefault",
 					"resource.leave_request.vdefault/acme",

--- a/docs/modules/configuration/pages/engine.adoc
+++ b/docs/modules/configuration/pages/engine.adoc
@@ -13,3 +13,38 @@ engine:
   defaultPolicyVersion: "default"
 ----
 
+[#globals]
+== Globals
+
+Global variables are a way to pass environment-specific information to xref:policies:conditions.adoc[policy conditions]. For example, you might want to grant additional permissions to a role in your staging environment, without creating separate policy versions for different environments.
+
+[source,yaml,linenums]
+----
+engine:
+  globals:
+    environment: "staging"
+----
+
+Values set in `globals` can then be referenced in policy conditions:
+
+[source,yaml,linenums]
+----
+rules:
+  - actions:
+      - view
+    effect: EFFECT_ALLOW
+    roles:
+      - developer
+    condition:
+      match:
+        expr: globals.environment != "production"
+----
+
+As with other configuration settings, environment variables can be used to set global values.
+
+[source,yaml,linenums]
+----
+engine:
+  globals:
+    environment: ${CERBOS_ENVIRONMENT:development}
+----

--- a/docs/modules/configuration/pages/index.adoc
+++ b/docs/modules/configuration/pages/index.adoc
@@ -10,7 +10,7 @@ The Cerbos server is configured with a YAML file. Start the server by passing th
 ./{app-name} server --config=/path/to/config.yaml --set=server.httpListenAddr=:3592 --set=engine.defaultPolicyVersion=staging
 ----
 
-NOTE: Config values can reference environment variables by enclosing them between `${}`. E.g. `$$${HOME}$$`.
+NOTE: Config values can reference environment variables by enclosing them between `${}`, for example `$$${HOME}$$`. Defaults can be set using `$$${VAR:default}$$`.
 
 
 == Minimal Configuration

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -50,6 +50,7 @@ compile:
   cacheSize: 1024 # CacheSize is the number of compiled policies to cache in memory.
 engine:
   defaultPolicyVersion: "default" # DefaultPolicyVersion defines what version to assume if the request does not specify one.
+  globals: {"environment": "staging"} # Globals are environment-specific variables to be made available to policy conditions.
 schema:
   cacheSize: 1024 # CacheSize defines the number of schemas to cache in memory.
   enforcement: reject # Enforcement defines level of the validations. Possible values are none, warn, reject.

--- a/docs/modules/policies/pages/conditions.adoc
+++ b/docs/modules/policies/pages/conditions.adoc
@@ -21,9 +21,11 @@ Within a condition block you have access to several special variables:
 
 `request`:: The entire request object containing data provided about the resource and the principal. Use dots to access nested fields. For example, the expression to get the principal's department attribute is `request.principal.attr.department`.
 `variables`:: Access variables declared in the `variables` section of the policy.
+`globals`:: Access global variables declared in the xref:configuration:engine.adoc#globals[policy engine configuration].
 `P`:: An alias for `request.principal` for accessing the principal object.
 `R`:: An alias for `request.resource` for accessing the resource object.
 `V`:: An alias for `variables` for accessing the policy variables object.
+`G`:: An alias for `globals` for accessing the global variables object.
 
 Every condition expression must evaluate to a boolean true/false value. You can combine complex expressions together in a single condition block by using the `all`, `any`, or `none` operators.
 

--- a/internal/conditions/cel.go
+++ b/internal/conditions/cel.go
@@ -25,6 +25,8 @@ const (
 	CELPrincipalField  = "principal"
 	CELVariablesIdent  = "variables"
 	CELVariablesAbbrev = "V"
+	CELGlobalsIdent    = "globals"
+	CELGlobalsAbbrev   = "G"
 	CELAuxDataField    = "aux_data"
 	CELAttrField       = "attr"
 )
@@ -42,6 +44,8 @@ var StdEnvDecls = []*exprpb.Decl{
 	decls.NewVar(CELResourceAbbrev, decls.NewObjectType("cerbos.engine.v1.Resource")),
 	decls.NewVar(CELVariablesIdent, decls.NewMapType(decls.String, decls.Dyn)),
 	decls.NewVar(CELVariablesAbbrev, decls.NewMapType(decls.String, decls.Dyn)),
+	decls.NewVar(CELGlobalsIdent, decls.NewMapType(decls.String, decls.Dyn)),
+	decls.NewVar(CELGlobalsAbbrev, decls.NewMapType(decls.String, decls.Dyn)),
 }
 
 func init() {
@@ -114,6 +118,8 @@ func ExpandAbbrev(s string) string {
 		expanded = Fqn(CELResourceField)
 	case CELVariablesAbbrev:
 		expanded = CELVariablesIdent
+	case CELGlobalsAbbrev:
+		expanded = CELGlobalsIdent
 	}
 
 	if ok {
@@ -136,6 +142,8 @@ func newCELQueryPlanEnvOptions() []cel.EnvOption {
 			decls.NewVar(CELResourceAbbrev, decls.NewObjectType("cerbos.engine.v1.Resource")),
 			decls.NewVar(CELVariablesIdent, decls.NewMapType(decls.String, decls.Dyn)),
 			decls.NewVar(CELVariablesAbbrev, decls.NewMapType(decls.String, decls.Dyn)),
+			decls.NewVar(CELGlobalsIdent, decls.NewMapType(decls.String, decls.Dyn)),
+			decls.NewVar(CELGlobalsAbbrev, decls.NewMapType(decls.String, decls.Dyn)),
 		),
 		ext.Strings(),
 		ext.Encoders(),

--- a/internal/conditions/cel_test.go
+++ b/internal/conditions/cel_test.go
@@ -45,6 +45,10 @@ func TestExpandAbbrev(t *testing.T) {
 			want:  "variables.is_admin",
 		},
 		{
+			input: "G.environment",
+			want:  "globals.environment",
+		},
+		{
 			input: "request.principal.attr.department",
 			want:  "request.principal.attr.department",
 		},

--- a/internal/engine/conf.go
+++ b/internal/engine/conf.go
@@ -18,6 +18,8 @@ var errEmptyDefaultVersion = errors.New("engine.defaultVersion must not be an em
 
 // Conf is optional configuration for engine.
 type Conf struct {
+	// Globals are environment-specific variables to be made available to policy conditions.
+	Globals map[string]any `yaml:"globals" conf:",example={\"environment\": \"staging\"}"`
 	// DefaultPolicyVersion defines what version to assume if the request does not specify one.
 	DefaultPolicyVersion string `yaml:"defaultPolicyVersion" conf:",example=\"default\""`
 	NumWorkers           uint   `yaml:"numWorkers" conf:",ignore"`

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -196,13 +196,16 @@ func mkEngine(tb testing.TB, p param) (*Engine, context.CancelFunc) {
 		auditLog = audit.NewNopLog()
 	}
 
-	eng, err := New(ctx, Components{
+	engineConf := &Conf{}
+	engineConf.SetDefaults()
+	engineConf.Globals = map[string]any{"environment": "test"}
+
+	eng := NewFromConf(ctx, engineConf, Components{
 		PolicyLoader:      compiler,
 		SchemaMgr:         schemaMgr,
 		AuditLog:          auditLog,
 		MetadataExtractor: audit.NewMetadataExtractorFromConf(&audit.Conf{}),
 	})
-	require.NoError(tb, err)
 
 	return eng, cancelFunc
 }

--- a/internal/engine/evaluator.go
+++ b/internal/engine/evaluator.go
@@ -31,11 +31,15 @@ import (
 var ErrPolicyNotExecutable = errors.New("policy not executable")
 
 type evalParams struct {
+	globals map[string]any
 	nowFunc func() time.Time
 }
 
-func defaultEvalParams() evalParams {
-	return evalParams{nowFunc: time.Now}
+func defaultEvalParams(globals map[string]any) evalParams {
+	return evalParams{
+		globals: globals,
+		nowFunc: time.Now,
+	}
 }
 
 type Evaluator interface {
@@ -431,6 +435,8 @@ func (ep evalParams) evaluateCELExpr(expr *exprpb.CheckedExpr, variables map[str
 		conditions.CELPrincipalAbbrev: input.Principal,
 		conditions.CELVariablesIdent:  variables,
 		conditions.CELVariablesAbbrev: variables,
+		conditions.CELGlobalsIdent:    ep.globals,
+		conditions.CELGlobalsAbbrev:   ep.globals,
 	}, ep.nowFunc)
 	if err != nil {
 		// ignore expressions that access non-existent keys

--- a/internal/engine/planner/planner_test.go
+++ b/internal/engine/planner/planner_test.go
@@ -160,7 +160,7 @@ func Test_evaluateCondition(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("Expr:%q", tt.args.expr), func(t *testing.T) {
 			is := require.New(t)
-			got, err := evaluateCondition(tt.args.condition, tt.args.input, nil)
+			got, err := evaluateCondition(tt.args.condition, tt.args.input, nil, nil)
 			is.NoError(err)
 			expression := got.GetExpression()
 			is.Equal(tt.want, unparse(t, expression))
@@ -216,7 +216,7 @@ func Test_evaluateCondition(t *testing.T) {
 			got, err := evaluateCondition(c, &enginev1.PlanResourcesInput{
 				Principal: &enginev1.Principal{Attr: principalAttr},
 				Resource:  &enginev1.PlanResourcesInput_Resource{Attr: resourceAttr},
-			}, nil)
+			}, nil, nil)
 			is.NotNil(got)
 			is.NoError(err)
 			operation := got.GetLogicalOperation()

--- a/internal/storage/blob/cloner_test.go
+++ b/internal/storage/blob/cloner_test.go
@@ -49,5 +49,6 @@ func TestCloneResult(t *testing.T) {
 		"resource_policies/policy_06.yaml",
 		"resource_policies/policy_07.yaml",
 		"resource_policies/policy_07_acme.yaml",
+		"resource_policies/policy_08.yaml",
 	}, result.updateOrAdd)
 }

--- a/internal/storage/index/builder_test.go
+++ b/internal/storage/index/builder_test.go
@@ -44,7 +44,7 @@ func TestBuildIndexWithDisk(t *testing.T) {
 
 	t.Run("check_contents", func(t *testing.T) {
 		data := idxImpl.Inspect()
-		require.Len(t, data, 21)
+		require.Len(t, data, 22)
 
 		rp1 := filepath.Join("resource_policies", "policy_01.yaml")
 		rp2 := filepath.Join("resource_policies", "policy_02.yaml")

--- a/internal/test/testdata/engine/case_18.yaml
+++ b/internal/test/testdata/engine/case_18.yaml
@@ -1,0 +1,30 @@
+---
+description: Globals
+inputs: [
+  {
+    "requestId": "test",
+    "actions": ["test"],
+    "principal": {
+      "id": "andy",
+      "roles": [
+        "employee"
+      ]
+    },
+    "resource": {
+      "kind": "global",
+      "id": "test"
+    }
+  }
+]
+wantOutputs: [
+  {
+    "requestId": "test",
+    "resourceId": "test",
+    "actions": {
+      "test": {
+        "effect": "EFFECT_ALLOW",
+        "policy": "resource.global.vdefault"
+      }
+    }
+  }
+]

--- a/internal/test/testdata/query_planner/policies/resource_policy_basics.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policy_basics.yaml
@@ -22,3 +22,12 @@ resourcePolicy:
         match:
           expr: |-
             P.attr.userQid == request.resource.id
+    - actions:
+        - reference_globals
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: |-
+            R.attr.environment == G.environment

--- a/internal/test/testdata/query_planner/suite/basics.yaml
+++ b/internal/test/testdata/query_planner/suite/basics.yaml
@@ -32,3 +32,15 @@ tests:
             operands:
               - value: z0
               - variable: request.resource.id
+    - action: reference_globals
+      resource:
+        kind: x
+        policyVersion: default
+      want:
+        kind: KIND_CONDITIONAL
+        condition:
+          expression:
+            operator: eq
+            operands:
+              - variable: request.resource.attr.environment
+              - value: test

--- a/internal/test/testdata/store/resource_policies/policy_08.yaml
+++ b/internal/test/testdata/store/resource_policies/policy_08.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+---
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: global
+  rules:
+    - actions:
+        - test
+      effect: EFFECT_ALLOW
+      roles:
+        - employee
+      condition:
+        match:
+          expr: globals.environment == "test"


### PR DESCRIPTION
Closes #1623

This PR introduces a new configuration section, `engine.globals`, which takes a string-to-any map of global variables to be made available in policy conditions as `globals` (aliased to `G`).