### PR TITLE
chore(ci): Disable cache of Go installation for GolangCI

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -178,6 +178,7 @@ jobs:
         with:
           go-version: 1.20.x
           check-latest: true
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.6.0
         with:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,5 @@
 ---
 run:
-  go: "1.19"
   timeout: 300s
   skip-dirs:
     - "^api/"


### PR DESCRIPTION
Disable caching in the `setup-go` step.

Also removes the Go version config line from .golangci.yaml which would
then force golangci-lint to pick the Go version from `go.mod`.

https://github.com/golangci/golangci-lint/blob/043c368f2d6f5a4f5a46dcd1a14155cbc090ebdd/.golangci.reference.yml#L71-L74

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
