### PR TITLE
docs: Change wording for prerelease caveat

### DIFF
--- a/docs/modules/ROOT/partials/attributes.adoc
+++ b/docs/modules/ROOT/partials/attributes.adoc
@@ -13,5 +13,12 @@
 :tutorial-base: {app-github-url}/tree/main/docs/modules/ROOT/examples/tutorial
 
 ifndef::page-component-version-is-latest[]
-NOTE: This documentation is for a previous version of Cerbos. Choose {page-component-latest-version} from the version picker at the top right or navigate to https://docs.cerbos.dev for the latest version.
+NOTE: This documentation is for
+ifeval::["{page-component-version}" > "{page-component-latest-version}"]
+an as-yet unreleased
 endif::[]
+ifeval::["{page-component-version}" < "{page-component-latest-version}"]
+a previous
+endif::[]
+version of Cerbos. Choose {page-component-latest-version} from the version picker at the top right or navigate to https://docs.cerbos.dev for the latest version.
+endif::page-component-version-is-latest[]


### PR DESCRIPTION
Currently, the prerelease docs have a note warning that you're looking at "a previous version". This changes it to say "an as-yet unreleased version".