### PR TITLE
enhancement: Configurable time skew for JWT validation

### DIFF
--- a/docs/modules/configuration/pages/auxdata.adoc
+++ b/docs/modules/configuration/pages/auxdata.adoc
@@ -2,14 +2,14 @@ include::ROOT:partial$attributes.adoc[]
 
 = AuxData block
 
-The `auxData` block configures the auxiliary data sources that can be referenced in policy conditions. 
+The `auxData` block configures the auxiliary data sources that can be referenced in policy conditions.
 
 
 == JWT
 
 Cerbos supports reading claims from a JWT issued by an authentication system. This helps reduce the boilerplate on the client side to extract the claims from a JWT and add them as attributes to the Cerbos API request. (See xref:api:index.adoc[] and xref:policies:conditions.adoc#auxdata[Auxiliary Data] for more information on how to craft the API request and access the JWT claims in policies.)
 
-In order to verify the JWT, the Cerbos instance must have access to the appropriate keysets. They can be fetched from a URL or read from the local file system. Verification involves checking that the signature is valid and that the token has not expired. 
+In order to verify the JWT, the Cerbos instance must have access to the appropriate keysets. They can be fetched from a URL or read from the local file system. Verification involves checking that the signature is valid and that the token has not expired.
 
 
 .Using multiple keysets
@@ -19,10 +19,10 @@ auxData:
   jwt:
     keySets:
       - id: ks1 # Unique ID that can be used in API requests to indicate the keyset to use to verify a particular token.
-        remote: # Fetch from a JWKS URL. 
+        remote: # Fetch from a JWKS URL.
           url: https://domain.tld/.well-known/keys.jwks
       - id: ks2
-        remote: 
+        remote:
           url: https://other-domain.tld/.well-known/keys.jwks
           refreshInterval: 1h # Explicitly set the refresh interval.
       - id: ks3
@@ -42,15 +42,16 @@ IMPORTANT: When multiple keysets are defined in the configuration file, all API 
 
 When keysets are fetched from a `remote` source, if the `refreshInterval` is not defined in the configuration, Cerbos will respect the `Cache-Control` and `Expiry` headers returned from the remote source when determining the refresh interval. If none of these data points are available, then the default refresh interval is one hour.
 
-You can disable JWT verification by setting `disableVerification` to `true`.
+You can disable JWT verification by setting `disableVerification` to `true`. When verification is disabled, Cerbos will not perform cryptographic verification of the JWT but the `exp` and `nbf` claims are still checked to ensure that the token is valid. You can configure the acceptable time skew for those claims by setting `acceptableTimeSkew` to a positive time duration.
 
-WARNING: Disabling JWT verification is not recommended because it makes the system insecure by forcing Cerbos to evaluate policies using potentially tampered data.
+WARNING: Disabling JWT verification is not recommended because it makes the system insecure by forcing Cerbos to evaluate policies using potentially tampered data. Similarly, it's not recommended to set `acceptableTimeSkew` to more than a few seconds.
 
 [source,yaml,linenums]
 ----
 auxData:
   jwt:
     disableVerification: true
+    acceptableTimeSkew: 2s
 ----
 
 Cerbos maintains an in-memory cache of verified JWTs to avoid repeating the cryptographic verification step on each request. Cached tokens are still validated on each request to make sure they are still valid for use. You can increase the size of the cache by setting `cacheSize`.
@@ -62,7 +63,7 @@ auxData:
     cacheSize: 256
     keySets:
       - id: default
-        remote: 
+        remote:
           url: https://domain.tld/.well-known/keys.jwks
 ----
 

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -45,6 +45,7 @@ audit:
     storagePath: /path/to/dir # Path to store the data
 auxData:
   jwt: # JWT holds the configuration for JWTs used as an auxiliary data source for the engine.
+    acceptableTimeSkew: 2s # AcceptableTimeSkew sets the acceptable skew when checking exp and nbf claims.
     cacheSize: 256 # CacheSize sets the number of verified tokens cached in memory. Set to negative value to disable caching.
     disableVerification: false # DisableVerification disables JWT verification.
     keySets: # KeySets is the list of keysets to be used to verify tokens.

--- a/internal/auxdata/auxdata.go
+++ b/internal/auxdata/auxdata.go
@@ -5,12 +5,16 @@ package auxdata
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	requestv1 "github.com/cerbos/cerbos/api/genpb/cerbos/request/v1"
 	"github.com/cerbos/cerbos/internal/config"
 	"github.com/cerbos/cerbos/internal/observability/tracing"
 )
