### PR TITLE
fix: Record HTTP remote address as peer address for HTTP requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ build: generate lint test package
 
 .PHONY: package
 package: $(GORELEASER)
-	@ TELEMETRY_WRITE_KEY=$(TELEMETRY_WRITE_KEY) TELEMETRY_URL=$(TELEMETRY_URL) $(GORELEASER) release --config=.goreleaser.yml --snapshot --skip=publish --clean
+	@ TELEMETRY_WRITE_KEY=$(TELEMETRY_WRITE_KEY) TELEMETRY_URL=$(TELEMETRY_URL) $(GORELEASER) release --config=.goreleaser.yml --snapshot --skip=announce,publish,validate,sign --clean
 
 .PHONY: docs
 docs: confdocs

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -73,7 +73,7 @@ func TestCheck(t *testing.T) {
 				haveDecisionLogs,
 				protocmp.Transform(),
 				protocmp.SortRepeatedFields(&enginev1.CheckOutput{}, "effective_derived_roles"),
-				protocmp.IgnoreFields(&auditv1.DecisionLogEntry{}, "call_id", "timestamp"),
+				protocmp.IgnoreFields(&auditv1.DecisionLogEntry{}, "call_id", "timestamp", "peer"),
 			))
 		})
 	}
@@ -115,7 +115,7 @@ func TestCheckWithLenientScopeSearch(t *testing.T) {
 				haveDecisionLogs,
 				protocmp.Transform(),
 				protocmp.SortRepeatedFields(&enginev1.CheckOutput{}, "effective_derived_roles"),
-				protocmp.IgnoreFields(&auditv1.DecisionLogEntry{}, "call_id", "timestamp"),
+				protocmp.IgnoreFields(&auditv1.DecisionLogEntry{}, "call_id", "timestamp", "peer"),
 			))
 		})
 	}


### PR DESCRIPTION
The peer address stored in the audit log is the gRPC peer address. When
there's a HTTP request, because it goes through the gRPC gateway, the
peer address reported by gRPC metadata is the localhost address.

This PR updates the gateway configuration to capture the HTTP remote
address and store it in metadata so that the audit log can record the
actual originator of the request.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
