### PR TITLE
feat: Update Otel HTTP semantic conventions

### DIFF
--- a/internal/observability/otel/metrics.go
+++ b/internal/observability/otel/metrics.go
@@ -109,17 +109,17 @@ func dropHighCardinalityLabels() sdkmetric.View {
 	attributeFilter := func(attr attribute.KeyValue) bool {
 		attrStr := string(attr.Key)
 		switch {
-		case attrStr == "http.client_ip":
+		case attrStr == "client.address":
 			return false
-		case attrStr == "http.user_agent":
+		case attrStr == "user_agent.original":
 			return false
-		case attrStr == "http.flavor":
+		case attrStr == "network.protocol.version":
 			return false
-		case attrStr == "http.scheme":
+		case attrStr == "url.scheme":
 			return false
-		case strings.HasPrefix(attrStr, "net.peer."):
+		case strings.HasPrefix(attrStr, "server."):
 			return false
-		case strings.HasPrefix(attrStr, "net.sock.peer."):
+		case strings.HasPrefix(attrStr, "network.peer."):
 			return false
 		}
 		return true


### PR DESCRIPTION
#### Description

Updated the Otel HTTP semantic conventions to the stable release version convention. 

Previous Conventions(v1.20.0): https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/semantic_conventions/http.md#http-server

New Conventions(1.23.0): https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md#http-server

I have not yet tested this PR and hence opened this as a draft, need knowledge transfer on how correct metrics can be traced and tested with Cerbos.

cc - @charithe 


Fixes #1910 

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [X] The PR title has the correct prefix 
- [X] PR is linked to the corresponding issue
- [X] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
