### PR TITLE
chore: Refactor Cerbos Hub configuration

### DIFF
--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -75,6 +75,16 @@ engine:
   globals: {"environment": "staging"} # Globals are environment-specific variables to be made available to policy conditions.
   lenientScopeSearch: false # LenientScopeSearch configures the engine to ignore missing scopes and search upwards through the scope tree until it finds a usable policy.
 hub:
+  connection: # Connection holds advanced connection settings for Cerbos Hub.
+    apiEndpoint: https://api.cerbos.cloud # Required. APIEndpoint is the address of the API server.
+    bootstrapEndpoint: https://cdn.cerbos.cloud # Required. BootstrapEndpoint is the addresses of the server serving the bootstrap configuration.
+    heartbeatInterval: 2m # HeartbeatInterval is the interval for sending regular heartbeats.
+    maxRetryWait: 120s # MaxRetryWait is the maximum amount of time to wait between retries.
+    minRetryWait: 1s # MinRetryWait is the minimum amount of time to wait between retries.
+    numRetries: 5 # NumRetries is the number of times to retry before giving up.
+    tls: # TLS defines settings for TLS connections.
+      authority: domain.tld # Authority overrides the Cerbos PDP server authority if it is different from what is provided in the address.
+      caCert: /path/to/CA_certificate # CACert is the path to the CA certificate chain to use for certificate verification.
   credentials: # Credentials holds Cerbos Hub client credentials.
     clientID: 92B0K05B6HOF # ClientID of the Cerbos Hub credential. Defaults to the value of the CERBOS_HUB_CLIENT_ID environment variable.
     clientSecret: ${CERBOS_HUB_CLIENT_SECRET} # ClientSecret of the Cerbos Hub credential. Defaults to the value of the CERBOS_HUB_CLIENT_SECRET environment variable.
@@ -138,16 +148,6 @@ storage:
     remote: # Remote holds configuration for remote bundle source. Takes precedence over local if both are defined.
       bundleLabel: latest # Required. BundleLabel to fetch from the server.
       cacheDir: ${XDG_CACHE_DIR} # CacheDir is the directory to use for caching downloaded bundles.
-      connection: # Connection defines settings for the remote server connection.
-        apiEndpoint: https://api.cerbos.cloud # Required. APIEndpoint is the address of the API server.
-        bootstrapEndpoint: https://cdn.cerbos.cloud # Required. BootstrapEndpoint is the addresses of the server serving the bootstrap configuration.
-        heartbeatInterval: 2m # HeartbeatInterval is the interval for sending regular heartbeats.
-        maxRetryWait: 120s # MaxRetryWait is the maximum amount of time to wait between retries.
-        minRetryWait: 1s # MinRetryWait is the minimum amount of time to wait between retries.
-        numRetries: 5 # NumRetries is the number of times to retry before giving up.
-        tls: # TLS defines settings for TLS connections.
-          authority: domain.tld # Authority overrides the Cerbos PDP server authority if it is different from what is provided in the address.
-          caCert: /path/to/CA_certificate # CACert is the path to the CA certificate chain to use for certificate verification.
       disableAutoUpdate: <DEFAULT_VALUE_NOT_SET> # DisableAutoUpdate sets whether new bundles should be automatically downloaded and applied.
       tempDir: ${TEMP} # TempDir is the directory to use for temporary files.
   disk:

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -75,16 +75,6 @@ engine:
   globals: {"environment": "staging"} # Globals are environment-specific variables to be made available to policy conditions.
   lenientScopeSearch: false # LenientScopeSearch configures the engine to ignore missing scopes and search upwards through the scope tree until it finds a usable policy.
 hub:
-  connection: # Connection holds advanced connection settings for Cerbos Hub.
-    apiEndpoint: https://api.cerbos.cloud # Required. APIEndpoint is the address of the API server.
-    bootstrapEndpoint: https://cdn.cerbos.cloud # Required. BootstrapEndpoint is the addresses of the server serving the bootstrap configuration.
-    heartbeatInterval: 2m # HeartbeatInterval is the interval for sending regular heartbeats.
-    maxRetryWait: 120s # MaxRetryWait is the maximum amount of time to wait between retries.
-    minRetryWait: 1s # MinRetryWait is the minimum amount of time to wait between retries.
-    numRetries: 5 # NumRetries is the number of times to retry before giving up.
-    tls: # TLS defines settings for TLS connections.
-      authority: domain.tld # Authority overrides the Cerbos PDP server authority if it is different from what is provided in the address.
-      caCert: /path/to/CA_certificate # CACert is the path to the CA certificate chain to use for certificate verification.
   credentials: # Credentials holds Cerbos Hub client credentials.
     clientID: 92B0K05B6HOF # ClientID of the Cerbos Hub credential. Defaults to the value of the CERBOS_HUB_CLIENT_ID environment variable.
     clientSecret: ${CERBOS_HUB_CLIENT_SECRET} # ClientSecret of the Cerbos Hub credential. Defaults to the value of the CERBOS_HUB_CLIENT_SECRET environment variable.

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -74,6 +74,12 @@ engine:
   defaultPolicyVersion: "default" # DefaultPolicyVersion defines what version to assume if the request does not specify one.
   globals: {"environment": "staging"} # Globals are environment-specific variables to be made available to policy conditions.
   lenientScopeSearch: false # LenientScopeSearch configures the engine to ignore missing scopes and search upwards through the scope tree until it finds a usable policy.
