### PR TITLE
chore: Remove start-period from Docker health check

### DIFF
--- a/Dockerfile.cerbos
+++ b/Dockerfile.cerbos
@@ -7,7 +7,7 @@ ENV CERBOS_CONFIG="__default__"
 VOLUME ["/policies", "/tmp", "/.cache"]
 ENTRYPOINT ["/cerbos"]
 CMD ["server"]
-HEALTHCHECK --interval=10s --timeout=2s --retries=2 --start-period=5s CMD ["/cerbos", "healthcheck"]
+HEALTHCHECK --interval=10s --timeout=2s --retries=2 CMD ["/cerbos", "healthcheck"]
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY cerbos /cerbos
 


### PR DESCRIPTION
Thanks to @haines for pointing out that `start-period` being less than
`interval` doesn't make sense.

Since Cerbos is pretty quick to start up, there's no point in setting
`start-period` at all.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
