### PR TITLE
chore: Add tests to check fixture loading from testdata

### DIFF
--- a/internal/jsonschema/jsonschema.go
+++ b/internal/jsonschema/jsonschema.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"sort"
 	"strings"
 
 	"github.com/santhosh-tekuri/jsonschema/v5"
@@ -96,6 +97,10 @@ func newValidationErrorList(validationErr *jsonschema.ValidationError) validatio
 	for _, err := range validationErr.Causes {
 		errs = append(errs, newValidationErrorList(err)...)
 	}
+
+	sort.Slice(errs, func(i, j int) bool {
+		return errs[i].Path > errs[j].Path
+	})
 
 	return errs
 }

--- a/internal/test/testdata/verify/cases/case_016.yaml
+++ b/internal/test/testdata/verify/cases/case_016.yaml
@@ -1,0 +1,1 @@
+description: Principal testdata file not named principals.yaml

--- a/internal/test/testdata/verify/cases/case_016.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_016.yaml.golden
@@ -1,0 +1,16 @@
+{
+  "suites": [
+    {
+      "file": "udf_test.yaml",
+      "name": "TestSuite",
+      "summary": {
+        "overallResult": "RESULT_ERRORED"
+      },
+      "error": "Failed to load the test suite: invalid test \"John and his leave request\": principal \"bev\" not found",
+      "description": "Tests for verifying something"
+    }
+  ],
+  "summary": {
+    "overallResult": "RESULT_ERRORED"
+  }
+}

--- a/internal/test/testdata/verify/cases/case_016.yaml.input
+++ b/internal/test/testdata/verify/cases/case_016.yaml.input
@@ -1,0 +1,102 @@
+-- testdata/some_principals.yaml --
+---
+principals:
+  john:
+    id: john
+    policyVersion: '20210210'
+    roles:
+      - employee
+    attr:
+      department: marketing
+      geography: GB
+      team: design
+  bev: &bev
+    id: bev
+    policyVersion: '20210210'
+    roles:
+      - employee
+      - manager
+    attr: &bev_attr
+      department: marketing
+      geography: GB
+      managed_geographies: GB
+      ip_address: 10.20.1.2
+      team: design
+  matt:
+    << : *bev
+    id: matt
+    attr:
+      << : *bev_attr
+      ip_address: 10.10.1.2
+
+-- testdata/resources.yaml --
+---
+resources:
+  john_leave_request:
+    kind: leave_request
+    policyVersion: '20210210'
+    id: XX125
+    attr: &attr
+      department: marketing
+      geography: GB
+      id: XX125
+      owner: john
+      team: design
+  pending_leave_request:
+    kind: leave_request
+    policyVersion: '20210210'
+    id: XX125
+    attr:
+      << : *attr
+      status: PENDING_APPROVAL
+  stale_leave_request:
+    kind: leave_request
+    policyVersion: '20210210'
+    id: XX225
+    attr:
+      << : *attr
+      modifiedAt: "2022-08-01T15:00:00Z"
+  stale_pending_leave_request:
+    kind: leave_request
+    policyVersion: '20210210'
+    id: XX225
+    attr:
+      << : *attr
+      modifiedAt: "2022-08-01T15:00:00Z"
+      status: PENDING_APPROVAL
+
+-- testdata/auxdata.yaml --
+---
+auxData:
+  myJWT:
+    jwt:
+      iss: cerbos-test-suite
+      aud: [cerbos-jwt-tests]
+      customArray: [A, B]
+
+-- udf_test.yaml --
+---
+name: TestSuite
+description: Tests for verifying something
+tests:
+  - name: John and his leave request
+    input:
+      principals:
+        - bev
+        - matt
+      resources:
+        - pending_leave_request
+      actions:
+        - delete
+        - approve
+    expected:
+      - principal: bev
+        resource: pending_leave_request
+        actions:
+          delete: EFFECT_ALLOW
+          approve: EFFECT_ALLOW
+      - principal: matt
+        resource: pending_leave_request
+        actions:
+          delete: EFFECT_DENY
+          approve: EFFECT_ALLOW

--- a/internal/test/testdata/verify/cases/case_017.yaml
+++ b/internal/test/testdata/verify/cases/case_017.yaml
@@ -1,0 +1,1 @@
+description: Resources testdata file not named resources.yaml

--- a/internal/test/testdata/verify/cases/case_017.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_017.yaml.golden
@@ -1,0 +1,16 @@
+{
+  "suites": [
+    {
+      "file": "udf_test.yaml",
+      "name": "TestSuite",
+      "summary": {
+        "overallResult": "RESULT_ERRORED"
+      },
+      "error": "Failed to load the test suite: invalid test \"John and his leave request\": resource \"pending_leave_request\" not found",
+      "description": "Tests for verifying something"
+    }
+  ],
+  "summary": {
+    "overallResult": "RESULT_ERRORED"
+  }
+}