+hub:
+  credentials: # Credentials holds Cerbos Hub client credentials.
+    clientID: 92B0K05B6HOF # ClientID of the Cerbos Hub credential. Defaults to the value of the CERBOS_HUB_CLIENT_ID environment variable.
+    clientSecret: ${CERBOS_HUB_CLIENT_SECRET} # ClientSecret of the Cerbos Hub credential. Defaults to the value of the CERBOS_HUB_CLIENT_SECRET environment variable.
+    pdpID: crb-004 # PDPID is the unique identifier for this Cerbos instance. Defaults to the value of the CERBOS_HUB_PDP_ID environment variable.
+    workspaceSecret: ${CERBOS_HUB_WORKSPACE_SECRET} # WorkspaceSecret used to decrypt the bundles. Defaults to the value of the CERBOS_HUB_WORKSPACE_SECRET environment variable.
 schema:
   cacheSize: 1024 # CacheSize defines the number of schemas to cache in memory.
   enforcement: reject # Enforcement defines level of the validations. Possible values are none, warn, reject.
@@ -126,11 +132,6 @@ storage:
   bundle:
     # This section is required only if storage.driver is bundle.
     cacheSize: 1024 # CacheSize defines the number of policies to cache in memory.
-    credentials: # Credentials holds bundle source credentials.
-      clientID: 92B0K05B6HOF # ClientID of the Cerbos Hub credential. Defaults to the value of the CERBOS_HUB_CLIENT_ID environment variable.
-      clientSecret: ${CERBOS_HUB_CLIENT_SECRET} # ClientSecret of the Cerbos Hub credential. Defaults to the value of the CERBOS_HUB_CLIENT_SECRET environment variable.
-      pdpID: crb-004 # PDPID is the unique identifier for this Cerbos instance. Defaults to the value of the CERBOS_HUB_PDP_ID environment variable.
-      workspaceSecret: ${CERBOS_HUB_WORKSPACE_SECRET} # WorkspaceSecret used to decrypt the bundles. Defaults to the value of the CERBOS_HUB_WORKSPACE_SECRET environment variable.
     local: # Local holds configuration for local bundle source.
       bundlePath: /path/to/bundle.crbp # Required. BundlePath is the full path to the local bundle file.
       tempDir: ${TEMP} # TempDir is the directory to use for temporary files.

--- a/hack/dev/conf.secure.bundle.yaml
+++ b/hack/dev/conf.secure.bundle.yaml
@@ -30,13 +30,15 @@ audit:
   file:
     path: stdout
 
+hub:
+  credentials:
+    workspaceSecret: CERBOS-1HDHY70IHFLXD-4SPXE0NZUG25FE5RW5PD7FKGPKP5CZAG53TR6HHAAN7NPMYP0YES4RQFVS
+
 storage:
   driver: "bundle"
   bundle:
     local:
       bundlePath: internal/test/testdata/bundle/bundle.crbp
-    credentials:
-      workspaceSecret: CERBOS-1HDHY70IHFLXD-4SPXE0NZUG25FE5RW5PD7FKGPKP5CZAG53TR6HHAAN7NPMYP0YES4RQFVS
 
 schema:
   enforcement: reject

