### PR TITLE
enhancement(helm): Add support for defining topology spread constraints

### DIFF
--- a/deploy/charts/cerbos/templates/_helpers.tpl
+++ b/deploy/charts/cerbos/templates/_helpers.tpl
@@ -167,3 +167,23 @@ The image reference to use in pods
 {{- end -}}
 "
 {{- end }}
+
+{{/*
+Topology spread constraints with label selector injected
+*/}}
+{{- define "cerbos.topologySpreadConstraints" -}}
+{{- if .Values.topologySpreadConstraints }}
+{{- $defaultLabels := (fromYaml (include "cerbos.selectorLabels" $)) }}
+{{- $defaultLabelSelector := (dict "labelSelector" (dict "matchLabels" $defaultLabels)) }}
+{{- $constraints := list }}
+{{- range $c := .Values.topologySpreadConstraints }}
+{{- if (hasKey $c "labelSelector") }}
+{{- $constraints = (append $constraints $c) }}
+{{- else }}
+{{- $constraints = (append $constraints (mergeOverwrite $c $defaultLabelSelector)) }}
+{{- end }}
+{{- end }}
+topologySpreadConstraints:
+{{ toYaml $constraints | indent 2 }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/cerbos/templates/deployment.yaml
+++ b/deploy/charts/cerbos/templates/deployment.yaml
@@ -128,6 +128,17 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range $constraint := . }}
+      - {{ toYaml $constraint | nindent 8 | trim }}
+        {{- if not $constraint.labelSelector }}
+        labelSelector:
+          matchLabels:
+            {{- include "cerbos.selectorLabels" (dict "Chart" $.Chart "Values" $.Values "Release" $.Release) | nindent 12 }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/cerbos/templates/deployment.yaml
+++ b/deploy/charts/cerbos/templates/deployment.yaml
@@ -128,18 +128,8 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.topologySpreadConstraints }}
-      topologySpreadConstraints:
-        {{- range $constraint := . }}
-      - {{ toYaml $constraint | nindent 8 | trim }}
-        {{- if not $constraint.labelSelector }}
-        labelSelector:
-          matchLabels:
-            {{- include "cerbos.selectorLabels" (dict "Chart" $.Chart "Values" $.Values "Release" $.Release) | nindent 12 }}
-        {{- end }}
-        {{- end }}
-      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "cerbos.topologySpreadConstraints" . | nindent 6}}

--- a/deploy/charts/cerbos/values.yaml
+++ b/deploy/charts/cerbos/values.yaml
@@ -79,6 +79,12 @@ tolerations: []
 # Pod affinity rules.
 affinity: {}
 
+# Topology Spread Constraints rules.
+topologySpreadConstraints: []
+  # - topologyKey: topology.kubernetes.io/zone
+  #   maxSkew: 1
+  #   whenUnsatisfiable: ScheduleAnyway
+
 # Volumes to add to the pod.
 volumes: []
 


### PR DESCRIPTION
Adds ability to define `topologySpreadConstraints` for the Cerbos deployment. 

Supersedes #1820 
Thanks to @psolarcz for the original PR.