### PR TITLE
chore: Tag API module during release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,10 @@
 snapshot:
   name_template: '{{ incminor .Version }}-prerelease'
 
+git:
+  ignore_tags:
+    - 'api/genpb/*'
+
 builds:
   - main: ./cmd/cerbos
     binary: cerbos

--- a/hack/scripts/prep-release.sh
+++ b/hack/scripts/prep-release.sh
@@ -4,10 +4,9 @@
 
 set -euo pipefail
 
-
 if [[ $# -ne 2 ]]; then
-    echo "Usage: $0 <version-to-release> <next-version>"
-    exit 2
+	echo "Usage: $0 <version-to-release> <next-version>"
+	exit 2
 fi
 
 VERSION="$1"
@@ -18,23 +17,23 @@ DOCS_DIR="${SCRIPT_DIR}/../../docs"
 CHARTS_DIR="${SCRIPT_DIR}/../../deploy/charts/cerbos"
 
 update_version() {
-    local VER="$1"
+	local VER="$1"
 
-    echo "Setting version to $VER"
+	echo "Setting version to $VER"
 
-    # Docs version
-    sed -i -E "s#app\-version: \"[0-9]+\.[0-9]+\.[0-9]+.*\"#app-version: \"${VER}@\"#" "${DOCS_DIR}/antora-playbook.yml"
-    sed -i -E "s#^version: \"[0-9]+\.[0-9]+\.[0-9]+.*\"#version: \"$VER\"#" "${DOCS_DIR}/antora.yml"
-    sed -i -E "/^prerelease:/d" "${DOCS_DIR}/antora.yml"
+	# Docs version
+	sed -i -E "s#app\-version: \"[0-9]+\.[0-9]+\.[0-9]+.*\"#app-version: \"${VER}@\"#" "${DOCS_DIR}/antora-playbook.yml"
+	sed -i -E "s#^version: \"[0-9]+\.[0-9]+\.[0-9]+.*\"#version: \"$VER\"#" "${DOCS_DIR}/antora.yml"
+	sed -i -E "/^prerelease:/d" "${DOCS_DIR}/antora.yml"
 
-    # Helm chart version
-    sed -i -E "s#appVersion: \"[0-9]+\.[0-9]+\.[0-9]+.*\"#appVersion: \"$VER\"#" "${CHARTS_DIR}/Chart.yaml"
-    sed -i -E "s#version: \"[0-9]+\.[0-9]+\.[0-9]+.*\"#version: \"$VER\"#" "${CHARTS_DIR}/Chart.yaml"
+	# Helm chart version
+	sed -i -E "s#appVersion: \"[0-9]+\.[0-9]+\.[0-9]+.*\"#appVersion: \"$VER\"#" "${CHARTS_DIR}/Chart.yaml"
+	sed -i -E "s#version: \"[0-9]+\.[0-9]+\.[0-9]+.*\"#version: \"$VER\"#" "${CHARTS_DIR}/Chart.yaml"
 }
 
 set_branch() {
-    local BRANCH="$1"
-    sed -i -E "s#branches:.*#branches: [${BRANCH}, 'v*']#g" "${DOCS_DIR}/antora-playbook.yml"
+	local BRANCH="$1"
+	sed -i -E "s#branches:.*#branches: [${BRANCH}, 'v*']#g" "${DOCS_DIR}/antora-playbook.yml"
 }
 
 # Generate NOTICE.txt
@@ -46,6 +45,7 @@ set_branch "HEAD"
 # Commit changes and tag release
 git -C "$PROJECT_DIR" commit -s -a -m "chore(release): Prepare release $VERSION"
 git tag "v${VERSION}" -m "v${VERSION}"
+git tag "api/genpb/v${VERSION}" -m "api/genpb/v${VERSION}"
 # Create a release branch
 SEGMENTS=(${VERSION//./ })
 RELEASE_BRANCH="v${SEGMENTS[0]}.${SEGMENTS[1]}"
@@ -61,4 +61,4 @@ sed -i -E "/^version:/a prerelease: -prerelease" "${DOCS_DIR}/antora.yml"
 git -C "$PROJECT_DIR" commit -s -a -m "chore(version): Bump version to $NEXT_VERSION"
 
 echo "Run the following commands to trigger the release"
-echo "git push --atomic upstream main ${RELEASE_BRANCH} v${VERSION}"
+echo "git push --atomic upstream main ${RELEASE_BRANCH} v${VERSION} api/genpb/v${VERSION}"


### PR DESCRIPTION
Modules within a monorepo should be tagged with the path to the module
according to https://go.dev/ref/mod#vcs-version. This PR updates the
release script to tag the API module appropriately as Renovate seems to
trip over it.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
