### PR TITLE
fix(planner): Query planner must (pre)evaluate expressions with resource kind

### DIFF
--- a/internal/conditions/cel.go
+++ b/internal/conditions/cel.go
@@ -17,17 +17,18 @@ import (
 )
 
 const (
-	CELRequestIdent    = "request"
-	CELResourceAbbrev  = "R"
-	CELResourceField   = "resource"
-	CELPrincipalAbbrev = "P"
-	CELPrincipalField  = "principal"
-	CELRuntimeIdent    = "runtime"
-	CELVariablesIdent  = "variables"
-	CELVariablesAbbrev = "V"
-	CELGlobalsIdent    = "globals"
-	CELGlobalsAbbrev   = "G"
-	CELAttrField       = "attr"
+	CELRequestIdent      = "request"
+	CELResourceAbbrev    = "R"
+	CELResourceKindField = "kind"
+	CELResourceField     = "resource"
+	CELPrincipalAbbrev   = "P"
+	CELPrincipalField    = "principal"
+	CELRuntimeIdent      = "runtime"
+	CELVariablesIdent    = "variables"
+	CELVariablesAbbrev   = "V"
+	CELGlobalsIdent      = "globals"
+	CELGlobalsAbbrev     = "G"
+	CELAttrField         = "attr"
 )
 
 var (
@@ -109,6 +110,13 @@ func ResourceAttributeNames(s string) []string {
 	return []string{
 		fmt.Sprintf("%s.%s.%s", CELResourceAbbrev, CELAttrField, s),     // R.attr.<s>
 		fmt.Sprintf("%s.%s.%s", Fqn(CELResourceField), CELAttrField, s), // request.resource.attr.<s>
+	}
+}
+
+func ResourceFieldNames(s string) []string {
+	return []string{
+		fmt.Sprintf("%s.%s", CELResourceAbbrev, s),     // R.<s>
+		fmt.Sprintf("%s.%s", Fqn(CELResourceField), s), // request.resource.<s>
 	}
 }
 

--- a/internal/engine/planner/planner.go
+++ b/internal/engine/planner/planner.go
@@ -581,8 +581,10 @@ func newEvaluator(request *enginev1.Request, globals map[string]any) (p *partial
 			}
 		}
 	}
