### PR TITLE
fix: Fix overlay e2e test caused by troublesome bitnami postgres image

### DIFF
--- a/e2e/overlay/helmfile.yaml
+++ b/e2e/overlay/helmfile.yaml
@@ -17,6 +17,13 @@ releases:
       e2e-run: '{{ requiredEnv "E2E_RUN_ID" }}'
       e2e-ctx: '{{ requiredEnv "E2E_CONTEXT_ID" }}'
     chart: bitnami/postgresql
+    # There were a few issues around version 12.6.1 of the postgresql image. It manifested here as problems related to
+    # duplicate kube namespaces (possibly due to being unable to clear up previous namespace between runs).
+    # Locking the version to a known working image.
+    # https://artifacthub.io/packages/helm/bitnami/postgresql
+    # https://github.com/bitnami/charts/commit/262f4f1d2906226cee8cabb49c8fedf97ecc30e4
+    # https://github.com/bitnami/charts/commit/d6234d8b8921470066e567832660164d84192975
+    version: 12.6.2
     hooks:
       - events: ["presync"]
         showlogs: true

--- a/e2e/overlay/helmfile.yaml
+++ b/e2e/overlay/helmfile.yaml
@@ -23,7 +23,7 @@ releases:
     # https://artifacthub.io/packages/helm/bitnami/postgresql
     # https://github.com/bitnami/charts/commit/262f4f1d2906226cee8cabb49c8fedf97ecc30e4
     # https://github.com/bitnami/charts/commit/d6234d8b8921470066e567832660164d84192975
-    version: 12.6.2
+    version: 12.6.0
     hooks:
       - events: ["presync"]
         showlogs: true

--- a/e2e/overlay/helmfile.yaml
+++ b/e2e/overlay/helmfile.yaml
@@ -17,8 +17,8 @@ releases:
       e2e-run: '{{ requiredEnv "E2E_RUN_ID" }}'
       e2e-ctx: '{{ requiredEnv "E2E_CONTEXT_ID" }}'
     chart: bitnami/postgresql
-    # There were a few issues around version 12.6.1 of the postgresql image. It manifested here as problems related to
-    # duplicate kube namespaces (possibly due to being unable to clear up previous namespace between runs).
+    # There were a few issues around versions 12.6.1->12.6.2 of the postgresql image. It manifested here as problems
+    # related to duplicate kube namespaces (possibly due to being unable to clear up previous namespace between runs).
     # Locking the version to a known working image.
     # https://artifacthub.io/packages/helm/bitnami/postgresql
     # https://github.com/bitnami/charts/commit/262f4f1d2906226cee8cabb49c8fedf97ecc30e4


### PR DESCRIPTION
A change to the [underlying postgres image](https://artifacthub.io/packages/helm/bitnami/postgresql) used in our e2e overlay test caused some errors related to duplicate namespaces with the `kubectl create namespace` command - perhaps (and I'm guessing here) due to being unable to teardown the namespace prior to generating it again on the next test. There were a few fixes for bugs appearing around version 12.6.1:

https://github.com/bitnami/charts/commit/262f4f1d2906226cee8cabb49c8fedf97ecc30e4
https://github.com/bitnami/charts/commit/d6234d8b8921470066e567832660164d84192975

Locking to this image version resolves this for now.


