### PR TITLE
feat: Lenient scope search

### DIFF
--- a/docs/modules/configuration/pages/engine.adoc
+++ b/docs/modules/configuration/pages/engine.adoc
@@ -54,6 +54,8 @@ engine:
 
 When working with xref:policies:scoped_policies.adoc[scopes], the default behaviour of the Cerbos engine is to expect that a policy file exists for the requested scope. For example, if the API request defines `a.b.c` as the `scope`, a policy file _must exist_ in the policy repository with the `a.b.c` scope. This behaviour can be overridden by setting `lenientScopeSearch` configuration to `true`. When lenient scope search is enabled, if a policy with scope `a.b.c` does not exist in the store, Cerbos will attempt to find scopes `a.b`, `a` and `` in that order.
 
+NOTE: This setting only affects how Cerbos treats missing leaf scopes when searching for policies. The policies stored in your policy store _must_ have unbroken scope chains (for example, if you have a scoped policy `a.b.c` in the store, the policy files for scopes `a.b`, `a` and `` must also exist).
+
 
 [source,yaml,linenums]
 ----

--- a/docs/modules/configuration/pages/engine.adoc
+++ b/docs/modules/configuration/pages/engine.adoc
@@ -48,3 +48,15 @@ engine:
   globals:
     environment: ${CERBOS_ENVIRONMENT:development}
 ----
