### PR TITLE
docs: Update examples for handling expressions beginning with quote

### DIFF
--- a/docs/modules/policies/pages/conditions.adoc
+++ b/docs/modules/policies/pages/conditions.adoc
@@ -32,11 +32,11 @@ Every condition expression must evaluate to a boolean true/false value. You can 
 
 .Quotes in expressions
 ****
-Because single and double quotes have special meanings in YAML, if your expression contains quotation marks, use the YAML literal block syntax to avoid YAML parsing errors.
+Single and double quotes have special meanings in YAML. If your expression contains quotes, use the YAML block syntax to avoid parsing errors.
 
 [source,yaml]
 ----
-expr: |
+expr: >
   "GB" in R.attr.geographies
 ----  
 ****

--- a/docs/modules/policies/pages/conditions.adoc
+++ b/docs/modules/policies/pages/conditions.adoc
@@ -14,7 +14,8 @@ condition:
     all:
       of:
         - expr: request.resource.attr.status == "PENDING_APPROVAL"
-        - expr: "GB" in request.resource.attr.geographies
+        - expr: >
+            "GB" in request.resource.attr.geographies
 ----
 
 Within a condition block you have access to several special variables:
@@ -28,6 +29,8 @@ Within a condition block you have access to several special variables:
 `G`:: An alias for `globals` for accessing the global variables object.
 
 Every condition expression must evaluate to a boolean true/false value. You can combine complex expressions together in a single condition block by using the `all`, `any`, or `none` operators.
+
+TIP: If the condition starts with a quotation mark, then it needs to be moved to a new line via the `>` syntax in the example above.
 
 .Single boolean expression
 [source,yaml,linenums]
@@ -45,7 +48,8 @@ condition:
     all:
       of:
         - expr: R.attr.status == "PENDING_APPROVAL"
-        - expr: "GB" in R.attr.geographies
+        - expr: >
+            "GB" in R.attr.geographies
         - expr: P.attr.geography == "GB"
 ----
 
@@ -57,7 +61,8 @@ condition:
     any:
       of:
         - expr: R.attr.status == "PENDING_APPROVAL"
-        - expr: "GB" in R.attr.geographies
+        - expr: >
+            "GB" in R.attr.geographies
         - expr: P.attr.geography == "GB"
 ----
 
@@ -70,7 +75,8 @@ condition:
     none:
       of:
         - expr: R.attr.status == "PENDING_APPROVAL"
-        - expr: "GB" in R.attr.geographies
+        - expr: >
+            "GB" in R.attr.geographies
         - expr: P.attr.geography == "GB"
 ----
 

--- a/docs/modules/policies/pages/conditions.adoc
+++ b/docs/modules/policies/pages/conditions.adoc
@@ -30,7 +30,7 @@ Within a condition block you have access to several special variables:
 
 Every condition expression must evaluate to a boolean true/false value. You can combine complex expressions together in a single condition block by using the `all`, `any`, or `none` operators.
 
-TIP: If the condition starts with a quotation mark, then it needs to be moved to a new line via the `>` syntax in the example above.
+TIP: If the expression starts with a quotation mark, then it needs to be moved to a new line via the `>` syntax in the example above.
 
 .Single boolean expression
 [source,yaml,linenums]

--- a/docs/modules/policies/pages/conditions.adoc
+++ b/docs/modules/policies/pages/conditions.adoc
@@ -30,7 +30,16 @@ Within a condition block you have access to several special variables:
 
 Every condition expression must evaluate to a boolean true/false value. You can combine complex expressions together in a single condition block by using the `all`, `any`, or `none` operators.
 
-TIP: If the expression starts with a quotation mark, then it needs to be moved to a new line via the `>` syntax in the example above.
+.Quotes in expressions
+****
+Because single and double quotes have special meanings in YAML, if your expression contains quotation marks, use the YAML literal block syntax to avoid YAML parsing errors.
+
+[source,yaml]
+----
+expr: |
+  "GB" in R.attr.geographies
+----  
+****
 
 .Single boolean expression
 [source,yaml,linenums]


### PR DESCRIPTION
Updates example conditions and add a tip explaining why