### PR TITLE
feat: Add `--client` flag to `cerbosctl version`

### DIFF
--- a/cmd/cerbos/main.go
+++ b/cmd/cerbos/main.go
@@ -26,12 +26,12 @@ const (
 func main() {
 	//nolint: govet
 	var cli struct {
-		Compile     compile.Cmd     `cmd:"" help:"Compile and test policies"`
-		Server      server.Cmd      `cmd:"" help:"Start Cerbos server (PDP)"`
-		Healthcheck healthcheck.Cmd `cmd:"" help:"Healthcheck utility" aliases:"hc"`
-		Run         run.Cmd         `cmd:"" help:"Run a command in the context of a Cerbos PDP"`
-		Repl        repl.Cmd        `cmd:"" help:"Start a REPL to try out conditions"`
-		Version     kong.VersionFlag
+		Compile     compile.Cmd      `cmd:"" help:"Compile and test policies"`
+		Server      server.Cmd       `cmd:"" help:"Start Cerbos server (PDP)"`
+		Healthcheck healthcheck.Cmd  `cmd:"" help:"Healthcheck utility" aliases:"hc"`
+		Run         run.Cmd          `cmd:"" help:"Run a command in the context of a Cerbos PDP"`
+		Repl        repl.Cmd         `cmd:"" help:"Start a REPL to try out conditions"`
+		Version     kong.VersionFlag `help:"Show cerbos version"`
 	}
 
 	ctx := kong.Parse(&cli,

--- a/cmd/cerbosctl/main.go
+++ b/cmd/cerbosctl/main.go
@@ -11,11 +11,34 @@ import (
 	"github.com/cerbos/cerbos/internal/util"
 )
 
+const description = `A CLI for managing Cerbos
+
+The Cerbos Admin API must be enabled in order for these commands to work.
+The Admin API requires credentials. They can be provided using a netrc file,
+environment variables or command-line arguments.
+
+Environment variables
+
+	- CERBOS_SERVER: gRPC address of the Cerbos server
+	- CERBOS_USERNAME: Admin username
+	- CERBOS_PASSWORD: Admin password
+
+When more than one method is used to provide credentials, the precedence from lowest to
+highest is: netrc < environment < command line.
+
+Examples
+
+	# Connect to a TLS enabled server while skipping certificate verification and launch the decisions viewer
+	cerbosctl --server=localhost:3593 --username=user --password=password --insecure decisions
+
+	# Connect to a non-TLS server and launch the decisions viewer
+	cerbosctl --server=localhost:3593 --username=user --password=password --plaintext decisions`
+
 func main() {
 	cli := &root.Cli{}
 	ctx := kong.Parse(cli,
 		kong.Name("cerbosctl"),
-		kong.Description("A CLI for managing Cerbos"),
+		kong.Description(description),
 		kong.UsageOnError(),
 		kong.Vars{"version": util.AppVersion()},
 	)

--- a/cmd/cerbosctl/main.go
+++ b/cmd/cerbosctl/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cerbos/cerbos/cmd/cerbosctl/internal/client"
 	"github.com/cerbos/cerbos/cmd/cerbosctl/root"
+	"github.com/cerbos/cerbos/internal/util"
 )
 
 func main() {
@@ -16,6 +17,7 @@ func main() {
 		kong.Name("cerbosctl"),
 		kong.Description("A CLI for managing Cerbos"),
 		kong.UsageOnError(),
+		kong.Vars{"version": util.AppVersion()},
 	)
 
 	c, err := client.GetClient(&cli.Globals)

--- a/cmd/cerbosctl/root/root.go
+++ b/cmd/cerbosctl/root/root.go
@@ -18,8 +18,8 @@ import (
 
 var help = `Cerbos instance administration commands
 The Cerbos Admin API must be enabled in order for these commands to work.
-The Admin API requires credentials. They can be provided using a netrc file, 
-environment variables or command-line arguments. 
+The Admin API requires credentials. They can be provided using a netrc file,
+environment variables or command-line arguments.
 
 Environment variables
 
@@ -27,7 +27,7 @@ CERBOS_SERVER: gRPC address of the Cerbos server
 CERBOS_USERNAME: Admin username
 CERBOS_PASSWORD: Admin password
 
-When more than one method is used to provide credentials, the precedence from lowest to 
+When more than one method is used to provide credentials, the precedence from lowest to
 highest is: netrc < environment < command line.
 
 # Connect to a TLS enabled server while skipping certificate verification and launch the decisions viewer
@@ -37,16 +37,16 @@ cerbosctl --server=localhost:3593 --username=user --password=password --insecure
 cerbosctl --server=localhost:3593 --username=user --password=password --plaintext decisions`
 
 type Cli struct {
-	Version version.Cmd `cmd:"" help:"Show cerbosctl and PDP version"`
-	Get     get.Cmd     `cmd:"" help:"List or view policies and schemas"`
-	Store   store.Cmd   `cmd:"" help:"Store operations"`
+	Get get.Cmd `cmd:"" help:"List or view policies and schemas"`
 	flagset.Globals
+	Store     store.Cmd     `cmd:"" help:"Store operations"`
 	Delete    del.Cmd       `cmd:"" help:"Delete schemas"`
 	Disable   disable.Cmd   `cmd:"" help:"Disable policies"`
 	Enable    enable.Cmd    `cmd:"" help:"Enable policies"`
 	Put       put.Cmd       `cmd:"" help:"Put policies or schemas"`
 	Decisions decisions.Cmd `cmd:"" help:"Interactive decision log viewer"`
 	Audit     audit.Cmd     `cmd:"" help:"View audit logs"`
+	Version   version.Cmd   `cmd:"" help:"Show cerbosctl and PDP version"`
 }
 
 func (c *Cli) Help() string {

--- a/cmd/cerbosctl/root/root.go
+++ b/cmd/cerbosctl/root/root.go
@@ -16,26 +16,6 @@ import (
 	"github.com/cerbos/cerbos/cmd/cerbosctl/version"
 )
 
-var help = `Cerbos instance administration commands
-The Cerbos Admin API must be enabled in order for these commands to work.
-The Admin API requires credentials. They can be provided using a netrc file,
-environment variables or command-line arguments.
-
-Environment variables
-
-CERBOS_SERVER: gRPC address of the Cerbos server
-CERBOS_USERNAME: Admin username
-CERBOS_PASSWORD: Admin password
-
-When more than one method is used to provide credentials, the precedence from lowest to
-highest is: netrc < environment < command line.
-
-# Connect to a TLS enabled server while skipping certificate verification and launch the decisions viewer
-cerbosctl --server=localhost:3593 --username=user --password=password --insecure decisions
-
-# Connect to a non-TLS server and launch the decisions viewer
-cerbosctl --server=localhost:3593 --username=user --password=password --plaintext decisions`
-
 type Cli struct {
 	Get get.Cmd `cmd:"" help:"List or view policies and schemas"`
 	flagset.Globals
@@ -47,8 +27,4 @@ type Cli struct {
 	Decisions decisions.Cmd `cmd:"" help:"Interactive decision log viewer"`
 	Audit     audit.Cmd     `cmd:"" help:"View audit logs"`
 	Version   version.Cmd   `cmd:"" help:"Show cerbosctl and PDP version"`
-}
-
-func (c *Cli) Help() string {
-	return help
 }

--- a/cmd/cerbosctl/version/version.go
+++ b/cmd/cerbosctl/version/version.go
@@ -13,7 +13,9 @@ import (
 	"github.com/cerbos/cerbos/internal/util"
 )
 
-type Cmd struct{}
+type Cmd struct {
+	Client kong.VersionFlag `help:"Only show cerbosctl version"`
+}
 
 func (c *Cmd) Run(k *kong.Kong, ctx *cmdclient.Context) error {
 	_, err := fmt.Fprintf(k.Stdout, "Client version %s; commit sha: %s, build date: %s\n", util.Version, util.Commit, util.BuildDate)

--- a/docs/modules/cli/pages/cerbos.adoc
+++ b/docs/modules/cli/pages/cerbos.adoc
@@ -67,7 +67,7 @@ Arguments:
 
 Flags:
   -h, --help                       Show context-sensitive help.
-      --version
+      --version                    Show cerbos version
 
       --ignore-schemas             Ignore schemas during compilation
       --tests=STRING               Path to the directory containing tests. Defaults to policy directory.
@@ -122,7 +122,7 @@ cerbos healthcheck --kind=http --host-port=10.0.1.5:3592 --no-tls
 
 Flags:
   -h, --help           Show context-sensitive help.
-      --version
+      --version        Show cerbos version
 
       --kind="grpc"    Healthcheck kind (grpc,http) ($CERBOS_HC_KIND)
       --insecure       Do not verify server certificate ($CERBOS_HC_INSECURE)
@@ -293,7 +293,7 @@ Arguments:
 
 Flags:
   -h, --help                                    Show context-sensitive help.
-      --version
+      --version                                 Show cerbos version
 
       --log-level="info"                        Log level (debug,info,warn,error)
       --config=.cerbos.yaml                     Path to config file
@@ -325,7 +325,7 @@ cerbos server --config=/path/to/.cerbos.yaml --set=server.adminAPI.enabled=true 
 
 Flags:
   -h, --help                                    Show context-sensitive help.
-      --version
+      --version                                 Show cerbos version
 
       --debug-listen-addr=:6666                 Address to start the gops listener
       --log-level="info"                        Log level (debug,info,warn,error)

--- a/docs/modules/cli/pages/cerbosctl.adoc
+++ b/docs/modules/cli/pages/cerbosctl.adoc
@@ -1,6 +1,6 @@
 include::ROOT:partial$attributes.adoc[]
 
-= `cerbosctl` 
+= `cerbosctl`
 :page-aliases: ctl.adoc
 
 This utility can be downloaded as a separate container or a tar archive. It is automatically installed when installing Cerbos through xref:ROOT:installation/binary.adoc#linux-packages[Linux packages or the Homebrew tap].
@@ -13,14 +13,14 @@ docker run -it {cerbosctl-docker-img} \
     --server=192.168.1.10:3593 \
     --username=user \
     --password=password \
-    get rp  
+    get rp
 ----
 
 .Download and run the appropriate binary from {app-github-releases-page}
 [caption=]
 [%header,cols=".^1,.^1,3m",grid=rows]
 |===
-|OS | Arch | Bundle 
+|OS | Arch | Bundle
 |Linux | x86-64 | cerbosctl_{app-version}_Linux_x86_64.tar.gz
 |Linux | arm64 | cerbosctl_{app-version}_Linux_arm64.tar.gz
 |MacOS | universal | cerbosctl_{app-version}_Darwin_all.tar.gz
@@ -33,63 +33,63 @@ Cerbosctl requires the xref:configuration:server.adoc#admin-api[Admin API to be 
 
 The server address to connect to and the credentials to authenticate can be provided through environment variables or as arguments to the command.
 
-[source,sh]
+[source]
 ----
-Cerbos instance administration commands
-The Cerbos Admin API must be enabled in order for these commands to work.
-The Admin API requires credentials. They can be provided using a netrc file, 
-environment variables or command-line arguments. 
+Usage: cerbosctl <command>
 
-Environment variables
-
-CERBOS_SERVER: gRPC address of the Cerbos server
-CERBOS_USERNAME: Admin username
-CERBOS_PASSWORD: Admin password
-
-When more than one method is used to provide credentials, the precedence from lowest to 
-highest is: netrc < environment < command line.
-
-Usage:
-  cerbosctl [command]
-
-Examples:
-
-# Connect to a TLS enabled server while skipping certificate verification and launch the decisions viewer
-cerbosctl --server=localhost:3593 --username=user --password=password --insecure decisions
-
-# Connect to a non-TLS server and launch the decisions viewer
-cerbosctl --server=localhost:3593 --username=user --password=password --plaintext decisions
-
-Available Commands:
-  audit       View audit logs
-  completion  Generate the autocompletion script for the specified shell
-  decisions   Interactive decision log viewer
-  disable     Disable policies
-  enable      Enable policies
-  get         List or view policies and schemas
-  help        Help about any command
-  put         Put policies or schemas
-  store       Store operations
-  version     Show cerbosctl and PDP version
+A CLI for managing Cerbos
 
 Flags:
-      --ca-cert string       Path to the CA certificate for verifying server identity
-      --client-cert string   Path to the TLS client certificate
-      --client-key string    Path to the TLS client key
-  -h, --help                 help for cerbosctl
-      --insecure             Skip validating server certificate
-      --password string      Admin password
-      --plaintext            Use plaintext protocol without TLS
-      --server string        Address of the Cerbos server
-      --username string      Admin username
-  -v, --version              version for cerbosctl
+  -h, --help                       Show context-sensitive help.
+      --server="localhost:3593"    Address of the Cerbos server ($CERBOS_SERVER)
+      --username=STRING            Admin username ($CERBOS_USERNAME)
+      --password=STRING            Admin password ($CERBOS_PASSWORD)
+      --ca-cert=STRING             Path to the CA certificate for verifying server identity
+      --client-cert=STRING         Path to the TLS client certificate
+      --client-key=STRING          Path to the TLS client key
+      --insecure                   Skip validating server certificate
+      --plaintext                  Use plaintext protocol without TLS
 
-Use "cerbosctl [command] --help" for more information about a command.
+Commands:
+  get derived_roles (derived_role,dr) [<id> ...]
+
+  get export_variables (ev) [<id> ...]
+
+  get principal_policies (principal_policy,pp) [<id> ...]
+
+  get resource_policies (resource_policy,rp) [<id> ...]
+
+  get schemas (schema,s) [<id> ...]
+
+  store export (e) <path>
+
+  store reload (r)
+
+  delete schema (schemas,s) <id> ...
+
+  disable policy (policies,p) <id> ...
+
+  enable policy (policies,p) <id> ...
+
+  put policy (policies,p) <paths> ...
+
+  put schema (schemas,s) <paths> ...
+
+  decisions
+    Interactive decision log viewer
+
+  audit
+    View audit logs
+
+  version
+    Show cerbosctl and PDP version
+
+Run "cerbosctl <command> --help" for more information on a command.
 ----
 
 
 [#audit]
-== `audit` 
+== `audit`
 
 This command allows you to view the audit logs captured by the Cerbos server. xref:configuration:audit.adoc[Audit logging] must be enabled on the server to obtain the data through this command.
 
@@ -98,7 +98,7 @@ This command allows you to view the audit logs captured by the Cerbos server. xr
 ****
 
 tail:: Get the last N records (e.g. `--tail=10`)
-between:: Get records between two ISO-8601 timestamps. If the last timestamp is left out, get records from the first timestamp up to now. 
+between:: Get records between two ISO-8601 timestamps. If the last timestamp is left out, get records from the first timestamp up to now.
 +
 - `--between=2021-07-01T00:00:00Z,2021-07-02T00:00:00Z`: From midnight of 2021-07-01 to midnight of 2021-07-02.
 - `--between=2021-07-01T00:00:00Z`: From midnight of 2021-07-01 to now.

--- a/docs/modules/cli/pages/cerbosctl.adoc
+++ b/docs/modules/cli/pages/cerbosctl.adoc
@@ -39,6 +39,27 @@ Usage: cerbosctl <command>
 
 A CLI for managing Cerbos
 
+The Cerbos Admin API must be enabled in order for these commands to work.
+The Admin API requires credentials. They can be provided using a netrc file,
+environment variables or command-line arguments.
+
+Environment variables
+
+  - CERBOS_SERVER: gRPC address of the Cerbos server
+  - CERBOS_USERNAME: Admin username
+  - CERBOS_PASSWORD: Admin password
+
+When more than one method is used to provide credentials, the precedence from
+lowest to highest is: netrc < environment < command line.
+
+Examples
+
+    # Connect to a TLS enabled server while skipping certificate verification and launch the decisions viewer
+    cerbosctl --server=localhost:3593 --username=user --password=password --insecure decisions
+
+    # Connect to a non-TLS server and launch the decisions viewer
+    cerbosctl --server=localhost:3593 --username=user --password=password --plaintext decisions
+
 Flags:
   -h, --help                       Show context-sensitive help.
       --server="localhost:3593"    Address of the Cerbos server ($CERBOS_SERVER)


### PR DESCRIPTION
This PR adds a `--client` flag to `cerbosctl version`, so that it is possible to check the version of `cerbosctl` without specifying credentials or attempting to connect to a PDP server.

It also adds missing help text to the `cerbos --version` flag, and fixes the top-level help of `cerbosctl` to include the information about providing credentials.