### PR TITLE
docs: Fix branch filter

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -9,7 +9,7 @@ site:
 content:
   sources:
     - url: ./../
-      branches: [HEAD, 'v{0..9}*', '!v{0..29}']
+      branches: [HEAD, 'v{0..9}*', '!v0.{0..29}']
       edit_url: "https://github.com/cerbos/cerbos/tree/main/{path}"
       start_path: docs
     - url: https://github.com/cerbos/cloud-docs.git

--- a/hack/scripts/prep-release.sh
+++ b/hack/scripts/prep-release.sh
@@ -33,7 +33,7 @@ update_version() {
 
 set_branch() {
 	local BRANCH="$1"
-	sed -i -E "s#branches:.*#branches: [${BRANCH}, 'v{0..9}*', '!v{0..29}']#g" "${DOCS_DIR}/antora-playbook.yml"
+	sed -i -E "s#branches:.*#branches: [${BRANCH}, 'v{0..9}*', '!v0.{0..29}']#g" "${DOCS_DIR}/antora-playbook.yml"
 }
 
 # Generate NOTICE.txt


### PR DESCRIPTION
A typo in the release script made the old branch filter ineffective

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
