### PR TITLE
chore: Expose discovered test fixture paths

### DIFF
--- a/internal/util/filesystem.go
+++ b/internal/util/filesystem.go
@@ -158,29 +158,20 @@ func LoadFromJSONOrYAML(fsys fs.FS, path string, dest proto.Message) error {
 	return ReadJSONOrYAML(f, dest)
 }
 
-// OpenOneOfSupportedFiles attempts to open a fileName adding supported extensions.
-func OpenOneOfSupportedFiles(fsys fs.FS, fileName string) (fs.File, error) {
+// GetOneOfSupportedFileNames attempts to retrieve a fileName adding supported extensions.
+func GetOneOfSupportedFileNames(fsys fs.FS, fileName string) (string, error) {
 	matches, err := fs.Glob(fsys, fileName+".*")
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	var filepath string
+
 	for _, match := range matches {
 		if IsSupportedFileType(match) {
-			filepath = match
-			break
+			return match, nil
 		}
 	}
-	if filepath == "" {
-		return nil, ErrNoMatchingFiles
-	}
 
-	file, err := fsys.Open(filepath)
-	if err != nil {
-		return nil, err
-	}
-
-	return file, nil
+	return "", ErrNoMatchingFiles
 }
 
 type IndexedFileType uint8

--- a/internal/util/filesystem_test.go
+++ b/internal/util/filesystem_test.go
@@ -37,7 +37,7 @@ func TestIsSupportedTestFile(t *testing.T) {
 	}
 }
 
