### PR TITLE
feat: Integrate `hub` audit backend with cloud api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ generate-testdata-json-schemas: $(BUF)
 .PHONY: generate-mocks
 generate-mocks: $(MOCKERY)
 	@-rm -rf $(MOCK_DIR)
-	@ $(MOCKERY) $(MOCK_QUIET) --srcpkg=./internal/audit/hub --name=IngestSyncer --output=$(MOCK_DIR)
+	@ $(MOCKERY) $(MOCK_QUIET) --srcpkg=./internal/audit/cerboshub --name=IngestSyncer --output=$(MOCK_DIR)
 	@ $(MOCKERY) $(MOCK_QUIET) --srcpkg=./internal/storage/index --name=Index --output=$(MOCK_DIR)
 	@ $(MOCKERY) $(MOCK_QUIET) --srcpkg=./internal/storage --name=Store --output=$(MOCK_DIR)
 	@ $(MOCKERY) $(MOCK_QUIET) --srcpkg=./internal/storage/bundle --name=CloudAPIClient --output=$(MOCK_DIR)

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ generate-testdata-json-schemas: $(BUF)
 .PHONY: generate-mocks
 generate-mocks: $(MOCKERY)
 	@-rm -rf $(MOCK_DIR)
-	@ $(MOCKERY) $(MOCK_QUIET) --srcpkg=./internal/audit/cerboshub --name=IngestSyncer --output=$(MOCK_DIR)
+	@ $(MOCKERY) $(MOCK_QUIET) --srcpkg=./internal/audit/hub --name=IngestSyncer --output=$(MOCK_DIR)
 	@ $(MOCKERY) $(MOCK_QUIET) --srcpkg=./internal/storage/index --name=Index --output=$(MOCK_DIR)
 	@ $(MOCKERY) $(MOCK_QUIET) --srcpkg=./internal/storage --name=Store --output=$(MOCK_DIR)
 	@ $(MOCKERY) $(MOCK_QUIET) --srcpkg=./internal/storage/bundle --name=CloudAPIClient --output=$(MOCK_DIR)

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -13,10 +13,10 @@ audit:
   includeMetadataKeys: ['content-type'] # IncludeMetadataKeys defines which gRPC request metadata keys should be included in the audit logs.
   cerboshub:
     ingest: 
-      flushTimeout: 5s 
-      maxBatchSize: 32 
-      minFlushInterval: 10s 
-      numGoRoutines: 8
+      flushTimeout: 5s # FlushTimeout defines the max allowable timeout for each Ingest request.
+      maxBatchSize: 32 # MaxBatchSize defines the max number of log entries to send in each Ingest request.
+      minFlushInterval: 10s # MinFlushInterval is the minimal duration between Ingest requests.
+      numGoRoutines: 8 # NumGoRoutines defines the max number of goroutines used when streaming log entries from the local DB.
   file:
     additionalPaths: [stdout] # AdditionalPaths to mirror the log output. Has performance implications. Use with caution.
     logRotation: # LogRotation settings (optional).

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -11,6 +11,13 @@ audit:
   enabled: false # Enabled defines whether audit logging is enabled.
   excludeMetadataKeys: ['authorization'] # ExcludeMetadataKeys defines which gRPC request metadata keys should be excluded from the audit logs. Takes precedence over includeMetadataKeys.
   includeMetadataKeys: ['content-type'] # IncludeMetadataKeys defines which gRPC request metadata keys should be included in the audit logs.
+  cerboshub:
+    ingest: 
+      flushTimeout: 5s # FlushTimeout defines the max allowable timeout for each Ingest request.
+      maxBatchSize: 32 # MaxBatchSize defines the max number of log entries to send in each Ingest request.
+      minFlushInterval: 10s # MinFlushInterval is the minimal duration between Ingest requests.
+      numGoRoutines: 8 # NumGoRoutines defines the max number of goroutines used when streaming log entries from the local DB.
+    local: see audit.local section # Local is configuration for the local Audit backend. See 'audit.local' section for documentation
   file:
     additionalPaths: [stdout] # AdditionalPaths to mirror the log output. Has performance implications. Use with caution.
     logRotation: # LogRotation settings (optional).
@@ -18,13 +25,6 @@ audit:
       maxFileCount: 10 # MaxFileCount sets the maximum number of files to retain.
       maxFileSizeMB: 100 # MaxFileSizeMB sets the maximum size of individual log files in megabytes.
     path: /path/to/file.log # Required. Path to the log file to use as output. The special values stdout and stderr can be used to write to stdout or stderr respectively.
-  hub:
-    ingest: 
-      flushTimeout: 5s # FlushTimeout defines the max allowable timeout for each Ingest request.
-      maxBatchSize: 32 # MaxBatchSize defines the max number of log entries to send in each Ingest request.
-      minFlushInterval: 10s # MinFlushInterval is the minimal duration between Ingest requests.
-      numGoRoutines: 8 # NumGoRoutines defines the max number of goroutines used when streaming log entries from the local DB.
-    local: see audit.local section # Local is configuration for the local Audit backend. See 'audit.local' section for documentation
   kafka:
     ack: all # Ack mode for producing messages. Valid values are "none", "leader" or "all" (default). Idempotency is disabled when mode is not "all".
     authentication: # Authentication

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -15,7 +15,7 @@ audit:
     ingest: 
       flushTimeout: 5s # FlushTimeout defines the max allowable timeout for each Ingest request.
       maxBatchSize: 32 # MaxBatchSize defines the max number of log entries to send in each Ingest request.
-      minFlushInterval: 10s # MinFlushInterval is the minimal duration between Ingest requests.
+      minFlushInterval: 3s # MinFlushInterval is the minimal duration between Ingest requests.
       numGoRoutines: 8 # NumGoRoutines defines the max number of goroutines used when streaming log entries from the local DB.
     local: see audit.local section # Local is configuration for the local Audit backend. See 'audit.local' section for documentation
   file:

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -11,7 +11,14 @@ audit:
   enabled: false # Enabled defines whether audit logging is enabled.
   excludeMetadataKeys: ['authorization'] # ExcludeMetadataKeys defines which gRPC request metadata keys should be excluded from the audit logs. Takes precedence over includeMetadataKeys.
   includeMetadataKeys: ['content-type'] # IncludeMetadataKeys defines which gRPC request metadata keys should be included in the audit logs.
-  cerboshub:
+  file:
+    additionalPaths: [stdout] # AdditionalPaths to mirror the log output. Has performance implications. Use with caution.
+    logRotation: # LogRotation settings (optional).
+      maxFileAgeDays: 10 # MaxFileAgeDays sets the maximum age in days of old log files before they are deleted.
+      maxFileCount: 10 # MaxFileCount sets the maximum number of files to retain.
+      maxFileSizeMB: 100 # MaxFileSizeMB sets the maximum size of individual log files in megabytes.
+    path: /path/to/file.log # Required. Path to the log file to use as output. The special values stdout and stderr can be used to write to stdout or stderr respectively.
+  hub:
     advanced: 
       bufferSize: 256 
       flushInterval: 1s 
@@ -24,13 +31,6 @@ audit:
       numGoRoutines: 8 # NumGoRoutines defines the max number of goroutines used when streaming log entries from the local DB.
     retentionPeriod: 168h # How long to keep records for
     storagePath: /path/to/dir # Path to store the data
