### PR TITLE
chore(ci): Upload test coverage from snapshot builds

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,12 +51,6 @@ jobs:
           E2E_SKIP_CLUSTER: "true"
           E2E_NO_CLEANUP: "true"
 
-      - name: Upload coverage to Coveralls
-        uses: shogo82148/actions-goveralls@v1
-        with:
-          path-to-profile: e2e.cover
-          flag-name: e2e
-
       - name: Notify Slack
         if: failure()
         env:

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -57,11 +57,17 @@ jobs:
       - name: Test
         run: make test-all
 
-      - name: Upload to CodeCov
-        uses: codecov/codecov-action@v3
+      - name: Upload unit coverage to Coveralls
+        uses: shogo82148/actions-goveralls@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: "unit.cover,integration.cover"
+          path-to-profile: unit.cover
+          flag-name: unit-main
+
+      - name: Upload integration coverage to Coveralls
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: integration.cover
+          flag-name: integration-main
 
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -30,7 +30,7 @@ run_tests() {
     (
         cd "$SCRIPT_DIR"
         telepresence helm upgrade
-        telepresence connect --no-report -- go test -v -failfast -p=1 -cover -coverprofile=../e2e.cover --tags="tests e2e" "$@"
+        telepresence connect --no-report -- go test -v -failfast -p=1 --tags="tests e2e" "$@"
     )
 }
 


### PR DESCRIPTION
Also removes the E2E upload because we need to build a special binary to
capture E2E coverage (#1763).

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
