### PR TITLE
chore: Enable Otel interceptor for grpc-gateway client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cerbos/cerbos-sdk-go v0.2.1
 	github.com/cerbos/cerbos/api/genpb v0.0.0-20231123140427-ce425d92a037
-	github.com/cerbos/cloud-api v0.1.10
+	github.com/cerbos/cloud-api v0.1.11
 	github.com/cespare/xxhash v1.1.0
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cloudflare/certinel v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/cerbos/cerbos-sdk-go v0.2.1 h1:t60WgGCg8oaIZoengZJF5LRa4EAg4Zu+RyG1wv
 github.com/cerbos/cerbos-sdk-go v0.2.1/go.mod h1:qCehuSddvfb4v85QTUbBDQ5IWQD8zWDvgRdUhMeplfo=
 github.com/cerbos/cerbos/api/genpb v0.0.0-20231123140427-ce425d92a037 h1:++YhXFcjnsZnItDEQM8yJUtY+HY9OnF4UNBw5E0oDyQ=
 github.com/cerbos/cerbos/api/genpb v0.0.0-20231123140427-ce425d92a037/go.mod h1:JpCoBGE4L7ulmSwVvtfnxepzh3CA16C06Eo6wp1TZCk=
-github.com/cerbos/cloud-api v0.1.10 h1:s9LrQG4Mg/2TjrOABEsYNDZcSOUUZJocmqqFWXqzCuk=
-github.com/cerbos/cloud-api v0.1.10/go.mod h1:Mp/jHvSLH2zG3f3nTaRQzi7ZN/JDuHaGTQ5+40JM3SI=
+github.com/cerbos/cloud-api v0.1.11 h1:dW2JXBCzs6RnxBOAE6j+EqjJvJ6zCgG7wS8PXHAItUI=
+github.com/cerbos/cloud-api v0.1.11/go.mod h1:Mp/jHvSLH2zG3f3nTaRQzi7ZN/JDuHaGTQ5+40JM3SI=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -552,6 +552,7 @@ func defaultGRPCDialOpts() []grpc.DialOption {
 	return []grpc.DialOption{
 		grpc.WithUserAgent("grpc-gateway"),
 		grpc.WithConnectParams(grpc.ConnectParams{MinConnectTimeout: minGRPCConnectTimeout}),
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 	}
 }
 


### PR DESCRIPTION
The traces don't propagate correctly without it.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
