### PR TITLE
chore(ci): Increase timeout for client tests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -28,8 +28,8 @@ const (
 	adminPassword = "cerbosAdmin"
 
 	readyTimeout       = 90 * time.Second
-	readyPollInterval  = 100 * time.Millisecond
-	healthCheckTimeout = 80 * time.Millisecond
+	readyPollInterval  = 120 * time.Millisecond
+	healthCheckTimeout = 100 * time.Millisecond
 )
 
 func TestClient(t *testing.T) {


### PR DESCRIPTION
The GH runners have gotten slower recently and lots of tests fail due to timeouts.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
