### PR TITLE
chore: Reduce Docker healthcheck interval

### DIFF
--- a/Dockerfile.cerbos
+++ b/Dockerfile.cerbos
@@ -7,7 +7,7 @@ ENV CERBOS_CONFIG="__default__"
 VOLUME ["/policies", "/tmp", "/.cache"]
 ENTRYPOINT ["/cerbos"]
 CMD ["server"]
-HEALTHCHECK --interval=1m --timeout=3s CMD ["/cerbos", "healthcheck"]
+HEALTHCHECK --interval=10s --timeout=2s --retries=2 --start-period=5s CMD ["/cerbos", "healthcheck"]
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY cerbos /cerbos
 


### PR DESCRIPTION
In Docker Compose, the helathcheck interval can add an artificial delay
because it waits for the first healthcheck to run.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
