### PR TITLE
chore(ci): Use master version of govulncheck

### DIFF
--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -3,7 +3,7 @@ name: Vulnerability Check
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 8 * * 1,3,5'
+    - cron: "0 8 * * 1,3,5"
 jobs:
   runVulnerabilityCheck:
     name: Run Vulnerability Check
@@ -18,8 +18,8 @@ jobs:
 
       - name: Check vulnerabilities
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          GOWORK=off govulncheck ./...
+          go install golang.org/x/vuln/cmd/govulncheck@master
+          govulncheck ./...
 
       - name: Notify Slack
         if: failure()

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/sony/gobreaker v0.5.0
 	github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/afero v1.11.0
+	github.com/stoewer/go-strcase v1.3.0
 	github.com/stretchr/testify v1.8.4
 	github.com/tidwall/gjson v1.17.0
 	github.com/tidwall/pretty v1.2.1
@@ -261,7 +262,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.2.1 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
-	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect


### PR DESCRIPTION
The currently released version seems to have a bug because it
incorrectly complains about missing symbols.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