-func TestOpenOneOfSupportedFiles(t *testing.T) {
+func TestGetOneOfSupportedFileNames(t *testing.T) {
 	fsys := make(fstest.MapFS)
 	file := &fstest.MapFile{Data: []byte{}}
 	fsys["testdata/a.json"] = file
@@ -46,27 +46,24 @@ func TestOpenOneOfSupportedFiles(t *testing.T) {
 	fsys["testdata/d.csv"] = file
 
 	tests := []struct {
-		fileName string
-		wantErr  bool
+		fileName, expectedNewFileName string
+		wantErr                       bool
 	}{
-		{"a", false},
-		{"b", false},
-		{"c", false},
-		{"d", true},
-		{"not_exist", true},
+		{"a", "testdata/a.json", false},
+		{"b", "testdata/b.yml", false},
+		{"c", "testdata/c.yaml", false},
+		{"d", "", true},
+		{"not_exist", "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.fileName, func(t *testing.T) {
 			is := require.New(t)
-			file, err := util.OpenOneOfSupportedFiles(fsys, filepath.Join("testdata", tt.fileName))
-			if err == nil && file != nil {
-				file.Close()
-			}
+			newName, err := util.GetOneOfSupportedFileNames(fsys, filepath.Join("testdata", tt.fileName))
 			if tt.wantErr {
 				is.Error(err)
-				is.Nil(file)
 			} else {
 				is.NoError(err)
+				is.Equal(tt.expectedNewFileName, newName)
 			}
 		})
 	}

--- a/internal/verify/test_fixture.go
+++ b/internal/verify/test_fixture.go
@@ -25,10 +25,25 @@ import (
 	"github.com/cerbos/cerbos/internal/validator"
 )
 
+type PrincipalsTestFixture struct {
+	Map      map[string]*enginev1.Principal
+	FilePath string
+}
+
+type ResourcesTestFixture struct {
+	Map      map[string]*enginev1.Resource
+	FilePath string
+}
+
+type AuxDataTestFixture struct {
+	Map      map[string]*enginev1.AuxData
+	FilePath string
+}
+
 type TestFixture struct {
-	Principals map[string]*enginev1.Principal
-	Resources  map[string]*enginev1.Resource
-	AuxData    map[string]*enginev1.AuxData
+	Principals *PrincipalsTestFixture
+	Resources  *ResourcesTestFixture
+	AuxData    *AuxDataTestFixture
 }
 
 const (
@@ -58,56 +73,77 @@ func LoadTestFixture(fsys fs.FS, path string) (tf *TestFixture, err error) {
 	return tf, nil
 }
 
-func loadResources(fsys fs.FS, path string) (map[string]*enginev1.Resource, error) {
+func loadResources(fsys fs.FS, path string) (*ResourcesTestFixture, error) {
+	fp, err := util.GetOneOfSupportedFileNames(fsys, filepath.Join(path, resourcesFileName))
+	if err != nil {
+		if errors.Is(err, util.ErrNoMatchingFiles) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
 	pb := &policyv1.TestFixture_Resources{}
-	fp := filepath.Join(path, resourcesFileName)
 	if err := loadFixtureElement(fsys, fp, pb); err != nil {
+		return nil, err
+	}
+
+	return &ResourcesTestFixture{
+		FilePath: fp,
+		Map:      pb.Resources,
+	}, nil
+}
+
+func loadPrincipals(fsys fs.FS, path string) (*PrincipalsTestFixture, error) {
+	fp, err := util.GetOneOfSupportedFileNames(fsys, filepath.Join(path, principalsFileName))
+	if err != nil {
 		if errors.Is(err, util.ErrNoMatchingFiles) {
 			return nil, nil
 		}
 		return nil, err
 	}
 
-	return pb.Resources, nil
-}
-
-func loadPrincipals(fsys fs.FS, path string) (map[string]*enginev1.Principal, error) {
 	pb := &policyv1.TestFixture_Principals{}
-	fp := filepath.Join(path, principalsFileName)
 	if err := loadFixtureElement(fsys, fp, pb); err != nil {
-		if errors.Is(err, util.ErrNoMatchingFiles) {
-			return nil, nil
-		}
 		return nil, err
 	}
 
-	return pb.Principals, nil
+	return &PrincipalsTestFixture{
+		FilePath: fp,
+		Map:      pb.Principals,
+	}, nil
 }
 
-func loadAuxData(fsys fs.FS, path string) (map[string]*enginev1.AuxData, error) {
-	pb := &policyv1.TestFixture_AuxData{}
+func loadAuxData(fsys fs.FS, path string) (*AuxDataTestFixture, error) {
 	for _, fn := range auxDataFileNames {
-		fp := filepath.Join(path, fn)
-		if err := loadFixtureElement(fsys, fp, pb); err != nil {
+		fp, err := util.GetOneOfSupportedFileNames(fsys, filepath.Join(path, fn))
+		if err != nil {
 			if errors.Is(err, util.ErrNoMatchingFiles) {
 				continue
 			}
 			return nil, err
 		}
 
-		return pb.AuxData, nil
+		pb := &policyv1.TestFixture_AuxData{}
+		if err := loadFixtureElement(fsys, fp, pb); err != nil {
+			return nil, err
+		}
+
+		return &AuxDataTestFixture{
+			FilePath: fp,
+			Map:      pb.AuxData,
+		}, nil
 	}
 
 	return nil, nil
 }
 
 func loadFixtureElement(fsys fs.FS, path string, pb proto.Message) error {
-	file, err := util.OpenOneOfSupportedFiles(fsys, path)
-	if err != nil || file == nil {
+	file, err := fsys.Open(path)
+	if err != nil {
 		return err
 	}
-
 	defer file.Close()
+
 	err = util.ReadJSONOrYAML(file, pb)
 	if err != nil {
 		return err
@@ -431,7 +467,7 @@ func (tf *TestFixture) lookupPrincipal(ts *policyv1.TestSuite, k string) (*engin
 	}
 
 	if tf != nil {
-		if v, ok := tf.Principals[k]; ok {
+		if v, ok := tf.Principals.Map[k]; ok {
 			return v, nil
 		}
 	}
@@ -445,7 +481,7 @@ func (tf *TestFixture) lookupResource(ts *policyv1.TestSuite, k string) (*engine
 	}
 
 	if tf != nil {
-		if v, ok := tf.Resources[k]; ok {
+		if v, ok := tf.Resources.Map[k]; ok {
 			return v, nil
 		}
 	}
@@ -463,7 +499,7 @@ func (tf *TestFixture) lookupAuxData(ts *policyv1.TestSuite, k string) (*enginev
 	}
 
 	if tf != nil {
-		if v, ok := tf.AuxData[k]; ok {
+		if v, ok := tf.AuxData.Map[k]; ok {
 			return v, nil
 		}
 	}

--- a/internal/verify/test_fixture.go
+++ b/internal/verify/test_fixture.go
@@ -25,25 +25,25 @@ import (
 	"github.com/cerbos/cerbos/internal/validator"
 )
 
-type PrincipalsTestFixture struct {
-	Map      map[string]*enginev1.Principal
+type Principals struct {
+	Fixtures map[string]*enginev1.Principal
 	FilePath string
 }
 
-type ResourcesTestFixture struct {
-	Map      map[string]*enginev1.Resource
+type Resources struct {
+	Fixtures map[string]*enginev1.Resource
 	FilePath string
 }
 
-type AuxDataTestFixture struct {
-	Map      map[string]*enginev1.AuxData
+type AuxData struct {
+	Fixtures map[string]*enginev1.AuxData
 	FilePath string
 }
 
 type TestFixture struct {
-	Principals *PrincipalsTestFixture
-	Resources  *ResourcesTestFixture
-	AuxData    *AuxDataTestFixture
+	Principals *Principals
+	Resources  *Resources
+	AuxData    *AuxData
 }
 
 const (
@@ -73,7 +73,7 @@ func LoadTestFixture(fsys fs.FS, path string) (tf *TestFixture, err error) {
 	return tf, nil
 }
 
-func loadResources(fsys fs.FS, path string) (*ResourcesTestFixture, error) {
+func loadResources(fsys fs.FS, path string) (*Resources, error) {
 	fp, err := util.GetOneOfSupportedFileNames(fsys, filepath.Join(path, resourcesFileName))
 	if err != nil {
 		if errors.Is(err, util.ErrNoMatchingFiles) {
@@ -87,13 +87,13 @@ func loadResources(fsys fs.FS, path string) (*ResourcesTestFixture, error) {
 		return nil, err
 	}
 
-	return &ResourcesTestFixture{
+	return &Resources{
 		FilePath: fp,
-		Map:      pb.Resources,
+		Fixtures: pb.Resources,
 	}, nil
 }
 
-func loadPrincipals(fsys fs.FS, path string) (*PrincipalsTestFixture, error) {
+func loadPrincipals(fsys fs.FS, path string) (*Principals, error) {
 	fp, err := util.GetOneOfSupportedFileNames(fsys, filepath.Join(path, principalsFileName))
 	if err != nil {
 		if errors.Is(err, util.ErrNoMatchingFiles) {
@@ -107,13 +107,13 @@ func loadPrincipals(fsys fs.FS, path string) (*PrincipalsTestFixture, error) {
 		return nil, err
 	}
 
-	return &PrincipalsTestFixture{
+	return &Principals{
 		FilePath: fp,
-		Map:      pb.Principals,
+		Fixtures: pb.Principals,
 	}, nil
 }
 
-func loadAuxData(fsys fs.FS, path string) (*AuxDataTestFixture, error) {
+func loadAuxData(fsys fs.FS, path string) (*AuxData, error) {
 	for _, fn := range auxDataFileNames {
 		fp, err := util.GetOneOfSupportedFileNames(fsys, filepath.Join(path, fn))
 		if err != nil {
@@ -128,9 +128,9 @@ func loadAuxData(fsys fs.FS, path string) (*AuxDataTestFixture, error) {
 			return nil, err
 		}
 
-		return &AuxDataTestFixture{
+		return &AuxData{
 			FilePath: fp,
-			Map:      pb.AuxData,
+			Fixtures: pb.AuxData,
 		}, nil
 	}
 
@@ -467,7 +467,7 @@ func (tf *TestFixture) lookupPrincipal(ts *policyv1.TestSuite, k string) (*engin
 	}
 
 	if tf != nil {
-		if v, ok := tf.Principals.Map[k]; ok {
+		if v, ok := tf.Principals.Fixtures[k]; ok {
 			return v, nil
 		}
 	}
@@ -481,7 +481,7 @@ func (tf *TestFixture) lookupResource(ts *policyv1.TestSuite, k string) (*engine
 	}
 
 	if tf != nil {
-		if v, ok := tf.Resources.Map[k]; ok {
+		if v, ok := tf.Resources.Fixtures[k]; ok {
 			return v, nil
 		}
 	}
@@ -499,7 +499,7 @@ func (tf *TestFixture) lookupAuxData(ts *policyv1.TestSuite, k string) (*enginev
 	}
 
 	if tf != nil {
-		if v, ok := tf.AuxData.Map[k]; ok {
+		if v, ok := tf.AuxData.Fixtures[k]; ok {
 			return v, nil
 		}
 	}

--- a/internal/verify/test_fixture_test.go
+++ b/internal/verify/test_fixture_test.go
@@ -37,15 +37,15 @@ principals:
 	fsys[expectedPath] = newMapFile(principals)
 
 	tests := []struct {
-		want    *PrincipalsTestFixture
+		want    *Principals
 		name    string
 		wantErr bool
 	}{
 		{
 			name: "a/" + util.TestDataDirectory,
-			want: &PrincipalsTestFixture{
+			want: &Principals{
 				FilePath: expectedPath,
-				Map: map[string]*v1.Principal{
+				Fixtures: map[string]*v1.Principal{
 					"harry": {
 						Id:    "harry",
 						Roles: []string{"employee"},
@@ -77,22 +77,22 @@ principals:
 
 func Test_testFixture_getTests(t *testing.T) {
 	tf := &TestFixture{
-		Principals: &PrincipalsTestFixture{
-			Map: map[string]*v1.Principal{
+		Principals: &Principals{
+			Fixtures: map[string]*v1.Principal{
 				"employee":        {Id: "employee", Roles: []string{"user"}},
 				"manager":         {Id: "manager", Roles: []string{"user"}},
 				"department_head": {Id: "department_head", Roles: []string{"user"}},
 			},
 		},
-		Resources: &ResourcesTestFixture{
-			Map: map[string]*v1.Resource{
+		Resources: &Resources{
+			Fixtures: map[string]*v1.Resource{
 				"employee_leave_request":        {Kind: "leave_request", Id: "employee"},
 				"manager_leave_request":         {Kind: "leave_request", Id: "manager"},
 				"department_head_leave_request": {Kind: "leave_request", Id: "department_head"},
 			},
 		},
-		AuxData: &AuxDataTestFixture{
-			Map: map[string]*v1.AuxData{
+		AuxData: &AuxData{
+			Fixtures: map[string]*v1.AuxData{
 				"test_aux_data": {Jwt: map[string]*structpb.Value{"answer": structpb.NewNumberValue(42)}},
 			},
 		},

--- a/internal/verify/test_fixture_test.go
+++ b/internal/verify/test_fixture_test.go
@@ -33,23 +33,27 @@ principals:
       team: design
 `
 	fsys := make(fstest.MapFS)
-	fsys["a/"+util.TestDataDirectory+"/principals.yaml"] = newMapFile(principals)
+	expectedPath := "a/" + util.TestDataDirectory + "/principals.yaml"
+	fsys[expectedPath] = newMapFile(principals)
 
 	tests := []struct {
-		want    map[string]*v1.Principal
+		want    *PrincipalsTestFixture
 		name    string
 		wantErr bool
 	}{
 		{
 			name: "a/" + util.TestDataDirectory,
-			want: map[string]*v1.Principal{
-				"harry": {
-					Id:    "harry",
-					Roles: []string{"employee"},
-					Attr: map[string]*structpb.Value{
-						"department": structpb.NewStringValue("marketing"),
-						"geography":  structpb.NewStringValue("GB"),
-						"team":       structpb.NewStringValue("design"),
+			want: &PrincipalsTestFixture{
+				FilePath: expectedPath,
+				Map: map[string]*v1.Principal{
+					"harry": {
+						Id:    "harry",
+						Roles: []string{"employee"},
+						Attr: map[string]*structpb.Value{
+							"department": structpb.NewStringValue("marketing"),
+							"geography":  structpb.NewStringValue("GB"),
+							"team":       structpb.NewStringValue("design"),
+						},
 					},
 				},
 			},
@@ -73,18 +77,24 @@ principals:
 
 func Test_testFixture_getTests(t *testing.T) {
 	tf := &TestFixture{
-		Principals: map[string]*v1.Principal{
-			"employee":        {Id: "employee", Roles: []string{"user"}},
-			"manager":         {Id: "manager", Roles: []string{"user"}},
-			"department_head": {Id: "department_head", Roles: []string{"user"}},
+		Principals: &PrincipalsTestFixture{
+			Map: map[string]*v1.Principal{
+				"employee":        {Id: "employee", Roles: []string{"user"}},
+				"manager":         {Id: "manager", Roles: []string{"user"}},
+				"department_head": {Id: "department_head", Roles: []string{"user"}},
+			},
 		},
-		Resources: map[string]*v1.Resource{
-			"employee_leave_request":        {Kind: "leave_request", Id: "employee"},
-			"manager_leave_request":         {Kind: "leave_request", Id: "manager"},
-			"department_head_leave_request": {Kind: "leave_request", Id: "department_head"},
+		Resources: &ResourcesTestFixture{
+			Map: map[string]*v1.Resource{
+				"employee_leave_request":        {Kind: "leave_request", Id: "employee"},
+				"manager_leave_request":         {Kind: "leave_request", Id: "manager"},
+				"department_head_leave_request": {Kind: "leave_request", Id: "department_head"},
+			},
 		},
-		AuxData: map[string]*v1.AuxData{
-			"test_aux_data": {Jwt: map[string]*structpb.Value{"answer": structpb.NewNumberValue(42)}},
+		AuxData: &AuxDataTestFixture{
+			Map: map[string]*v1.AuxData{
+				"test_aux_data": {Jwt: map[string]*structpb.Value{"answer": structpb.NewNumberValue(42)}},
+			},
 		},
 	}
 


### PR DESCRIPTION
Test fixtures now carry info on the discovered path where the fixture file resides. The initial use case for this is to return the filenames from a new method in the private `TestFixtureGetter` API.