### PR TITLE
chore: Add test cases for comments inside condition blocks

### DIFF
--- a/internal/test/testdata/compile/simple_valid_policy_set.yaml.golden
+++ b/internal/test/testdata/compile/simple_valid_policy_set.yaml.golden
@@ -777,7 +777,7 @@
             },
             "condition": {
               "expr": {
-                "original": "request.resource.attr.status == \"PENDING_APPROVAL\"",
+                "original": "// Comment\nrequest.resource.attr.status == \"PENDING_APPROVAL\"",
                 "checked": {
                   "referenceMap": {
                     "1": {
@@ -819,15 +819,16 @@
                   "sourceInfo": {
                     "location": "<input>",
                     "lineOffsets": [
-                      51
+                      11,
+                      62
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 7,
-                      "3": 16,
-                      "4": 21,
-                      "5": 29,
-                      "6": 32
+                      "1": 11,
+                      "2": 18,
+                      "3": 27,
+                      "4": 32,
+                      "5": 40,
+                      "6": 43
                     }
                   },
                   "expr": {

--- a/internal/test/testdata/compile/simple_valid_policy_set.yaml.input
+++ b/internal/test/testdata/compile/simple_valid_policy_set.yaml.input
@@ -47,7 +47,9 @@ resourcePolicy:
     - actions: ["approve"]
       condition:
         match:
-          expr: request.resource.attr.status == "PENDING_APPROVAL"
+          expr: |-
+            // Comment
+            request.resource.attr.status == "PENDING_APPROVAL"
       derivedRoles:
         - direct_manager
       effect: EFFECT_ALLOW

--- a/internal/test/testdata/compile/yaml_comment_in_condition.yaml
+++ b/internal/test/testdata/compile/yaml_comment_in_condition.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../.jsonschema/CompileTestCase.schema.json
+---
+mainDef: "resource_policies/leave_request_20210210.yaml"
+wantErrors:
+  - file: resource_policies/leave_request_20210210.yaml
+    error: |-
+      failed to compile `# YAML comment
+      request.resource.attr.status == "PENDING_APPROVAL"` [Syntax error: token recognition error at: '#', Syntax error: mismatched input 'comment' expecting <EOF>]
+    description: |-
+      Invalid expression: `# YAML comment
+      request.resource.attr.status == "PENDING_APPROVAL"`
+    position:
+      line: 15
+      column: 11
+      path: "$.resourcePolicy.rules[1].condition.match.expr"

--- a/internal/test/testdata/compile/yaml_comment_in_condition.yaml.input
+++ b/internal/test/testdata/compile/yaml_comment_in_condition.yaml.input
@@ -1,0 +1,21 @@
+-- resource_policies/leave_request_20210210.yaml --
+---
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  resource: leave_request
+  version: "20210210"
+  rules:
+    - actions: ['*']
+      effect: EFFECT_ALLOW
+      roles:
+        - admin
+      name: wildcard
+    - actions: ["approve"]
+      condition:
+        match:
+          expr: |-
+            # YAML comment
+            request.resource.attr.status == "PENDING_APPROVAL"
+      roles:
+        - direct_manager
+      effect: EFFECT_ALLOW

--- a/internal/test/testdata/parser/case_001.json
+++ b/internal/test/testdata/parser/case_001.json
@@ -107,7 +107,7 @@
                             ],
                             "condition": {
                                 "match": {
-                                    "expr": "request.resource.attr.geography == variables.principal_location"
+                                    "expr": "// Some comment\nrequest.resource.attr.geography == variables.principal_location\n"
                                 }
                             },
                             "derivedRoles": [

--- a/internal/test/testdata/parser/case_001.json.input
+++ b/internal/test/testdata/parser/case_001.json.input
@@ -64,7 +64,9 @@ resourcePolicy:
     - actions: ["delete"]
       condition:
         match:
-          expr: request.resource.attr.geography == variables.principal_location
+          expr: |
+            // Some comment
+            request.resource.attr.geography == variables.principal_location
       derivedRoles:
         - direct_manager
       effect: EFFECT_ALLOW

--- a/internal/test/testdata/store/resource_policies/policy_01.yaml
+++ b/internal/test/testdata/store/resource_policies/policy_01.yaml
@@ -17,7 +17,7 @@ resourcePolicy:
       ref: cerbos:///resources/leave_request.json
   resource: leave_request
   rules:
-    - actions: ['*']
+    - actions: ["*"]
       effect: EFFECT_ALLOW
       roles:
         - admin
@@ -63,7 +63,9 @@ resourcePolicy:
     - actions: ["delete"]
       condition:
         match:
-          expr: request.resource.attr.geography == variables.principal_location
+          expr: |
+            // comment
+            request.resource.attr.geography == variables.principal_location
       derivedRoles:
         - direct_manager
       effect: EFFECT_ALLOW


### PR DESCRIPTION
The old parser stripped out YAML comments from inside literal blocks as
well. That behaviour is incorrect because the spec doesn't allow
comments inside scalars. Comments for CEL expressions should use `//`
for comments instead.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>