### PR TITLE
enhancement: Add `ListPolicies` filtering ability to `cerbosctl get`

### DIFF
--- a/cmd/cerbosctl/get/derivedroles/derived_roles.go
+++ b/cmd/cerbosctl/get/derivedroles/derived_roles.go
@@ -44,7 +44,6 @@ cerbosctl get derived_roles derived_roles.my_derived_roles -ojson
 # Get derived role policy definition as pretty json
 cerbosctl get derived_roles derived_roles.my_derived_roles -oprettyjson`
 
-//nolint:govet
 type Cmd struct {
 	flagset.Filters
 	flagset.Format

--- a/cmd/cerbosctl/get/internal/flagset/filter.go
+++ b/cmd/cerbosctl/get/internal/flagset/filter.go
@@ -9,9 +9,13 @@ import (
 	"github.com/cerbos/cerbos/internal/policy"
 )
 
+//nolint:govet
 type Filters struct {
 	Name            []string `help:"Filter policies by name"`
+	NameRegexp      string   `help:"Filter policies by name, using regular expression"`
 	Version         []string `help:"Filter policies by version"`
+	VersionRegexp   string   `help:"Filter policies by version, using regular expression"`
+	ScopeRegexp     string   `help:"Filter policies by scope, using regular expression"`
 	IncludeDisabled bool     `help:"Include disabled policies"`
 }
 
@@ -24,8 +28,20 @@ func (f Filters) Validate(kind policy.Kind, listing bool) error {
 		return fmt.Errorf("--name and --version flags are only available when listing")
 	}
 
-	if kind == policy.DerivedRolesKind && len(f.Version) > 0 {
-		return fmt.Errorf("--version flag is not available when listing derived roles")
+	if !listing && (f.NameRegexp != "" || f.VersionRegexp != "" || f.ScopeRegexp != "") {
+		return fmt.Errorf("--{name|version|scope}-regexp flags are only available when listing")
+	}
+
+	if kind == policy.DerivedRolesKind && (len(f.Version) > 0 || f.VersionRegexp != "") {
+		return fmt.Errorf("--version and --version-regexp flags are not available when listing derived roles")
+	}
+
+	if len(f.Name) > 0 && f.NameRegexp != "" {
+		return fmt.Errorf("--name and --name-regexp flags cannot be used together")
+	}
+
+	if len(f.Version) > 0 && f.VersionRegexp != "" {
+		return fmt.Errorf("--version and --version-regexp flags cannot be used together")
 	}
 
 	return nil

--- a/cmd/cerbosctl/get/internal/policy/policy.go
+++ b/cmd/cerbosctl/get/internal/policy/policy.go
@@ -37,6 +37,15 @@ func List(k *kong.Kong, c client.AdminClient, filters *flagset.Filters, format *
 	if filters.IncludeDisabled {
 		opts = append(opts, client.WithIncludeDisabled())
 	}
+	if filters.NameRegexp != "" {
+		opts = append(opts, client.WithNameRegexp(filters.NameRegexp))
+	}
+	if filters.ScopeRegexp != "" {
+		opts = append(opts, client.WithScopeRegexp(filters.ScopeRegexp))
+	}
+	if filters.VersionRegexp != "" {
+		opts = append(opts, client.WithVersionRegexp(filters.VersionRegexp))
+	}
 
 	policyIds, err := c.ListPolicies(context.Background(), opts...)
 	if err != nil {

--- a/cmd/cerbosctl/get/principalpolicy/principal_policy.go
+++ b/cmd/cerbosctl/get/principalpolicy/principal_policy.go
@@ -40,7 +40,6 @@ cerbosctl get principal_policies principal.donald_duck.default -ojson
 # Get principal policy definition as pretty json
 cerbosctl get principal_policies principal.donald_duck.default -oprettyjson`
 
-//nolint:govet
 type Cmd struct {
 	flagset.Filters
 	flagset.Format

--- a/cmd/cerbosctl/get/resourcepolicy/resource_policy.go
+++ b/cmd/cerbosctl/get/resourcepolicy/resource_policy.go
@@ -40,7 +40,6 @@ cerbosctl get resource_policies resource.leave_request.default -ojson
 # Get resource policy definition as pretty json
 cerbosctl get resource_policies resource.leave_request.default -oprettyjson`
 
-//nolint:govet
 type Cmd struct {
 	flagset.Filters
 	flagset.Format

--- a/docs/modules/cli/pages/cerbosctl.adoc
+++ b/docs/modules/cli/pages/cerbosctl.adoc
@@ -227,6 +227,8 @@ You can also retrieve individual policies or schemas by their identifiers and vi
 
 You can filter the output using the `name` and `version` flags. Each flag accepts multiple comma-separated values which are OR'ed together. For example, `--name=a.yaml,b.yaml` matches policies that are either named `a.yaml` or `b.yaml`.
 
+Separately, you can filter the output using the `name-regexp`, `version-regexp` and `scope-regexp` flags. Each flag accepts a regular expression string. These are separate from the `name` and `version` flags above, and cannot be used with their respective counterparts.
+
 You can include disabled policies in the results by adding `--include-disabled` flag.
 
 .List derived roles
@@ -256,10 +258,28 @@ cerbosctl get derived_roles --name my_policy,a_policy
 cerbosctl get dr --name my_policy,a_policy
 ----
 
+.List derived_roles where `name` is `my_policy` or `a_policy`, using regular expression
+----
+cerbosctl get derived_roles --name-regexp "^(my|a)_policy\$"
+cerbosctl get dr --name-regexp "^(my|a)_policy\$"
+----
+
 .List principal_policies where `version` is `default` or `v1`
 ----
 cerbosctl get principal_policies --version default,v1
 cerbosctl get pp --version default,v1
+----
+
+.List principal_policies where `version` is `default` or `v1`, using regular expression
+----
+cerbosctl get principal_policies --version-regexp "(default|v1)"
+cerbosctl get pp --version-regexp "(default|v1)"
+----
+
+.List resource_policies where `scope` includes the substring `foo`, using regular expression
+----
+cerbosctl get resource_policies --scope-regexp foo
+cerbosctl get rp --scope-regexp foo
 ----
 
 .List derived_roles and sort by column `policyId` or `name`

--- a/internal/svc/admin_svc.go
+++ b/internal/svc/admin_svc.go
@@ -124,7 +124,7 @@ func (cas *CerbosAdminService) ListPolicies(ctx context.Context, req *requestv1.
 	// We've historically supported ListPolicies on non-mutable stores, but later introduced filters are not scalable.
 	// Therefore, if any of the filters in question are passed and the store is not mutable, we reject the request.
 	if _, ok := cas.store.(storage.MutableStore); !ok && (req.NameRegexp != "" || req.ScopeRegexp != "" || req.VersionRegexp != "") {
-		return nil, status.Error(codes.Unimplemented, "Store does not support filters")
+		return nil, status.Error(codes.Unimplemented, "Store does not support regexp filters")
 	}
 
 	filterParams := storage.ListPolicyIDsParams{


### PR DESCRIPTION
Following on from the [newly introduced ListPolicies regex filtering](https://github.com/cerbos/cerbos/pull/1642), used like so:

```sh
cerbosctl --plaintext get rp --name-regexp=foo --scope-regexp=bar --version-regexp=baz
```

closes #1647 