### PR TITLE
enhancement(helm): Allow deploying as a DaemonSet

### DIFF
--- a/deploy/charts/cerbos/templates/deployment.yaml
+++ b/deploy/charts/cerbos/templates/deployment.yaml
@@ -1,7 +1,13 @@
 {{- $tlsDisabled := (eq (include "cerbos.tlsSecretName" .) "None") -}}
 {{- $defaultHubDriverEnabled := (eq (include "cerbos.defaultHubDriverEnabled" .) "yes") -}}
 apiVersion: apps/v1
+{{- if eq .Values.type "deployment" }}
 kind: Deployment
+{{- else if eq .Values.type "daemonset" }}
+kind: DaemonSet
+{{- else }}
+{{- fail "valid values for .Values.type are deployment or daemonset" }}
+{{- end}}
 metadata:
   name: {{ include "cerbos.fullname" . }}
   labels:
@@ -12,7 +18,9 @@ metadata:
   {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
+  {{-   if eq .Values.type "deployment" }}
   replicas: {{ .Values.replicaCount }}
+  {{-   end }}
   {{- end }}
   selector:
     matchLabels:
@@ -41,6 +49,9 @@ spec:
       {{- with .Values.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{- .Values.priorityClassName }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/deploy/charts/cerbos/templates/hpa.yaml
+++ b/deploy/charts/cerbos/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if and .Values.autoscaling.enabled (eq .Values.type "deployment") }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/deploy/charts/cerbos/templates/service.yaml
+++ b/deploy/charts/cerbos/templates/service.yaml
@@ -16,6 +16,11 @@ spec:
   {{- with .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ . }}
   {{- end }}
+  {{- if .Values.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ .Values.service.internalTrafficPolicy }}
+  {{- else if eq .Values.type "daemonset" }}
+  internalTrafficPolicy: Local
+  {{- end }}
   ports:
     - port: {{ .Values.service.httpPort }}
       targetPort: http

--- a/deploy/charts/cerbos/values.yaml
+++ b/deploy/charts/cerbos/values.yaml
@@ -107,6 +107,12 @@ envFrom: []
 certManager:
   certSpec: {}
 
+# Kubernetes to to use
+type: deployment
+
+# PriorityClassName to set on deployed pods
+priorityClassName: ""
+
 # Cerbos service settings.
 service:
   type: ClusterIP
@@ -117,6 +123,9 @@ service:
   annotations: {}
   clusterIP: null
   loadBalancerIP: null
+  # Set the internalTrafficPolicy. If this is unset, and .Values.type
+  # is set to daemonset, this will default to "Local"
+  internalTrafficPolicy: ""
 
 # Cerbos deployment settings.
 cerbos:

--- a/deploy/charts/cerbos/values.yaml
+++ b/deploy/charts/cerbos/values.yaml
@@ -107,7 +107,7 @@ envFrom: []
 certManager:
   certSpec: {}
 
-# Kubernetes to to use
+# Kubernetes workload type to use. Valid values are `deployment` or `daemonset`.
 type: deployment
 
 # PriorityClassName to set on deployed pods

--- a/docs/modules/deployment/assets/images/daemonset_deployment.png
+++ b/docs/modules/deployment/assets/images/daemonset_deployment.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dde9ed239293138a215d1b08c87b5b3511d6672ec67cd76bcffe3108f86a3394
+size 293119

--- a/docs/modules/deployment/pages/index.adoc
+++ b/docs/modules/deployment/pages/index.adoc
@@ -23,3 +23,11 @@ image:sidecar_deployment.png[Sidecar model,role="center-img"]
 * Each application instance gets its own Cerbos instance — ensuring high performance and availability.
 * Upgrades to Cerbos would require a rolling update to all the application instances.
 * Policy updates could take slightly longer to propagate to all the individual application instances — resulting in a period where both the old and new policies are in effect at the same time.
+
+== DaemonSet model
+
+image:daemonset_deployment.png[DaemonSet model,role="center-img"]
+
+* Each cluster node gets its own Cerbos instance — ensuring high performance and efficient resource usage.
+* Policy updates must roll out to nodes individually — resulting in a period where both the old and new policies are in effect at the same time.
+* When deployed as a daemonset the service `internalTrafficPolicy` defaults to `Local`. This causes all requests to the service to be forced to the local node for minimum latency. Upgrades to Cerbos could result in application seeing a short outage to the cerbos instance on their own node, client retries may be neccessary. If this is unacceptable you can set `service.internalTrafficPolicy` to `Cluster`. You may be able to improve availability via the `service.kubernetes.io/topology-mode: Auto` annotation.

--- a/docs/modules/deployment/pages/k8s-daemonset.adoc
+++ b/docs/modules/deployment/pages/k8s-daemonset.adoc
@@ -1,0 +1,5 @@
+include::ROOT:partial$attributes.adoc[]
+
+= Deploy Cerbos as DaemonSet
+
+You can use the xref:ROOT:installation/helm.adoc[Cerbos Helm chart] to deploy Cerbos as a daemonset inside your Kubernetes cluster. Refer to the xref:ROOT:installation/helm.adoc[Helm chart instructions] for more details. 


### PR DESCRIPTION
#### Description

This adds support to the chart for deploying as a DaemonSet, and adds additional options
that are common in that scenario. The new settings are
- `type`: defaults to deployment, but can be set to daemonset
- `priorityClassName`: allows setting the pod priorityClassName
- `service.internalTrafficPolicy`: allows forcing traffic to this service to the local pod instance.

TODO:
- Not tested at all
- should add schema validation of the fields

Fixes cerbos/cerbos#1640

- [ ] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [ ] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
