### PR TITLE
fix: Log request_id in the grpc "Handled request" log message

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -455,7 +455,7 @@ func (s *Server) mkGRPCServer(log *zap.Logger, auditLog audit.Log) (*grpc.Server
 			grpc_recovery.UnaryServerInterceptor(),
 			telemetryInt.UnaryServerInterceptor(),
 			grpc_validator.UnaryServerInterceptor(),
-			grpc_ctxtags.UnaryServerInterceptor(grpc_ctxtags.WithFieldExtractor(svc.ExtractRequestFields)),
+			grpc_ctxtags.UnaryServerInterceptor(grpc_ctxtags.WithFieldExtractorForInitialReq(svc.ExtractRequestFields)),
 			XForwardedHostUnaryServerInterceptor,
 			grpc_zap.UnaryServerInterceptor(log,
 				grpc_zap.WithDecider(loggingDecider),

--- a/internal/svc/helpers.go
+++ b/internal/svc/helpers.go
@@ -25,7 +25,17 @@ func ExtractRequestFields(fullMethod string, req any) map[string]any {
 	}
 
 	switch fullMethod {
-	case "/cerbos.vc.v1.CerbosService/CheckResourceSet":
+	case "/cerbos.svc.v1.CerbosService/CheckResources":
+		crsReq, ok := req.(*requestv1.CheckResourcesRequest)
+		if !ok || crsReq.RequestId == "" {
+			return nil
+		}
+
+		return map[string]any{
+			metaTagKey: map[string]string{requestIDTagKey: crsReq.RequestId},
+		}
+
+	case "/cerbos.svc.v1.CerbosService/CheckResourceSet":
 		crsReq, ok := req.(*requestv1.CheckResourceSetRequest)
 		if !ok || crsReq.RequestId == "" {
 			return nil
@@ -43,6 +53,16 @@ func ExtractRequestFields(fullMethod string, req any) map[string]any {
 
 		return map[string]any{
 			metaTagKey: map[string]string{requestIDTagKey: crbReq.RequestId},
+		}
+
+	case "/cerbos.svc.v1.CerbosService/PlanResources":
+		plReq, ok := req.(*requestv1.PlanResourcesRequest)
+		if !ok || plReq.RequestId == "" {
+			return nil
+		}
+
+		return map[string]any{
+			metaTagKey: map[string]string{requestIDTagKey: plReq.RequestId},
 		}
 
 	case "/cerbos.svc.v1.CerbosPlaygroundService/PlaygroundValidate":


### PR DESCRIPTION
fix: request_id is not logged in the "Handled request" log message (cerbos#1690)