--- a/internal/test/testdata/verify/cases/case_017.yaml.input
+++ b/internal/test/testdata/verify/cases/case_017.yaml.input
@@ -1,0 +1,102 @@
+-- testdata/principals.yaml --
+---
+principals:
+  john:
+    id: john
+    policyVersion: '20210210'
+    roles:
+      - employee
+    attr:
+      department: marketing
+      geography: GB
+      team: design
+  bev: &bev
+    id: bev
+    policyVersion: '20210210'
+    roles:
+      - employee
+      - manager
+    attr: &bev_attr
+      department: marketing
+      geography: GB
+      managed_geographies: GB
+      ip_address: 10.20.1.2
+      team: design
+  matt:
+    << : *bev
+    id: matt
+    attr:
+      << : *bev_attr
+      ip_address: 10.10.1.2
+
+-- testdata/some_resources.yaml --
+---
+resources:
+  john_leave_request:
+    kind: leave_request
+    policyVersion: '20210210'
+    id: XX125
+    attr: &attr
+      department: marketing
+      geography: GB
+      id: XX125
+      owner: john
+      team: design
+  pending_leave_request:
+    kind: leave_request
+    policyVersion: '20210210'
+    id: XX125
+    attr:
+      << : *attr
+      status: PENDING_APPROVAL
+  stale_leave_request:
+    kind: leave_request
+    policyVersion: '20210210'
+    id: XX225
+    attr:
+      << : *attr
+      modifiedAt: "2022-08-01T15:00:00Z"
+  stale_pending_leave_request:
+    kind: leave_request
+    policyVersion: '20210210'
+    id: XX225
+    attr:
+      << : *attr
+      modifiedAt: "2022-08-01T15:00:00Z"
+      status: PENDING_APPROVAL
+
+-- testdata/auxdata.yaml --
+---
+auxData:
+  myJWT:
+    jwt:
+      iss: cerbos-test-suite
+      aud: [cerbos-jwt-tests]
+      customArray: [A, B]
+
+-- udf_test.yaml --
+---
+name: TestSuite
+description: Tests for verifying something
+tests:
+  - name: John and his leave request
+    input:
+      principals:
+        - bev
+        - matt
+      resources:
+        - pending_leave_request
+      actions:
+        - delete
+        - approve
+    expected:
+      - principal: bev
+        resource: pending_leave_request
+        actions:
+          delete: EFFECT_ALLOW
+          approve: EFFECT_ALLOW
+      - principal: matt
+        resource: pending_leave_request
+        actions:
+          delete: EFFECT_DENY
+          approve: EFFECT_ALLOW

--- a/internal/test/testdata/verify/cases/case_018.yaml
+++ b/internal/test/testdata/verify/cases/case_018.yaml
@@ -1,0 +1,1 @@
+description: AuxData testdata file not named auxdata.yaml

--- a/internal/test/testdata/verify/cases/case_018.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_018.yaml.golden
@@ -1,0 +1,16 @@
+{
+  "suites": [
+    {
+      "file": "udf_test.yaml",
+      "name": "TestSuite",
+      "summary": {
+        "overallResult": "RESULT_ERRORED"
+      },
+      "error": "Failed to load the test suite: invalid test \"John and his leave request\": auxData \"myJWT\" not found",
+      "description": "Tests for verifying something"
+    }
+  ],
+  "summary": {
+    "overallResult": "RESULT_ERRORED"
+  }
+}

--- a/internal/test/testdata/verify/cases/case_018.yaml.input
+++ b/internal/test/testdata/verify/cases/case_018.yaml.input
@@ -1,0 +1,103 @@
+-- testdata/principals.yaml --
+---
+principals:
+  john:
+    id: john
+    policyVersion: '20210210'
+    roles:
+      - employee
+    attr:
+      department: marketing
+      geography: GB
+      team: design
+  bev: &bev
+    id: bev
+    policyVersion: '20210210'
+    roles:
+      - employee
+      - manager
+    attr: &bev_attr
+      department: marketing
+      geography: GB
+      managed_geographies: GB
+      ip_address: 10.20.1.2
+      team: design
+  matt:
+    << : *bev
+    id: matt
+    attr:
+      << : *bev_attr
+      ip_address: 10.10.1.2
+
+-- testdata/resources.yaml --
+---
+resources:
+  john_leave_request:
+    kind: leave_request
+    policyVersion: '20210210'
+    id: XX125
+    attr: &attr
+      department: marketing
+      geography: GB
+      id: XX125
+      owner: john
+      team: design
+  pending_leave_request:
+    kind: leave_request
+    policyVersion: '20210210'
+    id: XX125
+    attr:
+      << : *attr
+      status: PENDING_APPROVAL
+  stale_leave_request:
+    kind: leave_request
+    policyVersion: '20210210'
+    id: XX225
+    attr:
+      << : *attr
+      modifiedAt: "2022-08-01T15:00:00Z"
+  stale_pending_leave_request:
+    kind: leave_request
+    policyVersion: '20210210'
+    id: XX225
+    attr:
+      << : *attr
+      modifiedAt: "2022-08-01T15:00:00Z"
+      status: PENDING_APPROVAL
+
+-- testdata/some_auxdata.yaml --
+---
+auxData:
+  myJWT:
+    jwt:
+      iss: cerbos-test-suite
+      aud: [cerbos-jwt-tests]
+      customArray: [A, B]
+
+-- udf_test.yaml --
+---
+name: TestSuite
+description: Tests for verifying something
+tests:
+  - name: John and his leave request
+    input:
+      principals:
+        - bev
+        - matt
+      resources:
+        - pending_leave_request
+      auxData: myJWT
+      actions:
+        - delete
+        - approve
+    expected:
+      - principal: bev
+        resource: pending_leave_request
+        actions:
+          delete: EFFECT_ALLOW
+          approve: EFFECT_ALLOW
+      - principal: matt
+        resource: pending_leave_request
+        actions:
+          delete: EFFECT_DENY
+          approve: EFFECT_ALLOW


### PR DESCRIPTION
If the fixture files were not named
`testdata/{auxdata,principals,resources}.yaml` Cerbos versions up to
0.31 panicked. That's been inadvertently fixed in `main` but it needs
  tests to make sure there are no regressions.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
