### PR TITLE
chore(docs): Add redirects for image URLs

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -9,7 +9,7 @@ site:
 content:
   sources:
     - url: ./../
-      branches: [HEAD, 'v{0..9}*', '!v0.{0..29}']
+      branches: [HEAD, "v{0..9}*", "!v0.{0..30}"]
       edit_url: "https://github.com/cerbos/cerbos/tree/main/{path}"
       start_path: docs
     - url: https://github.com/cerbos/cloud-docs.git

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,8 +15,49 @@ to = "/cerbos/prerelease/:module/_images/:splat"
 status = 302
 force = true
 
+
+# Version-specific redirects because Netlify creates a redirect loop if we try to use a version wildcard.
+
+[[redirects]]
+from = "/cerbos/0.31.0/_images/*"
+to = "/cerbos/prerelease/_images/:splat"
+status = 302
+force = true
+
+[[redirects]]
+from = "/cerbos/0.31.0/:module/_images/*"
+to = "/cerbos/prerelease/:module/_images/:splat"
+status = 302
+force = true
+
+[[redirects]]
+from = "/cerbos/0.32.0/_images/*"
+to = "/cerbos/prerelease/_images/:splat"
+status = 302
+force = true
+
+[[redirects]]
+from = "/cerbos/0.32.0/:module/_images/*"
+to = "/cerbos/prerelease/:module/_images/:splat"
+status = 302
+force = true
+
+[[redirects]]
+from = "/cerbos/0.33.0/_images/*"
+to = "/cerbos/prerelease/_images/:splat"
+status = 302
+force = true
+
+[[redirects]]
+from = "/cerbos/0.33.0/:module/_images/*"
+to = "/cerbos/prerelease/:module/_images/:splat"
+status = 302
+force = true
+
+# IMG_REDIRECTS_END
+
+# This has to be at the bottom for the above redirects to work
 [[redirects]]
 from = "/cerbos/:version/*"
 to = "/cerbos/latest/:splat"
 status = 404
-

--- a/netlify.toml
+++ b/netlify.toml
@@ -54,6 +54,18 @@ to = "/cerbos/prerelease/:module/_images/:splat"
 status = 302
 force = true
 
+[[redirects]]
+from = "/cerbos/0.34.0/_images/*"
+to = "/cerbos/prerelease/_images/:splat"
+status = 302
+force = true
+
+[[redirects]]
+from = "/cerbos/0.34.0/:module/_images/*"
+to = "/cerbos/prerelease/:module/_images/:splat"
+status = 302
+force = true
+
 # IMG_REDIRECTS_END
 
 # This has to be at the bottom for the above redirects to work


### PR DESCRIPTION
Because Antora doesn't have support for Git LFS, we need to create
redirect rules to load the images correctly. This has to be done on a
version-by-version basis to avoid redirect loops.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
