### PR TITLE
chore: Update Go to v1.20

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Submitting pull requests
 - Run the pre-commit checks that are appropriate for the kind of change. (See below for details.)
 - Submit your pull request.
     - We require all pull requests to follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
-    - Use [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to link the PR to the original issue. 
+    - Use [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to link the PR to the original issue.
     - At least one approval from a maintainer is required to merge the pull request.
 
 
@@ -33,7 +33,7 @@ Submitting pull requests
 - Add tests to cover the functionality you are adding or modifying.
 - Add new documentation or update existing content to ensure that the documentation stays consistent with the change you are introducing. See [below](#submitting-pull-requests-for-documentation-changes) for tips on writing documentation.
 - Avoid introducing new dependencies if possible. All dependencies must have an appropriate open source licence (Apache-2.0, BSD, MIT).
-- Make sure your code is `gofmt`ed. Run `make lint` and fix any warnings produced by the linter. 
+- Make sure your code is `gofmt`ed. Run `make lint` and fix any warnings produced by the linter.
 - Sign-off your commits to provide a [DCO](https://developercertificate.org). You can do this by adding the `-s` flag to your `git commit` command.
     ```sh
     git commit -s -m 'bug: Fix for bug X'
@@ -53,7 +53,7 @@ Submitting pull requests
 Developing Cerbos
 -----------------
 
-Cerbos is developed using the [Go programming language](https://golang.org). We currently require Go 1.19.x for development.
+Cerbos is developed using the [Go programming language](https://golang.org). We currently require Go 1.20.x for development.
 
 The `Makefile` automatically installs required build tools using the versions defined in `tools/go.mod`. Run `make clean-tools` to clear the cache and force the installation of new versions.
 
@@ -61,7 +61,7 @@ Useful `make` targets:
 
 - `make build`: Compile, test and build the Cerbos binaries and container. Binaries will be output to the `dist` directory. The container name would be `ghcr.io/cerbos/cerbos:<VERSION>-prerelease`.
 - `make pre-commit`: Run tests, lint, and generate code and documentation. Run this before submitting a PR to make sure your code is ready to submit.
-- `make dev-server`: Start a Cerbos server 
+- `make dev-server`: Start a Cerbos server
 - `make docs`: Generate docs and preview in browser.
 
 

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ confdocs:
 
 .PHONY: deps
 deps:
-	@ go mod tidy -compat=1.19
+	@ go mod tidy -compat=1.20
 
 .PHONY: test-all
 test-all: test-race test-integration

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cerbos/cerbos
 
-go 1.19
+go 1.20
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2

--- a/hack/tools/protoc-gen-jsonschema/go.mod
+++ b/hack/tools/protoc-gen-jsonschema/go.mod
@@ -1,6 +1,6 @@
 module github.com/cerbos/cerbos/hack/tools/protoc-gen-jsonschema
 
-go 1.19
+go 1.20
 
 require (
 	github.com/envoyproxy/protoc-gen-validate v1.0.2

--- a/hack/tools/testsplit/go.mod
+++ b/hack/tools/testsplit/go.mod
@@ -1,6 +1,6 @@
 module github.com/cerbos/cerbos/hack/tools/testsplit
 
-go 1.19
+go 1.20
 
 require (
 	github.com/alecthomas/kong v0.8.0

--- a/internal/storage/git/store.go
+++ b/internal/storage/git/store.go
@@ -445,12 +445,11 @@ func (s *Store) normalizePath(path string) (string, util.IndexedFileType) {
 	}
 
 	if s.subDir != "." {
-		relativePath := strings.TrimPrefix(path, s.subDir+"/")
-		if path == relativePath { // not in policies directory
+		var ok bool
+		path, ok = strings.CutPrefix(path, s.subDir+"/")
+		if !ok { // not in policies directory
 			return path, util.FileTypeNotIndexed
 		}
-
-		path = relativePath
 	}
 
 	fileType := util.FileType(path)

--- a/internal/util/filesystem.go
+++ b/internal/util/filesystem.go
@@ -224,10 +224,10 @@ func FileType(path string) IndexedFileType {
 // and a flag to indicate whether the path was actually contained in that directory.
 // The path must be "/"-separated and relative to the root policies directory.
 func RelativeSchemaPath(path string) (string, bool) {
-	schemaPath := strings.TrimPrefix(path, SchemasDirectory+"/")
-	if schemaPath == path {
-		return "", false
+	schemaPath, ok := strings.CutPrefix(path, SchemasDirectory+"/")
+	if !ok {
+		schemaPath = ""
 	}
 
-	return schemaPath, true
+	return schemaPath, ok
 }

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/cerbos/cerbos/tools
 
-go 1.19
+go 1.20
 
 require (
 	github.com/bojand/ghz v0.117.0


### PR DESCRIPTION
Go 1.19 is no longer supported now that 1.21 is out. We already use 1.20 in CI, so this PR updates the version in go.mod and CONTRIBUTING.md to match.

I've also replaced a couple of usages of `strings.TrimPrefix` followed by a check if the string was actually trimmed with the [`strings.CutPrefix`](https://pkg.go.dev/strings#CutPrefix) function introduced in Go 1.20.