### PR TITLE
enhancement(security)!: Configure gRPC max concurrent streams

### DIFF
--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -81,6 +81,7 @@ server:
   advanced: # Advanced server settings.
     grpc: # GRPC server settings.
       connectionTimeout: 60s # ConnectionTimeout sets the timeout for establishing a new connection.
+      maxConcurrentStreams: 1024 # MaxConcurrentStreams sets the maximum concurrent streams per connection. Defaults to 1024. Set to 0 to allow the maximum possible number of streams.
       maxConnectionAge: 600s # MaxConnectionAge sets the maximum age of a connection.
       maxRecvMsgSizeBytes: 4194304 # MaxRecvMsgSizeBytes sets the maximum size of a single request message. Defaults to 4MiB. Affects performance and resource utilisation.
     http: # HTTP server settings.

--- a/internal/server/conf.go
+++ b/internal/server/conf.go
@@ -18,23 +18,24 @@ import (
 )
 
 const (
-	confKey                        = "server"
-	defaultAdminPassword           = "cerbosAdmin"
-	defaultAdminUsername           = "cerbos"
-	defaultGRPCConnectionTimeout   = 60 * time.Second
-	defaultGRPCListenAddr          = ":3593"
-	defaultGRPCMaxConnectionAge    = 10 * time.Minute
-	defaultGRPCMaxRecvMsgSizeBytes = 4 * 1024 * 1024 // 4MiB
-	defaultHTTPIdleTimeout         = 120 * time.Second
-	defaultHTTPListenAddr          = ":3592"
-	defaultHTTPReadHeaderTimeout   = 15 * time.Second
-	defaultHTTPReadTimeout         = 30 * time.Second
-	defaultHTTPWriteTimeout        = 30 * time.Second
-	defaultMaxActionsPerResource   = 50
-	defaultMaxResourcesPerRequest  = 50
-	defaultRawAdminPasswordHash    = "$2y$10$VlPwcwpgcGZ5KjTaN1Pzk.vpFiQVG6F2cSWzQa9RtrNo3IacbzsEi" //nolint:gosec
-	defaultUDSFileMode             = "0o766"
-	requestItemsMax                = 500
+	confKey                         = "server"
+	defaultAdminPassword            = "cerbosAdmin"
+	defaultAdminUsername            = "cerbos"
+	defaultGRPCConnectionTimeout    = 60 * time.Second
+	defaultGRPCListenAddr           = ":3593"
+	defaultGRPCMaxConcurrentStreams = 1024
+	defaultGRPCMaxConnectionAge     = 10 * time.Minute
+	defaultGRPCMaxRecvMsgSizeBytes  = 4 * 1024 * 1024 // 4MiB
+	defaultHTTPIdleTimeout          = 120 * time.Second
+	defaultHTTPListenAddr           = ":3592"
+	defaultHTTPReadHeaderTimeout    = 15 * time.Second
+	defaultHTTPReadTimeout          = 30 * time.Second
+	defaultHTTPWriteTimeout         = 30 * time.Second
+	defaultMaxActionsPerResource    = 50
+	defaultMaxResourcesPerRequest   = 50
+	defaultRawAdminPasswordHash     = "$2y$10$VlPwcwpgcGZ5KjTaN1Pzk.vpFiQVG6F2cSWzQa9RtrNo3IacbzsEi" //nolint:gosec
+	defaultUDSFileMode              = "0o766"
+	requestItemsMax                 = 500
 )
 
 var (
@@ -161,6 +162,8 @@ type AdvancedGRPCConf struct {
 	MaxConnectionAge time.Duration `yaml:"maxConnectionAge" conf:",example=600s"`
 	// ConnectionTimeout sets the timeout for establishing a new connection.
 	ConnectionTimeout time.Duration `yaml:"connectionTimeout" conf:",example=60s"`
+	// MaxConcurrentStreams sets the maximum concurrent streams per connection. Defaults to 1024. Set to 0 to allow the maximum possible number of streams.
+	MaxConcurrentStreams uint32 `yaml:"maxConcurrentStreams" conf:",example=1024"`
 }
 
 func (c *Conf) Key() string {
@@ -193,9 +196,10 @@ func (c *Conf) SetDefaults() {
 			IdleTimeout:       defaultHTTPIdleTimeout,
 		},
 		GRPC: AdvancedGRPCConf{
-			MaxRecvMsgSizeBytes: defaultGRPCMaxRecvMsgSizeBytes,
-			MaxConnectionAge:    defaultGRPCMaxConnectionAge,
-			ConnectionTimeout:   defaultGRPCConnectionTimeout,
+			MaxRecvMsgSizeBytes:  defaultGRPCMaxRecvMsgSizeBytes,
+			MaxConcurrentStreams: defaultGRPCMaxConcurrentStreams,
+			MaxConnectionAge:     defaultGRPCMaxConnectionAge,
+			ConnectionTimeout:    defaultGRPCConnectionTimeout,
 		},
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -468,6 +468,7 @@ func (s *Server) mkGRPCServer(log *zap.Logger, auditLog audit.Log) (*grpc.Server
 		),
 		grpc.StatsHandler(&ocgrpc.ServerHandler{}),
 		grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionAge: s.conf.Advanced.GRPC.MaxConnectionAge}),
+		grpc.MaxConcurrentStreams(s.conf.Advanced.GRPC.MaxConcurrentStreams),
 		grpc.ConnectionTimeout(s.conf.Advanced.GRPC.ConnectionTimeout),
 		grpc.MaxRecvMsgSize(int(s.conf.Advanced.GRPC.MaxRecvMsgSizeBytes)),
 		grpc.UnknownServiceHandler(handleUnknownServices),


### PR DESCRIPTION
Allow users to configure the maximum concurrent streams per gRPC
connection. The default in the `grpc` package is `Math.MaxUint32`
but that seems rather excessive so the new default set by Cerbos
is 1024. Users can set the configuration value to 0 to get back
the previous behaviour.

See https://deps.dev/advisory/osv/GHSA-m425-mq94-257g

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