--- a/internal/hub/conf.go
+++ b/internal/hub/conf.go
@@ -1,0 +1,123 @@
+// Copyright 2021-2024 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package hub
+
+import (
+	"os"
+
+	"github.com/cerbos/cerbos/internal/config"
+	"github.com/cerbos/cloud-api/credentials"
+)
+
+type EnvVarKey int
+
+const (
+	BundleLabelKey EnvVarKey = iota
+	ClientIDKey
+	ClientSecretKey
+	OfflineKey
+	PDPIDKey
+	WorkspaceSecretKey
+)
+
+var envVars = map[EnvVarKey][]string{
+	BundleLabelKey:     {"CERBOS_HUB_BUNDLE", "CERBOS_CLOUD_BUNDLE"},
+	ClientIDKey:        {"CERBOS_HUB_CLIENT_ID", "CERBOS_CLOUD_CLIENT_ID"},
+	ClientSecretKey:    {"CERBOS_HUB_CLIENT_SECRET", "CERBOS_CLOUD_CLIENT_SECRET"},
+	OfflineKey:         {"CERBOS_HUB_OFFLINE", "CERBOS_CLOUD_OFFLINE"},
+	PDPIDKey:           {"CERBOS_HUB_PDP_ID", "CERBOS_PDP_ID"},
+	WorkspaceSecretKey: {"CERBOS_HUB_WORKSPACE_SECRET", "CERBOS_CLOUD_SECRET_KEY"},
+}
+
+func GetEnv(key EnvVarKey) string {
+	varNames, ok := envVars[key]
+	if !ok {
+		return ""
+	}
+
+	for _, v := range varNames {
+		val, ok := os.LookupEnv(v)
+		if ok {
+			return val
+		}
+	}
+
+	return ""
+}
+
+const (
+	confKey = "hub"
+
+	DefaultAPIEndpoint   = "https://api.cerbos.cloud"
+	DefaultBootstrapHost = "https://cdn.cerbos.cloud"
+)
+
+type Conf struct {
+	// Credentials holds Cerbos Hub client credentials.
+	Credentials CredentialsConf `yaml:"credentials"`
+}
+
+func (conf *Conf) Key() string {
+	return confKey
+}
+
+// CredentialsConf holds credentials for accessing Cerbos Hub.
+type CredentialsConf struct {
+	// PDPID is the unique identifier for this Cerbos instance. Defaults to the value of the CERBOS_HUB_PDP_ID environment variable.
+	PDPID string `yaml:"pdpID" conf:",example=crb-004"`
+	// ClientID of the Cerbos Hub credential. Defaults to the value of the CERBOS_HUB_CLIENT_ID environment variable.
+	ClientID string `yaml:"clientID" conf:",example=92B0K05B6HOF"`
+	// ClientSecret of the Cerbos Hub credential. Defaults to the value of the CERBOS_HUB_CLIENT_SECRET environment variable.
+	ClientSecret string `yaml:"clientSecret" conf:",example=${CERBOS_HUB_CLIENT_SECRET}"`
+	// WorkspaceSecret used to decrypt the bundles. Defaults to the value of the CERBOS_HUB_WORKSPACE_SECRET environment variable.
+	WorkspaceSecret string `yaml:"workspaceSecret" conf:",example=${CERBOS_HUB_WORKSPACE_SECRET}"`
+	// Deprecated: Use PDPID
+	InstanceID string `yaml:"instanceID" conf:",ignore"`
+	// Deprecated: Use WorkspaceSecret
+	SecretKey string `yaml:"secretKey" conf:",ignore"`
+}
+
+func (cc CredentialsConf) IsUnset() bool {
+	return cc == CredentialsConf{}
+}
+
+func (cc *CredentialsConf) Validate() (outErr error) {
+	// SecretKey was renamed to WorkspaceSecret in Cerbos 0.31.0
+	if cc.WorkspaceSecret == "" && cc.SecretKey != "" {
+		cc.WorkspaceSecret = cc.SecretKey
+	}
+
+	// InstanceID was renamed to PDPID in Cerbos 0.31.0
+	if cc.PDPID == "" && cc.InstanceID != "" {
+		cc.PDPID = cc.InstanceID
+	}
+
+	// We don't do any validation here because some fields are optional depending on the use case.
+
+	return nil
+}
+
+func (cc CredentialsConf) ToCredentials() (*credentials.Credentials, error) {
+	return credentials.New(cc.ClientID, cc.ClientSecret, cc.WorkspaceSecret)
+}
+
+func (conf *Conf) SetDefaults() {
+	conf.Credentials = CredentialsConf{
+		ClientID:        GetEnv(ClientIDKey),
+		ClientSecret:    GetEnv(ClientSecretKey),
+		PDPID:           GetEnv(PDPIDKey),
+		WorkspaceSecret: GetEnv(WorkspaceSecretKey),
+	}
+}
+
+func (conf *Conf) Validate() error {
+	return conf.Credentials.Validate()
+}
+
+func GetConf() (*Conf, error) {
+	conf := &Conf{}
+	err := config.GetSection(conf)
+
+	return conf, err
+}