-  file:
-    additionalPaths: [stdout] # AdditionalPaths to mirror the log output. Has performance implications. Use with caution.
-    logRotation: # LogRotation settings (optional).
-      maxFileAgeDays: 10 # MaxFileAgeDays sets the maximum age in days of old log files before they are deleted.
-      maxFileCount: 10 # MaxFileCount sets the maximum number of files to retain.
-      maxFileSizeMB: 100 # MaxFileSizeMB sets the maximum size of individual log files in megabytes.
-    path: /path/to/file.log # Required. Path to the log file to use as output. The special values stdout and stderr can be used to write to stdout or stderr respectively.
   kafka:
     ack: all # Ack mode for producing messages. Valid values are "none", "leader" or "all" (default). Idempotency is disabled when mode is not "all".
     authentication: # Authentication

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -17,6 +17,7 @@ audit:
       maxBatchSize: 32 # MaxBatchSize defines the max number of log entries to send in each Ingest request.
       minFlushInterval: 10s # MinFlushInterval is the minimal duration between Ingest requests.
       numGoRoutines: 8 # NumGoRoutines defines the max number of goroutines used when streaming log entries from the local DB.
+    local: see audit.local section # Local is configuration for the local Audit backend. See 'audit.local' section for documentation
   file:
     additionalPaths: [stdout] # AdditionalPaths to mirror the log output. Has performance implications. Use with caution.
     logRotation: # LogRotation settings (optional).

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -11,13 +11,6 @@ audit:
   enabled: false # Enabled defines whether audit logging is enabled.
   excludeMetadataKeys: ['authorization'] # ExcludeMetadataKeys defines which gRPC request metadata keys should be excluded from the audit logs. Takes precedence over includeMetadataKeys.
   includeMetadataKeys: ['content-type'] # IncludeMetadataKeys defines which gRPC request metadata keys should be included in the audit logs.
-  cerboshub:
-    ingest: 
-      flushTimeout: 5s # FlushTimeout defines the max allowable timeout for each Ingest request.
-      maxBatchSize: 32 # MaxBatchSize defines the max number of log entries to send in each Ingest request.
-      minFlushInterval: 10s # MinFlushInterval is the minimal duration between Ingest requests.
-      numGoRoutines: 8 # NumGoRoutines defines the max number of goroutines used when streaming log entries from the local DB.
-    local: see audit.local section # Local is configuration for the local Audit backend. See 'audit.local' section for documentation
   file:
     additionalPaths: [stdout] # AdditionalPaths to mirror the log output. Has performance implications. Use with caution.
     logRotation: # LogRotation settings (optional).
@@ -25,6 +18,13 @@ audit:
       maxFileCount: 10 # MaxFileCount sets the maximum number of files to retain.
       maxFileSizeMB: 100 # MaxFileSizeMB sets the maximum size of individual log files in megabytes.
     path: /path/to/file.log # Required. Path to the log file to use as output. The special values stdout and stderr can be used to write to stdout or stderr respectively.
+  hub:
+    ingest: 
+      flushTimeout: 5s # FlushTimeout defines the max allowable timeout for each Ingest request.
+      maxBatchSize: 32 # MaxBatchSize defines the max number of log entries to send in each Ingest request.
+      minFlushInterval: 10s # MinFlushInterval is the minimal duration between Ingest requests.
+      numGoRoutines: 8 # NumGoRoutines defines the max number of goroutines used when streaming log entries from the local DB.
+    local: see audit.local section # Local is configuration for the local Audit backend. See 'audit.local' section for documentation
   kafka:
     ack: all # Ack mode for producing messages. Valid values are "none", "leader" or "all" (default). Idempotency is disabled when mode is not "all".
     authentication: # Authentication

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -17,7 +17,6 @@ audit:
       maxBatchSize: 32 # MaxBatchSize defines the max number of log entries to send in each Ingest request.
       minFlushInterval: 3s # MinFlushInterval is the minimal duration between Ingest requests.
       numGoRoutines: 8 # NumGoRoutines defines the max number of goroutines used when streaming log entries from the local DB.
-    local: see audit.local section # Local is configuration for the local Audit backend. See 'audit.local' section for documentation
   file:
     additionalPaths: [stdout] # AdditionalPaths to mirror the log output. Has performance implications. Use with caution.
     logRotation: # LogRotation settings (optional).

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -24,11 +24,6 @@ audit:
       flushInterval: 1s 
       gcInterval: 60s 
       maxBatchSize: 32 
-    ingest: 
-      flushTimeout: 5s # FlushTimeout defines the max allowable timeout for each Ingest request.
-      maxBatchSize: 32 # MaxBatchSize defines the max number of log entries to send in each Ingest request.
-      minFlushInterval: 3s # MinFlushInterval is the minimal duration between Ingest requests.
-      numGoRoutines: 8 # NumGoRoutines defines the max number of goroutines used when streaming log entries from the local DB.
     retentionPeriod: 168h # How long to keep records for
     storagePath: /path/to/dir # Path to store the data
   kafka:

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -12,11 +12,18 @@ audit:
   excludeMetadataKeys: ['authorization'] # ExcludeMetadataKeys defines which gRPC request metadata keys should be excluded from the audit logs. Takes precedence over includeMetadataKeys.
   includeMetadataKeys: ['content-type'] # IncludeMetadataKeys defines which gRPC request metadata keys should be included in the audit logs.
   cerboshub:
+    advanced: 
+      bufferSize: 256 
+      flushInterval: 1s 
+      gcInterval: 60s 
+      maxBatchSize: 32 
     ingest: 
       flushTimeout: 5s # FlushTimeout defines the max allowable timeout for each Ingest request.
       maxBatchSize: 32 # MaxBatchSize defines the max number of log entries to send in each Ingest request.
       minFlushInterval: 3s # MinFlushInterval is the minimal duration between Ingest requests.
       numGoRoutines: 8 # NumGoRoutines defines the max number of goroutines used when streaming log entries from the local DB.
+    retentionPeriod: 168h # How long to keep records for
+    storagePath: /path/to/dir # Path to store the data
   file:
     additionalPaths: [stdout] # AdditionalPaths to mirror the log output. Has performance implications. Use with caution.
     logRotation: # LogRotation settings (optional).

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,7 @@ atomicgo.dev/keyboard v0.2.9 h1:tOsIid3nlPLZ3lwgG8KZMp/SFmr7P0ssEN5JUsm78K8=
 atomicgo.dev/keyboard v0.2.9/go.mod h1:BC4w9g00XkxH/f1HXhW2sXmJFOCWbKn9xrOunSFtExQ=
 atomicgo.dev/schedule v0.1.0 h1:nTthAbhZS5YZmgYbb2+DH8uQIZcTlIrd4eYr3UQxEjs=
 atomicgo.dev/schedule v0.1.0/go.mod h1:xeUa3oAkiuHYh8bKiQBRojqAMq3PXXbJujjb0hw8pEU=
-buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.32.0-20240221180331-f05a6f4403ce.1 h1:AmmAwHbvaeOIxDKG2+aTn5C36HjmFIMkrdTp49rp80Q=
-buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.32.0-20240221180331-f05a6f4403ce.1/go.mod h1:tiTMKD8j6Pd/D2WzREoweufjzaJKHZg35f/VGcZ2v3I=
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.33.0-20240221180331-f05a6f4403ce.1 h1:0nWhrRcnkgw1kwJ7xibIO8bqfOA7pBzBjGCDBxIHch8=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.33.0-20240221180331-f05a6f4403ce.1/go.mod h1:Tgn5bgL220vkFOI0KPStlcClPeOJzAv4uT+V8JXGUnw=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.112.0 h1:tpFCD7hpHFlQ8yPwT3x+QeXqc2T6+n6T+hmABHfDUSM=
@@ -79,8 +78,8 @@ github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371 h1:kkhsdkhsCvIsutKu5zLMgWtgh9YxGCNAw8Ad8hjwfYg=
 github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
-github.com/Shopify/toxiproxy/v2 v2.7.0 h1:Zz2jdyqtYw1SpihfMWzLFGpOO92p9effjAkURG57ifc=
-github.com/Shopify/toxiproxy/v2 v2.7.0/go.mod h1:k0V84e/dLQmVNuI6S0G7TpXCl611OSRYdptoxm0XTzA=
+github.com/Shopify/toxiproxy/v2 v2.8.0 h1:d7OzvAc0Rco3QO8jVsDSfadQ1up0Ca42hK+EGEpnQWs=
+github.com/Shopify/toxiproxy/v2 v2.8.0/go.mod h1:k0V84e/dLQmVNuI6S0G7TpXCl611OSRYdptoxm0XTzA=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/alecthomas/assert/v2 v2.6.0 h1:o3WJwILtexrEUk3cUVal3oiQY2tfgr/FHWiz/v2n4FU=
@@ -159,8 +158,6 @@ github.com/cerbos/cerbos-sdk-go v0.2.3 h1:3wZkTypuLdXD8KYieQY0xYM8AEMdcM9FnRUs2d
 github.com/cerbos/cerbos-sdk-go v0.2.3/go.mod h1:4qfDZCgoMSZaK3yOqvKb3ZprNM8LEAiCfKobDfiqrkk=
 github.com/cerbos/cerbos/api/genpb v0.34.0 h1:HY8k9HVHv000EKU61KrhAia5TmjW4sX2AXNee4I+DZg=
 github.com/cerbos/cerbos/api/genpb v0.34.0/go.mod h1:KEUMaRkMsCvEcOI8aptMFscKh6H2bfWgjjjSmRWKg8g=
-github.com/cerbos/cloud-api v0.1.17 h1:DiiVhrkGQVPfRSipqAOhhmPXwGDjuy8KVE/G5D9ZAyA=
-github.com/cerbos/cloud-api v0.1.17/go.mod h1:iXJaWIfuho/FpIhYyonsLDLiDBqNghvj1hgOPlAXCQE=
 github.com/cerbos/cloud-api v0.1.18-0.20240311082340-cd73b618b1fd h1:bGjPBhNwtsKxSibrkAtF9y/nwonylgcXRL7kJwHG/48=
 github.com/cerbos/cloud-api v0.1.18-0.20240311082340-cd73b618b1fd/go.mod h1:enuBEz4y/96jl0ejsd91H2kWgda5ausOqRAeMH6e7tw=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
