### PR TITLE
enhancement: Add Admin API update timestamp to policy

### DIFF
--- a/cmd/cerbosctl/put/put_test.go
+++ b/cmd/cerbosctl/put/put_test.go
@@ -270,7 +270,7 @@ func mustNew(t *testing.T, cli any) *kong.Kong {
 }
 
 func withMeta(p *policyv1.Policy) *policyv1.Policy {
-	return policy.WithMetadata(p, "", nil, namer.PolicyKey(p))
+	return policy.WithMetadata(p, "", nil, namer.PolicyKey(p), policy.SourceDriver("sqlite3"))
 }
 
 const (

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -6,6 +6,7 @@ package policy
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -207,6 +208,16 @@ func SourceDriver(driver string) SourceAttribute {
 // SourceFile creates a source attribute describing the file name of the policy.
 func SourceFile(source string) SourceAttribute {
 	return SourceAttribute{Key: "source", Value: structpb.NewStringValue(source)}
+}
+
+// SourceUpdateTS creates a source attribute describing the time a policy was updated in a mutable store.
+func SourceUpdateTS(timestamp time.Time) SourceAttribute {
+	return SourceAttribute{Key: "update_ts", Value: structpb.NewStringValue(timestamp.Format(time.RFC3339))}
+}
+
+// SourceUpdateTSNow creates a source attribute setting the update time to now.
+func SourceUpdateTSNow() SourceAttribute {
+	return SourceUpdateTS(time.Now())
 }
 
 // WithSourceAttributes adds given source attributes to the policy.

--- a/internal/svc/admin_svc.go
+++ b/internal/svc/admin_svc.go
@@ -73,7 +73,7 @@ func (cas *CerbosAdminService) AddOrUpdatePolicy(ctx context.Context, req *reque
 
 	policies := make([]policy.Wrapper, len(req.Policies))
 	for i, p := range req.Policies {
-		policies[i] = policy.Wrap(p)
+		policies[i] = policy.Wrap(policy.WithSourceAttributes(p, policy.SourceUpdateTSNow()))
 	}
 
 	log := logging.ReqScopeLog(ctx)


### PR DESCRIPTION
Preserve the timestamp the Admin API was used to update a policy by
saving it as a source attribute.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
