### PR TITLE
chore: Add keywords to npm packages

### DIFF
--- a/hack/tools/generate-npm-packages/templates/wrapper/package.json
+++ b/hack/tools/generate-npm-packages/templates/wrapper/package.json
@@ -19,6 +19,21 @@
   "files": [
     "index.js"
   ],
+  "keywords": [
+    "Cerbos",
+    "authorization",
+    "access control",
+    "roles",
+    "permissions",
+    "policy",
+    "security",
+    "role-based access control",
+    "RBAC",
+    "attribute-based access control",
+    "ABAC",
+    "policy decision point",
+    "PDP"
+  ],
   "scripts": {},
   "optionalDependencies": {{ .OptionalDependencies }}
 }

--- a/npm/packages/cerbos/package.json
+++ b/npm/packages/cerbos/package.json
@@ -19,6 +19,21 @@
   "files": [
     "index.js"
   ],
+  "keywords": [
+    "Cerbos",
+    "authorization",
+    "access control",
+    "roles",
+    "permissions",
+    "policy",
+    "security",
+    "role-based access control",
+    "RBAC",
+    "attribute-based access control",
+    "ABAC",
+    "policy decision point",
+    "PDP"
+  ],
   "scripts": {},
   "optionalDependencies": {
     "@cerbos/cerbos-darwin-arm64": "0.35.0-prerelease",

--- a/npm/packages/cerbosctl/package.json
+++ b/npm/packages/cerbosctl/package.json
@@ -19,6 +19,21 @@
   "files": [
     "index.js"
   ],
+  "keywords": [
+    "Cerbos",
+    "authorization",
+    "access control",
+    "roles",
+    "permissions",
+    "policy",
+    "security",
+    "role-based access control",
+    "RBAC",
+    "attribute-based access control",
+    "ABAC",
+    "policy decision point",
+    "PDP"
+  ],
   "scripts": {},
   "optionalDependencies": {
     "@cerbos/cerbosctl-darwin-arm64": "0.35.0-prerelease",


### PR DESCRIPTION
This PR adds keywords to the `cerbos` and `cerbosctl` npm packages to improve discoverability on npmjs.com.

Related PR for the JS SDK: https://github.com/cerbos/cerbos-sdk-javascript/pull/859