### PR TITLE
chore(ci): Unpin cosign version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,8 +61,6 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.4.0
-        with:
-          cosign-release: 'v2.1.1'
 
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v5
@@ -196,4 +194,4 @@ jobs:
           CHART=$(ls ${{ env.CHARTS_DIR }}/cerbos/*.tgz); helm push $CHART oci://${{ env.OCI_REGISTRY }}
           helm registry logout ${{ env.OCI_REGISTRY }}
         env:
-          HELM_EXPERIMENTAL_OCI: '1'
+          HELM_EXPERIMENTAL_OCI: "1"

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -113,8 +113,6 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.4.0
-        with:
-          cosign-release: "v2.1.1"
 
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v5


### PR DESCRIPTION
The cosign step is failing because of a failure to read remote keys.
This seems to be a problem that crops up from time-to-time with new
releases of cosign. Unpinning the version and installing the latest
available one should help fix it.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
