### PR TITLE
fix: Ignore empty files in policy repository

### DIFF
--- a/internal/jsonschema/jsonschema.go
+++ b/internal/jsonschema/jsonschema.go
@@ -13,8 +13,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/ghodss/yaml"
 	"github.com/santhosh-tekuri/jsonschema/v5"
-	"gopkg.in/yaml.v3"
 
 	"github.com/cerbos/cerbos/schema"
 )

--- a/internal/jsonschema/jsonschema.go
+++ b/internal/jsonschema/jsonschema.go
@@ -4,6 +4,7 @@
 package jsonschema
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -19,6 +20,8 @@ import (
 )
 
 var (
+	ErrEmptyFile = errors.New("empty file")
+
 	policySchema *jsonschema.Schema
 	testSchema   *jsonschema.Schema
 )
@@ -54,6 +57,10 @@ func validate(s *jsonschema.Schema, fsys fs.FS, path string) error {
 	data, err := io.ReadAll(f)
 	if err != nil {
 		return fmt.Errorf("failed to read file %s: %w", path, err)
+	}
+
+	if len(bytes.TrimSpace(data)) == 0 {
+		return fmt.Errorf("%w: %s", ErrEmptyFile, path)
 	}
 
 	var y any

--- a/internal/storage/index/builder.go
+++ b/internal/storage/index/builder.go
@@ -5,6 +5,7 @@ package index
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -113,12 +114,18 @@ func build(ctx context.Context, fsys fs.FS, opts buildOptions) (Index, error) {
 		}
 
 		if err := internaljsonschema.ValidatePolicy(fsys, filePath); err != nil {
+			if errors.Is(err, internaljsonschema.ErrEmptyFile) {
+				return nil
+			}
 			ib.addLoadFailure(filePath, err)
 			return nil
 		}
 
 		p := &policyv1.Policy{}
 		if err := util.LoadFromJSONOrYAML(fsys, filePath, p); err != nil {
+			if errors.Is(err, util.ErrEmptyFile) {
+				return nil
+			}
 			ib.addLoadFailure(filePath, err)
 			return nil
 		}

--- a/internal/storage/index/builder_test.go
+++ b/internal/storage/index/builder_test.go
@@ -183,7 +183,7 @@ func TestBuildIndex(t *testing.T) {
 				errList := new(BuildError)
 				require.True(t, errors.As(haveErr, &errList))
 				require.Empty(t,
-					cmp.Diff(errList.IndexBuildErrors, tc.WantErrList,
+					cmp.Diff(tc.WantErrList, errList.IndexBuildErrors,
 						protocmp.Transform(),
 						protocmp.SortRepeatedFields(&runtimev1.IndexBuildErrors{},
 							"disabled", "duplicate_defs", "load_failures", "missing_imports", "missing_scopes"),

--- a/internal/test/testdata/index/corrupt_files.yaml
+++ b/internal/test/testdata/index/corrupt_files.yaml
@@ -3,10 +3,16 @@
 wantErrList:
   loadFailures:
     - error: |-
-        file is not valid: [/: missing properties: 'apiVersion', /: additionalProperties 'key' not allowed, /: missing properties: 'resourcePolicy', /: missing properties: 'principalPolicy', /: missing properties: 'derivedRoles', /: missing properties: 'exportVariables']
+        file is not valid: [/: expected object, but got string]
+      file: invalid.json
+    - error: |-
+        file is not valid: [/: expected object, but got string]
+      file: invalid.yml
+    - error: |-
+        file is not valid: [/: additionalProperties 'key' not allowed]
       file: principal.json
     - error: |-
-        file is not valid: [/: missing properties: 'apiVersion', /: additionalProperties 'some' not allowed, /: missing properties: 'resourcePolicy', /: missing properties: 'principalPolicy', /: missing properties: 'derivedRoles', /: missing properties: 'exportVariables']
+        file is not valid: [/: additionalProperties 'some' not allowed]
       file: resource.yaml
 files:
   "resource.yaml": |-
@@ -15,3 +21,21 @@ files:
 
   "principal.json": |-
     {"key": "value"}
+
+  "empty.yaml": ""
+
+  "empty_whitespace.yaml": "          "
+
+  "commented.yaml": |-
+    # I am commented out
+    # Foo
+
+  "invalid.yml": |-
+    wat
+
+  "empty.json": ""
+
+  "empty_whitespace.json": "           "
+
+  "invalid.json": |-
+    wat

--- a/internal/test/testdata/index/corrupt_files.yaml
+++ b/internal/test/testdata/index/corrupt_files.yaml
@@ -3,16 +3,16 @@
 wantErrList:
   loadFailures:
     - error: |-
-        file is not valid: [/: expected object, but got string]
+        file is not valid: { /: [expected object, but got string] }
       file: invalid.json
     - error: |-
-        file is not valid: [/: expected object, but got string]
+        file is not valid: { /: [expected object, but got string] }
       file: invalid.yml
     - error: |-
-        file is not valid: [/: additionalProperties 'key' not allowed]
+        file is not valid: { /: [additionalProperties 'key' not allowed | missing properties: 'apiVersion' | missing properties: 'derivedRoles' | missing properties: 'exportVariables' | missing properties: 'principalPolicy' | missing properties: 'resourcePolicy'] }
       file: principal.json
     - error: |-
-        file is not valid: [/: additionalProperties 'some' not allowed]
+        file is not valid: { /: [additionalProperties 'some' not allowed | missing properties: 'apiVersion' | missing properties: 'derivedRoles' | missing properties: 'exportVariables' | missing properties: 'principalPolicy' | missing properties: 'resourcePolicy'] }
       file: resource.yaml
 files:
   "resource.yaml": |-

--- a/internal/test/testdata/index/incomplete_files.yaml
+++ b/internal/test/testdata/index/incomplete_files.yaml
@@ -4,6 +4,8 @@ wantErrList:
   loadFailures:
     - error: "file is not valid: [/derivedRoles: missing properties: 'definitions']"
       file: derived.yaml
+    - error: "file is not valid: [/resourcePolicy/version: expected string, but got boolean]"
+      file: foo.yaml
     - error: "file is not valid: [/: missing properties: 'resourcePolicy', /: missing properties: 'principalPolicy', /: missing properties: 'derivedRoles', /: missing properties: 'exportVariables']"
       file: resource.yaml
 files:
@@ -16,3 +18,9 @@ files:
     apiVersion: "api.cerbos.dev/v1"
     derivedRoles:
       name: my_derived_roles
+
+  "foo.yaml": |-
+    apiVersion: api.cerbos.dev/v1
+    resourcePolicy:
+      resource: foo
+      version: yes

--- a/internal/test/testdata/index/incomplete_files.yaml
+++ b/internal/test/testdata/index/incomplete_files.yaml
@@ -6,7 +6,7 @@ wantErrList:
       file: derived.yaml
     - error: "file is not valid: [/resourcePolicy/version: expected string, but got boolean]"
       file: foo.yaml
-    - error: "file is not valid: [/: missing properties: 'resourcePolicy', /: missing properties: 'principalPolicy', /: missing properties: 'derivedRoles', /: missing properties: 'exportVariables']"
+    - error: "file is not valid: [/: missing properties: 'derivedRoles']"
       file: resource.yaml
 files:
   "resource.yaml": |-

--- a/internal/test/testdata/index/incomplete_files.yaml
+++ b/internal/test/testdata/index/incomplete_files.yaml
@@ -2,11 +2,12 @@
 ---
 wantErrList:
   loadFailures:
-    - error: "file is not valid: [/derivedRoles: missing properties: 'definitions']"
+    - error: "file is not valid: { /derivedRoles: [missing properties: 'definitions'] }"
       file: derived.yaml
-    - error: "file is not valid: [/resourcePolicy/version: expected string, but got boolean]"
+    - error: "file is not valid: { /resourcePolicy/version: [expected string, but got boolean] }"
       file: foo.yaml
-    - error: "file is not valid: [/: missing properties: 'derivedRoles']"
+    - error: |-
+        file is not valid: { /: [missing properties: 'derivedRoles' | missing properties: 'exportVariables' | missing properties: 'principalPolicy' | missing properties: 'resourcePolicy'] }
       file: resource.yaml
 files:
   "resource.yaml": |-

--- a/internal/test/testdata/index/valid_files.yaml
+++ b/internal/test/testdata/index/valid_files.yaml
@@ -225,6 +225,14 @@ files:
         roles:
           - admin
 
+  "empty_resource.yaml": ""
+
+  "commented_resource.yaml": |-
+    # I am commented out
+    # Foo
+
+  "empty_resource.json": "           "
+
 wantCompilationUnits:
   - mainFqn: cerbos.principal.donald_duck.v20210210
     definitionFqns:

--- a/internal/test/testdata/server/playground/evaluate/pge_invalid_case_01.yaml
+++ b/internal/test/testdata/server/playground/evaluate/pge_invalid_case_01.yaml
@@ -5,44 +5,38 @@ wantStatus:
   httpStatusCode: 400
   grpcStatusCode: 0
 playgroundEvaluate:
-  input: {
-    "playgroundId": "test",
-    "files": [
-      {
-        "fileName": "common_roles.yaml",
-        "contents": "rubbish"
-      },
-      {
-        "fileName": "resource.yaml",
-        "contents": "rubbish"
-      }
-    ],
-    "actions": ["view", "delete"],
-    "principal": {
-      "id": "eduardo",
-      "roles": ["user"]
-    },
-    "resource": {
-      "kind": "album_object",
-      "id": "XX125",
-      "attr": {
-        "owner": "alicia",
-        "public": false
-      }
-    }
-  }
-  wantResponse: {
-    "playgroundId": "test",
-    "failure": {
-      "errors": [
+  input:
+    {
+      "playgroundId": "test",
+      "files":
+        [
+          { "fileName": "common_roles.yaml", "contents": "rubbish" },
+          { "fileName": "resource.yaml", "contents": "rubbish" },
+        ],
+      "actions": ["view", "delete"],
+      "principal": { "id": "eduardo", "roles": ["user"] },
+      "resource":
         {
-          "file": "resource.yaml",
-          "error": "Failed to read: failed to unmarshal file resource.yaml: yaml: invalid leading UTF-8 octet"
+          "kind": "album_object",
+          "id": "XX125",
+          "attr": { "owner": "alicia", "public": false },
         },
-        {
-          "file": "common_roles.yaml",
-          "error": "Failed to read: failed to unmarshal file common_roles.yaml: yaml: invalid leading UTF-8 octet"
-        }
-      ]
     }
-  }
+  wantResponse:
+    {
+      "playgroundId": "test",
+      "failure":
+        {
+          "errors":
+            [
+              {
+                "file": "resource.yaml",
+                "error": "Failed to read: failed to unmarshal file resource.yaml: error converting YAML to JSON: yaml: invalid leading UTF-8 octet",
+              },
+              {
+                "file": "common_roles.yaml",
+                "error": "Failed to read: failed to unmarshal file common_roles.yaml: error converting YAML to JSON: yaml: invalid leading UTF-8 octet",
+              },
+            ],
+        },
+    }

--- a/internal/test/testdata/server/playground/test/pgt_invalid_case_01.yaml
+++ b/internal/test/testdata/server/playground/test/pgt_invalid_case_01.yaml
@@ -5,35 +5,34 @@ wantStatus:
   httpStatusCode: 400
   grpcStatusCode: 0
 playgroundTest:
-  input: {
-    "playgroundId": "test",
-    "files": [
-      {
-        "fileName": "common_roles.yaml",
-        "contents": "rubbish"
-      },
-      {
-        "fileName": "resource.yaml",
-        "contents": "rubbish"
-      },
-      {
-        "fileName": "policy_04_test.yaml",
-        "contents": "{{ fileString `store/tests/policy_04_test.yaml` | b64enc }}"
-      }
-    ]
-  }
-  wantResponse: {
-    "playgroundId": "test",
-    "failure": {
-      "errors": [
-        {
-          "file": "resource.yaml",
-          "error": "Failed to read: failed to unmarshal file resource.yaml: yaml: invalid leading UTF-8 octet"
-        },
-        {
-          "file": "common_roles.yaml",
-          "error": "Failed to read: failed to unmarshal file common_roles.yaml: yaml: invalid leading UTF-8 octet"
-        }
-      ]
+  input:
+    {
+      "playgroundId": "test",
+      "files":
+        [
+          { "fileName": "common_roles.yaml", "contents": "rubbish" },
+          { "fileName": "resource.yaml", "contents": "rubbish" },
+          {
+            "fileName": "policy_04_test.yaml",
+            "contents": "{{ fileString `store/tests/policy_04_test.yaml` | b64enc }}",
+          },
+        ],
     }
-  }
+  wantResponse:
+    {
+      "playgroundId": "test",
+      "failure":
+        {
+          "errors":
+            [
+              {
+                "file": "resource.yaml",
+                "error": "Failed to read: failed to unmarshal file resource.yaml: error converting YAML to JSON: yaml: invalid leading UTF-8 octet",
+              },
+              {
+                "file": "common_roles.yaml",
+                "error": "Failed to read: failed to unmarshal file common_roles.yaml: error converting YAML to JSON: yaml: invalid leading UTF-8 octet",
+              },
+            ],
+        },
+    }

--- a/internal/test/testdata/server/playground/test/pgt_invalid_case_02.yaml
+++ b/internal/test/testdata/server/playground/test/pgt_invalid_case_02.yaml
@@ -5,40 +5,39 @@ wantStatus:
   httpStatusCode: 200
   grpcStatusCode: 0
 playgroundTest:
-  input: {
-    "playgroundId": "test",
-    "files": [
-      {
-        "fileName": "common_roles.yaml",
-        "contents": "{{ fileString `store/derived_roles/common_roles.yaml` | b64enc }}",
-      },
-      {
-        "fileName": "policy_04.yaml",
-        "contents": "{{ fileString `store/resource_policies/policy_04.yaml` | b64enc }}",
-      },
-      {
-        "fileName": "policy_04_test.yaml",
-        "contents": "rubbish"
-      }
-    ]
-  }
-  wantResponse: {
-    "playgroundId": "test",
-    "success": {
-      "results": {
-        "suites": [
+  input:
+    {
+      "playgroundId": "test",
+      "files":
+        [
           {
-            "file": "policy_04_test.yaml",
-            "name": "Unknown",
-            "error": "failed to unmarshal file policy_04_test.yaml: yaml: invalid leading UTF-8 octet",
-            "summary": {
-              "overallResult": "RESULT_ERRORED"
-            }
-          }
+            "fileName": "common_roles.yaml",
+            "contents": "{{ fileString `store/derived_roles/common_roles.yaml` | b64enc }}",
+          },
+          {
+            "fileName": "policy_04.yaml",
+            "contents": "{{ fileString `store/resource_policies/policy_04.yaml` | b64enc }}",
+          },
+          { "fileName": "policy_04_test.yaml", "contents": "rubbish" },
         ],
-        "summary": {
-          "overallResult": "RESULT_ERRORED"
-        }
-      }
     }
-  }
+  wantResponse:
+    {
+      "playgroundId": "test",
+      "success":
+        {
+          "results":
+            {
+              "suites":
+                [
+                  {
+                    "file": "policy_04_test.yaml",
+                    "name": "Unknown",
+                    "error": "failed to unmarshal file policy_04_test.yaml: error converting YAML to JSON: yaml: invalid leading UTF-8 octet",
+                    "summary": { "overallResult": "RESULT_ERRORED" },
+                  },
+                ],
+              "summary": { "overallResult": "RESULT_ERRORED" },
+            },
+        },
+    }

--- a/internal/test/testdata/server/playground/validate/pgv_invalid_case_01.yaml
+++ b/internal/test/testdata/server/playground/validate/pgv_invalid_case_01.yaml
@@ -5,31 +5,30 @@ wantStatus:
   httpStatusCode: 400
   grpcStatusCode: 0
 playgroundValidate:
-  input: {
-    "playgroundId": "test",
-    "files": [
-      {
-        "fileName": "common_roles.yaml",
-        "contents": "rubbish"
-      },
-      {
-        "fileName": "resource.yaml",
-        "contents": "rubbish"
-      }
-    ]
-  }
-  wantResponse: {
-    "playgroundId": "test",
-    "failure": {
-      "errors": [
-        {
-          "file": "resource.yaml",
-          "error": "Failed to read: failed to unmarshal file resource.yaml: yaml: invalid leading UTF-8 octet"
-        },
-        {
-          "file": "common_roles.yaml",
-          "error": "Failed to read: failed to unmarshal file common_roles.yaml: yaml: invalid leading UTF-8 octet"
-        }
-      ]
+  input:
+    {
+      "playgroundId": "test",
+      "files":
+        [
+          { "fileName": "common_roles.yaml", "contents": "rubbish" },
+          { "fileName": "resource.yaml", "contents": "rubbish" },
+        ],
     }
-  }
+  wantResponse:
+    {
+      "playgroundId": "test",
+      "failure":
+        {
+          "errors":
+            [
+              {
+                "file": "resource.yaml",
+                "error": "Failed to read: failed to unmarshal file resource.yaml: error converting YAML to JSON: yaml: invalid leading UTF-8 octet",
+              },
+              {
+                "file": "common_roles.yaml",
+                "error": "Failed to read: failed to unmarshal file common_roles.yaml: error converting YAML to JSON: yaml: invalid leading UTF-8 octet",
+              },
+            ],
+        },
+    }

--- a/internal/test/testdata/verify/cases/case_004.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_004.yaml.golden
@@ -6,7 +6,7 @@
       "summary": {
         "overallResult": "RESULT_ERRORED"
       },
-      "error": "file is not valid: [/: expected object, but got string]"
+      "error": "file is not valid: { /: [expected object, but got string] }"
     }
   ],
   "summary": {

--- a/internal/test/testdata/verify/cases/case_005.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_005.yaml.golden
@@ -6,7 +6,7 @@
       "summary": {
         "overallResult": "RESULT_ERRORED"
       },
-      "error": "file is not valid: [/: missing properties: 'tests']"
+      "error": "file is not valid: { /: [missing properties: 'tests'] }"
     }
   ],
   "summary": {

--- a/internal/test/testdata/verify/cases/case_007.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_007.yaml.golden
@@ -6,7 +6,7 @@
       "summary": {
         "overallResult": "RESULT_ERRORED"
       },
-      "error": "file is not valid: [/options/now: 'blah' is not valid 'date-time']"
+      "error": "file is not valid: { /options/now: ['blah' is not valid 'date-time'] }"
     }
   ],
   "summary": {

--- a/internal/test/testdata/verify/cases/case_014.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_014.yaml.golden
@@ -15,7 +15,7 @@
       "summary": {
         "overallResult": "RESULT_ERRORED"
       },
-      "error": "file is not valid: [/tests/0/expected/0/actions/view:public: value must be one of \"EFFECT_ALLOW\", \"EFFECT_DENY\", /tests/0/expected/0/actions/approve: value must be one of \"EFFECT_ALLOW\", \"EFFECT_DENY\"]"
+      "error": "file is not valid: [/tests/0/expected/0/actions/approve: value must be one of \"EFFECT_ALLOW\", \"EFFECT_DENY\"|/tests/0/expected/0/actions/view:public: value must be one of \"EFFECT_ALLOW\", \"EFFECT_DENY\"]"
     }
   ],
   "summary": {

--- a/internal/test/testdata/verify/cases/case_014.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_014.yaml.golden
@@ -15,7 +15,7 @@
       "summary": {
         "overallResult": "RESULT_ERRORED"
       },
-      "error": "file is not valid: [/tests/0/expected/0/actions/approve: value must be one of \"EFFECT_ALLOW\", \"EFFECT_DENY\"|/tests/0/expected/0/actions/view:public: value must be one of \"EFFECT_ALLOW\", \"EFFECT_DENY\"]"
+      "error": "file is not valid: { /tests/0/expected/0/actions/approve: [value must be one of \"EFFECT_ALLOW\", \"EFFECT_DENY\"],/tests/0/expected/0/actions/view:public: [value must be one of \"EFFECT_ALLOW\", \"EFFECT_DENY\"] }"
     }
   ],
   "summary": {

--- a/internal/util/serdeio.go
+++ b/internal/util/serdeio.go
@@ -26,6 +26,7 @@ var (
 	jsonStart           = []byte("{")
 	yamlSep             = []byte("---")
 	yamlComment         = []byte("#")
+	ErrEmptyFile        = errors.New("empty file")
 	ErrMultipleYAMLDocs = errors.New("more than one YAML document detected")
 )
 
@@ -61,6 +62,10 @@ func newJSONDecoder(src *bufio.Reader) decoderFunc {
 		jsonBytes, err := io.ReadAll(src)
 		if err != nil {
 			return err
+		}
+
+		if len(bytes.TrimSpace(jsonBytes)) == 0 {
+			return ErrEmptyFile
 		}
 
 		if err := protojson.Unmarshal(jsonBytes, dest); err != nil {
@@ -107,6 +112,11 @@ func newYAMLDecoder(src *bufio.Reader) decoderFunc {
 
 		if err := s.Err(); err != nil {
 			return fmt.Errorf("failed to read from source: %w", err)
+		}
+
+		yamlBytes := buf.Bytes()
+		if len(bytes.TrimSpace(yamlBytes)) == 0 {
+			return ErrEmptyFile
 		}
 
 		jsonBytes, err := yaml.YAMLToJSON(buf.Bytes())

--- a/internal/util/serdeio.go
+++ b/internal/util/serdeio.go
@@ -119,7 +119,7 @@ func newYAMLDecoder(src *bufio.Reader) decoderFunc {
 			return ErrEmptyFile
 		}
 
-		jsonBytes, err := yaml.YAMLToJSON(buf.Bytes())
+		jsonBytes, err := yaml.YAMLToJSON(yamlBytes)
 		if err != nil {
 			return fmt.Errorf("failed to convert YAML to JSON: %w", err)
 		}


### PR DESCRIPTION
- Ignore empty files or files with commented out contents when building the index.
- Use the same YAML library for reading policies and validating them

Fixes #1880
Fixes #1883

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
