### PR TITLE
enhancement: Expose private Check API

### DIFF
--- a/internal/verify/test_fixture.go
+++ b/internal/verify/test_fixture.go
@@ -25,10 +25,10 @@ import (
 	"github.com/cerbos/cerbos/internal/validator"
 )
 
-type testFixture struct {
-	principals map[string]*enginev1.Principal
-	resources  map[string]*enginev1.Resource
-	auxData    map[string]*enginev1.AuxData
+type TestFixture struct {
+	Principals map[string]*enginev1.Principal
+	Resources  map[string]*enginev1.Resource
+	AuxData    map[string]*enginev1.AuxData
 }
 
 const (
@@ -38,19 +38,19 @@ const (
 
 var auxDataFileNames = []string{"auxdata", "auxData", "aux_data"}
 
-func loadTestFixture(fsys fs.FS, path string) (tf *testFixture, err error) {
-	tf = new(testFixture)
-	tf.principals, err = loadPrincipals(fsys, path)
+func LoadTestFixture(fsys fs.FS, path string) (tf *TestFixture, err error) {
+	tf = new(TestFixture)
+	tf.Principals, err = loadPrincipals(fsys, path)
 	if err != nil {
 		return nil, err
 	}
 
-	tf.resources, err = loadResources(fsys, path)
+	tf.Resources, err = loadResources(fsys, path)
 	if err != nil {
 		return nil, err
 	}
 
-	tf.auxData, err = loadAuxData(fsys, path)
+	tf.AuxData, err = loadAuxData(fsys, path)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func loadFixtureElement(fsys fs.FS, path string, pb proto.Message) error {
 	return validator.Validate(pb)
 }
 
-func (tf *testFixture) checkDupes(suite *policyv1.TestSuite) error {
+func (tf *TestFixture) checkDupes(suite *policyv1.TestSuite) error {
 	dupes := make(map[string]struct{})
 	var errs error
 	for _, t := range suite.Tests {
@@ -129,7 +129,7 @@ func (tf *testFixture) checkDupes(suite *policyv1.TestSuite) error {
 	return errs
 }
 
-func (tf *testFixture) runTestSuite(ctx context.Context, eng Checker, shouldRun func(string) bool, file string, suite *policyv1.TestSuite, trace bool) *policyv1.TestResults_Suite {
+func (tf *TestFixture) runTestSuite(ctx context.Context, eng Checker, shouldRun func(string) bool, file string, suite *policyv1.TestSuite, trace bool) *policyv1.TestResults_Suite {
 	suiteResult := &policyv1.TestResults_Suite{
 		File:        file,
 		Name:        suite.Name,
@@ -337,7 +337,7 @@ func addAction(resource *policyv1.TestResults_Resource, name string) *policyv1.T
 	return action
 }
 
-func (tf *testFixture) getTests(suite *policyv1.TestSuite) ([]*policyv1.Test, error) {
+func (tf *TestFixture) getTests(suite *policyv1.TestSuite) ([]*policyv1.Test, error) {
 	var allTests []*policyv1.Test
 
 	for _, table := range suite.Tests {
@@ -352,7 +352,7 @@ func (tf *testFixture) getTests(suite *policyv1.TestSuite) ([]*policyv1.Test, er
 	return allTests, nil
 }
 
-func (tf *testFixture) buildTests(suite *policyv1.TestSuite, table *policyv1.TestTable) ([]*policyv1.Test, error) {
+func (tf *TestFixture) buildTests(suite *policyv1.TestSuite, table *policyv1.TestTable) ([]*policyv1.Test, error) {
 	matrix, err := buildTestMatrix(table)
 	if err != nil {
 		return nil, err
@@ -370,7 +370,7 @@ func (tf *testFixture) buildTests(suite *policyv1.TestSuite, table *policyv1.Tes
 	return tests, nil
 }
 
-func (tf *testFixture) buildTest(suite *policyv1.TestSuite, table *policyv1.TestTable, matrixElement testMatrixElement) (*policyv1.Test, error) {
+func (tf *TestFixture) buildTest(suite *policyv1.TestSuite, table *policyv1.TestTable, matrixElement testMatrixElement) (*policyv1.Test, error) {
 	name := &policyv1.Test_TestName{
 		TestTableName: table.Name,
 		PrincipalKey:  matrixElement.Principal,
@@ -414,13 +414,13 @@ func (tf *testFixture) buildTest(suite *policyv1.TestSuite, table *policyv1.Test
 	}, nil
 }
 
-func (tf *testFixture) lookupPrincipal(ts *policyv1.TestSuite, k string) (*enginev1.Principal, error) {
+func (tf *TestFixture) lookupPrincipal(ts *policyv1.TestSuite, k string) (*enginev1.Principal, error) {
 	if v, ok := ts.Principals[k]; ok {
 		return v, nil
 	}
 
 	if tf != nil {
-		if v, ok := tf.principals[k]; ok {
+		if v, ok := tf.Principals[k]; ok {
 			return v, nil
 		}
 	}
@@ -428,13 +428,13 @@ func (tf *testFixture) lookupPrincipal(ts *policyv1.TestSuite, k string) (*engin
 	return nil, fmt.Errorf("principal %q not found", k)
 }
 
-func (tf *testFixture) lookupResource(ts *policyv1.TestSuite, k string) (*enginev1.Resource, error) {
+func (tf *TestFixture) lookupResource(ts *policyv1.TestSuite, k string) (*enginev1.Resource, error) {
 	if v, ok := ts.Resources[k]; ok {
 		return v, nil
 	}
 
 	if tf != nil {
-		if v, ok := tf.resources[k]; ok {
+		if v, ok := tf.Resources[k]; ok {
 			return v, nil
 		}
 	}
@@ -442,7 +442,7 @@ func (tf *testFixture) lookupResource(ts *policyv1.TestSuite, k string) (*engine
 	return nil, fmt.Errorf("resource %q not found", k)
 }
 
-func (tf *testFixture) lookupAuxData(ts *policyv1.TestSuite, k string) (*enginev1.AuxData, error) {
+func (tf *TestFixture) lookupAuxData(ts *policyv1.TestSuite, k string) (*enginev1.AuxData, error) {
 	if k == "" {
 		return nil, nil
 	}
@@ -452,7 +452,7 @@ func (tf *testFixture) lookupAuxData(ts *policyv1.TestSuite, k string) (*enginev
 	}
 
 	if tf != nil {
-		if v, ok := tf.auxData[k]; ok {
+		if v, ok := tf.AuxData[k]; ok {
 			return v, nil
 		}
 	}

--- a/internal/verify/test_fixture_test.go
+++ b/internal/verify/test_fixture_test.go
@@ -72,18 +72,18 @@ principals:
 }
 
 func Test_testFixture_getTests(t *testing.T) {
-	tf := &testFixture{
-		principals: map[string]*v1.Principal{
+	tf := &TestFixture{
+		Principals: map[string]*v1.Principal{
 			"employee":        {Id: "employee", Roles: []string{"user"}},
 			"manager":         {Id: "manager", Roles: []string{"user"}},
 			"department_head": {Id: "department_head", Roles: []string{"user"}},
 		},
-		resources: map[string]*v1.Resource{
+		Resources: map[string]*v1.Resource{
 			"employee_leave_request":        {Kind: "leave_request", Id: "employee"},
 			"manager_leave_request":         {Kind: "leave_request", Id: "manager"},
 			"department_head_leave_request": {Kind: "leave_request", Id: "department_head"},
 		},
-		auxData: map[string]*v1.AuxData{
+		AuxData: map[string]*v1.AuxData{
 			"test_aux_data": {Jwt: map[string]*structpb.Value{"answer": structpb.NewNumberValue(42)}},
 		},
 	}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -77,16 +77,16 @@ func Verify(ctx context.Context, fsys fs.FS, eng Checker, conf Config) (*policyv
 		return nil, err
 	}
 
-	fixtures := make(map[string]*testFixture, len(fixtureDefs))
+	fixtures := make(map[string]*TestFixture, len(fixtureDefs))
 
-	getFixture := func(path string) (*testFixture, error) {
+	getFixture := func(path string) (*TestFixture, error) {
 		f, ok := fixtures[path]
 		if ok {
 			return f, nil
 		}
 
 		if _, exists := fixtureDefs[path]; exists {
-			f, err := loadTestFixture(fsys, path)
+			f, err := LoadTestFixture(fsys, path)
 			if err != nil {
 				return nil, err
 			}

--- a/private/check/check.go
+++ b/private/check/check.go
@@ -1,3 +1,6 @@
+// Copyright 2021-2023 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 package check
 
 import (

--- a/private/check/check.go
+++ b/private/check/check.go
@@ -1,0 +1,53 @@
+package check
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
+	internalcompile "github.com/cerbos/cerbos/internal/compile"
+	"github.com/cerbos/cerbos/internal/engine"
+	"github.com/cerbos/cerbos/internal/schema"
+	"github.com/cerbos/cerbos/internal/storage/disk"
+	"github.com/cerbos/cerbos/internal/storage/index"
+	"github.com/cerbos/cerbos/internal/verify"
+)
+
+type TestFixtureGetter struct {
+	fsys  fs.FS
+	cache map[string]*verify.TestFixture
+}
+
+func NewTestFixtureGetter(fsys fs.FS) *TestFixtureGetter {
+	return &TestFixtureGetter{
+		fsys:  fsys,
+		cache: make(map[string]*verify.TestFixture),
+	}
+}
+
+func (g *TestFixtureGetter) LoadTestFixture(path string) (*verify.TestFixture, error) {
+	fixture, ok := g.cache[path]
+	if !ok {
+		var err error
+		fixture, err = verify.LoadTestFixture(g.fsys, path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load test fixture file: %w", err)
+		}
+
+		g.cache[path] = fixture
+	}
+	return fixture, nil
+}
+
+func Check(ctx context.Context, idx index.Index, inputs []*enginev1.CheckInput) ([]*enginev1.CheckOutput, error) {
+	store := disk.NewFromIndexWithConf(idx, &disk.Conf{})
+	schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
+	compiler := internalcompile.NewManagerFromDefaultConf(ctx, store, schemaMgr)
+	eng, err := engine.NewEphemeral(compiler, schemaMgr)
+	if err != nil {
+		return nil, err
+	}
+
+	return eng.Check(ctx, inputs)
+}

--- a/private/compile/compile.go
+++ b/private/compile/compile.go
@@ -39,19 +39,19 @@ func (e *Errors) Error() string {
 	}
 }
 
-func Files(ctx context.Context, fsys fs.FS) (<-chan Artefact, error) {
+func Files(ctx context.Context, fsys fs.FS) (index.Index, <-chan Artefact, error) {
 	idx, err := index.Build(ctx, fsys)
 	if err != nil {
 		idxErrs := new(index.BuildError)
 		if errors.As(err, &idxErrs) {
-			return nil, &Errors{
+			return nil, nil, &Errors{
 				Errors: &runtimev1.Errors{
 					Kind: &runtimev1.Errors_IndexBuildErrors{IndexBuildErrors: idxErrs.IndexBuildErrors},
 				},
 			}
 		}
 
-		return nil, fmt.Errorf("failed to build index: %w", err)
+		return nil, nil, fmt.Errorf("failed to build index: %w", err)
 	}
 
 	outChan := make(chan Artefact, 1)
@@ -97,5 +97,5 @@ func Files(ctx context.Context, fsys fs.FS) (<-chan Artefact, error) {
 		}
 	}()
 
-	return outChan, nil
+	return idx, outChan, nil
 }

--- a/private/verify/verify_test.go
+++ b/private/verify/verify_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestFiles(t *testing.T) {
-	results, err := verify.Files(context.Background(), os.DirFS(test.PathToDir(t, "store")))
+	results, err := verify.Files(context.Background(), os.DirFS(test.PathToDir(t, "store")), nil)
 	require.NoError(t, err)
 
 	require.Equal(t, results.Summary.OverallResult, policyv1.TestResults_RESULT_PASSED)


### PR DESCRIPTION
Introduce an additional public API to the engine Check functionality.

Additionally, the `compile.Files` API returns an optional index which can be passed to `verify.Files` to prevent the need to build the index twice.

Lastly, an API is exposed which allows the retrieval of TestFixtures from a path within a given FS implementation.