### PR TITLE
docs: Remove older versions

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -5,12 +5,12 @@ site:
   start_page: cerbos:ROOT:index.adoc
   robots: allow
   keys:
-    google_analytics: 'G-8G3G3MS838'
+    google_analytics: "G-8G3G3MS838"
 content:
   sources:
     - url: ./../
-      branches: [HEAD, 'v{0..9}*']
-      edit_url: 'https://github.com/cerbos/cerbos/tree/main/{path}'
+      branches: [HEAD, "v{0..9}*", "!v0.{0..29}"]
+      edit_url: "https://github.com/cerbos/cerbos/tree/main/{path}"
       start_path: docs
     - url: https://github.com/cerbos/cloud-docs.git
 urls:

--- a/docs/modules/ROOT/partials/attributes.adoc
+++ b/docs/modules/ROOT/partials/attributes.adoc
@@ -11,3 +11,7 @@
 :cerbos-openapi-schema: /schema/swagger.json
 :cerbosctl-docker-img: {app-container-registry}/cerbos/cerbosctl:{app-version}
 :tutorial-base: {app-github-url}/tree/main/docs/modules/ROOT/examples/tutorial
+
+ifndef::page-component-version-is-latest[]
+NOTE: This documentation is for a previous version of Cerbos. Choose {page-component-latest-version} from the version picker at the top right or navigate to https://docs.cerbos.dev for the latest version.
+endif::[]

--- a/hack/scripts/prep-release.sh
+++ b/hack/scripts/prep-release.sh
@@ -33,7 +33,7 @@ update_version() {
 
 set_branch() {
 	local BRANCH="$1"
-	sed -i -E "s#branches:.*#branches: [${BRANCH}, 'v{0..9}*']#g" "${DOCS_DIR}/antora-playbook.yml"
+	sed -i -E "s#branches:.*#branches: [${BRANCH}, 'v{0..9}*', '!v{0..29}']#g" "${DOCS_DIR}/antora-playbook.yml"
 }
 
 # Generate NOTICE.txt

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,9 @@ from = "/cerbos/latest/:module/_images/*"
 to = "/cerbos/prerelease/:module/_images/:splat"
 status = 302
 force = true
+
+[[redirects]]
+from = "/cerbos/:version/*"
+to = "/cerbos/latest/:splat"
+status = 404
+


### PR DESCRIPTION
Remove the older versions of documentation because they just add to
build times. We've managed to maintain backward compatibility quite well
over the releases so referencing the newer docs should still work for
those who are absolutely stuck running very old versions of Cerbos.

Also adds a banner to docs to warn users that they are looking at an old
version.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
