### PR TITLE
chore: Remove deprecated field storeIdentifer

### DIFF
--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -168,8 +168,6 @@ func WithStoreIdentifier(p *policyv1.Policy, storeIdentifier string) *policyv1.P
 		p.Metadata = &policyv1.Metadata{}
 	}
 
-	//nolint:staticcheck
-	p.Metadata.StoreIdentifer = storeIdentifier // TODO: Remove this after deprecated StoreIdentifer no longer exists
 	p.Metadata.StoreIdentifier = storeIdentifier
 
 	return p


### PR DESCRIPTION
This PR removes the -misspelled- `storeIdentifer` field. It was deprecated in the PR: #1458 