### PR TITLE
chore(ci): Always run `upload-test-times` after `test`

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -131,10 +131,14 @@ jobs:
 
   upload-test-times:
     needs: test
+    if: ${{ always() && needs.test.result != 'skipped' }}
     name: Upload test times
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Check test results
+        run: test "${{ needs.test.result }}" = "success"
+
       - name: Checkout code
         uses: actions/checkout@v3
 


### PR DESCRIPTION
The `upload-test-times` job is currently being skipped if a `test` job fails, which means the required PR check is ignored.

This PR ensures that the `upload-test-time` job runs if the `test` jobs run, and that it fails if the tests failed.