### PR TITLE
chore(ci): Add correct permissions to snapshot job

### DIFF
--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -58,6 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: ["tests"]
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Cosign requires `id-token: write` permission.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