+
+[#lenient_scopes]
+== Lenient scope search
+
+When working with xref:policies:scoped_policies.adoc[scopes], the default behaviour of the Cerbos engine is to expect that a policy file exists for the requested scope. For example, if the API request defines `a.b.c` as the `scope`, a policy file _must exist_ in the policy repository with the `a.b.c` scope. This behaviour can be overridden by setting `lenientScopeSearch` configuration to `true`. When lenient scope search is enabled, if a policy with scope `a.b.c` does not exist in the store, Cerbos will attempt to find scopes `a.b`, `a` and `` in that order.
+
+
+[source,yaml,linenums]
+----
+engine:
+  lenientScopeSearch: true
+----

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -51,6 +51,7 @@ compile:
 engine:
   defaultPolicyVersion: "default" # DefaultPolicyVersion defines what version to assume if the request does not specify one.
   globals: {"environment": "staging"} # Globals are environment-specific variables to be made available to policy conditions.
+  lenientScopeSearch: false # LenientScopeSearch configures the engine to ignore missing scopes and search upwards through the scope tree until it finds a usable policy.
 schema:
   cacheSize: 1024 # CacheSize defines the number of schemas to cache in memory.
   enforcement: reject # Enforcement defines level of the validations. Possible values are none, warn, reject.

--- a/docs/modules/policies/pages/scoped_policies.adoc
+++ b/docs/modules/policies/pages/scoped_policies.adoc
@@ -15,11 +15,11 @@ Cerbos resource and principal policies have an optional `scope` field that can b
 ----
 apiVersion: api.cerbos.dev/v1
 resourcePolicy:
-  version: "default" 
+  version: "default"
   scope: "acme.corp" <1>
-  resource: "album:object"  
+  resource: "album:object"
   rules:
-    - actions: ['*'] 
+    - actions: ['*']
       effect: EFFECT_ALLOW
       roles: ["admin"]
 ----
@@ -37,15 +37,15 @@ To illustrate, consider the following Check request:
 [source,json,linenums]
 ----
 {
-  "requestId":  "test01", 
-  "actions":  ["view", "comment"], 
+  "requestId":  "test01",
+  "actions":  ["view", "comment"],
   "resource":  {
-    "kind":  "album:object", 
+    "kind":  "album:object",
     "policyVersion": "default",
     "scope": "customer.abc", <1>
-    "instances": { 
-      "XX125": { 
-        "attr":  { 
+    "instances": {
+      "XX125": {
+        "attr":  {
           "owner":  "alicia",
           "public": false,
           "tags": ["x", "y"],
@@ -54,11 +54,11 @@ To illustrate, consider the following Check request:
     }
   },
   "principal":  {
-    "id":  "alicia", 
+    "id":  "alicia",
     "policyVersion": "default",
     "scope": "customer", <2>
-    "roles":  ["user"], 
-    "attr": { 
+    "roles":  ["user"],
+    "attr": {
       "geography": "GB"
     }
   }
@@ -78,5 +78,6 @@ image::decision_flow.png[]
 * There must be no gaps in the policy chain. For example, if you define a policy with scope `a.b.c`, then policies with scopes `a.b`, `a`, and no-scope should also exist in the policy repository.
 * xref:schemas.adoc[Schemas] must be the same among all the policies in the chain. The schemas used to validate the request are taken from the base policy (policy without a scope). Schemas defined in other policies of the chain will be ignored.
 * Variables and derived roles imports are not inherited between policies. Explicitly import any derived roles and re-define any variables in each policy that requires them.
-* First match wins. As illustrated in the flow chart above, scoped policies are evaluated from the most specific to the least specific. The first policy to produce a decision (ALLOW/DENY) for an action is the winner. The remaining policies cannot override the decision for that particular action (but they will still be evaluated if there are other actions that don't yet have a decision). 
+* First match wins. As illustrated in the flow chart above, scoped policies are evaluated from the most specific to the least specific. The first policy to produce a decision (ALLOW/DENY) for an action is the winner. The remaining policies cannot override the decision for that particular action (but they will still be evaluated if there are other actions that don't yet have a decision).
+* Unless xref:configuration:engine.adoc#lenient_scopes[lenient scope search] is enabled, a policy file matching the exact scope requested in the API request must exist in the store.
 

--- a/internal/compile/manager_test.go
+++ b/internal/compile/manager_test.go
@@ -255,6 +255,21 @@ func (ms *MockStore) Unsubscribe(s storage.Subscriber) {
 	ms.subscriber = nil
 }
 
+func (ms *MockStore) GetFirstMatch(ctx context.Context, candidates []namer.ModuleID) (*policy.CompilationUnit, error) {
+	args := ms.MethodCalled("GetFirstMatch", ctx, candidates)
+	res := args.Get(0)
+	switch t := res.(type) {
+	case nil:
+		return nil, args.Error(1)
+	case *policy.CompilationUnit:
+		return t, args.Error(1)
+	case func() (*policy.CompilationUnit, error):
+		return t()
+	default:
+		panic(fmt.Errorf("unknown return value type: %T", res))
+	}
+}
+
 func (ms *MockStore) GetCompilationUnits(ctx context.Context, ids ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error) {
 	args := ms.MethodCalled("GetCompilationUnits", ctx, ids)
 	res := args.Get(0)

--- a/internal/engine/conf.go
+++ b/internal/engine/conf.go
@@ -22,7 +22,9 @@ type Conf struct {
 	Globals map[string]any `yaml:"globals" conf:",example={\"environment\": \"staging\"}"`
 	// DefaultPolicyVersion defines what version to assume if the request does not specify one.
 	DefaultPolicyVersion string `yaml:"defaultPolicyVersion" conf:",example=\"default\""`
-	NumWorkers           uint   `yaml:"numWorkers" conf:",ignore"`
+	// LenientScopeSearch configures the engine to ignore missing scopes and search upwards through the scope tree until it finds a usable policy.
+	LenientScopeSearch bool `yaml:"lenientScopeSearch" conf:",example=false"`
+	NumWorkers         uint `yaml:"numWorkers" conf:",ignore"`
 }
 
 func (c *Conf) Key() string {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -64,6 +64,38 @@ func TestCheck(t *testing.T) {
 	}
 }
 
+func TestCheckWithLenientScopeSearch(t *testing.T) {
+	eng, cancelFunc := mkEngine(t, param{schemaEnforcement: schema.EnforcementNone, lenientScopeSearch: true})
+	defer cancelFunc()
+
+	testCases := test.LoadTestCases(t, "engine")
+	testCases = append(testCases, test.LoadTestCases(t, "engine_lenient_scope_search")...)
+
+	for _, tcase := range testCases {
+		tcase := tcase
+		t.Run(tcase.Name, func(t *testing.T) {
+			tc := readTestCase(t, tcase.Input)
+
+			traceCollector := tracer.NewCollector()
+			haveOutputs, err := eng.Check(context.Background(), tc.Inputs, WithTraceSink(traceCollector))
+
+			if tc.WantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			for i, have := range haveOutputs {
+				require.Empty(t, cmp.Diff(tc.WantOutputs[i],
+					have,
+					protocmp.Transform(),
+					protocmp.SortRepeatedFields(&enginev1.CheckOutput{}, "effective_derived_roles"),
+				))
+			}
+		})
+	}
+}
+
 func TestSchemaValidation(t *testing.T) {
 	for _, enforcement := range []string{"warn", "reject"} {
 		enforcement := enforcement
@@ -159,9 +191,10 @@ func runBenchmarks(b *testing.B, eng *Engine, testCases []test.Case) {
 }
 
 type param struct {
-	enableAuditLog    bool
-	schemaEnforcement schema.Enforcement
-	subDir            string
+	enableAuditLog     bool
+	schemaEnforcement  schema.Enforcement
+	subDir             string
+	lenientScopeSearch bool
 }
 
 func mkEngine(tb testing.TB, p param) (*Engine, context.CancelFunc) {
@@ -199,6 +232,7 @@ func mkEngine(tb testing.TB, p param) (*Engine, context.CancelFunc) {
 	engineConf := &Conf{}
 	engineConf.SetDefaults()
 	engineConf.Globals = map[string]any{"environment": "test"}
+	engineConf.LenientScopeSearch = p.lenientScopeSearch
 
 	eng := NewFromConf(ctx, engineConf, Components{
 		PolicyLoader:      compiler,

--- a/internal/storage/blob/store.go
+++ b/internal/storage/blob/store.go
@@ -306,6 +306,10 @@ func (s *Store) Driver() string {
 	return DriverName
 }
 
+func (s *Store) GetFirstMatch(_ context.Context, candidates []namer.ModuleID) (*policy.CompilationUnit, error) {
+	return s.idx.GetFirstMatch(candidates)
+}
+
 func (s *Store) GetCompilationUnits(_ context.Context, ids ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error) {
 	return s.idx.GetCompilationUnits(ids...)
 }

--- a/internal/storage/bundle/local_source.go
+++ b/internal/storage/bundle/local_source.go
@@ -140,9 +140,9 @@ func (ls *LocalSource) LoadSchema(ctx context.Context, id string) (schema io.Rea
 	return schema, err
 }
 
-func (ls *LocalSource) GetPolicySet(ctx context.Context, id namer.ModuleID) (ps *runtimev1.RunnablePolicySet, err error) {
+func (ls *LocalSource) GetFirstMatch(ctx context.Context, candidates []namer.ModuleID) (ps *runtimev1.RunnablePolicySet, err error) {
 	ls.mu.RLock()
-	ps, err = ls.bundle.GetPolicySet(ctx, id)
+	ps, err = ls.bundle.GetFirstMatch(ctx, candidates)
 	ls.mu.RUnlock()
 	return ps, err
 }

--- a/internal/storage/bundle/local_source_test.go
+++ b/internal/storage/bundle/local_source_test.go
@@ -64,11 +64,13 @@ func runTests(have *bundle.LocalSource, manifest *bundlev1.Manifest) func(*testi
 			}
 		})
 
-		t.Run("getPolicySet", func(t *testing.T) {
+		t.Run("getFirstMatch", func(t *testing.T) {
+			blahMod := namer.GenModuleIDFromFQN("blah")
+
 			t.Run("existing", func(t *testing.T) {
 				for fqn := range manifest.PolicyIndex {
 					modID := namer.GenModuleIDFromFQN(fqn)
-					havePolicy, err := have.GetPolicySet(context.Background(), modID)
+					havePolicy, err := have.GetFirstMatch(context.Background(), []namer.ModuleID{blahMod, modID})
 					require.NoError(t, err, "Failed to get policy set for %q", fqn)
 					require.NotNil(t, havePolicy, "Policy set %q is nil", fqn)
 					require.Equal(t, havePolicy.Fqn, fqn, "FQN mismatch for policy set %q", fqn)
@@ -76,8 +78,7 @@ func runTests(have *bundle.LocalSource, manifest *bundlev1.Manifest) func(*testi
 			})
 
 			t.Run("nonExisting", func(t *testing.T) {
-				modID := namer.GenModuleIDFromFQN("blah")
-				havePolicy, err := have.GetPolicySet(context.Background(), modID)
+				havePolicy, err := have.GetFirstMatch(context.Background(), []namer.ModuleID{blahMod})
 				require.NoError(t, err)
 				require.Nil(t, havePolicy)
 			})

--- a/internal/storage/bundle/remote_source.go
+++ b/internal/storage/bundle/remote_source.go
@@ -409,7 +409,7 @@ func (s *RemoteSource) IsHealthy() bool {
 	return s.healthy
 }
 
-func (s *RemoteSource) GetPolicySet(ctx context.Context, id namer.ModuleID) (*runtimev1.RunnablePolicySet, error) {
+func (s *RemoteSource) GetFirstMatch(ctx context.Context, candidates []namer.ModuleID) (*runtimev1.RunnablePolicySet, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -417,7 +417,7 @@ func (s *RemoteSource) GetPolicySet(ctx context.Context, id namer.ModuleID) (*ru
 		return nil, ErrBundleNotLoaded
 	}
 
-	return s.bundle.GetPolicySet(ctx, id)
+	return s.bundle.GetFirstMatch(ctx, candidates)
 }
 
 func (s *RemoteSource) ListPolicyIDs(ctx context.Context, params storage.ListPolicyIDsParams) ([]string, error) {

--- a/internal/storage/bundle/source_wrappers.go
+++ b/internal/storage/bundle/source_wrappers.go
@@ -51,9 +51,9 @@ func (is instrumentedSource) LoadSchema(ctx context.Context, id string) (io.Read
 	})
 }
 
-func (is instrumentedSource) GetPolicySet(ctx context.Context, id namer.ModuleID) (*runtimev1.RunnablePolicySet, error) {
-	return measureBinaryOp(ctx, is.name, "GetPolicySet", func(ctx context.Context) (*runtimev1.RunnablePolicySet, error) {
-		return is.source.GetPolicySet(ctx, id)
+func (is instrumentedSource) GetFirstMatch(ctx context.Context, candidates []namer.ModuleID) (*runtimev1.RunnablePolicySet, error) {
+	return measureBinaryOp(ctx, is.name, "GetFirstMatch", func(ctx context.Context) (*runtimev1.RunnablePolicySet, error) {
+		return is.source.GetFirstMatch(ctx, candidates)
 	})
 }
 

--- a/internal/storage/bundle/store.go
+++ b/internal/storage/bundle/store.go
@@ -116,8 +116,8 @@ func (hs *HybridStore) LoadSchema(ctx context.Context, id string) (io.ReadCloser
 	return hs.withActiveSource().LoadSchema(ctx, id)
 }
 
-func (hs *HybridStore) GetPolicySet(ctx context.Context, id namer.ModuleID) (*runtimev1.RunnablePolicySet, error) {
-	return hs.withActiveSource().GetPolicySet(ctx, id)
+func (hs *HybridStore) GetFirstMatch(ctx context.Context, candidates []namer.ModuleID) (*runtimev1.RunnablePolicySet, error) {
+	return hs.withActiveSource().GetFirstMatch(ctx, candidates)
 }
 
 func (hs *HybridStore) SourceKind() string {

--- a/internal/storage/db/internal/tests.go
+++ b/internal/storage/db/internal/tests.go
@@ -187,6 +187,43 @@ func TestSuite(store DBStorage) func(*testing.T) {
 			require.Empty(t, have)
 		})
 
+		t.Run("get_first_match_resource_policy", func(t *testing.T) {
+			modIDs := namer.ScopedResourcePolicyModuleIDs(rpAcmeHR.Name, rpAcmeHR.Version, "acme.hr.france.marseille", true)
+			have, err := store.GetFirstMatch(ctx, modIDs)
+			require.NoError(t, err)
+			require.NotNil(t, have)
+			require.Equal(t, rpAcmeHR.ID, have.ModID)
+			require.Contains(t, have.Definitions, rpAcmeHR.ID)
+			require.Empty(t, cmp.Diff(rpAcmeHR, have.Definitions[rpAcmeHR.ID], protocmp.Transform()))
+			require.Contains(t, have.Definitions, rpAcme.ID)
+			require.Empty(t, cmp.Diff(rpAcme, have.Definitions[rpAcme.ID], protocmp.Transform()))
+			require.Contains(t, have.Definitions, rp.ID)
+			require.Empty(t, cmp.Diff(rp, have.Definitions[rp.ID], protocmp.Transform()))
+			require.Contains(t, have.Definitions, dr.ID)
+			require.Empty(t, cmp.Diff(dr, have.Definitions[dr.ID], protocmp.Transform()))
+		})
+
+		t.Run("get_first_match_principal_policy", func(t *testing.T) {
+			modIDs := namer.ScopedPrincipalPolicyModuleIDs(ppAcmeHR.Name, ppAcmeHR.Version, "acme.hr.france.marseille", true)
+			have, err := store.GetFirstMatch(ctx, modIDs)
+			require.NoError(t, err)
+			require.NotNil(t, have)
+			require.Equal(t, ppAcmeHR.ID, have.ModID)
+			require.Contains(t, have.Definitions, ppAcmeHR.ID)
+			require.Empty(t, cmp.Diff(ppAcmeHR, have.Definitions[ppAcmeHR.ID], protocmp.Transform()))
+			require.Contains(t, have.Definitions, ppAcme.ID)
+			require.Empty(t, cmp.Diff(ppAcme, have.Definitions[ppAcme.ID], protocmp.Transform()))
+			require.Contains(t, have.Definitions, pp.ID)
+			require.Empty(t, cmp.Diff(pp, have.Definitions[pp.ID], protocmp.Transform()))
+		})
+
+		t.Run("get_first_match_non_existent", func(t *testing.T) {
+			modIDs := namer.ScopedResourcePolicyModuleIDs("foo", "bar", "acme.hr.france.marseille", true)
+			have, err := store.GetFirstMatch(ctx, modIDs)
+			require.NoError(t, err)
+			require.Nil(t, have)
+		})
+
 		t.Run("get_dependents", func(t *testing.T) {
 			have, err := store.GetDependents(ctx, dr.ID)
 			require.NoError(t, err)

--- a/internal/storage/disk/disk.go
+++ b/internal/storage/disk/disk.go
@@ -91,6 +91,10 @@ func (s *Store) Driver() string {
 	return DriverName
 }
 
+func (s *Store) GetFirstMatch(_ context.Context, candidates []namer.ModuleID) (*policy.CompilationUnit, error) {
+	return s.idx.GetFirstMatch(candidates)
+}
+
 func (s *Store) GetCompilationUnits(_ context.Context, ids ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error) {
 	return s.idx.GetCompilationUnits(ids...)
 }

--- a/internal/storage/git/store.go
+++ b/internal/storage/git/store.go
@@ -134,6 +134,10 @@ func (s *Store) Driver() string {
 	return DriverName
 }
 
+func (s *Store) GetFirstMatch(_ context.Context, candidates []namer.ModuleID) (*policy.CompilationUnit, error) {
+	return s.idx.GetFirstMatch(candidates)
+}
+
 func (s *Store) GetCompilationUnits(_ context.Context, ids ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error) {
 	return s.idx.GetCompilationUnits(ids...)
 }

--- a/internal/storage/overlay/store.go
+++ b/internal/storage/overlay/store.go
@@ -162,12 +162,13 @@ func withCircuitBreaker[T any](s *Store, baseFn, fallbackFn func() (T, error)) (
 // PolicyLoader interface
 //
 
-func (s *Store) GetPolicySet(ctx context.Context, id namer.ModuleID) (*runtimev1.RunnablePolicySet, error) {
-	// Both `SourceStore` (via `compile.Manager`) and `BinaryStore` implement GetPolicySet
+func (s *Store) GetFirstMatch(ctx context.Context, candidates []namer.ModuleID) (*runtimev1.RunnablePolicySet, error) {
 	return withCircuitBreaker(
 		s,
-		func() (*runtimev1.RunnablePolicySet, error) { return s.basePolicyLoader.GetPolicySet(ctx, id) },
-		func() (*runtimev1.RunnablePolicySet, error) { return s.fallbackPolicyLoader.GetPolicySet(ctx, id) },
+		func() (*runtimev1.RunnablePolicySet, error) { return s.basePolicyLoader.GetFirstMatch(ctx, candidates) },
+		func() (*runtimev1.RunnablePolicySet, error) {
+			return s.fallbackPolicyLoader.GetFirstMatch(ctx, candidates)
+		},
 	)
 }
 

--- a/internal/storage/overlay/store_test.go
+++ b/internal/storage/overlay/store_test.go
@@ -110,8 +110,8 @@ func TestFailover(t *testing.T) {
 		nFailures := fallbackErrorThreshold - 1
 		nRequests := nFailures + 1
 		basePolicyLoader := new(MockPolicyLoader)
-		basePolicyLoader.On("GetPolicySet", ctx, mock.AnythingOfType("namer.ModuleID")).Return((*runtimev1.RunnablePolicySet)(nil), errors.New("base store error")).Times(nFailures)
-		basePolicyLoader.On("GetPolicySet", ctx, mock.AnythingOfType("namer.ModuleID")).Return(&runtimev1.RunnablePolicySet{}, nil).Once()
+		basePolicyLoader.On("GetFirstMatch", ctx, mock.AnythingOfType("[]namer.ModuleID")).Return((*runtimev1.RunnablePolicySet)(nil), errors.New("base store error")).Times(nFailures)
+		basePolicyLoader.On("GetFirstMatch", ctx, mock.AnythingOfType("[]namer.ModuleID")).Return(&runtimev1.RunnablePolicySet{}, nil).Once()
 
 		fallbackPolicyLoader := new(MockPolicyLoader)
 
@@ -123,7 +123,7 @@ func TestFailover(t *testing.T) {
 		}
 
 		for i := 0; i < nRequests; i++ {
-			_, err := wrappedSourceStore.GetPolicySet(ctx, namer.GenModuleIDFromFQN("example"))
+			_, err := wrappedSourceStore.GetFirstMatch(ctx, []namer.ModuleID{namer.GenModuleIDFromFQN("example")})
 			if i < nFailures {
 				require.Error(t, err, "expected base store to return an error")
 			} else {
@@ -141,10 +141,10 @@ func TestFailover(t *testing.T) {
 		nFailures := fallbackErrorThreshold
 		nRequests := nFailures + 1
 		basePolicyLoader := new(MockPolicyLoader)
-		basePolicyLoader.On("GetPolicySet", ctx, mock.AnythingOfType("namer.ModuleID")).Return((*runtimev1.RunnablePolicySet)(nil), errors.New("base store error")).Times(nFailures)
+		basePolicyLoader.On("GetFirstMatch", ctx, mock.AnythingOfType("[]namer.ModuleID")).Return((*runtimev1.RunnablePolicySet)(nil), errors.New("base store error")).Times(nFailures)
 
 		fallbackPolicyLoader := new(MockPolicyLoader)
-		fallbackPolicyLoader.On("GetPolicySet", ctx, mock.AnythingOfType("namer.ModuleID")).Return(&runtimev1.RunnablePolicySet{}, nil).Once()
+		fallbackPolicyLoader.On("GetFirstMatch", ctx, mock.AnythingOfType("[]namer.ModuleID")).Return(&runtimev1.RunnablePolicySet{}, nil).Once()
 
 		wrappedSourceStore := &Store{
 			log:                  zap.S(),
@@ -154,7 +154,7 @@ func TestFailover(t *testing.T) {
 		}
 
 		for i := 0; i < nRequests; i++ {
-			_, err := wrappedSourceStore.GetPolicySet(ctx, namer.GenModuleIDFromFQN("example"))
+			_, err := wrappedSourceStore.GetFirstMatch(ctx, []namer.ModuleID{namer.GenModuleIDFromFQN("example")})
 			if i < nFailures {
 				require.Error(t, err, "expected base store to return an error")
 			} else {
@@ -239,8 +239,8 @@ type MockPolicyLoader struct {
 	mock.Mock
 }
 
-func (m *MockPolicyLoader) GetPolicySet(ctx context.Context, id namer.ModuleID) (*runtimev1.RunnablePolicySet, error) {
-	args := m.Called(ctx, id)
+func (m *MockPolicyLoader) GetFirstMatch(ctx context.Context, candidates []namer.ModuleID) (*runtimev1.RunnablePolicySet, error) {
+	args := m.Called(ctx, candidates)
 	return args.Get(0).(*runtimev1.RunnablePolicySet), args.Error(1)
 }
 
@@ -282,8 +282,8 @@ type MockBinaryStore struct {
 	MockStore
 }
 
-func (m *MockBinaryStore) GetPolicySet(ctx context.Context, id namer.ModuleID) (*runtimev1.RunnablePolicySet, error) {
-	args := m.Called(ctx, id)
+func (m *MockBinaryStore) GetFirstMatch(ctx context.Context, candidates []namer.ModuleID) (*runtimev1.RunnablePolicySet, error) {
+	args := m.Called(ctx, candidates)
 	return args.Get(0).(*runtimev1.RunnablePolicySet), args.Error(1)
 }
 

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -127,6 +127,8 @@ type Store interface {
 type SourceStore interface {
 	Store
 	Subscribable
+	// GetFirstMatch searches for the given module IDs in order and returns the first one found.
+	GetFirstMatch(context.Context, []namer.ModuleID) (*policy.CompilationUnit, error)
 	// GetCompilationUnits gets the compilation units for the given module IDs.
 	GetCompilationUnits(context.Context, ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error)
 	// GetDependents returns the dependents of the given modules.
@@ -138,8 +140,8 @@ type SourceStore interface {
 // BinaryStore is implemented by stores that have pre-compiled policies in binary format.
 type BinaryStore interface {
 	Store
-	// GetPolicySet gets the compiled policy set identified by the given module ID.
-	GetPolicySet(context.Context, namer.ModuleID) (*runtimev1.RunnablePolicySet, error)
+	// GetFirstMatch searches for the given module IDs in order and returns the first one found.
+	GetFirstMatch(context.Context, []namer.ModuleID) (*runtimev1.RunnablePolicySet, error)
 }
 
 // MutableStore is a store that allows mutations.

--- a/internal/test/mocks/Index.go
+++ b/internal/test/mocks/Index.go
@@ -399,6 +399,60 @@ func (_c *Index_GetFiles_Call) RunAndReturn(run func() []string) *Index_GetFiles
 	return _c
 }
 
+// GetFirstMatch provides a mock function with given fields: _a0
+func (_m *Index) GetFirstMatch(_a0 []namer.ModuleID) (*policy.CompilationUnit, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *policy.CompilationUnit
+	var r1 error
+	if rf, ok := ret.Get(0).(func([]namer.ModuleID) (*policy.CompilationUnit, error)); ok {
+		return rf(_a0)
+	}
+	if rf, ok := ret.Get(0).(func([]namer.ModuleID) *policy.CompilationUnit); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*policy.CompilationUnit)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func([]namer.ModuleID) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Index_GetFirstMatch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFirstMatch'
+type Index_GetFirstMatch_Call struct {
+	*mock.Call
+}
+
+// GetFirstMatch is a helper method to define mock.On call
+//   - _a0 []namer.ModuleID
+func (_e *Index_Expecter) GetFirstMatch(_a0 interface{}) *Index_GetFirstMatch_Call {
+	return &Index_GetFirstMatch_Call{Call: _e.mock.On("GetFirstMatch", _a0)}
+}
+
+func (_c *Index_GetFirstMatch_Call) Run(run func(_a0 []namer.ModuleID)) *Index_GetFirstMatch_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]namer.ModuleID))
+	})
+	return _c
+}
+
+func (_c *Index_GetFirstMatch_Call) Return(_a0 *policy.CompilationUnit, _a1 error) *Index_GetFirstMatch_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Index_GetFirstMatch_Call) RunAndReturn(run func([]namer.ModuleID) (*policy.CompilationUnit, error)) *Index_GetFirstMatch_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListPolicyIDs provides a mock function with given fields: _a0
 func (_m *Index) ListPolicyIDs(_a0 context.Context) ([]string, error) {
 	ret := _m.Called(_a0)

--- a/internal/test/testdata/engine_lenient_scope_search/case_lenient_00.yaml
+++ b/internal/test/testdata/engine_lenient_scope_search/case_lenient_00.yaml
@@ -1,5 +1,5 @@
 ---
-description: "Scoped policy: missing policy"
+description: "Scoped policy: lenient search"
 inputs: [
   {
     "requestId": "test",
@@ -21,8 +21,8 @@ inputs: [
       }
     },
     "resource": {
-      "kind": "leave_request_x",
-      "scope": "acme.hr.fr",
+      "kind": "leave_request",
+      "scope": "acme.hr.uk.wales.cardiff",
       "id": "XX125",
       "attr": {
         "department": "marketing",
@@ -40,17 +40,24 @@ wantOutputs: [
     "resourceId": "XX125",
     "actions": {
       "view:public": {
-        "effect": "EFFECT_DENY",
-        "policy": "NO_MATCH"
+        "effect": "EFFECT_ALLOW",
+        "policy": "resource.leave_request.vdefault/acme.hr.uk",
+        "scope": "acme.hr"
       },
       "delete": {
-        "effect": "EFFECT_DENY",
-        "policy": "NO_MATCH"
+        "effect": "EFFECT_ALLOW",
+        "policy": "resource.leave_request.vdefault/acme.hr.uk",
+        "scope": "acme.hr.uk"
       },
       "create": {
-        "effect": "EFFECT_DENY",
-        "policy": "NO_MATCH"
+        "effect": "EFFECT_ALLOW",
+        "policy": "resource.leave_request.vdefault/acme.hr.uk",
+        "scope": "acme"
       }
-    }
+    },
+    "effectiveDerivedRoles": [
+      "any_employee",
+      "employee_that_owns_the_record"
+    ]
   }
 ]

--- a/internal/test/testdata/engine_lenient_scope_search/case_lenient_01.yaml
+++ b/internal/test/testdata/engine_lenient_scope_search/case_lenient_01.yaml
@@ -1,0 +1,101 @@
+---
+description: "Scoped principal policy: lenient scope search"
+inputs: [
+  {
+    "requestId": "test",
+    "actions": [
+      "view:public",
+      "delete"
+    ],
+    "principal": {
+      "id": "donald_duck",
+      "scope": "acme.hr.france.marseille",
+      "roles": [
+        "employee"
+      ],
+      "attr": {
+        "department": "marketing",
+        "geography": "GB",
+        "team": "design",
+        "managed_geographies": "GB"
+      }
+    },
+    "resource": {
+      "kind": "salary_record",
+      "id": "XX125",
+      "attr": {
+        "department": "marketing",
+        "geography": "GB",
+        "id": "XX125",
+        "owner": "john",
+        "team": "design"
+      }
+    }
+  },
+  {
+    "requestId": "test",
+    "actions": [
+      "approve",
+      "view:public"
+    ],
+    "principal": {
+      "id": "donald_duck",
+      "scope": "acme.hr",
+      "roles": [
+        "employee"
+      ],
+      "attr": {
+        "department": "marketing",
+        "geography": "GB",
+        "team": "design",
+        "managed_geographies": "GB"
+      }
+    },
+    "resource": {
+      "kind": "leave_request",
+      "id": "XX126",
+      "attr": {
+        "department": "marketing",
+        "geography": "GB",
+        "id": "XX125",
+        "owner": "mickey_mouse",
+        "team": "design",
+        "dev_record": true
+      }
+    }
+  }
+]
+wantOutputs: [
+  {
+    "requestId": "test",
+    "resourceId": "XX125",
+    "actions": {
+      "view:public": {
+        "effect": "EFFECT_ALLOW",
+        "policy": "principal.donald_duck.vdefault/acme.hr",
+        "scope": "acme.hr"
+      },
+      "delete": {
+        "effect": "EFFECT_DENY",
+        "policy": "principal.donald_duck.vdefault/acme.hr",
+        "scope": "acme"
+      }
+    }
+  },
+  {
+    "requestId": "test",
+    "resourceId": "XX126",
+    "actions": {
+      "approve": {
+        "effect": "EFFECT_DENY",
+        "policy": "principal.donald_duck.vdefault/acme.hr",
+        "scope": "acme"
+      },
+      "view:public": {
+        "effect": "EFFECT_DENY",
+        "policy": "principal.donald_duck.vdefault/acme.hr",
+        "scope": "acme"
+      }
+    }
+  }
+]


### PR DESCRIPTION
When configured with `--set=engine.lenientScopeSearch=true`, performs a
search down the scope tree until a policy is found. Originally, if the
request defined scope `a.b.c` a policy file with scope `a.b.c` had to
exist in the store. With this configuration if `a.b.c` doesn't exist,
the engine will try to load `a.b`, `a` and `` in that order.

Fixes #1587

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
