### PR TITLE
chore: Allow LoadTestFixture to continue on error

### DIFF
--- a/internal/verify/test_fixture.go
+++ b/internal/verify/test_fixture.go
@@ -26,21 +26,21 @@ import (
 )
 
 type Principals struct {
+	LoadError error
 	Fixtures  map[string]*enginev1.Principal
 	FilePath  string
-	LoadError error
 }
 
 type Resources struct {
+	LoadError error
 	Fixtures  map[string]*enginev1.Resource
 	FilePath  string
-	LoadError error
 }
 
 type AuxData struct {
+	LoadError error
 	Fixtures  map[string]*enginev1.AuxData
 	FilePath  string
-	LoadError error
 }
 
 type TestFixture struct {

--- a/internal/verify/test_fixture.go
+++ b/internal/verify/test_fixture.go
@@ -26,18 +26,21 @@ import (
 )
 
 type Principals struct {
-	Fixtures map[string]*enginev1.Principal
-	FilePath string
+	Fixtures  map[string]*enginev1.Principal
+	FilePath  string
+	LoadError error
 }
 
 type Resources struct {
-	Fixtures map[string]*enginev1.Resource
-	FilePath string
+	Fixtures  map[string]*enginev1.Resource
+	FilePath  string
+	LoadError error
 }
 
 type AuxData struct {
-	Fixtures map[string]*enginev1.AuxData
-	FilePath string
+	Fixtures  map[string]*enginev1.AuxData
+	FilePath  string
+	LoadError error
 }
 
 type TestFixture struct {
@@ -53,20 +56,20 @@ const (
 
 var auxDataFileNames = []string{"auxdata", "auxData", "aux_data"}
 
-func LoadTestFixture(fsys fs.FS, path string) (tf *TestFixture, err error) {
+func LoadTestFixture(fsys fs.FS, path string, continueOnError bool) (tf *TestFixture, err error) {
 	tf = new(TestFixture)
 	tf.Principals, err = loadPrincipals(fsys, path)
-	if err != nil {
+	if err != nil && !continueOnError {
 		return nil, err
 	}
 
 	tf.Resources, err = loadResources(fsys, path)
-	if err != nil {
+	if err != nil && !continueOnError {
 		return nil, err
 	}
 
 	tf.AuxData, err = loadAuxData(fsys, path)
-	if err != nil {
+	if err != nil && !continueOnError {
 		return nil, err
 	}
 
@@ -82,15 +85,18 @@ func loadResources(fsys fs.FS, path string) (*Resources, error) {
 		return nil, err
 	}
 
-	pb := &policyv1.TestFixture_Resources{}
-	if err := loadFixtureElement(fsys, fp, pb); err != nil {
-		return nil, err
+	resources := &Resources{
+		FilePath: fp,
 	}
 
-	return &Resources{
-		FilePath: fp,
-		Fixtures: pb.Resources,
-	}, nil
+	pb := &policyv1.TestFixture_Resources{}
+	if err := loadFixtureElement(fsys, fp, pb); err != nil {
+		resources.LoadError = err
+		return resources, err
+	}
+
+	resources.Fixtures = pb.Resources
+	return resources, nil
 }
 
 func loadPrincipals(fsys fs.FS, path string) (*Principals, error) {
@@ -102,15 +108,18 @@ func loadPrincipals(fsys fs.FS, path string) (*Principals, error) {
 		return nil, err
 	}
 
-	pb := &policyv1.TestFixture_Principals{}
-	if err := loadFixtureElement(fsys, fp, pb); err != nil {
-		return nil, err
+	principals := &Principals{
+		FilePath: fp,
 	}
 
-	return &Principals{
-		FilePath: fp,
-		Fixtures: pb.Principals,
-	}, nil
+	pb := &policyv1.TestFixture_Principals{}
+	if err := loadFixtureElement(fsys, fp, pb); err != nil {
+		principals.LoadError = err
+		return principals, err
+	}
+
+	principals.Fixtures = pb.Principals
+	return principals, nil
 }
 
 func loadAuxData(fsys fs.FS, path string) (*AuxData, error) {
@@ -123,15 +132,18 @@ func loadAuxData(fsys fs.FS, path string) (*AuxData, error) {
 			return nil, err
 		}
 
-		pb := &policyv1.TestFixture_AuxData{}
-		if err := loadFixtureElement(fsys, fp, pb); err != nil {
-			return nil, err
+		auxData := &AuxData{
+			FilePath: fp,
 		}
 
-		return &AuxData{
-			FilePath: fp,
-			Fixtures: pb.AuxData,
-		}, nil
+		pb := &policyv1.TestFixture_AuxData{}
+		if err := loadFixtureElement(fsys, fp, pb); err != nil {
+			auxData.LoadError = err
+			return auxData, err
+		}
+
+		auxData.Fixtures = pb.AuxData
+		return auxData, nil
 	}
 
 	return nil, nil

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -86,7 +86,7 @@ func Verify(ctx context.Context, fsys fs.FS, eng Checker, conf Config) (*policyv
 		}
 
 		if _, exists := fixtureDefs[path]; exists {
-			f, err := LoadTestFixture(fsys, path)
+			f, err := LoadTestFixture(fsys, path, false)
 			if err != nil {
 				return nil, err
 			}

--- a/private/check/check.go
+++ b/private/check/check.go
@@ -5,7 +5,6 @@ package check
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
@@ -29,19 +28,13 @@ func NewTestFixtureGetter(fsys fs.FS) *TestFixtureGetter {
 	}
 }
 
-func (g *TestFixtureGetter) LoadTestFixture(path string) (*verify.TestFixture, error) {
-	fixture, ok := g.cache[path]
-	if !ok {
-		var err error
-		fixture, err = verify.LoadTestFixture(g.fsys, path)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load test fixture file: %w", err)
-		}
-
+func (g *TestFixtureGetter) LoadTestFixture(path string) (fixture *verify.TestFixture) {
+	fixture = g.cache[path]
+	if fixture == nil {
+		fixture, _ = verify.LoadTestFixture(g.fsys, path, true)
 		g.cache[path] = fixture
 	}
-
-	return fixture, nil
+	return
 }
 
 type TestFixtureCtx struct {


### PR DESCRIPTION
Passing `continueOnError == true` to `LoadTestFixture` will finish attempting to load all principals, resources and auxData. Any errors that occur will be stored on the type for processing later. Passing `false` will maintain current behaviour.