+
+var ErrFailedToExtractJWT = errors.New("failed to extract JWT")
 
 type AuxData struct {
 	jwt *jwtHelper
@@ -44,7 +48,7 @@ func (ad *AuxData) Extract(ctx context.Context, adProto *requestv1.AuxData) (*en
 
 	jwtPB, err := ad.jwt.extract(ctx, adProto.Jwt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrFailedToExtractJWT, err)
 	}
 
 	return &enginev1.AuxData{Jwt: jwtPB}, nil

--- a/internal/auxdata/conf.go
+++ b/internal/auxdata/conf.go
@@ -27,6 +27,8 @@ type JWTConf struct {
 	DisableVerification bool `yaml:"disableVerification" conf:",example=false"`
 	// CacheSize sets the number of verified tokens cached in memory. Set to negative value to disable caching.
 	CacheSize int `yaml:"cacheSize" conf:",example=256"`
+	// AcceptableTimeSkew sets the acceptable skew when checking exp and nbf claims.
+	AcceptableTimeSkew time.Duration `yaml:"acceptableTimeSkew" conf:",example=2s"`
 }
 
 type JWTKeySet struct {
@@ -65,6 +67,10 @@ func (c *Conf) Validate() (errs error) {
 
 	if c.JWT.CacheSize == 0 {
 		c.JWT.CacheSize = defaultCacheSize
+	}
+
+	if c.JWT.AcceptableTimeSkew < 0 {
+		errs = multierr.Append(errs, fmt.Errorf("acceptableTimeSkew must be positive"))
 	}
 
 	idSet := make(map[string]struct{}, len(c.JWT.KeySets))

--- a/internal/auxdata/conf_test.go
+++ b/internal/auxdata/conf_test.go
@@ -5,6 +5,7 @@ package auxdata_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -116,6 +117,27 @@ func TestConfigValidate(t *testing.T) {
 							{"id": "foo", "remote": map[string]any{"url": "https://domain.tld/.well-known/foo.jwks"}},
 							{"id": "bar", "local": map[string]any{"data": "", "file": ""}},
 						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "positive acceptableTimeSkew",
+			conf: map[string]any{
+				"auxData": map[string]any{
+					"jwt": map[string]any{
+						"acceptableTimeSkew": 1 * time.Minute,
+					},
+				},
+			},
+		},
+		{
+			name: "negative acceptableTimeSkew",
+			conf: map[string]any{
+				"auxData": map[string]any{
+					"jwt": map[string]any{
+						"acceptableTimeSkew": -1 * time.Minute,
 					},
 				},
 			},

--- a/internal/auxdata/jwt.go
+++ b/internal/auxdata/jwt.go
@@ -36,9 +36,10 @@ var (
 )
 
 type jwtHelper struct {
-	keySets map[string]keySet
-	cache   *cache.Cache[string, struct{}]
-	verify  bool
+	keySets        map[string]keySet
+	cache          *cache.Cache[string, struct{}]
+	verify         bool
+	acceptableSkew time.Duration
 }
 
 func newJWTHelper(ctx context.Context, conf *JWTConf) *jwtHelper {
@@ -49,6 +50,7 @@ func newJWTHelper(ctx context.Context, conf *JWTConf) *jwtHelper {
 	}
 
 	jh.verify = !conf.DisableVerification
+	jh.acceptableSkew = conf.AcceptableTimeSkew
 
 	if jh.verify {
 		jh.keySets = make(map[string]keySet, len(conf.KeySets))
@@ -104,15 +106,19 @@ func (j *jwtHelper) extract(ctx context.Context, auxJWT *requestv1.AuxData_JWT) 
 	return j.doExtract(ctx, auxJWT, parseOpts, cacheKey)
 }
 
-func (j *jwtHelper) parseOptions(ctx context.Context, auxJWT *requestv1.AuxData_JWT, cacheKey string) ([]jwt.ParseOption, error) {
+func (j *jwtHelper) parseOptions(ctx context.Context, auxJWT *requestv1.AuxData_JWT, cacheKey string) (opts []jwt.ParseOption, _ error) {
+	if j.acceptableSkew > 0 {
+		opts = []jwt.ParseOption{jwt.WithAcceptableSkew(j.acceptableSkew)}
+	}
+
 	if !j.verify {
-		return []jwt.ParseOption{jwt.WithVerify(false), jwt.WithValidate(true)}, nil
+		return append(opts, jwt.WithVerify(false), jwt.WithValidate(true)), nil
 	}
 
 	// Check whether this token has already been verified
 	if cacheKey != "" {
 		if _, ok := j.cache.Get(cacheKey); ok {
-			return []jwt.ParseOption{jwt.WithVerify(false), jwt.WithValidate(true)}, nil
+			return append(opts, jwt.WithVerify(false), jwt.WithValidate(true)), nil
 		}
 	}
 
@@ -140,7 +146,7 @@ func (j *jwtHelper) parseOptions(ctx context.Context, auxJWT *requestv1.AuxData_
 		return nil, fmt.Errorf("failed to retrieve keyset: %w", err)
 	}
 
-	return []jwt.ParseOption{jwt.WithKeySet(jwks), jwt.WithValidate(true)}, nil
+	return append(opts, jwt.WithKeySet(jwks), jwt.WithValidate(true)), nil
 }
 
 func (j *jwtHelper) doExtract(ctx context.Context, auxJWT *requestv1.AuxData_JWT, parseOpts []jwt.ParseOption, cacheKey string) (map[string]*structpb.Value, error) {

--- a/internal/svc/cerbos_svc.go
+++ b/internal/svc/cerbos_svc.go
@@ -53,7 +53,7 @@ func (cs *CerbosService) PlanResources(ctx context.Context, request *requestv1.P
 	auxData, err := cs.auxData.Extract(ctx, request.AuxData)
 	if err != nil {
 		log.Error("Failed to extract auxData", zap.Error(err))
-		return nil, status.Error(codes.InvalidArgument, "failed to extract auxData")
+		return nil, status.Error(codes.InvalidArgument, "invalid auxData")
 	}
 
 	input := &enginev1.PlanResourcesInput{
@@ -109,7 +109,7 @@ func (cs *CerbosService) CheckResourceSet(ctx context.Context, req *requestv1.Ch
 	auxData, err := cs.auxData.Extract(ctx, req.AuxData)
 	if err != nil {
 		log.Error("Failed to extract auxData", zap.Error(err))
-		return nil, status.Error(codes.InvalidArgument, "failed to extract auxData")
+		return nil, status.Error(codes.InvalidArgument, "invalid auxData")
 	}
 
 	inputs := make([]*enginev1.CheckInput, len(req.Resource.Instances))
@@ -163,7 +163,7 @@ func (cs *CerbosService) CheckResourceBatch(ctx context.Context, req *requestv1.
 	auxData, err := cs.auxData.Extract(ctx, req.AuxData)
 	if err != nil {
 		log.Error("Failed to extract auxData", zap.Error(err))
-		return nil, status.Error(codes.InvalidArgument, "failed to extract auxData")
+		return nil, status.Error(codes.InvalidArgument, "invalid auxData")
 	}
 
 	inputs := make([]*enginev1.CheckInput, len(req.Resources))
@@ -223,7 +223,7 @@ func (cs *CerbosService) CheckResources(ctx context.Context, req *requestv1.Chec
 	auxData, err := cs.auxData.Extract(ctx, req.AuxData)
 	if err != nil {
 		log.Error("Failed to extract auxData", zap.Error(err))
-		return nil, status.Error(codes.InvalidArgument, "failed to extract auxData")
+		return nil, status.Error(codes.InvalidArgument, "invalid auxData")
 	}
 
 	inputs := make([]*enginev1.CheckInput, len(req.Resources))


### PR DESCRIPTION
Allow users to configure how much skew to tolerate when validating `exp`
and `nbf` claims in JWTs.

Also updates the error message returned by the server when invalid JWTs
are encountered because some users found the old message confusing.

Fixes #1789

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
