### PR TITLE
feat: Quit REPL when Ctrl-D is pressed on an empty prompt

### DIFF
--- a/cmd/cerbos/repl/repl.go
+++ b/cmd/cerbos/repl/repl.go
@@ -31,6 +31,7 @@ func (c *Cmd) Run(k *kong.Kong) error {
 	histFile := getHistoryFile(c.History)
 
 	reader := liner.NewLiner()
+	reader.SetCtrlCAborts(true)
 	reader.SetMultiLineMode(true)
 
 	defer func() {


### PR DESCRIPTION
This PR allows the REPL to be stopped by hitting <kbd>Ctrl</kbd>-<kbd>D</kbd> with an empty prompt, as well as the `:q`/`:quit`/`:exit` directives.

It also allows <kbd>Ctrl</kbd>-<kbd>C</kbd> to abort a partially-completed multiline prompt.