### PR TITLE
chore(ci): Fix disk space problem on E2E tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,6 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false # this might remove tools that are actually needed, if set to "true" but frees about 6 GB
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
E2E tests were failing due to no disk space being available. This PR fixes this by executing the action https://github.com/marketplace/actions/free-disk-space-ubuntu.

Errors
```
setup.go:88:   Warning  Failed     2m8s (x6 over 4m41s)   kubelet            Error: ImagePullBackOff
setup.go:88:   Normal   BackOff    117s (x7 over 4m41s)   kubelet            Back-off pulling image "mcr.microsoft.com/azure-sql-edge:latest"
setup.go:88:   Warning  Failed     2m19s                  kubelet            Failed to pull image “[mcr.microsoft.com/azure-sql-edge:latest](http://mcr.microsoft.com/azure-sql-edge:latest)”: rpc error: code = Unknown desc = failed to pull and unpack image “[mcr.microsoft.com/azure-sql-edge:latest](http://mcr.microsoft.com/azure-sql-edge:latest)”: failed to extract layer sha256:20c7d93c7e0efccc09d55fe96f971ca9b642550eaa8176932396c0e658bc824c: write /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/65/fs/usr/share/dotnet/shared/Microsoft.NETCore.App/3.1.32/libcoreclr.so: no space left on device: unknown
[36430](https://github.com/cerbos/cerbos/actions/runs/8084470471/job/22089801218#step:7:36431)
```