### PR TITLE
chore: Move `gonum` dependency into correct group

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,6 +95,7 @@ require (
 	golang.org/x/net v0.14.0
 	golang.org/x/sync v0.3.0
 	golang.org/x/tools v0.12.0
+	gonum.org/v1/gonum v0.14.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20230822172742-b8732ec3820d
 	google.golang.org/grpc v1.57.0
 	google.golang.org/protobuf v1.31.0
@@ -270,7 +271,6 @@ require (
 	golang.org/x/term v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
-	gonum.org/v1/gonum v0.14.0
 	google.golang.org/api v0.134.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230803162519-f966b187b2e5 // indirect


### PR DESCRIPTION
It's annoying that `go get` doesn't seem to place the dependency in the correct group (at least when run via VS Code "quick fix" menu 🤷‍♂️), and `go mod tidy` doesn't move it.