### PR TITLE
enhancement(helm): Add topologySpreadConstraints to the helm chart

### DIFF
--- a/deploy/charts/cerbos/templates/deployment.yaml
+++ b/deploy/charts/cerbos/templates/deployment.yaml
@@ -128,6 +128,17 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range $constraint := . }}
+      - {{ toYaml $constraint | nindent 8 | trim }}
+        {{- if not $constraint.labelSelector }}
+        labelSelector:
+          matchLabels:
+            {{- include "cerbos.selectorLabels" (dict "Chart" $.Chart "Values" $.Values "Release" $.Release) | nindent 12 }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/cerbos/values.yaml
+++ b/deploy/charts/cerbos/values.yaml
@@ -79,6 +79,12 @@ tolerations: []
 # Pod affinity rules.
 affinity: {}
 
+# Topology Spread Constraints rules.
+topologySpreadConstraints: []
+  # - topologyKey: topology.kubernetes.io/zone
+  #   maxSkew: 1
+  #   whenUnsatisfiable: ScheduleAnyway
+
 # Volumes to add to the pod.
 volumes: []
 


### PR DESCRIPTION
#### Description

Adding topologySpreadConstraints to the helm chart in order to use [topology spread](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)

<!-- Thank you for contributing Cerbos! Please describe the changes made in this PR here and provide any other useful information for reviewers. Make sure that you included some automated tests (e.g unit tests) to verify your changes.  If there is a requirement for user input for testing, please include the instructions as well. -->

Fixes #<!-- Link the relevant issue here -->

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
