### PR TITLE
docs: Fix broken callout

### DIFF
--- a/docs/modules/policies/pages/compile.adoc
+++ b/docs/modules/policies/pages/compile.adoc
@@ -79,7 +79,7 @@ tests: <9>
       actions: <17>
         - view
         - delete
-      auxData: validJWT <17>
+      auxData: validJWT <18>
     expected: <19>
       - principal: alicia <20>
         resource: alicia_album <21>


### PR DESCRIPTION
```
WARN (asciidoctor): no callout found for <18>
    file: /github/workspace/cerbos/docs/modules/policies/pages/compile.adoc:121
```