### PR TITLE
chore: Switch workspace mode off for vulnerability check

### DIFF
--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Check vulnerabilities
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
+          GOWORK=off govulncheck ./...
 
       - name: Notify Slack
         if: failure()


### PR DESCRIPTION
It otherwise fails with:

```
govulncheck: loading modules: /opt/hostedtoolcache/go/1.21.6/x64/bin/go list -m -json -mod=mod all: exit status 1
go: -mod may only be set to readonly when in workspace mode, but it is set to "mod"
	Remove the -mod flag to use the default readonly value,
	or set GOWORK=off to disable workspace mode.
```

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
