### PR TITLE
chore(ci): Use experimental 'loopvar' released with Go 1.21

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -30,7 +30,7 @@ runs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
         cache: false
         check-latest: true
 

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -105,6 +105,8 @@ jobs:
       - name: Test
         run: make test-all TESTSPLIT_INDEX=${{ strategy.job-index }} TESTSPLIT_TOTAL=${{ strategy.job-total }}
         env:
+          GOEXPERIMENT: loopvar # https://github.com/golang/go/wiki/LoopvarExperiment
+          CERBOS_LOG_LEVEL: "debug"
           CERBOS_TEST_LOG_LEVEL: "debug"
           CERBOS_DEBUG_DB: "true"
           CERBOS_DEBUG_ENGINE: "true"
@@ -193,7 +195,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
           cache: false
       - name: golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ test-all: test-race test-integration
 
 .PHONY: test
 test: $(GOTESTSUM)
-	@ CGO_ENABLED=0 $(GOTESTSUM) -- -tags=tests $(COVERPROFILE) -cover ./...
+	@ CGO_ENABLED=0 GOEXPERIMENT=loopvar $(GOTESTSUM) -- -tags=tests $(COVERPROFILE) -cover ./...
 
 .PHONY: test-race
 test-race: $(GOTESTSUM) $(TESTSPLIT)
@@ -113,7 +113,7 @@ coverage:
 
 .PHONY: compile
 compile:
-	@ CGO_ENABLED=0 go build ./... && CGO_ENABLED=0 go test -tags="tests e2e" -run=ignore  ./... > /dev/null
+	@ CGO_ENABLED=0 GOEXPERIMENT=loopvar go build ./... && CGO_ENABLED=0 go test -tags="tests e2e" -run=ignore  ./... > /dev/null
 
 .PHONY: pre-commit
 pre-commit: lint-helm generate lint test-all


### PR DESCRIPTION
[Go 1.21](https://go.dev/doc/go1.21) released, and introduces a preview of a language change that could find its place in the newer versions: [LoopvarExperiment](https://go.dev/wiki/LoopvarExperiment)

This PR enables this experimental change in the CI. Also, it changes `CERBOS_LOG_LEVEL` to `DEBUG` for the tests.