### PR TITLE
enhancement: Allow parsing JWTs with legacy keysets

### DIFF
--- a/docs/modules/configuration/pages/auxdata.adoc
+++ b/docs/modules/configuration/pages/auxdata.adoc
@@ -67,3 +67,18 @@ auxData:
           url: https://domain.tld/.well-known/keys.jwks
 ----
 
+Some legacy authentication systems have key sets that do not contain `alg` or `kid` fields. Not having these fields defined is a security risk and the default behaviour of Cerbos is to fail the parsing of JWT. If you are aware of the risks and still want to enable those tokens to be parsed, set the `optionalAlg` and `optionalKid` options.
+
+[source,yaml,linenums]
+----
+auxData:
+  jwt:
+    keySets:
+      - id: default
+        remote:
+          url: https://domain.tld/.well-known/keys.jwks
+        insecure:
+          optionalAlg: true # Set to true only if the keyset doesn't have an alg field
+          optionalKid: true # Set to true only if the keyset doesn't have a kid field
+----
+

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -51,6 +51,9 @@ auxData:
     keySets: # KeySets is the list of keysets to be used to verify tokens.
       - 
         id: ks1 # Required. ID is the unique reference to this keyset.
+        insecure: # Insecure options for relaxing security. Not recommended for production use. Use with caution.
+          optionalAlg: <DEFAULT_VALUE_NOT_SET> # OptionalAlg configures Cerbos to not require the alg field to be set in the key set.
+          optionalKid: <DEFAULT_VALUE_NOT_SET> # OptionalKid configures Cerbos to not require the kid field to be set in the key set.
         local: # Local defines a local keyset. Mutually exclusive with Remote.
           data: base64encodedJWK # Data is the encoded JWK data for this keyset. Mutually exclusive with File.
           file: /path/to/keys.jwk # File is the path to file containing JWK data. Mutually exclusive with Data.

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -52,8 +52,8 @@ auxData:
       - 
         id: ks1 # Required. ID is the unique reference to this keyset.
         insecure: # Insecure options for relaxing security. Not recommended for production use. Use with caution.
-          optionalAlg: <DEFAULT_VALUE_NOT_SET> # OptionalAlg configures Cerbos to not require the alg field to be set in the key set.
-          optionalKid: <DEFAULT_VALUE_NOT_SET> # OptionalKid configures Cerbos to not require the kid field to be set in the key set.
+          optionalAlg: false # OptionalAlg configures Cerbos to not require the alg field to be set in the key set.
+          optionalKid: false # OptionalKid configures Cerbos to not require the kid field to be set in the key set.
         local: # Local defines a local keyset. Mutually exclusive with Remote.
           data: base64encodedJWK # Data is the encoded JWK data for this keyset. Mutually exclusive with File.
           file: /path/to/keys.jwk # File is the path to file containing JWK data. Mutually exclusive with Data.

--- a/internal/auxdata/conf.go
+++ b/internal/auxdata/conf.go
@@ -44,9 +44,9 @@ type JWTKeySet struct {
 
 type InsecureKeySetOpt struct {
 	// OptionalAlg configures Cerbos to not require the alg field to be set in the key set.
-	OptionalAlg bool `yaml:"optionalAlg"`
+	OptionalAlg bool `yaml:"optionalAlg" conf:",example=false"`
 	// OptionalKid configures Cerbos to not require the kid field to be set in the key set.
-	OptionalKid bool `yaml:"optionalKid"`
+	OptionalKid bool `yaml:"optionalKid" conf:",example=false"`
 }
 
 type RemoteSource struct {

--- a/internal/auxdata/conf.go
+++ b/internal/auxdata/conf.go
@@ -38,6 +38,15 @@ type JWTKeySet struct {
 	Local *LocalSource `yaml:"local"`
 	// ID is the unique reference to this keyset.
 	ID string `yaml:"id" conf:"required,example=ks1"`
+	// Insecure options for relaxing security. Not recommended for production use. Use with caution.
+	Insecure InsecureKeySetOpt `yaml:"insecure"`
+}
+
+type InsecureKeySetOpt struct {
+	// OptionalAlg configures Cerbos to not require the alg field to be set in the key set.
+	OptionalAlg bool `yaml:"optionalAlg"`
+	// OptionalKid configures Cerbos to not require the kid field to be set in the key set.
+	OptionalKid bool `yaml:"optionalKid"`
 }
 
 type RemoteSource struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -427,7 +427,7 @@ func checkForUnsafeAdminCredentials(log *zap.Logger, passwordHash []byte) {
 	if err != nil {
 		log.Error("Failed to check admin API credentials", zap.Error(err))
 	} else if unsafe {
-		log.Warn("[SECURITY RISK] Admin API uses default credentials which are unsafe for production use. Please change the credentials by updating the configuration file.")
+		log.Warn("[INSECURE CONFIG] Admin API uses default credentials which are unsafe for production use. Please change the credentials by updating the configuration file.")
 	}
 }
 


### PR DESCRIPTION
Allow the use of keysets that do not have an `alg` field or a `kid`
field. This is an opt-in feature.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