-	knownVars["R.kind"] = request.Resource.GetKind()
-	ds = append(ds, decls.NewVar("R.kind", decls.String))
+	for _, s := range conditions.ResourceFieldNames(conditions.CELResourceKindField) {
+		ds = append(ds, decls.NewVar(s, decls.String))
+		knownVars[s] = request.Resource.GetKind()
+	}
 	p.env, err = p.env.Extend(cel.Declarations(ds...))
 	if err != nil {
 		return nil, err

--- a/internal/engine/planner/planner.go
+++ b/internal/engine/planner/planner.go
@@ -572,7 +572,8 @@ func newEvaluator(request *enginev1.Request, globals map[string]any) (p *partial
 
 	p.env = conditions.StdEnv
 
-	var ds []*exprpb.Decl
+	const nNameVariants = 2 // qualified, unqualified name
+	ds := make([]*exprpb.Decl, 0, nNameVariants*(len(request.Resource.GetAttr())+1))
 	if len(request.Resource.GetAttr()) > 0 {
 		for name, value := range request.Resource.Attr {
 			for _, s := range conditions.ResourceAttributeNames(name) {

--- a/internal/engine/planner/planner_test.go
+++ b/internal/engine/planner/planner_test.go
@@ -101,6 +101,17 @@ func Test_evaluateCondition(t *testing.T) {
 			}),
 			want: `R.attr.owner == "harry"`,
 		},
+		{
+			args: compile(`R.kind == P.attr.resource_name`, &enginev1.Request{
+				Principal: &enginev1.Request_Principal{
+					Attr: map[string]*structpb.Value{"resource_name": structpb.NewStringValue("resource-1")},
+				},
+				Resource: &enginev1.Request_Resource{
+					Kind: "resource-1",
+				},
+			}),
+			want: "true",
+		},
 		{ // this test case reproduced the issue #1340
 			args: compile(`P.attr.department_role[R.attr.department] == "ADMIN"`, &enginev1.Request{
 				Principal: &enginev1.Request_Principal{

--- a/internal/test/testdata/query_planner/policies/derived_roles/org_admin.yaml
+++ b/internal/test/testdata/query_planner/policies/derived_roles/org_admin.yaml
@@ -12,4 +12,4 @@ derivedRoles:
           any:
             of:
               - expr: R.kind == "organization" && R.attr.team == "RED"
-              - expr: R.kind != "organization" && R.attr.team == "BLUE"
+              - expr: request.resource.kind != "organization" && R.attr.team == "BLUE"

--- a/internal/test/testdata/query_planner/policies/derived_roles/org_admin.yaml
+++ b/internal/test/testdata/query_planner/policies/derived_roles/org_admin.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../../../../../../schema/jsonschema/cerbos/policy/v1/Policy.schema.json
+---
+apiVersion: api.cerbos.dev/v1
+derivedRoles:
+  name: org_admin_role
+  definitions:
+    - name: org_admin
+      parentRoles:
+        - USER_ORG
+      condition:
+        match:
+          any:
+            of:
+              - expr: R.kind == "organization" && R.attr.team == "RED"
+              - expr: R.kind != "organization" && R.attr.team == "BLUE"

--- a/internal/test/testdata/query_planner/policies/derived_roles/org_admin.yaml
+++ b/internal/test/testdata/query_planner/policies/derived_roles/org_admin.yaml
@@ -12,4 +12,4 @@ derivedRoles:
           any:
             of:
               - expr: R.kind == "organization" && R.attr.team == "RED"
-              - expr: request.resource.kind != "organization" && R.attr.team == "BLUE"
+              - expr: R.attr.team == "BLUE" && request.resource.kind != "organization"

--- a/internal/test/testdata/query_planner/policies/resource_policy_not-org.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policy_not-org.yaml
@@ -3,7 +3,7 @@
 apiVersion: api.cerbos.dev/v1
 resourcePolicy:
   version: default
-  resource: organization
+  resource: not-organization
   importDerivedRoles:
     - org_admin_role
   rules:

--- a/internal/test/testdata/query_planner/policies/resource_policy_org.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policy_org.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+# docs: https://docs.cerbos.dev/cerbos/latest/policies/resource_policies
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: organization
+  importDerivedRoles:
+    - org_admin_role
+  rules:
+    - actions:
+        - read
+      effect: EFFECT_ALLOW
+      derivedRoles:
+        - org_admin

--- a/internal/test/testdata/query_planner/suite/resource_kind_evaluated.yaml
+++ b/internal/test/testdata/query_planner/suite/resource_kind_evaluated.yaml
@@ -19,3 +19,15 @@ tests:
             operands:
               - variable: request.resource.attr.team
               - value: RED
+    - action: read
+      resource:
+        kind: not-organization
+        policyVersion: default
+      want:
+        kind: KIND_CONDITIONAL
+        condition:
+          expression:
+            operator: eq
+            operands:
+              - variable: request.resource.attr.team
+              - value: BLUE

--- a/internal/test/testdata/query_planner/suite/resource_kind_evaluated.yaml
+++ b/internal/test/testdata/query_planner/suite/resource_kind_evaluated.yaml
@@ -17,5 +17,5 @@ tests:
           expression:
             operator: eq
             operands:
-              - value: RED
               - variable: request.resource.attr.team
+              - value: RED

--- a/internal/test/testdata/query_planner/suite/resource_kind_evaluated.yaml
+++ b/internal/test/testdata/query_planner/suite/resource_kind_evaluated.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../../.jsonschema/QueryPlannerTestSuite.schema.json
+---
+description: Resource kind tests
+principal:
+    id: user123
+    policyVersion: default
+    roles:
+        - USER_ORG
+tests:
+    - action: read
+      resource:
+        kind: organization
+        policyVersion: default
+      want:
+        kind: KIND_CONDITIONAL
+        condition:
+          expression:
+            operator: eq
+            operands:
+              - value: RED
+              - variable: request.resource.attr.team


### PR DESCRIPTION
Resource kind is a known variable and MUST be considered while evaluating expressions:

```yaml
apiVersion: api.cerbos.dev/v1
derivedRoles:
  name: org_admin_role
  definitions:
    - name: org_admin
      parentRoles:
        - USER_ORG
      condition:
        match:
          any:
            of:
              - expr: R.kind == "organization" && R.attr.team == "RED"
              - expr: request.resource.kind != "organization" && R.attr.team == "BLUE"
```

The PR fixes this.