### PR TITLE
chore(ci): Create PRs for Homebrew formula updates

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -192,11 +192,16 @@ docker_manifests:
       - "ghcr.io/cerbos/cerbosctl:dev-arm64"
 
 brews:
-  - tap:
+  - repository:
       owner: cerbos
       name: homebrew-tap
-      branch: main
+      branch: "release_{{ .Version }}"
       token: "{{ .Env.HOMEBREW_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+        base:
+          branch: main
+
     folder: Formula
     ids:
       - cerbos


### PR DESCRIPTION
Configure GoReleaser to create PRs instead of directly pushing to the
branch.

Also replaces the deprecated `tap` config with `repository`.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
