### PR TITLE
docs(backport): Remove deprecated endpoint/rpc (#1734)

### DIFF
--- a/docs/modules/api/pages/index.adoc
+++ b/docs/modules/api/pages/index.adoc
@@ -2,7 +2,7 @@ include::ROOT:partial$attributes.adoc[]
 
 = The Cerbos API
 
-The main API endpoint for making policy decisions is the `/api/check` REST endpoint (`cerbos.svc.v1.CerbosService/CheckResourceSet` RPC in the gRPC API). You can view the latest API documentation from a running Cerbos instance by accessing the root directory of the HTTP endpoint using a browser.
+The main API endpoint for making policy decisions is the `/api/check/resources` REST endpoint (`cerbos.svc.v1.CerbosService/CheckResources` RPC in the gRPC API). You can view the latest API documentation from a running Cerbos instance by accessing the root directory of the HTTP endpoint using a browser.
 
 [source,sh,subs="attributes"]
 ----


### PR DESCRIPTION
Backports #1734 to `v0.29`