### PR TITLE
chore(e2e): Run govulncheck without verbose flag

### DIFF
--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Check vulnerabilities
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck -v ./...
+          govulncheck ./...
 
       - name: Notify Slack
         if: failure()


### PR DESCRIPTION
`govulncheck` doesn't seem to recognize the `-v` flag.

Related issue: https://github.com/golang/go/issues/61144