### PR TITLE
chore(ci): Fix workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       id-token: write
-      contents: read
+      contents: write
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -61,6 +61,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
By adding explicit permissions to workflows in #1959 and #1962, the
default token permissions got removed and those include the ability to
write to the container registry and create releases.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
