### PR TITLE
chore(docs): Ignore PlaygroundEnabled configuration flag

### DIFF
--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -87,7 +87,6 @@ server:
   httpListenAddr: ":3592" # Required. HTTPListenAddr is the dedicated HTTP address.
   logRequestPayloads: false # LogRequestPayloads defines whether the request payloads should be logged.
   metricsEnabled: true # MetricsEnabled defines whether the metrics endpoint is enabled.
-  playgroundEnabled: false # PlaygroundEnabled defines whether the playground API is enabled.
   requestLimits: # RequestLimits defines the limits for requests.
     maxActionsPerResource: 50 # MaxActionsPerResource sets the maximum number of actions that could be checked for a resource in a single request.
     maxResourcesPerRequest: 50 # MaxResourcesPerBatch sets the maximum number of resources that could be sent in a single request.

--- a/internal/server/conf.go
+++ b/internal/server/conf.go
@@ -63,7 +63,7 @@ type Conf struct {
 	// LogRequestPayloads defines whether the request payloads should be logged.
 	LogRequestPayloads bool `yaml:"logRequestPayloads" conf:",example=false"`
 	// PlaygroundEnabled defines whether the playground API is enabled.
-	PlaygroundEnabled bool `yaml:"playgroundEnabled" conf:",example=false"`
+	PlaygroundEnabled bool `yaml:"playgroundEnabled" conf:",ignore"`
 	// Advanced server settings.
 	Advanced AdvancedConf `yaml:"advanced"`
 }


### PR DESCRIPTION
Ignore `PlaygroundEnabled` flag while generating configuration docs.