### PR TITLE
enhancement: Pass all HTTP headers through unmodified from gRPC-Gateway

### DIFF
--- a/internal/audit/context.go
+++ b/internal/audit/context.go
@@ -16,11 +16,10 @@ import (
 )
 
 const (
-	delimiter          = "|"
-	grpcGWUserAgentKey = "grpcgateway-user-agent"
-	userAgentKey       = "user-agent"
-	xffKey             = "x-forwarded-for"
-	callIDTagKey       = "call_id"
+	delimiter    = "|"
+	userAgentKey = "user-agent"
+	xffKey       = "x-forwarded-for"
+	callIDTagKey = "call_id"
 )
 
 type callIDCtxKeyType struct{}
@@ -62,9 +61,7 @@ func PeerFromContext(ctx context.Context) *auditv1.Peer {
 		return pp
 	}
 
-	if ua, ok := md[grpcGWUserAgentKey]; ok {
-		pp.UserAgent = strings.Join(ua, delimiter)
-	} else if ua, ok := md[userAgentKey]; ok {
+	if ua, ok := md[userAgentKey]; ok {
 		pp.UserAgent = strings.Join(ua, delimiter)
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -469,6 +469,7 @@ func (s *Server) startHTTPServer(ctx context.Context, l net.Listener, grpcSrv *g
 
 	gwmux := runtime.NewServeMux(
 		runtime.WithForwardResponseOption(customHTTPResponseCode),
+		runtime.WithIncomingHeaderMatcher(func(key string) (string, bool) { return key, true }),
 		runtime.WithMarshalerOption("application/json+pretty", &runtime.JSONPb{
 			MarshalOptions:   protojson.MarshalOptions{Indent: "  "},
 			UnmarshalOptions: protojson.UnmarshalOptions{DiscardUnknown: false},

--- a/internal/telemetry/middleware.go
+++ b/internal/telemetry/middleware.go
@@ -86,9 +86,7 @@ func (i *statsInterceptors) collectStats(ctx context.Context, method string) {
 
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
-		if v := md.Get("grpcgateway-user-agent"); len(v) > 0 {
-			mInfo.userAgent = v[0]
-		} else if v := md.Get("user-agent"); len(v) > 0 {
+		if v := md.Get("user-agent"); len(v) > 0 {
 			mInfo.userAgent = v[0]
 		}
 	}


### PR DESCRIPTION
Currently we are using gRPC-Gateway's [default header matcher](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime#DefaultHeaderMatcher), which passes standard HTTP headers through to the gRPC metadata prefixed with `grpcgateway-`. To add custom headers to the gRPC metadata, they have to have the prefix `Grpc-Metadata-` (which is stripped).

This is a bit painful when trying to implement gRPC and HTTP clients with the same interface; it means that either the HTTP client has to make a distinction between "normal" HTTP headers and gRPC metadata in order to add the prefix, or we have to document this behaviour and the user has to add the prefix themselves. Either way the HTTP client is no longer a drop-in replacement for the gRPC client because they handle headers/metadata differently.

I think it would be better if gRPC-Gateway was basically transparent as far as headers are concerned, so that gRPC and HTTP clients may send the same set of headers and have them treated in the same way.