### PR TITLE
chore(ci): Publish prerelease images tagged by commit hash

### DIFF
--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -77,6 +77,8 @@ jobs:
         run: |
           docker push ghcr.io/cerbos/cerbos:dev-amd64
           docker push ghcr.io/cerbos/cerbos:dev-arm64
+          docker manifest create ghcr.io/cerbos/cerbos:${{ github.sha }} ghcr.io/cerbos/cerbos:dev-arm64 ghcr.io/cerbos/cerbos:dev-amd64
+          docker manifest push ghcr.io/cerbos/cerbos:${{ github.sha }}
           docker manifest create ghcr.io/cerbos/cerbos:dev ghcr.io/cerbos/cerbos:dev-arm64 ghcr.io/cerbos/cerbos:dev-amd64
           docker manifest push ghcr.io/cerbos/cerbos:dev
 
@@ -84,6 +86,8 @@ jobs:
         run: |
           docker push ghcr.io/cerbos/cerbosctl:dev-amd64
           docker push ghcr.io/cerbos/cerbosctl:dev-arm64
+          docker manifest create ghcr.io/cerbos/cerbosctl:${{ github.sha }} ghcr.io/cerbos/cerbosctl:dev-arm64 ghcr.io/cerbos/cerbosctl:dev-amd64
+          docker manifest push ghcr.io/cerbos/cerbosctl:${{ github.sha }}
           docker manifest create ghcr.io/cerbos/cerbosctl:dev ghcr.io/cerbos/cerbosctl:dev-arm64 ghcr.io/cerbos/cerbosctl:dev-amd64
           docker manifest push ghcr.io/cerbos/cerbosctl:dev
 


### PR DESCRIPTION
At the moment, the only way to pin to a specific prerelease version is to use the image digest, which is difficult to trace back to the source commit.

This PR updates the snapshots workflow to push prerelease images tagged with the commit hash as well as `dev`.