--- a/internal/hub/conf.go
+++ b/internal/hub/conf.go
@@ -62,7 +62,7 @@ type Conf struct {
 	// Credentials holds Cerbos Hub client credentials.
 	Credentials CredentialsConf `yaml:"credentials"`
 	// Connection holds advanced connection settings for Cerbos Hub.
-	Connection ConnectionConf `yaml:"connection"`
+	Connection ConnectionConf `yaml:"connection" conf:",ignore"`
 }
 
 func (conf *Conf) Key() string {

--- a/internal/hub/conf.go
+++ b/internal/hub/conf.go
@@ -194,7 +194,7 @@ func (cc *ConnectionConf) Validate() error {
 
 // TLSConf holds TLS configuration for the remote connection.
 type TLSConf struct {
-	// Authority overrides the Cerbos PDP server authority if it is different from what is provided in the address.
+	// Authority overrides the Cerbos Hub server authority if it is different from what is provided in the API and bootstrap endpoints.
 	Authority string `yaml:"authority" conf:",example=domain.tld"`
 	// CACert is the path to the CA certificate chain to use for certificate verification.
 	CACert string `yaml:"caCert" conf:",example=/path/to/CA_certificate"`

--- a/internal/hub/conf.go
+++ b/internal/hub/conf.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cerbos/cerbos/internal/config"
+	"github.com/cerbos/cerbos/internal/util"
 	"github.com/cerbos/cloud-api/credentials"
 )
 
@@ -37,9 +38,12 @@ func GetEnv(key EnvVarKey) string {
 		return ""
 	}
 
-	for _, v := range varNames {
+	for i, v := range varNames {
 		val, ok := os.LookupEnv(v)
 		if ok {
+			if i > 0 {
+				util.DeprecationWarning(v, varNames[0])
+			}
 			return val
 		}
 	}
@@ -102,11 +106,13 @@ type CredentialsConf struct {
 func (cc *CredentialsConf) Validate() (outErr error) {
 	// SecretKey was renamed to WorkspaceSecret in Cerbos 0.31.0
 	if cc.WorkspaceSecret == "" && cc.SecretKey != "" {
+		util.DeprecationWarning("credentials.secretKey", "credentials.workspaceSecret")
 		cc.WorkspaceSecret = cc.SecretKey
 	}
 
 	// InstanceID was renamed to PDPID in Cerbos 0.31.0
 	if cc.PDPID == "" && cc.InstanceID != "" {
+		util.DeprecationWarning("credentials.instanceID", "credentials.pdpID")
 		cc.PDPID = cc.InstanceID
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -87,7 +87,7 @@ func TestServer(t *testing.T) {
 
 			conf := &bundle.Conf{
 				CacheSize:   1024,
-				Credentials: hub.CredentialsConf{WorkspaceSecret: string(bytes.TrimSpace(keyBytes))},
+				Credentials: &hub.CredentialsConf{WorkspaceSecret: string(bytes.TrimSpace(keyBytes))},
 				Local: &bundle.LocalSourceConf{
 					BundlePath: filepath.Join(dir, "bundle.crbp"),
 					TempDir:    t.TempDir(),

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cerbos/cerbos/internal/auxdata"
 	"github.com/cerbos/cerbos/internal/compile"
 	"github.com/cerbos/cerbos/internal/engine"
+	"github.com/cerbos/cerbos/internal/hub"
 	"github.com/cerbos/cerbos/internal/observability/logging"
 	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage"
@@ -86,7 +87,7 @@ func TestServer(t *testing.T) {
 
 			conf := &bundle.Conf{
 				CacheSize:   1024,
-				Credentials: bundle.CredentialsConf{WorkspaceSecret: string(bytes.TrimSpace(keyBytes))},
+				Credentials: hub.CredentialsConf{WorkspaceSecret: string(bytes.TrimSpace(keyBytes))},
 				Local: &bundle.LocalSourceConf{
 					BundlePath: filepath.Join(dir, "bundle.crbp"),
 					TempDir:    t.TempDir(),

--- a/internal/storage/bundle/conf.go
+++ b/internal/storage/bundle/conf.go
@@ -12,16 +12,13 @@ import (
 	"time"
 
 	"github.com/cerbos/cerbos/internal/config"
+	"github.com/cerbos/cerbos/internal/hub"
 	"github.com/cerbos/cerbos/internal/storage"
-	"github.com/cerbos/cloud-api/credentials"
 	"go.uber.org/multierr"
 )
 
 const (
-	confKey = storage.ConfKey + "." + DriverName
-
-	defaultAPIEndpoint       = "https://api.cerbos.cloud"
-	defaultBootstrapHost     = "https://cdn.cerbos.cloud"
+	confKey                  = storage.ConfKey + "." + DriverName
 	defaultCacheSize         = 1024
 	defaultHeartbeatInterval = 180 * time.Second
 	defaultMaxRetryWait      = 120 * time.Second
@@ -30,43 +27,10 @@ const (
 	minHeartbeatInterval     = 30 * time.Second
 )
 
-var ErrNoSource = errors.New("at least one of local or remote sources must be defined")
-
-type envVarKey int
-
-const (
-	bundleLabelKey envVarKey = iota
-	clientIDKey
-	clientSecretKey
-	offlineKey
-	pdpIDKey
-	workspaceSecretKey
+var (
+	ErrDuplicateCredentials = errors.New("both cerbosHub.credentials and storage.bundle.credentials are defined: please use cerbosHub.credentials")
+	ErrNoSource             = errors.New("at least one of local or remote sources must be defined")
 )
-
-var envVars = map[envVarKey][]string{
-	bundleLabelKey:     {"CERBOS_HUB_BUNDLE", "CERBOS_CLOUD_BUNDLE"},
-	clientIDKey:        {"CERBOS_HUB_CLIENT_ID", "CERBOS_CLOUD_CLIENT_ID"},
-	clientSecretKey:    {"CERBOS_HUB_CLIENT_SECRET", "CERBOS_CLOUD_CLIENT_SECRET"},
-	offlineKey:         {"CERBOS_HUB_OFFLINE", "CERBOS_CLOUD_OFFLINE"},
-	pdpIDKey:           {"CERBOS_HUB_PDP_ID", "CERBOS_PDP_ID"},
-	workspaceSecretKey: {"CERBOS_HUB_WORKSPACE_SECRET", "CERBOS_CLOUD_SECRET_KEY"},
-}
-
-func getEnv(key envVarKey) string {
-	varNames, ok := envVars[key]
-	if !ok {
-		return ""
-	}
-
-	for _, v := range varNames {
-		val, ok := os.LookupEnv(v)
-		if ok {
-			return val
-		}
-	}
-
-	return ""
-}
 
 // Conf is required (if driver is set to 'bundle') configuration for bundle storage driver.
 // +desc=This section is required only if storage.driver is bundle.
@@ -76,29 +40,9 @@ type Conf struct {
 	// Local holds configuration for local bundle source.
 	Local *LocalSourceConf `yaml:"local"`
 	// Credentials holds bundle source credentials.
-	Credentials CredentialsConf `yaml:"credentials"`
+	Credentials hub.CredentialsConf `yaml:"credentials" conf:",ignore"`
 	// CacheSize defines the number of policies to cache in memory.
 	CacheSize uint `yaml:"cacheSize" conf:",example=1024"`
-}
-
-// CredentialsConf holds credentials for accessing the bundle service.
-type CredentialsConf struct {
-	// PDPID is the unique identifier for this Cerbos instance. Defaults to the value of the CERBOS_HUB_PDP_ID environment variable.
-	PDPID string `yaml:"pdpID" conf:",example=crb-004"`
-	// ClientID of the Cerbos Hub credential. Defaults to the value of the CERBOS_HUB_CLIENT_ID environment variable.
-	ClientID string `yaml:"clientID" conf:",example=92B0K05B6HOF"`
-	// ClientSecret of the Cerbos Hub credential. Defaults to the value of the CERBOS_HUB_CLIENT_SECRET environment variable.
-	ClientSecret string `yaml:"clientSecret" conf:",example=${CERBOS_HUB_CLIENT_SECRET}"`
-	// WorkspaceSecret used to decrypt the bundles. Defaults to the value of the CERBOS_HUB_WORKSPACE_SECRET environment variable.
-	WorkspaceSecret string `yaml:"workspaceSecret" conf:",example=${CERBOS_HUB_WORKSPACE_SECRET}"`
-	// Deprecated: Use PDPID
-	InstanceID string `yaml:"instanceID" conf:",ignore"`
-	// Deprecated: Use WorkspaceSecret
-	SecretKey string `yaml:"secretKey" conf:",ignore"`
-}
-
-func (cc CredentialsConf) ToCredentials() (*credentials.Credentials, error) {
-	return credentials.New(cc.ClientID, cc.ClientSecret, cc.WorkspaceSecret)
 }
 
 // LocalSourceConf holds configuration for local bundle store.
@@ -141,6 +85,37 @@ type ConnectionConf struct {
 	HeartbeatInterval time.Duration `yaml:"heartbeatInterval" conf:",example=2m"`
 }
 
+func (cc *ConnectionConf) setDefaultsForUnsetFields() {
+	if cc.APIEndpoint == "" {
+		cc.APIEndpoint = hub.DefaultAPIEndpoint
+	}
+
+	if cc.BootstrapEndpoint == "" {
+		cc.BootstrapEndpoint = hub.DefaultBootstrapHost
+	}
+
+	if cc.MinRetryWait == 0 {
+		cc.MinRetryWait = defaultMinRetryWait
+	}
+
+	if cc.MaxRetryWait == 0 {
+		cc.MaxRetryWait = defaultMaxRetryWait
+	}
+
+	if cc.NumRetries == 0 {
+		cc.NumRetries = defaultNumRetries
+	}
+
+	switch {
+	case cc.HeartbeatInterval < 0:
+		cc.HeartbeatInterval = 0
+	case cc.HeartbeatInterval == 0:
+		cc.HeartbeatInterval = defaultHeartbeatInterval
+	case cc.HeartbeatInterval > 0 && cc.HeartbeatInterval < minHeartbeatInterval:
+		cc.HeartbeatInterval = minHeartbeatInterval
+	}
+}
+
 // TLSConf holds TLS configuration for the remote connection.
 type TLSConf struct {
 	// Authority overrides the Cerbos PDP server authority if it is different from what is provided in the address.
@@ -155,13 +130,6 @@ func (conf *Conf) Key() string {
 
 func (conf *Conf) SetDefaults() {
 	conf.CacheSize = defaultCacheSize
-
-	conf.Credentials = CredentialsConf{
-		ClientID:        getEnv(clientIDKey),
-		ClientSecret:    getEnv(clientSecretKey),
-		PDPID:           getEnv(pdpIDKey),
-		WorkspaceSecret: getEnv(workspaceSecretKey),
-	}
 }
 
 func (conf *Conf) Validate() (outErr error) {
@@ -181,17 +149,28 @@ func (conf *Conf) Validate() (outErr error) {
 		outErr = multierr.Append(outErr, err)
 	}
 
-	// SecretKey was renamed to WorkspaceSecret in Cerbos 0.31.0
-	if conf.Credentials.WorkspaceSecret == "" && conf.Credentials.SecretKey != "" {
-		conf.Credentials.WorkspaceSecret = conf.Credentials.SecretKey
-	}
-
-	// InstanceID was renamed to PDPID in Cerbos 0.31.0
-	if conf.Credentials.PDPID == "" && conf.Credentials.InstanceID != "" {
-		conf.Credentials.PDPID = conf.Credentials.InstanceID
+	if err := conf.validateCredentials(); err != nil {
+		outErr = multierr.Append(outErr, err)
 	}
 
 	return outErr
+}
+
+func (conf *Conf) validateCredentials() error {
+	hubConf, err := hub.GetConf()
+	if err != nil {
+		return fmt.Errorf("failed to read Cerbos Hub configuration: %w", err)
+	}
+
+	switch {
+	case hubConf.Credentials.IsUnset():
+		return conf.Credentials.Validate()
+	case conf.Credentials.IsUnset():
+		conf.Credentials = hubConf.Credentials
+		return conf.Credentials.Validate()
+	default:
+		return ErrDuplicateCredentials
+	}
 }
 
 func (lc *LocalSourceConf) validate() error {
@@ -211,7 +190,7 @@ func (lc *LocalSourceConf) validate() error {
 	return nil
 }
 
-func (lc *LocalSourceConf) setDefaults() error {
+func (lc *LocalSourceConf) setDefaultsForUnsetFields() error {
 	if lc == nil {
 		return errors.New("configuration is undefined")
 	}
@@ -233,7 +212,7 @@ func (rc *RemoteSourceConf) validate() error {
 	}
 
 	if rc.BundleLabel == "" {
-		rc.BundleLabel = getEnv(bundleLabelKey)
+		rc.BundleLabel = hub.GetEnv(hub.BundleLabelKey)
 	}
 
 	if strings.TrimSpace(rc.BundleLabel) == "" {
@@ -243,13 +222,13 @@ func (rc *RemoteSourceConf) validate() error {
 	return nil
 }
 
-func (rc *RemoteSourceConf) setDefaults() error {
+func (rc *RemoteSourceConf) setDefaultsForUnsetFields() error {
 	if rc == nil {
 		return errors.New("configuration is undefined")
 	}
 
 	if rc.BundleLabel == "" {
-		rc.BundleLabel = getEnv(bundleLabelKey)
+		rc.BundleLabel = hub.GetEnv(hub.BundleLabelKey)
 	}
 
 	if rc.TempDir == "" {
@@ -275,35 +254,7 @@ func (rc *RemoteSourceConf) setDefaults() error {
 		rc.CacheDir = dir
 	}
 
-	if rc.Connection.APIEndpoint == "" {
-		rc.Connection.APIEndpoint = defaultAPIEndpoint
-	}
-
-	if rc.Connection.BootstrapEndpoint == "" {
-		rc.Connection.BootstrapEndpoint = defaultBootstrapHost
-	}
-
-	if rc.Connection.MinRetryWait == 0 {
-		rc.Connection.MinRetryWait = defaultMinRetryWait
-	}
-
-	if rc.Connection.MaxRetryWait == 0 {
-		rc.Connection.MaxRetryWait = defaultMaxRetryWait
-	}
-
-	if rc.Connection.NumRetries == 0 {
-		rc.Connection.NumRetries = defaultNumRetries
-	}
-
-	switch {
-	case rc.Connection.HeartbeatInterval < 0:
-		rc.Connection.HeartbeatInterval = 0
-	case rc.Connection.HeartbeatInterval == 0:
-		rc.Connection.HeartbeatInterval = defaultHeartbeatInterval
-	case rc.Connection.HeartbeatInterval > 0 && rc.Connection.HeartbeatInterval < minHeartbeatInterval:
-		rc.Connection.HeartbeatInterval = minHeartbeatInterval
-	}
-
+	rc.Connection.setDefaultsForUnsetFields()
 	return nil
 }
 

--- a/internal/storage/bundle/conf.go
+++ b/internal/storage/bundle/conf.go
@@ -11,11 +11,11 @@ import (
 	"strings"
 
 	"go.uber.org/multierr"
-	"go.uber.org/zap"
 
 	"github.com/cerbos/cerbos/internal/config"
 	"github.com/cerbos/cerbos/internal/hub"
 	"github.com/cerbos/cerbos/internal/storage"
+	"github.com/cerbos/cerbos/internal/util"
 )
 
 const (
@@ -94,7 +94,7 @@ func (conf *Conf) Validate() (outErr error) {
 
 func (conf *Conf) validateCredentials() error {
 	if conf.Credentials != nil {
-		zap.L().Warn("[DEPRECATED CONFIG] storage.bundle.credentials section is deprecated and will be removed in a future release. Please use hub.credentials instead.")
+		util.DeprecationWarning("storage.bundle.credentials section", "hub.credentials")
 		conf.Credentials.LoadFromEnv()
 		return conf.Credentials.Validate()
 	}
@@ -190,7 +190,7 @@ func (rc *RemoteSourceConf) setDefaultsForUnsetFields() error {
 	}
 
 	if rc.Connection != nil {
-		zap.L().Warn("[DEPRECATED CONFIG] storage.bundle.remote.connection section is deprecated and will be removed in a future release. Please use hub.connection instead.")
+		util.DeprecationWarning("storage.bundle.remote.connection section", "hub.connection")
 		return rc.Connection.Validate()
 	}
 

--- a/internal/storage/bundle/conf_test.go
+++ b/internal/storage/bundle/conf_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cerbos/cerbos/internal/config"
+	"github.com/cerbos/cerbos/internal/hub"
 	"github.com/cerbos/cerbos/internal/storage/bundle"
 )
 
@@ -85,6 +86,59 @@ func TestConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "file/valid-credentials-from-hub",
+			conf: map[string]any{
+				"hub": map[string]any{
+					"credentials": map[string]any{
+						"pdpID":           "pdp-id",
+						"clientID":        "client-id",
+						"clientSecret":    "client-secret",
+						"workspaceSecret": "workspace-secret",
+					},
+				},
+				"storage": map[string]any{
+					"bundle": map[string]any{
+						"cacheSize": 1024,
+						"remote": map[string]any{
+							"bundleLabel": "latest",
+							"tempDir":     "/tmp",
+							"cacheDir":    "/tmp",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "file/duplicate-credentials",
+			conf: map[string]any{
+				"hub": map[string]any{
+					"credentials": map[string]any{
+						"pdpID":           "pdp-id",
+						"clientID":        "client-id",
+						"clientSecret":    "client-secret",
+						"workspaceSecret": "workspace-secret",
+					},
+				},
+				"storage": map[string]any{
+					"bundle": map[string]any{
+						"cacheSize": 1024,
+						"credentials": map[string]any{
+							"pdpID":           "pdp-id",
+							"clientID":        "client-id",
+							"clientSecret":    "client-secret",
+							"workspaceSecret": "workspace-secret",
+						},
+						"remote": map[string]any{
+							"bundleLabel": "latest",
+							"tempDir":     "/tmp",
+							"cacheDir":    "/tmp",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "env/valid-config",
 			conf: map[string]any{
 				"storage": map[string]any{
@@ -151,7 +205,7 @@ func TestConfig(t *testing.T) {
 
 	want := &bundle.Conf{
 		CacheSize: 1024,
-		Credentials: bundle.CredentialsConf{
+		Credentials: hub.CredentialsConf{
 			PDPID:           "pdp-id",
 			ClientID:        "client-id",
 			ClientSecret:    "client-secret",
@@ -180,7 +234,7 @@ func TestConfig(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Empty(t, cmp.Diff(want, have, cmpopts.IgnoreFields(bundle.CredentialsConf{}, "InstanceID", "SecretKey")))
+			require.Empty(t, cmp.Diff(want, have, cmpopts.IgnoreFields(hub.CredentialsConf{}, "InstanceID", "SecretKey")))
 		})
 	}
 }

--- a/internal/storage/bundle/conf_test.go
+++ b/internal/storage/bundle/conf_test.go
@@ -130,10 +130,10 @@ func TestConfig(t *testing.T) {
 			conf: map[string]any{
 				"hub": map[string]any{
 					"credentials": map[string]any{
-						"pdpID":           "pdp-id",
-						"clientID":        "client-id",
-						"clientSecret":    "client-secret",
-						"workspaceSecret": "workspace-secret",
+						"pdpID":           "Xpdp-id",
+						"clientID":        "Xclient-id",
+						"clientSecret":    "Xclient-secret",
+						"workspaceSecret": "Xworkspace-secret",
 					},
 					"connection": map[string]any{
 						"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
@@ -157,7 +157,6 @@ func TestConfig(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "file/duplicate-connection",
@@ -170,8 +169,8 @@ func TestConfig(t *testing.T) {
 						"workspaceSecret": "workspace-secret",
 					},
 					"connection": map[string]any{
-						"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
-						"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
+						"apiEndpoint":       "Xhttps://api.stg-spitfire.cerbos.tech",
+						"bootstrapEndpoint": "Xhttps://cdn.stg-spitfire.cerbos.tech",
 					},
 				},
 				"storage": map[string]any{
@@ -189,7 +188,6 @@ func TestConfig(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "env/valid-config",
@@ -270,7 +268,7 @@ func TestConfig(t *testing.T) {
 
 	want := &bundle.Conf{
 		CacheSize: 1024,
-		Credentials: hub.CredentialsConf{
+		Credentials: &hub.CredentialsConf{
 			PDPID:           "pdp-id",
 			ClientID:        "client-id",
 			ClientSecret:    "client-secret",
@@ -280,7 +278,7 @@ func TestConfig(t *testing.T) {
 			BundleLabel: "latest",
 			TempDir:     "/tmp",
 			CacheDir:    "/tmp",
-			Connection: hub.ConnectionConf{
+			Connection: &hub.ConnectionConf{
 				APIEndpoint:       "https://api.stg-spitfire.cerbos.tech",
 				BootstrapEndpoint: "https://cdn.stg-spitfire.cerbos.tech",
 				MinRetryWait:      1 * time.Second,

--- a/internal/storage/bundle/conf_test.go
+++ b/internal/storage/bundle/conf_test.go
@@ -5,6 +5,7 @@ package bundle_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -38,6 +39,10 @@ func TestConfig(t *testing.T) {
 							"bundleLabel": "latest",
 							"tempDir":     "/tmp",
 							"cacheDir":    "/tmp",
+							"connection": map[string]any{
+								"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
+								"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
+							},
 						},
 					},
 				},
@@ -59,6 +64,10 @@ func TestConfig(t *testing.T) {
 							"bundleLabel": "latest",
 							"tempDir":     "/tmp",
 							"cacheDir":    "/tmp",
+							"connection": map[string]any{
+								"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
+								"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
+							},
 						},
 					},
 				},
@@ -79,6 +88,10 @@ func TestConfig(t *testing.T) {
 						"remote": map[string]any{
 							"tempDir":  "/tmp",
 							"cacheDir": "/tmp",
+							"connection": map[string]any{
+								"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
+								"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
+							},
 						},
 					},
 				},
@@ -86,7 +99,7 @@ func TestConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "file/valid-credentials-from-hub",
+			name: "file/valid-config-from-hub",
 			conf: map[string]any{
 				"hub": map[string]any{
 					"credentials": map[string]any{
@@ -94,6 +107,10 @@ func TestConfig(t *testing.T) {
 						"clientID":        "client-id",
 						"clientSecret":    "client-secret",
 						"workspaceSecret": "workspace-secret",
+					},
+					"connection": map[string]any{
+						"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
+						"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
 					},
 				},
 				"storage": map[string]any{
@@ -118,6 +135,10 @@ func TestConfig(t *testing.T) {
 						"clientSecret":    "client-secret",
 						"workspaceSecret": "workspace-secret",
 					},
+					"connection": map[string]any{
+						"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
+						"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
+					},
 				},
 				"storage": map[string]any{
 					"bundle": map[string]any{
@@ -139,6 +160,38 @@ func TestConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "file/duplicate-connection",
+			conf: map[string]any{
+				"hub": map[string]any{
+					"credentials": map[string]any{
+						"pdpID":           "pdp-id",
+						"clientID":        "client-id",
+						"clientSecret":    "client-secret",
+						"workspaceSecret": "workspace-secret",
+					},
+					"connection": map[string]any{
+						"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
+						"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
+					},
+				},
+				"storage": map[string]any{
+					"bundle": map[string]any{
+						"cacheSize": 1024,
+						"remote": map[string]any{
+							"bundleLabel": "latest",
+							"tempDir":     "/tmp",
+							"cacheDir":    "/tmp",
+							"connection": map[string]any{
+								"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
+								"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "env/valid-config",
 			conf: map[string]any{
 				"storage": map[string]any{
@@ -147,6 +200,10 @@ func TestConfig(t *testing.T) {
 						"remote": map[string]any{
 							"tempDir":  "/tmp",
 							"cacheDir": "/tmp",
+							"connection": map[string]any{
+								"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
+								"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
+							},
 						},
 					},
 				},
@@ -168,6 +225,10 @@ func TestConfig(t *testing.T) {
 						"remote": map[string]any{
 							"tempDir":  "/tmp",
 							"cacheDir": "/tmp",
+							"connection": map[string]any{
+								"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
+								"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
+							},
 						},
 					},
 				},
@@ -189,6 +250,10 @@ func TestConfig(t *testing.T) {
 						"remote": map[string]any{
 							"tempDir":  "/tmp",
 							"cacheDir": "/tmp",
+							"connection": map[string]any{
+								"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
+								"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
+							},
 						},
 					},
 				},
@@ -215,6 +280,14 @@ func TestConfig(t *testing.T) {
 			BundleLabel: "latest",
 			TempDir:     "/tmp",
 			CacheDir:    "/tmp",
+			Connection: hub.ConnectionConf{
+				APIEndpoint:       "https://api.stg-spitfire.cerbos.tech",
+				BootstrapEndpoint: "https://cdn.stg-spitfire.cerbos.tech",
+				MinRetryWait:      1 * time.Second,
+				MaxRetryWait:      120 * time.Second,
+				NumRetries:        5,
+				HeartbeatInterval: 180 * time.Second,
+			},
 		},
 	}
 

--- a/internal/storage/bundle/local_source.go
+++ b/internal/storage/bundle/local_source.go
@@ -33,7 +33,7 @@ type LocalSource struct {
 }
 
 func NewLocalSourceFromConf(_ context.Context, conf *Conf) (*LocalSource, error) {
-	if err := conf.Local.setDefaults(); err != nil {
+	if err := conf.Local.setDefaultsForUnsetFields(); err != nil {
 		return nil, err
 	}
 

--- a/internal/storage/bundle/remote_source.go
+++ b/internal/storage/bundle/remote_source.go
@@ -62,10 +62,6 @@ type RemoteSource struct {
 }
 
 func NewRemoteSource(conf *Conf) (*RemoteSource, error) {
-	if err := conf.Remote.setDefaultsForUnsetFields(); err != nil {
-		return nil, err
-	}
-
 	credentials, err := conf.Credentials.ToCredentials()
 	if err != nil {
 		return nil, fmt.Errorf("invalid credentials: %w", err)

--- a/internal/storage/bundle/remote_source.go
+++ b/internal/storage/bundle/remote_source.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
+	"github.com/cerbos/cerbos/internal/hub"
 	"github.com/cerbos/cerbos/internal/namer"
 	"github.com/cerbos/cerbos/internal/observability/metrics"
 	"github.com/cerbos/cerbos/internal/storage"
@@ -61,7 +62,7 @@ type RemoteSource struct {
 }
 
 func NewRemoteSource(conf *Conf) (*RemoteSource, error) {
-	if err := conf.Remote.setDefaults(); err != nil {
+	if err := conf.Remote.setDefaultsForUnsetFields(); err != nil {
 		return nil, err
 	}
 
@@ -156,7 +157,7 @@ func (s *RemoteSource) InitWithClient(ctx context.Context, client CloudAPIClient
 }
 
 func shouldWorkOffline() bool {
-	v := getEnv(offlineKey)
+	v := hub.GetEnv(hub.OfflineKey)
 	offline, err := strconv.ParseBool(v)
 	if err != nil {
 		return false

--- a/internal/storage/bundle/remote_source_test.go
+++ b/internal/storage/bundle/remote_source_test.go
@@ -311,7 +311,7 @@ func mkConf(t *testing.T, disableAutoUpdate bool) *bundle.Conf {
 
 	conf := &bundle.Conf{
 		CacheSize: 1024,
-		Credentials: hub.CredentialsConf{
+		Credentials: &hub.CredentialsConf{
 			ClientID:        "client-id",
 			ClientSecret:    "client-secret",
 			WorkspaceSecret: loadKey(t),

--- a/internal/storage/bundle/remote_source_test.go
+++ b/internal/storage/bundle/remote_source_test.go
@@ -309,7 +309,7 @@ func TestRemoteSource(t *testing.T) {
 func mkConf(t *testing.T, disableAutoUpdate bool) *bundle.Conf {
 	t.Helper()
 
-	return &bundle.Conf{
+	conf := &bundle.Conf{
 		CacheSize: 1024,
 		Credentials: hub.CredentialsConf{
 			ClientID:        "client-id",
@@ -322,6 +322,9 @@ func mkConf(t *testing.T, disableAutoUpdate bool) *bundle.Conf {
 			DisableAutoUpdate: disableAutoUpdate,
 		},
 	}
+
+	require.NoError(t, conf.Validate())
+	return conf
 }
 
 func waitForCallsDone(t *testing.T, callsDone <-chan struct{}) {

--- a/internal/storage/bundle/remote_source_test.go
+++ b/internal/storage/bundle/remote_source_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cerbos/cerbos/internal/hub"
 	"github.com/cerbos/cerbos/internal/storage"
 	"github.com/cerbos/cerbos/internal/storage/bundle"
 	"github.com/cerbos/cerbos/internal/test"
@@ -310,7 +311,7 @@ func mkConf(t *testing.T, disableAutoUpdate bool) *bundle.Conf {
 
 	return &bundle.Conf{
 		CacheSize: 1024,
-		Credentials: bundle.CredentialsConf{
+		Credentials: hub.CredentialsConf{
 			ClientID:        "client-id",
 			ClientSecret:    "client-secret",
 			WorkspaceSecret: loadKey(t),

--- a/internal/util/app.go
+++ b/internal/util/app.go
@@ -12,6 +12,7 @@ import (
 
 	pdpv1 "github.com/cerbos/cloud-api/genpb/cerbos/cloud/pdp/v1"
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 )
 
 var (
@@ -70,4 +71,8 @@ func PDPIdentifier(pdpID string) *pdpv1.Identifier {
 		Instance: pdpID,
 		Version:  AppShortVersion(),
 	}
+}
+
+func DeprecationWarning(deprecated, replacement string) {
+	zap.S().Warnf("[DEPRECATED CONFIG] %s is deprecated and will be removed in a future release. Please use %s instead.", deprecated, replacement)
 }


### PR DESCRIPTION
Move credentials and connection settings to their own configuration section under `hub` so that they can be shared.