### PR TITLE
enhancement: Configuration to disable API explorer

### DIFF
--- a/cmd/cerbos/repl/internal/repl.go
+++ b/cmd/cerbos/repl/internal/repl.go
@@ -440,7 +440,7 @@ func (r *REPL) loadPolicy(path string) error {
 	case *policyv1.Policy_ExportVariables:
 		r.varExports[pt.ExportVariables.Name] = pt.ExportVariables.Definitions
 	case *policyv1.Policy_ResourcePolicy:
-		ph.variables, err = r.mergeVariableDefinitions(ph.key, pt.ResourcePolicy.Variables, p.Variables)
+		ph.variables, err = r.mergeVariableDefinitions(ph.key, pt.ResourcePolicy.Variables, p.Variables) //nolint:staticcheck
 		if err != nil {
 			return err
 		}
@@ -451,7 +451,7 @@ func (r *REPL) loadPolicy(path string) error {
 			}
 		}
 	case *policyv1.Policy_DerivedRoles:
-		ph.variables, err = r.mergeVariableDefinitions(ph.key, pt.DerivedRoles.Variables, p.Variables)
+		ph.variables, err = r.mergeVariableDefinitions(ph.key, pt.DerivedRoles.Variables, p.Variables) //nolint:staticcheck
 		if err != nil {
 			return err
 		}
@@ -462,7 +462,7 @@ func (r *REPL) loadPolicy(path string) error {
 			}
 		}
 	case *policyv1.Policy_PrincipalPolicy:
-		ph.variables, err = r.mergeVariableDefinitions(ph.key, pt.PrincipalPolicy.Variables, p.Variables)
+		ph.variables, err = r.mergeVariableDefinitions(ph.key, pt.PrincipalPolicy.Variables, p.Variables) //nolint:staticcheck
 		if err != nil {
 			return err
 		}

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -83,6 +83,7 @@ server:
     allowedOrigins: ['*'] # AllowedOrigins is the contents of the allowed-origins header.
     disabled: false # Disabled sets whether CORS is disabled.
     maxAge: 10s # MaxAge is the max age of the CORS preflight check.
+  disableAPIExplorer: false # DisableAPIExplorer disables the API explorer UI from being served on the HTTP port.
   grpcListenAddr: ":3593" # Required. GRPCListenAddr is the dedicated GRPC address.
   httpListenAddr: ":3592" # Required. HTTPListenAddr is the dedicated HTTP address.
   logRequestPayloads: false # LogRequestPayloads defines whether the request payloads should be logged.

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -462,7 +462,7 @@ func compileAllVariables(modCtx *moduleCtx, variables *policyv1.Variables) map[s
 	}
 
 	addVariables(modCtx, results, sources, variables.GetLocal(), "policy local variables")
-	addVariables(modCtx, results, sources, modCtx.def.Variables, "top-level policy variables (deprecated)")
+	addVariables(modCtx, results, sources, modCtx.def.Variables, "top-level policy variables (deprecated)") //nolint:staticcheck
 
 	for name, definedIn := range sources {
 		var definedInMsg string

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -218,6 +218,7 @@ func WithStoreIdentifier(p *policyv1.Policy, storeIdentifier string) *policyv1.P
 		p.Metadata = &policyv1.Metadata{}
 	}
 
+	//nolint:staticcheck
 	p.Metadata.StoreIdentifer = storeIdentifier // TODO: Remove this after deprecated StoreIdentifer no longer exists
 	p.Metadata.StoreIdentifier = storeIdentifier
 

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -107,6 +107,7 @@ func validateDerivedRoles(dr *policyv1.DerivedRoles) (err error) {
 }
 
 func validateExportVariables(p *policyv1.Policy) error {
+	//nolint:staticcheck
 	if len(p.Variables) > 0 {
 		return fmt.Errorf("export variables policies do not support the deprecated top-level variables field")
 	}

--- a/internal/server/conf.go
+++ b/internal/server/conf.go
@@ -64,6 +64,8 @@ type Conf struct {
 	LogRequestPayloads bool `yaml:"logRequestPayloads" conf:",example=false"`
 	// PlaygroundEnabled defines whether the playground API is enabled.
 	PlaygroundEnabled bool `yaml:"playgroundEnabled" conf:",ignore"`
+	// DisableAPIExplorer disables the API explorer UI from being served on the HTTP port.
+	DisableAPIExplorer bool `yaml:"disableAPIExplorer" conf:",example=false"`
 	// Advanced server settings.
 	Advanced AdvancedConf `yaml:"advanced"`
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -539,7 +539,9 @@ func (s *Server) startHTTPServer(ctx context.Context, l net.Listener, grpcSrv *g
 		cerbosMux.PathPrefix(zpagesEndpoint).Handler(hm)
 	}
 
-	cerbosMux.HandleFunc("/", schema.ServeUI)
+	if !s.conf.DisableAPIExplorer {
+		cerbosMux.HandleFunc("/", schema.ServeUI)
+	}
 
 	httpHandler := withCORS(s.conf, cerbosMux)
 


### PR DESCRIPTION
Several users have asked whether it's possible to disable the API
explorer UI. This PR adds a configuration option to disable it.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
