### PR TITLE
enhancement(helm): Add ability to set clusterIP

### DIFF
--- a/deploy/charts/cerbos/templates/service.yaml
+++ b/deploy/charts/cerbos/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
   {{- with .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ . }}
   {{- end }}

--- a/deploy/charts/cerbos/values.yaml
+++ b/deploy/charts/cerbos/values.yaml
@@ -104,6 +104,7 @@ service:
   httpNodePort: 13592
   grpcNodePort: 13593
   annotations: {}
+  clusterIP: null
   loadBalancerIP: null
 
 # Cerbos deployment settings.


### PR DESCRIPTION
For headless services, `clusterIP` should be set to `None`.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
