### PR TITLE
chore(ci): Don't use built-in caching in setup-go action

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -31,6 +31,7 @@ runs:
       uses: actions/setup-go@v4
       with:
         go-version: 1.20.x
+        cache: false
         check-latest: true
 
     - name: Cache dependencies


### PR DESCRIPTION
When we upgraded to setup-go v4, caching was turned on by default. We don't need it because we manage the cache manually.