### PR TITLE
fix: Evict policies from cache after disable or enable

### DIFF
--- a/internal/compile/manager.go
+++ b/internal/compile/manager.go
@@ -93,7 +93,7 @@ func (c *Manager) processUpdateQueue(ctx context.Context) {
 			case storage.EventReload:
 				c.log.Info("Purging compile cache")
 				c.cache.Purge()
-			case storage.EventAddOrUpdatePolicy, storage.EventDeletePolicy:
+			case storage.EventAddOrUpdatePolicy, storage.EventDeleteOrDisablePolicy:
 				if err := c.recompile(evt); err != nil {
 					c.log.Warnw("Error while processing storage event", "event", evt, "error", err)
 				}
@@ -106,7 +106,7 @@ func (c *Manager) processUpdateQueue(ctx context.Context) {
 
 func (c *Manager) recompile(evt storage.Event) error {
 	// if this is a delete event, remove the module from the cache
-	if evt.Kind == storage.EventDeletePolicy {
+	if evt.Kind == storage.EventDeleteOrDisablePolicy {
 		c.evict(evt.PolicyID)
 	}
 

--- a/internal/compile/manager_test.go
+++ b/internal/compile/manager_test.go
@@ -226,7 +226,7 @@ func TestManager(t *testing.T) {
 		require.NotNil(t, rps1)
 
 		// send event to trigger recompiliation
-		mockStore.subscriber.OnStorageEvent(storage.Event{Kind: storage.EventDeletePolicy, PolicyID: dr.ID})
+		mockStore.subscriber.OnStorageEvent(storage.Event{Kind: storage.EventDeleteOrDisablePolicy, PolicyID: dr.ID})
 
 		yield()
 

--- a/internal/storage/blob/store_test.go
+++ b/internal/storage/blob/store_test.go
@@ -195,7 +195,7 @@ func TestStore_updateIndex(t *testing.T) {
 		Kind: storage.EventAddOrUpdatePolicy,
 	}
 	deleteEvent := storage.Event{
-		Kind: storage.EventDeletePolicy,
+		Kind: storage.EventDeleteOrDisablePolicy,
 	}
 	store.idx = &mockIndex{
 		addOrUpdate: func(entry index.Entry) (storage.Event, error) {

--- a/internal/storage/db/internal/db.go
+++ b/internal/storage/db/internal/db.go
@@ -594,7 +594,7 @@ func (s *dbStorage) Disable(ctx context.Context, policyKey ...string) (uint32, e
 
 	events := make([]storage.Event, len(policyKey))
 	for i, pk := range policyKey {
-		events[i] = storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: namer.GenModuleIDFromFQN(namer.FQNFromPolicyKey(pk))}
+		events[i] = storage.NewPolicyEvent(storage.EventDeleteOrDisablePolicy, namer.GenModuleIDFromFQN(namer.FQNFromPolicyKey(pk)))
 	}
 	res, err := s.db.Update(PolicyTbl).Prepared(true).
 		Set(goqu.Record{PolicyTblDisabledCol: true}).
@@ -618,7 +618,7 @@ func (s *dbStorage) Enable(ctx context.Context, policyKey ...string) (uint32, er
 	events := make([]storage.Event, len(policyKey))
 	for idx, pk := range policyKey {
 		mIDs[idx] = namer.GenModuleIDFromFQN(namer.FQNFromPolicyKey(pk))
-		events[idx] = storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: namer.GenModuleIDFromFQN(namer.FQNFromPolicyKey(pk))}
+		events[idx] = storage.NewPolicyEvent(storage.EventAddOrUpdatePolicy, namer.GenModuleIDFromFQN(namer.FQNFromPolicyKey(pk)))
 	}
 
 	res, err := s.db.Update(PolicyTbl).Prepared(true).
@@ -647,7 +647,7 @@ func (s *dbStorage) Delete(ctx context.Context, ids ...namer.ModuleID) error {
 			return err
 		}
 
-		s.NotifySubscribers(storage.NewPolicyEvent(storage.EventDeletePolicy, ids[0]))
+		s.NotifySubscribers(storage.NewPolicyEvent(storage.EventDeleteOrDisablePolicy, ids[0]))
 
 		return nil
 	}
@@ -657,7 +657,7 @@ func (s *dbStorage) Delete(ctx context.Context, ids ...namer.ModuleID) error {
 
 	for i, id := range ids {
 		idList[i] = id
-		events[i] = storage.Event{Kind: storage.EventDeletePolicy, PolicyID: id}
+		events[i] = storage.Event{Kind: storage.EventDeleteOrDisablePolicy, PolicyID: id}
 	}
 	_, err := s.db.Delete(PolicyTbl).Prepared(true).
 		Where(goqu.C(PolicyTblIDCol).In(idList...)).

--- a/internal/storage/db/internal/tests.go
+++ b/internal/storage/db/internal/tests.go
@@ -272,7 +272,7 @@ func TestSuite(store DBStorage) func(*testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, have)
 
-			checkEvents(t, timeout, storage.Event{Kind: storage.EventDeletePolicy, PolicyID: rpx.ID})
+			checkEvents(t, timeout, storage.Event{Kind: storage.EventDeleteOrDisablePolicy, PolicyID: rpx.ID})
 		})
 
 		t.Run("add_schema", func(t *testing.T) {

--- a/internal/storage/disk/dirwatch_test.go
+++ b/internal/storage/disk/dirwatch_test.go
@@ -92,7 +92,7 @@ func TestDirWatch(t *testing.T) {
 		haveEntries := make(chan index.Entry, 8)
 		mockIdx.On("Delete", mock.Anything).Return(func(entry index.Entry) storage.Event {
 			haveEntries <- entry
-			return storage.Event{Kind: storage.EventDeletePolicy, PolicyID: entry.Policy.ID}
+			return storage.Event{Kind: storage.EventDeleteOrDisablePolicy, PolicyID: entry.Policy.ID}
 		}, nil)
 
 		checkEvents := storage.TestSubscription(subMgr)
@@ -111,7 +111,7 @@ func TestDirWatch(t *testing.T) {
 		// Check expectations
 		mockIdx.AssertExpectations(t)
 
-		wantEvent := storage.Event{Kind: storage.EventDeletePolicy}
+		wantEvent := storage.Event{Kind: storage.EventDeleteOrDisablePolicy}
 		checkEvents(t, timeOut, wantEvent)
 	})
 

--- a/internal/storage/git/store.go
+++ b/internal/storage/git/store.go
@@ -410,7 +410,7 @@ func (s *Store) updateIndex(ctx context.Context) error {
 			switch fromType {
 			case util.FileTypePolicy:
 				s.log.Debugf("Removing policy %s", fromPath)
-				if err := s.applyIndexUpdate(c.From, storage.EventDeletePolicy); err != nil {
+				if err := s.applyIndexUpdate(c.From, storage.EventDeleteOrDisablePolicy); err != nil {
 					return err
 				}
 

--- a/internal/storage/git/store_test.go
+++ b/internal/storage/git/store_test.go
@@ -336,7 +336,7 @@ func TestUpdateStore(t *testing.T) {
 
 		wantEvents := make([]storage.Event, 0, len(pset))
 		for _, p := range pset {
-			wantEvents = append(wantEvents, storage.Event{Kind: storage.EventDeletePolicy, PolicyID: namer.GenModuleID(p)})
+			wantEvents = append(wantEvents, storage.Event{Kind: storage.EventDeleteOrDisablePolicy, PolicyID: namer.GenModuleID(p)})
 		}
 
 		checkEvents(t, timeout, wantEvents...)
@@ -390,7 +390,7 @@ func TestUpdateStore(t *testing.T) {
 
 		wantEvents := make([]storage.Event, 0, len(pset))
 		for _, p := range pset {
-			wantEvents = append(wantEvents, storage.Event{Kind: storage.EventDeletePolicy, PolicyID: namer.GenModuleID(p)})
+			wantEvents = append(wantEvents, storage.Event{Kind: storage.EventDeleteOrDisablePolicy, PolicyID: namer.GenModuleID(p)})
 			wantEvents = append(wantEvents, storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: namer.GenModuleID(p)})
 		}
 
@@ -435,7 +435,7 @@ func TestUpdateStore(t *testing.T) {
 
 		wantEvents := make([]storage.Event, 0, len(pset))
 		for _, p := range pset {
-			wantEvents = append(wantEvents, storage.Event{Kind: storage.EventDeletePolicy, PolicyID: namer.GenModuleID(p)})
+			wantEvents = append(wantEvents, storage.Event{Kind: storage.EventDeleteOrDisablePolicy, PolicyID: namer.GenModuleID(p)})
 		}
 
 		checkEvents(t, timeout, wantEvents...)

--- a/internal/storage/index/index.go
+++ b/internal/storage/index/index.go
@@ -336,7 +336,7 @@ func (idx *index) Delete(entry Entry) (storage.Event, error) {
 		// nothing to do because we don't have that file in the index.
 		return storage.Event{Kind: storage.EventNop}, nil
 	}
-	evt := storage.NewPolicyEvent(storage.EventDeletePolicy, modID)
+	evt := storage.NewPolicyEvent(storage.EventDeleteOrDisablePolicy, modID)
 
 	// go through the dependencies and remove self from the dependents list for each dependency.
 	if deps, ok := idx.dependencies[modID]; ok {

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -189,7 +189,7 @@ type EventKind int
 
 const (
 	EventAddOrUpdatePolicy EventKind = iota
-	EventDeletePolicy
+	EventDeleteOrDisablePolicy
 	EventAddOrUpdateSchema
 	EventDeleteSchema
 	EventReload
@@ -210,8 +210,8 @@ func (evt Event) String() string {
 	switch evt.Kind {
 	case EventAddOrUpdatePolicy:
 		kind = "ADD/UPDATE"
-	case EventDeletePolicy:
-		kind = "DELETE"
+	case EventDeleteOrDisablePolicy:
+		kind = "DELETE/DISABLE"
 	case EventAddOrUpdateSchema:
 		kind = "ADD/UPDATE SCHEMA"
 		id = evt.SchemaFile


### PR DESCRIPTION
- Fixes the problem with `Disable` and `Enable`. (resolves #1710) 