### PR TITLE
fix: Ignore invalid expressions

### DIFF
--- a/cmd/cerbosctl/put/put_test.go
+++ b/cmd/cerbosctl/put/put_test.go
@@ -117,6 +117,7 @@ func testPutCmd(clientCtx *cmdclient.Context, globals *flagset.Globals) func(*te
 					"resource.leave_request.vdefault/acme.hr",
 					"resource.leave_request.vdefault/acme.hr.uk",
 					"resource.leave_request.vstaging",
+					"resource.missing_attr.vdefault",
 					"resource.products.vdefault",
 					"resource.purchase_order.vdefault",
 					"resource.variables_referencing_variables.vdefault",

--- a/internal/conditions/cerbos_lib.go
+++ b/internal/conditions/cerbos_lib.go
@@ -6,7 +6,6 @@ package conditions
 import (
 	"fmt"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/google/cel-go/cel"
@@ -30,16 +29,7 @@ const (
 	nowFn                       = "now"
 	timeSinceFn                 = "timeSince"
 	IDFn                        = "id"
-	noSuchKeyErrorPrefix        = "no such key: "
 )
-
-type NoSuchKeyError struct {
-	Key string
-}
-
-func (e *NoSuchKeyError) Error() string {
-	return noSuchKeyErrorPrefix + e.Key
-}
 
 // CerbosCELLib returns the custom CEL functions provided by Cerbos.
 func CerbosCELLib() cel.EnvOption {
@@ -148,11 +138,7 @@ func Eval(env *cel.Env, ast *cel.Ast, vars any, nowFunc func() time.Time, opts .
 		return nil, nil, err
 	}
 
-	result, details, err := prg.Eval(vars)
-	if err != nil && strings.HasPrefix(err.Error(), noSuchKeyErrorPrefix) {
-		err = &NoSuchKeyError{Key: strings.TrimPrefix(err.Error(), noSuchKeyErrorPrefix)}
-	}
-	return result, details, err
+	return prg.Eval(vars)
 }
 
 func newTimeDecorator(nowFunc func() time.Time) interpreter.InterpretableDecorator {

--- a/internal/storage/blob/cloner_test.go
+++ b/internal/storage/blob/cloner_test.go
@@ -58,5 +58,6 @@ func TestCloneResult(t *testing.T) {
 		"resource_policies/policy_10.yaml",
 		"resource_policies/policy_11.yaml",
 		"resource_policies/policy_12.yaml",
+		"resource_policies/policy_13.yaml",
 	}, result.updateOrAdd)
 }

--- a/internal/storage/bundle/remote_source_test.go
+++ b/internal/storage/bundle/remote_source_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const bundleID = "h1:lB6+Yh5gZXBBrSqeOihtpqulAS8mk94Zj2UU/4jRSEo="
+const bundleID = "h1:qbt0/fnuqkIo7lkljcvk8CwtHr7I8DA4Xtiuj73EfE4="
 
 func TestRemoteSource(t *testing.T) {
 	bundlePath := filepath.Join(test.PathToDir(t, "bundle"), "bundle.crbp")

--- a/internal/storage/index/builder_test.go
+++ b/internal/storage/index/builder_test.go
@@ -44,7 +44,7 @@ func TestBuildIndexWithDisk(t *testing.T) {
 
 	t.Run("check_contents", func(t *testing.T) {
 		data := idxImpl.Inspect()
-		require.Len(t, data, 30)
+		require.Len(t, data, 31)
 
 		rp1 := filepath.Join("resource_policies", "policy_01.yaml")
 		rp2 := filepath.Join("resource_policies", "policy_02.yaml")

--- a/internal/test/testdata/bundle/bundle.crbp
+++ b/internal/test/testdata/bundle/bundle.crbp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b29d3ac52d20a0441d0090c27e0289c67f426845fdaa4651ea585dfd1a7b9bf0
-size 22787
+oid sha256:636527b7d862946d5c90c9ef4de09fa3dacb40725110c568e0f67113e124d57a
+size 24021

--- a/internal/test/testdata/bundle/manifest.json
+++ b/internal/test/testdata/bundle/manifest.json
@@ -1,38 +1,40 @@
 {
-  "apiVersion":  "api.cerbos.cloud/v1",
-  "policyIndex":  {
-    "cerbos.principal.arn:aws:iam::123456789012:user/johndoe.vdefault":  "policies/F843045D554D5F7D",
-    "cerbos.principal.daisy_duck.vdefault":  "policies/1E0CD2615BE3760B",
-    "cerbos.principal.donald_duck.v20210210":  "policies/1CC91E277263674D",
-    "cerbos.principal.donald_duck.vdefault":  "policies/2F26F3660A97BECD",
-    "cerbos.principal.donald_duck.vdefault/acme":  "policies/4C6062CFBE8627DB",
-    "cerbos.principal.donald_duck.vdefault/acme.hr":  "policies/60C13DA6FD1DF10C",
-    "cerbos.principal.scrooge_mcduck.vdefault":  "policies/C1B3716695815705",
-    "cerbos.principal.terry_tibbs.vdefault":  "policies/BCD8E5E5F425900C",
-    "cerbos.resource.account.vdefault":  "policies/EE58DE7B0F7DA6B9",
-    "cerbos.resource.album_object.vdefault":  "policies/684ED25FF04663F2",
-    "cerbos.resource.arn:aws:sns:us-east-1:123456789012:topic-a.vdefault":  "policies/9F5F3F76EE98C8C8",
-    "cerbos.resource.equipment_request.vdefault":  "policies/51F53279EC2F9999",
-    "cerbos.resource.equipment_request.vdefault/acme":  "policies/4E007D10C67C7E53",
-    "cerbos.resource.global.vdefault":  "policies/CC4D718865FCB574",
-    "cerbos.resource.import_derived_roles_that_import_variables.vdefault":  "policies/3169CA50FA97BB24",
-    "cerbos.resource.import_variables.vdefault":  "policies/1DADD39B46DA6095",
-    "cerbos.resource.leave_request.v20210210":  "policies/EAE733C912F22DA",
-    "cerbos.resource.leave_request.vdefault":  "policies/EF8C9BEB57967AA0",
-    "cerbos.resource.leave_request.vdefault/acme":  "policies/827F815FFA0C2AC5",
-    "cerbos.resource.leave_request.vdefault/acme.hr":  "policies/FBAEBB70E5F8BBE6",
-    "cerbos.resource.leave_request.vdefault/acme.hr.uk":  "policies/BC5AE9FB81ACF7B2",
-    "cerbos.resource.leave_request.vstaging":  "policies/AD56144EE420A347",
-    "cerbos.resource.purchase_order.vdefault":  "policies/B55EE74E34DF4F2B"
+  "apiVersion": "api.cerbos.cloud/v1",
+  "policyIndex": {
+    "cerbos.principal.arn:aws:iam::123456789012:user/johndoe.vdefault": "policies/F843045D554D5F7D",
+    "cerbos.principal.daisy_duck.vdefault": "policies/1E0CD2615BE3760B",
+    "cerbos.principal.donald_duck.v20210210": "policies/1CC91E277263674D",
+    "cerbos.principal.donald_duck.vdefault": "policies/2F26F3660A97BECD",
+    "cerbos.principal.donald_duck.vdefault/acme": "policies/4C6062CFBE8627DB",
+    "cerbos.principal.donald_duck.vdefault/acme.hr": "policies/60C13DA6FD1DF10C",
+    "cerbos.principal.scrooge_mcduck.vdefault": "policies/C1B3716695815705",
+    "cerbos.principal.terry_tibbs.vdefault": "policies/BCD8E5E5F425900C",
+    "cerbos.resource.account.vdefault": "policies/EE58DE7B0F7DA6B9",
+    "cerbos.resource.album_object.vdefault": "policies/684ED25FF04663F2",
+    "cerbos.resource.arn:aws:sns:us-east-1:123456789012:topic-a.vdefault": "policies/9F5F3F76EE98C8C8",
+    "cerbos.resource.equipment_request.vdefault": "policies/51F53279EC2F9999",
+    "cerbos.resource.equipment_request.vdefault/acme": "policies/4E007D10C67C7E53",
+    "cerbos.resource.global.vdefault": "policies/CC4D718865FCB574",
+    "cerbos.resource.import_derived_roles_that_import_variables.vdefault": "policies/3169CA50FA97BB24",
+    "cerbos.resource.import_variables.vdefault": "policies/1DADD39B46DA6095",
+    "cerbos.resource.leave_request.v20210210": "policies/EAE733C912F22DA",
+    "cerbos.resource.leave_request.vdefault": "policies/EF8C9BEB57967AA0",
+    "cerbos.resource.leave_request.vdefault/acme": "policies/827F815FFA0C2AC5",
+    "cerbos.resource.leave_request.vdefault/acme.hr": "policies/FBAEBB70E5F8BBE6",
+    "cerbos.resource.leave_request.vdefault/acme.hr.uk": "policies/BC5AE9FB81ACF7B2",
+    "cerbos.resource.leave_request.vstaging": "policies/AD56144EE420A347",
+    "cerbos.resource.missing_attr.vdefault": "policies/131D16D1DB4AD8E7",
+    "cerbos.resource.purchase_order.vdefault": "policies/B55EE74E34DF4F2B",
+    "cerbos.resource.variables_referencing_variables.vdefault": "policies/528071D04EFEBBF9"
   },
-  "schemas":  [
+  "schemas": [
     "principal.json",
     "resources/leave_request.json",
     "resources/purchase_order.json",
     "resources/salary_record.json"
   ],
-  "meta":  {
-    "identifier":  "h1:lB6+Yh5gZXBBrSqeOihtpqulAS8mk94Zj2UU/4jRSEo=",
-    "source":  "/home/cell/work/cerbos/internal/test/testdata/store"
+  "meta": {
+    "identifier": "h1:qbt0/fnuqkIo7lkljcvk8CwtHr7I8DA4Xtiuj73EfE4=",
+    "source": "/home/cell/work/cerbos/internal/test/testdata/store"
   }
 }

--- a/internal/test/testdata/engine/case_20.yaml
+++ b/internal/test/testdata/engine/case_20.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=../.jsonschema/EngineTestCase.schema.json
+---
+description: Missing attribute referenced in a variable
+inputs: [
+  {
+    "requestId": "test",
+    "actions": ["use"],
+    "principal": {
+      "id": "abc",
+      "roles": [
+        "user"
+      ],
+      "attr": {
+        "email": "info@example.com",
+      }
+    },
+    "resource": {
+      "kind": "missing_attr",
+      "id": "test",
+    }
+  }
+]
+wantOutputs: [
+  {
+    "requestId": "test",
+    "resourceId": "test",
+    "actions": {
+      "use": {
+        "effect": "EFFECT_ALLOW",
+        "policy": "resource.missing_attr.vdefault"
+      }
+    },
+  }
+]

--- a/internal/test/testdata/query_planner/policies/resource_policy_missing_attr.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policy_missing_attr.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../../../../../schema/jsonschema/cerbos/policy/v1/Policy.schema.json
+---
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: missing_attr
+  variables:
+    local:
+      eng: P.attr.is_engineer
+  rules:
+    - actions:
+        - use
+      effect: EFFECT_ALLOW
+      roles:
+        - user
+      condition:
+        match:
+          any:
+            of:
+              - expr: V.eng && P.attr.org == "org-1"
+              - expr: P.attr.email == "info@example.com"

--- a/internal/test/testdata/query_planner/suite/missing_attr.yaml
+++ b/internal/test/testdata/query_planner/suite/missing_attr.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=../../.jsonschema/QueryPlannerTestSuite.schema.json
+---
+description: Reference to missing attr in variable
+principal:
+    id: adam
+    policyVersion: default
+    roles:
+        - user
+    attr:
+      email: info@example.com
+      org: org-1
+tests:
+    - action: "use"
+      resource:
+        kind: missing_attr
+        policyVersion: default
+      want:
+        kind: KIND_ALWAYS_ALLOWED

--- a/internal/test/testdata/store/resource_policies/policy_13.yaml
+++ b/internal/test/testdata/store/resource_policies/policy_13.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../../../../../schema/jsonschema/cerbos/policy/v1/Policy.schema.json
+---
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: missing_attr
+  variables:
+    local:
+      eng: P.attr.is_engineer
+  rules:
+    - actions:
+        - use
+      effect: EFFECT_ALLOW
+      roles:
+        - user
+      condition:
+        match:
+          any:
+            of:
+              - expr: V.eng && P.attr.org == "org-1"
+              - expr: P.attr.email == "info@example.com"


### PR DESCRIPTION
Ignore expressions that access non-existent keys or try to perform unsupported operations such as `null && true`. 

Fixes #1798
