### PR TITLE
docs(backport): Fix leading space in include directive (#1995)

### DIFF
--- a/docs/modules/policies/pages/resource_policies.adoc
+++ b/docs/modules/policies/pages/resource_policies.adoc
@@ -1,4 +1,4 @@
-    include::ROOT:partial$attributes.adoc[]
+include::ROOT:partial$attributes.adoc[]
 
 = Resource policies
 


### PR DESCRIPTION
The leading spaces cause the directive to be rendered literally

