### PR TITLE
enhancement(helm): Allow an image digest to be provided instead of a tag

### DIFF
--- a/deploy/charts/cerbos/templates/_helpers.tpl
+++ b/deploy/charts/cerbos/templates/_helpers.tpl
@@ -154,3 +154,16 @@ Detect if bundle driver is used with default config
 {{- $isDefaultCache := (eq (dig "config" "storage" "bundle" "remote" "cacheDir" "<not_defined>" .Values.cerbos) "<not_defined>") -}}
 {{- if (and $isBundleDriver $isDefaultTmp $isDefaultCache) -}}yes{{- else -}}no{{- end -}}
 {{- end }}
+
+{{/*
+The image reference to use in pods
+*/}}
+{{- define "cerbos.image" -}}
+"{{ .Values.image.repository }}
+{{- with .Values.image.digest -}}
+@{{ . }}
+{{- else -}}
+:{{ .Values.image.tag | default .Chart.AppVersion }}
+{{- end -}}
+"
+{{- end }}

--- a/deploy/charts/cerbos/templates/deployment.yaml
+++ b/deploy/charts/cerbos/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "cerbos.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "server"

--- a/deploy/charts/cerbos/values.yaml
+++ b/deploy/charts/cerbos/values.yaml
@@ -12,6 +12,8 @@ replicaCount: 1
 image:
   repository: ghcr.io/cerbos/cerbos
   pullPolicy: IfNotPresent
+  # Image digest to use. Takes precedence over tag if specified.
+  digest: ""
   # Image tag to use. Defaults to the chart appVersion.
   tag: ""
 


### PR DESCRIPTION
This PR adds an `image.digest` value to the Helm chart, to support pinning the image to a digest rather than a tag. This is particularly useful for deploying a specific prerelease version rather than tracking the `dev` tag.