### PR TITLE
docs: Stop building docs for older versions

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -9,7 +9,7 @@ site:
 content:
   sources:
     - url: ./../
-      branches: [HEAD, 'v*', '!v0.[0-25].*']
+      branches: [HEAD, 'v*', '!v0.{0..25}']
       edit_url: 'https://github.com/cerbos/cerbos/tree/main/{path}'
       start_path: docs
     - url: https://github.com/cerbos/cloud-docs.git

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -9,8 +9,8 @@ site:
 content:
   sources:
     - url: ./../
-      branches: [HEAD, 'v*']
-      edit_url: 'https://github.com/cerbos/cerbos/tree/{refname}/{path}'
+      branches: [HEAD, 'v*', '!v0.[0-25].*']
+      edit_url: 'https://github.com/cerbos/cerbos/tree/main/{path}'
       start_path: docs
     - url: https://github.com/cerbos/cloud-docs.git
 urls:

--- a/docs/modules/policies/pages/derived_roles.adoc
+++ b/docs/modules/policies/pages/derived_roles.adoc
@@ -60,6 +60,6 @@ derivedRoles:
       condition:
         match:
           expr: P.attr.isWearingBatCostume
----
+----
 
 ****

--- a/docs/modules/recipes/pages/orm/prisma/index.adoc
+++ b/docs/modules/recipes/pages/orm/prisma/index.adoc
@@ -18,7 +18,7 @@ Note that whilst authentication is out of scope of this article, Cerbos is compa
 
 You can find the Github repo for this tutorial  https://github.com/cerbos/express-prisma-cerbos/[here].
 
-=== Setting up Prisma
+== Setting up Prisma
 
 To get started, we need to install our various dependencies. Copy and run the following:
 
@@ -165,7 +165,7 @@ Now, to initialize our DB, generate the Prisma client and seed the database, run
 npx prisma migrate dev --name init
 ----
 
-=== Creating an access policy
+== Creating an access policy
 
 NOTE: We will be using a Docker container to run the Cerbos PDP instance, so ensure that you have https://docs.docker.com/get-docker/[Docker] set up first!
 
@@ -191,7 +191,7 @@ resourcePolicy:
   - actions: ["*"]
     effect: EFFECT_ALLOW
     roles:
-      - admin    
+      - admin
 
   # Users in the Sales department can read and create contacts
   - actions: ["read", "create"]
@@ -249,7 +249,7 @@ If everything is correct, we should see the following output:
 2022-12-07T16:43:40.632Z        INFO    cerbos.grpc     Starting gRPC server at :3593
 ----
 
-=== Setting up the server
+== Setting up the server
 
 Having now set up both our Cerbos policy and our Prisma database, it is time to implement our web server. For this example we will be using Express to set up a simple server running on port 3000. We will also import our Prisma and Cerbos clients which we will use later on.
 
@@ -303,7 +303,7 @@ app.get("/contacts/:id", async ({ params }, res) => {
 });
 ----
 
-=== Authorizing requests
+== Authorizing requests
 
 With our policy defined, we can call Cerbos from our request handler to authorize the principal to take the action on the resource.
 
@@ -369,7 +369,7 @@ In this case, we are only checking a single contact using the `checkResource` me
 
 Once we get the response back from Cerbos, calling the `.isAllowed` method for the required action (and optionally, the given resource ID in the `checkResources` case) will return a simple boolean of whether the user is authorized or not. Using this, we can either return the contact or throw an `HTTP 403 Unauthorized` response.
 
-=== The query planner
+== The query planner
 
 If we provide Cerbos with a `principal`, a description of the `resource` they're trying to access and the required `action`, we can ask it for a query plan.
 
@@ -449,7 +449,7 @@ We can then use the https://github.com/cerbos/query-plan-adapters/blob/main/pris
 
 In the case that the result `kind` is not `ALWAYS_DENIED`, we retrieve the filters from the adapter instance, and use them to construct a query using the Prisma ORM.
 
-=== Trying it out
+== Trying it out
 
 Run the Cerbos PDP, as described above, and separately, fire up the node server as follows:
 
@@ -466,7 +466,7 @@ curl -i http://localhost:3000/contacts/1
 curl -i http://localhost:3000/contacts
 ----
 
-=== Conclusion
+== Conclusion
 
 Through this simple example, we have used Primsa as our ORM to create a REST API which is authorized using Cerbos for a simple CRM system. This can be built upon to add more complex requirements, for example:
 

--- a/docs/modules/recipes/pages/orm/sqlalchemy/index.adoc
+++ b/docs/modules/recipes/pages/orm/sqlalchemy/index.adoc
@@ -10,11 +10,11 @@ Perhaps, in your case, a lot of the computational "heavy lifting" is done by the
 
 Regardless, there's _many_ ways to build an application (as the common idiom doesn't go). Application design is a vast and complex process, but one thing we can do to make that process more manageable is to use tools that take a lot of the implementation complexity away...
 
-=== Enter SQLAlchemy
+== Enter SQLAlchemy
 
 https://www.sqlalchemy.org/[SQLAlchemy] has established itself as one of the standards in database abstraction layers in the Python world. It offers two distinct ways of communicating with the DB; via it's lower-level `Core` SQL abstraction toolkit, or via it's `ORM` component, which extends `Core` to offer some convenient, higher-level abstractions.
 
-=== What we're building
+== What we're building
 
 In this run-through, we'll be building an application that manages a "Contact directory", enabling users to keep track of their contacts, along with useful information such as employment information (current company etc).
 


### PR DESCRIPTION
Exclude versions before 0.26 as they are quite old and slow down the
build process for not much benefit.

Also fixes some of the warnings from Antora on the `main` branch.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