@@ -1041,7 +1038,6 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/audit/cerboshub/cerboshub.go
+++ b/internal/audit/cerboshub/cerboshub.go
@@ -181,12 +181,7 @@ func schedule(db *badgerv4.DB, muTimer *mutexTimer, syncer IngestSyncer, minFlus
 	// (and therefore burdening the backend).
 	muTimer.set(minFlushInterval)
 
-	// TODO(saml) is the select necessary?
-	// https://github.com/cerbos/cerbos/pull/2056#discussion_r1528673965
-	select {
-	case waitCh <- struct{}{}:
-	default:
-	}
+	waitCh <- struct{}{}
 }
 
 func streamLogs(db *badgerv4.DB, syncer IngestSyncer, maxBatchSize, numGo int, flushTimeout time.Duration) error {

--- a/internal/audit/cerboshub/cerboshub.go
+++ b/internal/audit/cerboshub/cerboshub.go
@@ -1,7 +1,7 @@
 // Copyright 2021-2024 Zenauth Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-package hub
+package cerboshub
 
 import (
 	"context"
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	Backend = "hub"
+	Backend = "cerboshub"
 )
 
 var (
@@ -35,7 +35,7 @@ func init() {
 	audit.RegisterBackend(Backend, func(_ context.Context, confW *config.Wrapper, decisionFilter audit.DecisionLogEntryFilter) (audit.Log, error) {
 		conf := new(Conf)
 		if err := confW.GetSection(conf); err != nil {
-			return nil, fmt.Errorf("failed to read hub audit log configuration: %w", err)
+			return nil, fmt.Errorf("failed to read cerboshub audit log configuration: %w", err)
 		}
 
 		logger := zap.L().Named("auditlog").With(zap.String("backend", Backend))

--- a/internal/audit/cerboshub/cerboshub.go
+++ b/internal/audit/cerboshub/cerboshub.go
@@ -180,7 +180,10 @@ func schedule(db *badgerv4.DB, muTimer *mutexTimer, syncer IngestSyncer, minFlus
 	// (and therefore burdening the backend).
 	muTimer.set(minFlushInterval)
 
-	errCh <- err
+	select {
+	case errCh <- err:
+	default:
+	}
 }
 
 func streamLogs(db *badgerv4.DB, syncer IngestSyncer, maxBatchSize, numGo int, flushTimeout time.Duration) error {

--- a/internal/audit/cerboshub/cerboshub.go
+++ b/internal/audit/cerboshub/cerboshub.go
@@ -59,6 +59,8 @@ func NewLog(conf *Conf, decisionFilter audit.DecisionLogEntryFilter, syncer Inge
 		return nil, err
 	}
 
+	logger.Info("Extending audit log")
+
 	minFlushInterval := conf.Ingest.MinFlushInterval
 	maxBatchSize := int(conf.Ingest.MaxBatchSize)
 	flushTimeout := conf.Ingest.FlushTimeout

--- a/internal/audit/cerboshub/cerboshub.go
+++ b/internal/audit/cerboshub/cerboshub.go
@@ -54,7 +54,7 @@ type Log struct {
 }
 
 func NewLog(conf *Conf, decisionFilter audit.DecisionLogEntryFilter, syncer IngestSyncer, logger *zap.Logger) (*Log, error) {
-	localLog, err := local.NewLog(&conf.Local, decisionFilter)
+	localLog, err := local.NewLog(&conf.Conf, decisionFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/audit/cerboshub/cerboshub.go
+++ b/internal/audit/cerboshub/cerboshub.go
@@ -54,7 +54,7 @@ type Log struct {
 }
 
 func NewLog(conf *Conf, decisionFilter audit.DecisionLogEntryFilter, syncer IngestSyncer, logger *zap.Logger) (*Log, error) {
-	localLog, err := local.NewLog(&conf.Conf, decisionFilter)
+	localLog, err := local.NewLog(&conf.Local, decisionFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/audit/cerboshub/cerboshub.go
+++ b/internal/audit/cerboshub/cerboshub.go
@@ -213,6 +213,8 @@ func streamPrefix(ctx context.Context, db *badgerv4.DB, syncer IngestSyncer, max
 		stream.Prefix = AccessSyncPrefix
 	case logsv1.IngestBatch_ENTRY_KIND_DECISION_LOG:
 		stream.Prefix = DecisionSyncPrefix
+	case logsv1.IngestBatch_ENTRY_KIND_UNSPECIFIED:
+		return errors.New("unspecified IngestBatch_EntryKind")
 	}
 
 	stream.Send = func(buf *z.Buffer) error {
@@ -294,6 +296,8 @@ func syncThenDelete(ctx context.Context, db *badgerv4.DB, syncer IngestSyncer, k
 						},
 						Timestamp: decisionLog.Timestamp,
 					}
+				case logsv1.IngestBatch_ENTRY_KIND_UNSPECIFIED:
+					return errors.New("unspecified IngestBatch_EntryKind")
 				}
 
 				return nil

--- a/internal/audit/cerboshub/cerboshub_test.go
+++ b/internal/audit/cerboshub/cerboshub_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	badgerv4 "github.com/dgraph-io/badger/v4"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -120,7 +121,7 @@ func TestCerbosHubLog(t *testing.T) {
 
 	decisionFilter := audit.NewDecisionLogEntryFilterFromConf(&audit.Conf{})
 	syncer := newMockSyncer(t)
-	db, err := cerboshub.NewLog(conf, decisionFilter, syncer)
+	db, err := cerboshub.NewLog(conf, decisionFilter, syncer, zap.L().Named("auditlog"))
 	require.NoError(t, err)
 	defer db.Close()
 

--- a/internal/audit/cerboshub/cerboshub_test.go
+++ b/internal/audit/cerboshub/cerboshub_test.go
@@ -101,12 +101,6 @@ func TestCerbosHubLog(t *testing.T) {
 	}
 
 	conf := &cerboshub.Conf{
-		cerboshub.IngestConf{
-			MaxBatchSize:     batchSize,
-			MinFlushInterval: 2 * time.Second,
-			FlushTimeout:     1 * time.Second,
-			NumGoRoutines:    8,
-		},
 		local.Conf{
 			StoragePath:     t.TempDir(),
 			RetentionPeriod: 24 * time.Hour,
@@ -115,6 +109,12 @@ func TestCerbosHubLog(t *testing.T) {
 				MaxBatchSize:  32,
 				FlushInterval: 10 * time.Second,
 			},
+		},
+		cerboshub.IngestConf{
+			MaxBatchSize:     batchSize,
+			MinFlushInterval: 2 * time.Second,
+			FlushTimeout:     1 * time.Second,
+			NumGoRoutines:    8,
 		},
 	}
 

--- a/internal/audit/cerboshub/cerboshub_test.go
+++ b/internal/audit/cerboshub/cerboshub_test.go
@@ -101,6 +101,12 @@ func TestCerbosHubLog(t *testing.T) {
 	}
 
 	conf := &cerboshub.Conf{
+		cerboshub.IngestConf{
+			MaxBatchSize:     batchSize,
+			MinFlushInterval: 2 * time.Second,
+			FlushTimeout:     1 * time.Second,
+			NumGoRoutines:    8,
+		},
 		local.Conf{
 			StoragePath:     t.TempDir(),
 			RetentionPeriod: 24 * time.Hour,
@@ -109,12 +115,6 @@ func TestCerbosHubLog(t *testing.T) {
 				MaxBatchSize:  32,
 				FlushInterval: 10 * time.Second,
 			},
-		},
-		cerboshub.IngestConf{
-			MaxBatchSize:     batchSize,
-			MinFlushInterval: 2 * time.Second,
-			FlushTimeout:     1 * time.Second,
-			NumGoRoutines:    8,
 		},
 	}
 

--- a/internal/audit/cerboshub/conf.go
+++ b/internal/audit/cerboshub/conf.go
@@ -45,7 +45,7 @@ type IngestConf struct {
 	// MaxBatchSize defines the max number of log entries to send in each Ingest request.
 	MaxBatchSize uint `yaml:"maxBatchSize" conf:",example=32"`
 	// MinFlushInterval is the minimal duration between Ingest requests.
-	MinFlushInterval time.Duration `yaml:"minFlushInterval" conf:",example=10s"`
+	MinFlushInterval time.Duration `yaml:"minFlushInterval" conf:",example=3s"`
 	// FlushTimeout defines the max allowable timeout for each Ingest request.
 	FlushTimeout time.Duration `yaml:"flushTimeout" conf:",example=5s"`
 	// NumGoRoutines defines the max number of goroutines used when streaming log entries from the local DB.

--- a/internal/audit/cerboshub/conf.go
+++ b/internal/audit/cerboshub/conf.go
@@ -81,11 +81,12 @@ func (c *Conf) Validate() (outErr error) {
 		outErr = multierr.Append(outErr, errInvalidFlushTimeout)
 	}
 
-	if c.Ingest.FlushTimeout > c.Ingest.MinFlushInterval {
-		outErr = multierr.Append(outErr, errors.New("flushTimeout cannot be longer than flushInterval"))
-	}
+	// TODO(saml) is this a stupid rule?
+	// if c.Ingest.FlushTimeout > c.Ingest.MinFlushInterval {
+	// 	outErr = multierr.Append(outErr, errors.New("ingest.flushTimeout cannot be longer than ingest.minFlushInterval"))
+	// }
 
-	if c.Ingest.MinFlushInterval >= c.Conf.Advanced.FlushInterval {
+	if c.Ingest.MinFlushInterval >= c.Advanced.FlushInterval {
 		outErr = multierr.Append(outErr, errors.New("ingest.minFlushInterval must be less than advanced.flushInterval"))
 	}
 

--- a/internal/audit/cerboshub/conf.go
+++ b/internal/audit/cerboshub/conf.go
@@ -1,7 +1,7 @@
 // Copyright 2021-2024 Zenauth Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-package hub
+package cerboshub
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	confKey = audit.ConfKey + ".hub"
+	confKey = audit.ConfKey + ".cerboshub"
 
 	defaultMaxBatchSize     = 16
 	defaultMinFlushInterval = 5 * time.Second

--- a/internal/audit/cerboshub/conf.go
+++ b/internal/audit/cerboshub/conf.go
@@ -32,8 +32,8 @@ var (
 )
 
 type Conf struct {
-	local.Conf `yaml:"local"`
 	Ingest     IngestConf `yaml:"ingest"`
+	local.Conf `yaml:"local"`
 }
 
 type IngestConf struct {

--- a/internal/audit/cerboshub/conf.go
+++ b/internal/audit/cerboshub/conf.go
@@ -32,8 +32,8 @@ var (
 )
 
 type Conf struct {
-	Ingest     IngestConf `yaml:"ingest"`
-	local.Conf `yaml:"local"`
+	local.Conf
+	Ingest IngestConf `yaml:"ingest"`
 }
 
 type IngestConf struct {

--- a/internal/audit/cerboshub/conf.go
+++ b/internal/audit/cerboshub/conf.go
@@ -32,8 +32,9 @@ var (
 )
 
 type Conf struct {
-	local.Conf
 	Ingest IngestConf `yaml:"ingest"`
+	// Local is configuration for the local Audit backend. See 'audit.local' section for documentation
+	Local local.Conf `yaml:"local" conf:",example=see audit.local section"`
 }
 
 type IngestConf struct {
@@ -56,7 +57,7 @@ func (c *Conf) Key() string {
 }
 
 func (c *Conf) SetDefaults() {
-	c.Conf.SetDefaults()
+	c.Local.SetDefaults()
 
 	c.Ingest.MaxBatchSize = defaultMaxBatchSize
 	c.Ingest.MinFlushInterval = defaultMinFlushInterval
@@ -65,7 +66,7 @@ func (c *Conf) SetDefaults() {
 }
 
 func (c *Conf) Validate() (outErr error) {
-	if err := c.Conf.Validate(); err != nil {
+	if err := c.Local.Validate(); err != nil {
 		outErr = multierr.Append(outErr, err)
 	}
 
@@ -86,7 +87,7 @@ func (c *Conf) Validate() (outErr error) {
 	// 	outErr = multierr.Append(outErr, errors.New("ingest.flushTimeout cannot be longer than ingest.minFlushInterval"))
 	// }
 
-	if c.Ingest.MinFlushInterval >= c.Advanced.FlushInterval {
+	if c.Ingest.MinFlushInterval >= c.Local.Advanced.FlushInterval {
 		outErr = multierr.Append(outErr, errors.New("ingest.minFlushInterval must be less than advanced.flushInterval"))
 	}
 

--- a/internal/audit/cerboshub/conf.go
+++ b/internal/audit/cerboshub/conf.go
@@ -32,9 +32,8 @@ var (
 )
 
 type Conf struct {
-	Ingest IngestConf `yaml:"ingest"`
-	// Local is configuration for the local Audit backend. See 'audit.local' section for documentation
-	Local local.Conf `yaml:"local" conf:",example=see audit.local section"`
+	Ingest     IngestConf `yaml:"ingest"`
+	local.Conf `yaml:",inline"`
 }
 
 type IngestConf struct {
@@ -57,7 +56,7 @@ func (c *Conf) Key() string {
 }
 
 func (c *Conf) SetDefaults() {
-	c.Local.SetDefaults()
+	c.Conf.SetDefaults()
 
 	c.Ingest.MaxBatchSize = defaultMaxBatchSize
 	c.Ingest.MinFlushInterval = defaultMinFlushInterval
@@ -66,7 +65,7 @@ func (c *Conf) SetDefaults() {
 }
 
 func (c *Conf) Validate() (outErr error) {
-	if err := c.Local.Validate(); err != nil {
+	if err := c.Conf.Validate(); err != nil {
 		outErr = multierr.Append(outErr, err)
 	}
 
@@ -82,7 +81,7 @@ func (c *Conf) Validate() (outErr error) {
 		outErr = multierr.Append(outErr, errInvalidFlushTimeout)
 	}
 
-	if c.Ingest.MinFlushInterval >= c.Local.Advanced.FlushInterval {
+	if c.Ingest.MinFlushInterval >= c.Conf.Advanced.FlushInterval {
 		outErr = multierr.Append(outErr, errors.New("ingest.minFlushInterval must be less than advanced.flushInterval"))
 	}
 

--- a/internal/audit/cerboshub/conf.go
+++ b/internal/audit/cerboshub/conf.go
@@ -66,7 +66,7 @@ func (c *Conf) SetDefaults() {
 
 func (c *Conf) Validate() (outErr error) {
 	if err := c.Conf.Validate(); err != nil {
-		return err
+		outErr = multierr.Append(outErr, err)
 	}
 
 	if c.Ingest.MaxBatchSize < 1 {

--- a/internal/audit/cerboshub/ingest.go
+++ b/internal/audit/cerboshub/ingest.go
@@ -1,7 +1,7 @@
 // Copyright 2021-2024 Zenauth Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-package hub
+package cerboshub
 
 import (
 	"context"

--- a/internal/audit/hub/conf.go
+++ b/internal/audit/hub/conf.go
@@ -32,7 +32,7 @@ var (
 )
 
 type Conf struct {
-	Ingest     IngestConf `yaml:"ingest"`
+	Ingest     IngestConf `yaml:"ingest" conf:",ignore"`
 	local.Conf `yaml:",inline"`
 }
 

--- a/internal/audit/hub/conf.go
+++ b/internal/audit/hub/conf.go
@@ -82,11 +82,6 @@ func (c *Conf) Validate() (outErr error) {
 		outErr = multierr.Append(outErr, errInvalidFlushTimeout)
 	}
 
-	// TODO(saml) is this a stupid rule?
-	// if c.Ingest.FlushTimeout > c.Ingest.MinFlushInterval {
-	// 	outErr = multierr.Append(outErr, errors.New("ingest.flushTimeout cannot be longer than ingest.minFlushInterval"))
-	// }
-
 	if c.Ingest.MinFlushInterval >= c.Local.Advanced.FlushInterval {
 		outErr = multierr.Append(outErr, errors.New("ingest.minFlushInterval must be less than advanced.flushInterval"))
 	}

--- a/internal/audit/hub/conf.go
+++ b/internal/audit/hub/conf.go
@@ -1,7 +1,7 @@
 // Copyright 2021-2024 Zenauth Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-package cerboshub
+package hub
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	confKey = audit.ConfKey + ".cerboshub"
+	confKey = audit.ConfKey + ".hub"
 
 	defaultMaxBatchSize     = 16
 	defaultMinFlushInterval = 5 * time.Second

--- a/internal/audit/hub/hub.go
+++ b/internal/audit/hub/hub.go
@@ -1,7 +1,7 @@
 // Copyright 2021-2024 Zenauth Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-package cerboshub
+package hub
 
 import (
 	"context"
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	Backend = "cerboshub"
+	Backend = "hub"
 )
 
 var (
@@ -35,7 +35,7 @@ func init() {
 	audit.RegisterBackend(Backend, func(_ context.Context, confW *config.Wrapper, decisionFilter audit.DecisionLogEntryFilter) (audit.Log, error) {
 		conf := new(Conf)
 		if err := confW.GetSection(conf); err != nil {
-			return nil, fmt.Errorf("failed to read cerboshub audit log configuration: %w", err)
+			return nil, fmt.Errorf("failed to read hub audit log configuration: %w", err)
 		}
 
 		logger := zap.L().Named("auditlog").With(zap.String("backend", Backend))

--- a/internal/audit/hub/hub_test.go
+++ b/internal/audit/hub/hub_test.go
@@ -4,7 +4,7 @@
 //go:build !race
 // +build !race
 
-package cerboshub_test
+package hub_test
 
 import (
 	"context"
@@ -25,7 +25,7 @@ import (
 	effectv1 "github.com/cerbos/cerbos/api/genpb/cerbos/effect/v1"
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	"github.com/cerbos/cerbos/internal/audit"
-	"github.com/cerbos/cerbos/internal/audit/cerboshub"
+	"github.com/cerbos/cerbos/internal/audit/hub"
 	"github.com/cerbos/cerbos/internal/audit/local"
 	"github.com/cerbos/cerbos/internal/test/mocks"
 	logsv1 "github.com/cerbos/cloud-api/genpb/cerbos/cloud/logs/v1"
@@ -61,9 +61,9 @@ func (m *mockSyncer) Sync(ctx context.Context, batch *logsv1.IngestBatch) error 
 		var key []byte
 		switch e.Kind {
 		case logsv1.IngestBatch_ENTRY_KIND_ACCESS_LOG:
-			key = keyFromCallID(m.t, e.GetAccessLogEntry().CallId, cerboshub.AccessSyncPrefix)
+			key = keyFromCallID(m.t, e.GetAccessLogEntry().CallId, hub.AccessSyncPrefix)
 		case logsv1.IngestBatch_ENTRY_KIND_DECISION_LOG:
-			key = keyFromCallID(m.t, e.GetDecisionLogEntry().CallId, cerboshub.DecisionSyncPrefix)
+			key = keyFromCallID(m.t, e.GetDecisionLogEntry().CallId, hub.DecisionSyncPrefix)
 		case logsv1.IngestBatch_ENTRY_KIND_UNSPECIFIED:
 			return errors.New("unspecified IngestBatch_EntryKind")
 		}
@@ -95,13 +95,13 @@ func (m *mockSyncer) hasKeys(keys [][]byte) bool {
 	return true
 }
 
-func TestCerbosHubLog(t *testing.T) {
+func TestHubLog(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
 
-	conf := &cerboshub.Conf{
-		cerboshub.IngestConf{
+	conf := &hub.Conf{
+		hub.IngestConf{
 			MaxBatchSize:     batchSize,
 			MinFlushInterval: 2 * time.Second,
 			FlushTimeout:     1 * time.Second,
@@ -125,11 +125,11 @@ func TestCerbosHubLog(t *testing.T) {
 
 	decisionFilter := audit.NewDecisionLogEntryFilterFromConf(&audit.Conf{})
 	syncer := newMockSyncer(t)
-	db, err := cerboshub.NewLog(conf, decisionFilter, syncer, zap.L().Named("auditlog"))
+	db, err := hub.NewLog(conf, decisionFilter, syncer, zap.L().Named("auditlog"))
 	require.NoError(t, err)
 	defer db.Close()
 
-	require.Equal(t, cerboshub.Backend, db.Backend())
+	require.Equal(t, hub.Backend, db.Backend())
 	require.True(t, db.Enabled())
 
 	purgeKeys := func() {
@@ -146,7 +146,7 @@ func TestCerbosHubLog(t *testing.T) {
 			opts.PrefetchValues = false
 			it := txn.NewIterator(opts)
 			defer it.Close()
-			for it.Seek(cerboshub.SyncStatusPrefix); it.ValidForPrefix(cerboshub.SyncStatusPrefix); it.Next() {
+			for it.Seek(hub.SyncStatusPrefix); it.ValidForPrefix(hub.SyncStatusPrefix); it.Next() {
 				item := it.Item()
 				key := make([]byte, len(item.Key()))
 				copy(key, item.Key())
@@ -203,7 +203,7 @@ func TestCerbosHubLog(t *testing.T) {
 
 		// Server responds with backoff after first N pages
 		syncer.EXPECT().Sync(mock.Anything, mock.AnythingOfType("*logsv1.IngestBatch")).Return(nil).Times(initialNBatches)
-		syncer.EXPECT().Sync(mock.Anything, mock.AnythingOfType("*logsv1.IngestBatch")).Return(cerboshub.ErrIngestBackoff{
+		syncer.EXPECT().Sync(mock.Anything, mock.AnythingOfType("*logsv1.IngestBatch")).Return(hub.ErrIngestBackoff{
 			Backoff: 0,
 		}).Twice() // two concurrent streams receive the same backoff response
 		syncer.EXPECT().Sync(mock.Anything, mock.AnythingOfType("*logsv1.IngestBatch")).Return(nil).Times(wantNumBatches - initialNBatches)
@@ -215,7 +215,7 @@ func TestCerbosHubLog(t *testing.T) {
 	})
 }
 
-func loadData(t *testing.T, db *cerboshub.Log, startDate time.Time) [][]byte {
+func loadData(t *testing.T, db *hub.Log, startDate time.Time) [][]byte {
 	t.Helper()
 
 	ctx := context.Background()
@@ -229,8 +229,8 @@ func loadData(t *testing.T, db *cerboshub.Log, startDate time.Time) [][]byte {
 		require.NoError(t, err)
 		// We insert decision sync logs in the latter half as this is the same
 		// order that Badger retrieves keys from the LSM
-		syncKeys[i] = local.GenKey(cerboshub.AccessSyncPrefix, callID)
-		syncKeys[i+(numRecords/2)] = local.GenKey(cerboshub.DecisionSyncPrefix, callID)
+		syncKeys[i] = local.GenKey(hub.AccessSyncPrefix, callID)
+		syncKeys[i+(numRecords/2)] = local.GenKey(hub.DecisionSyncPrefix, callID)
 
 		err = db.WriteAccessLogEntry(ctx, mkAccessLogEntry(t, id, i, ts))
 		require.NoError(t, err)

--- a/internal/audit/hub/hub_test.go
+++ b/internal/audit/hub/hub_test.go
@@ -4,7 +4,7 @@
 //go:build !race
 // +build !race
 
-package cerboshub_test
+package hub_test
 
 import (
 	"context"
@@ -26,7 +26,7 @@ import (
 	effectv1 "github.com/cerbos/cerbos/api/genpb/cerbos/effect/v1"
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	"github.com/cerbos/cerbos/internal/audit"
-	"github.com/cerbos/cerbos/internal/audit/cerboshub"
+	"github.com/cerbos/cerbos/internal/audit/hub"
 	"github.com/cerbos/cerbos/internal/audit/local"
 	"github.com/cerbos/cerbos/internal/test/mocks"
 	logsv1 "github.com/cerbos/cloud-api/genpb/cerbos/cloud/logs/v1"
@@ -66,9 +66,9 @@ func (m *mockSyncer) Sync(ctx context.Context, batch *logsv1.IngestBatch) error 
 		var key []byte
 		switch e.Kind {
 		case logsv1.IngestBatch_ENTRY_KIND_ACCESS_LOG:
-			key = keyFromCallID(m.t, e.GetAccessLogEntry().CallId, cerboshub.AccessSyncPrefix)
+			key = keyFromCallID(m.t, e.GetAccessLogEntry().CallId, hub.AccessSyncPrefix)
 		case logsv1.IngestBatch_ENTRY_KIND_DECISION_LOG:
-			key = keyFromCallID(m.t, e.GetDecisionLogEntry().CallId, cerboshub.DecisionSyncPrefix)
+			key = keyFromCallID(m.t, e.GetDecisionLogEntry().CallId, hub.DecisionSyncPrefix)
 		case logsv1.IngestBatch_ENTRY_KIND_UNSPECIFIED:
 			return errors.New("unspecified IngestBatch_EntryKind")
 		}
@@ -103,13 +103,13 @@ func (m *mockSyncer) hasKeys(keys [][]byte) bool {
 	return true
 }
 
-func TestCerbosHubLog(t *testing.T) {
+func TestHubLog(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
 
-	conf := &cerboshub.Conf{
-		cerboshub.IngestConf{
+	conf := &hub.Conf{
+		hub.IngestConf{
 			MaxBatchSize:     batchSize,
 			MinFlushInterval: 2 * time.Second,
 			FlushTimeout:     1 * time.Second,
@@ -133,11 +133,11 @@ func TestCerbosHubLog(t *testing.T) {
 
 	decisionFilter := audit.NewDecisionLogEntryFilterFromConf(&audit.Conf{})
 	syncer := newMockSyncer(t)
-	db, err := cerboshub.NewLog(conf, decisionFilter, syncer, zap.L().Named("auditlog"))
+	db, err := hub.NewLog(conf, decisionFilter, syncer, zap.L().Named("auditlog"))
 	require.NoError(t, err)
 	defer db.Close()
 
-	require.Equal(t, cerboshub.Backend, db.Backend())
+	require.Equal(t, hub.Backend, db.Backend())
 	require.True(t, db.Enabled())
 
 	purgeKeys := func() {
@@ -154,7 +154,7 @@ func TestCerbosHubLog(t *testing.T) {
 			opts.PrefetchValues = false
 			it := txn.NewIterator(opts)
 			defer it.Close()
-			for it.Seek(cerboshub.SyncStatusPrefix); it.ValidForPrefix(cerboshub.SyncStatusPrefix); it.Next() {
+			for it.Seek(hub.SyncStatusPrefix); it.ValidForPrefix(hub.SyncStatusPrefix); it.Next() {
 				item := it.Item()
 				key := make([]byte, len(item.Key()))
 				copy(key, item.Key())
@@ -211,7 +211,7 @@ func TestCerbosHubLog(t *testing.T) {
 
 		// Server responds with backoff after first N pages
 		syncer.EXPECT().Sync(mock.Anything, mock.AnythingOfType("*logsv1.IngestBatch")).Return(nil).Times(initialNBatches)
-		syncer.EXPECT().Sync(mock.Anything, mock.AnythingOfType("*logsv1.IngestBatch")).Return(cerboshub.ErrIngestBackoff{
+		syncer.EXPECT().Sync(mock.Anything, mock.AnythingOfType("*logsv1.IngestBatch")).Return(hub.ErrIngestBackoff{
 			Backoff: 0,
 		}).Twice() // two concurrent streams receive the same backoff response
 		syncer.EXPECT().Sync(mock.Anything, mock.AnythingOfType("*logsv1.IngestBatch")).Return(nil).Times(wantNumBatches - initialNBatches)
@@ -223,7 +223,7 @@ func TestCerbosHubLog(t *testing.T) {
 	})
 }
 
-func loadData(t *testing.T, db *cerboshub.Log, startDate time.Time) [][]byte {
+func loadData(t *testing.T, db *hub.Log, startDate time.Time) [][]byte {
 	t.Helper()
 
 	ctx := context.Background()
@@ -237,8 +237,8 @@ func loadData(t *testing.T, db *cerboshub.Log, startDate time.Time) [][]byte {
 		require.NoError(t, err)
 		// We insert decision sync logs in the latter half as this is the same
 		// order that Badger retrieves keys from the LSM
-		syncKeys[i] = local.GenKey(cerboshub.AccessSyncPrefix, callID)
-		syncKeys[i+(numRecords/2)] = local.GenKey(cerboshub.DecisionSyncPrefix, callID)
+		syncKeys[i] = local.GenKey(hub.AccessSyncPrefix, callID)
+		syncKeys[i+(numRecords/2)] = local.GenKey(hub.DecisionSyncPrefix, callID)
 
 		err = db.WriteAccessLogEntry(ctx, mkAccessLogEntry(t, id, i, ts))
 		require.NoError(t, err)

--- a/internal/audit/hub/ingest.go
+++ b/internal/audit/hub/ingest.go
@@ -1,7 +1,7 @@
 // Copyright 2021-2024 Zenauth Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-package cerboshub
+package hub
 
 import (
 	"context"

--- a/internal/audit/local/badgerdb.go
+++ b/internal/audit/local/badgerdb.go
@@ -115,7 +115,7 @@ func (l *Log) batchWriter(maxBatchSize int, flushInterval time.Duration) {
 
 	awaitCallbackFn := func() {
 		if l.callbackFn != nil {
-			ch := make(chan struct{}, 1)
+			ch := make(chan struct{})
 			go l.callbackFn(ch)
 			<-ch
 		}

--- a/internal/audit/local/badgerdb.go
+++ b/internal/audit/local/badgerdb.go
@@ -30,8 +30,8 @@ const (
 )
 
 var (
-	accessLogPrefix   = []byte("aacc")
-	decisionLogPrefix = []byte("adec")
+	AccessLogPrefix   = []byte("aacc")
+	DecisionLogPrefix = []byte("adec")
 )
 
 func init() {
@@ -216,7 +216,7 @@ func (l *Log) WriteAccessLogEntry(ctx context.Context, record audit.AccessLogEnt
 		return fmt.Errorf("invalid call ID: %w", err)
 	}
 
-	key := GenKey(accessLogPrefix, callID)
+	key := GenKey(AccessLogPrefix, callID)
 
 	return l.Write(ctx, key, value)
 }
@@ -244,7 +244,7 @@ func (l *Log) WriteDecisionLogEntry(ctx context.Context, record audit.DecisionLo
 		return fmt.Errorf("invalid call ID: %w", err)
 	}
 
-	key := GenKey(decisionLogPrefix, callID)
+	key := GenKey(DecisionLogPrefix, callID)
 
 	return l.Write(ctx, key, value)
 }
@@ -260,14 +260,14 @@ func (l *Log) Write(ctx context.Context, key, value []byte) error {
 
 func (l *Log) LastNAccessLogEntries(ctx context.Context, n uint) audit.AccessLogIterator {
 	c := newAccessLogEntryCollector()
-	go l.listLastN(ctx, accessLogPrefix, n, c)
+	go l.listLastN(ctx, AccessLogPrefix, n, c)
 
 	return c
 }
 
 func (l *Log) LastNDecisionLogEntries(ctx context.Context, n uint) audit.DecisionLogIterator {
 	c := newDecisionLogEntryCollector()
-	go l.listLastN(ctx, decisionLogPrefix, n, c)
+	go l.listLastN(ctx, DecisionLogPrefix, n, c)
 
 	return c
 }
@@ -307,14 +307,14 @@ func (l *Log) listLastN(ctx context.Context, prefix []byte, n uint, c collector)
 
 func (l *Log) AccessLogEntriesBetween(ctx context.Context, fromTS, toTS time.Time) audit.AccessLogIterator {
 	c := newAccessLogEntryCollector()
-	go l.listBetweenTimestamps(ctx, accessLogPrefix, fromTS, toTS, c)
+	go l.listBetweenTimestamps(ctx, AccessLogPrefix, fromTS, toTS, c)
 
 	return c
 }
 
 func (l *Log) DecisionLogEntriesBetween(ctx context.Context, fromTS, toTS time.Time) audit.DecisionLogIterator {
 	c := newDecisionLogEntryCollector()
-	go l.listBetweenTimestamps(ctx, decisionLogPrefix, fromTS, toTS, c)
+	go l.listBetweenTimestamps(ctx, DecisionLogPrefix, fromTS, toTS, c)
 
 	return c
 }
@@ -364,13 +364,13 @@ func (l *Log) listBetweenTimestamps(ctx context.Context, prefix []byte, fromTS, 
 
 func (l *Log) AccessLogEntryByID(ctx context.Context, id audit.ID) audit.AccessLogIterator {
 	c := newAccessLogEntryCollector()
-	l.getByID(ctx, accessLogPrefix, id, c)
+	l.getByID(ctx, AccessLogPrefix, id, c)
 	return c
 }
 
 func (l *Log) DecisionLogEntryByID(ctx context.Context, id audit.ID) audit.DecisionLogIterator {
 	c := newDecisionLogEntryCollector()
-	l.getByID(ctx, decisionLogPrefix, id, c)
+	l.getByID(ctx, DecisionLogPrefix, id, c)
 	return c
 }
 

--- a/internal/audit/local/badgerdb_test.go
+++ b/internal/audit/local/badgerdb_test.go
@@ -53,7 +53,7 @@ func TestBadgerLog(t *testing.T) {
 	require.True(t, db.Enabled())
 
 	loadData(t, db, startDate)
-	db.ForceWrite(true)
+	db.ForceWrite()
 
 	t.Run("lastNAccessLogEntries", func(t *testing.T) {
 		n := 100

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,8 +55,8 @@ import (
 	_ "github.com/cerbos/cerbos/internal/audit/file"
 	// Import to register the kafka audit log backend.
 	_ "github.com/cerbos/cerbos/internal/audit/kafka"
-	// Import to register the cerboshub audit log backend.
-	_ "github.com/cerbos/cerbos/internal/audit/cerboshub"
+	// Import to register the hub audit log backend.
+	_ "github.com/cerbos/cerbos/internal/audit/hub"
 	"github.com/cerbos/cerbos/internal/auxdata"
 	"github.com/cerbos/cerbos/internal/compile"
 	"github.com/cerbos/cerbos/internal/engine"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,6 +55,8 @@ import (
 	_ "github.com/cerbos/cerbos/internal/audit/file"
 	// Import to register the kafka audit log backend.
 	_ "github.com/cerbos/cerbos/internal/audit/kafka"
+	// Import to register the cerboshub audit log backend.
+	_ "github.com/cerbos/cerbos/internal/audit/cerboshub"
 	"github.com/cerbos/cerbos/internal/auxdata"
 	"github.com/cerbos/cerbos/internal/compile"
 	"github.com/cerbos/cerbos/internal/engine"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,8 +55,8 @@ import (
 	_ "github.com/cerbos/cerbos/internal/audit/file"
 	// Import to register the kafka audit log backend.
 	_ "github.com/cerbos/cerbos/internal/audit/kafka"
-	// Import to register the hub audit log backend.
-	_ "github.com/cerbos/cerbos/internal/audit/hub"
+	// Import to register the cerboshub audit log backend.
+	_ "github.com/cerbos/cerbos/internal/audit/cerboshub"
 	"github.com/cerbos/cerbos/internal/auxdata"
 	"github.com/cerbos/cerbos/internal/compile"
 	"github.com/cerbos/cerbos/internal/engine"

--- a/internal/test/mocks/IngestSyncer.go
+++ b/internal/test/mocks/IngestSyncer.go
@@ -9,7 +9,6 @@ import (
 	context "context"
 
 	logsv1 "github.com/cerbos/cloud-api/genpb/cerbos/cloud/logs/v1"
-
 	mock "github.com/stretchr/testify/mock"
 )
 

--- a/internal/test/mocks/IngestSyncer.go
+++ b/internal/test/mocks/IngestSyncer.go
@@ -8,6 +8,7 @@ package mocks
 import (
 	context "context"
 
+	logsv1 "github.com/cerbos/cloud-api/genpb/cerbos/cloud/logs/v1"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -25,7 +26,7 @@ func (_m *IngestSyncer) EXPECT() *IngestSyncer_Expecter {
 }
 
 // Sync provides a mock function with given fields: _a0, _a1
-func (_m *IngestSyncer) Sync(_a0 context.Context, _a1 [][]byte) error {
+func (_m *IngestSyncer) Sync(_a0 context.Context, _a1 *logsv1.IngestBatch) error {
 	ret := _m.Called(_a0, _a1)
 
 	if len(ret) == 0 {
@@ -33,7 +34,7 @@ func (_m *IngestSyncer) Sync(_a0 context.Context, _a1 [][]byte) error {
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, [][]byte) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *logsv1.IngestBatch) error); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Error(0)
@@ -49,14 +50,14 @@ type IngestSyncer_Sync_Call struct {
 
 // Sync is a helper method to define mock.On call
 //   - _a0 context.Context
-//   - _a1 [][]byte
+//   - _a1 *logsv1.IngestBatch
 func (_e *IngestSyncer_Expecter) Sync(_a0 interface{}, _a1 interface{}) *IngestSyncer_Sync_Call {
 	return &IngestSyncer_Sync_Call{Call: _e.mock.On("Sync", _a0, _a1)}
 }
 
-func (_c *IngestSyncer_Sync_Call) Run(run func(_a0 context.Context, _a1 [][]byte)) *IngestSyncer_Sync_Call {
+func (_c *IngestSyncer_Sync_Call) Run(run func(_a0 context.Context, _a1 *logsv1.IngestBatch)) *IngestSyncer_Sync_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].([][]byte))
+		run(args[0].(context.Context), args[1].(*logsv1.IngestBatch))
 	})
 	return _c
 }
@@ -66,7 +67,7 @@ func (_c *IngestSyncer_Sync_Call) Return(_a0 error) *IngestSyncer_Sync_Call {
 	return _c
 }
 
-func (_c *IngestSyncer_Sync_Call) RunAndReturn(run func(context.Context, [][]byte) error) *IngestSyncer_Sync_Call {
+func (_c *IngestSyncer_Sync_Call) RunAndReturn(run func(context.Context, *logsv1.IngestBatch) error) *IngestSyncer_Sync_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/test/mocks/IngestSyncer.go
+++ b/internal/test/mocks/IngestSyncer.go
@@ -9,6 +9,7 @@ import (
 	context "context"
 
 	logsv1 "github.com/cerbos/cloud-api/genpb/cerbos/cloud/logs/v1"
+
 	mock "github.com/stretchr/testify/mock"
 )
 

--- a/internal/util/app.go
+++ b/internal/util/app.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
+	"sync"
 
 	pdpv1 "github.com/cerbos/cloud-api/genpb/cerbos/cloud/pdp/v1"
 	"github.com/google/uuid"
@@ -60,11 +61,15 @@ func AppShortVersion() string {
 	return sb.String()
 }
 
+var getPdpID = sync.OnceValue(func() string {
+	//nolint:gosec
+	nodeID := md5.Sum(uuid.NodeID())
+	return fmt.Sprintf("%X-%d", nodeID, os.Getpid())
+})
+
 func PDPIdentifier(pdpID string) *pdpv1.Identifier {
 	if pdpID == "" {
-		//nolint:gosec
-		nodeID := md5.Sum(uuid.NodeID())
-		pdpID = fmt.Sprintf("%X-%d", nodeID, os.Getpid())
+		pdpID = getPdpID()
 	}
 
 	return &pdpv1.Identifier{


### PR DESCRIPTION
This PR wires up the `IngestSyncer` with the new Cloud API client.

* I've separated the key scan into two concurrent streams (access + decision logs) to avoid fiddly logic to infer types from each key when retrieving the access log (retrieving the log requires reading sync keys, retrieving the actual log key, then retrieving the log value with that key).

* I've also reworked the `ForceWrite` logic in an attempt to fix the flakey tests 🤞.

* I've temporarily reverted the commit which renames `cerboshub` -> `hub` as it ruined the PR diff, I can add this back in afterwards.