### PR TITLE
chore(ci): Fix Postgres data volume for E2E tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -57,7 +57,7 @@ jobs:
           wait: 180s
 
       - name: Run E2E Tests
-        run: e2e/run.sh ./overlay/...
+        run: e2e/run.sh
         env:
           E2E_SKIP_CLUSTER: "true"
           E2E_NO_CLEANUP: "true"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -57,7 +57,7 @@ jobs:
           wait: 180s
 
       - name: Run E2E Tests
-        run: e2e/run.sh
+        run: e2e/run.sh ./overlay/...
         env:
           E2E_SKIP_CLUSTER: "true"
           E2E_NO_CLEANUP: "true"

--- a/e2e/kind.yaml
+++ b/e2e/kind.yaml
@@ -4,3 +4,4 @@ nodes:
   - role: control-plane
   - role: worker
   - role: worker
+  - role: worker

--- a/e2e/overlay/helmfile.yaml
+++ b/e2e/overlay/helmfile.yaml
@@ -58,6 +58,10 @@ releases:
             scriptsConfigMap: postgres-init
           persistence:
             enabled: false
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
 
   - name: cerbos
     namespace: '{{ requiredEnv "E2E_NS" }}'

--- a/e2e/overlay/helmfile.yaml
+++ b/e2e/overlay/helmfile.yaml
@@ -58,10 +58,9 @@ releases:
             scriptsConfigMap: postgres-init
           persistence:
             enabled: false
-          resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
+          extraVolumeMounts:
+            - name: data
+              mountPath: /bitnami/postgresql
 
   - name: cerbos
     namespace: '{{ requiredEnv "E2E_NS" }}'

--- a/e2e/postgres/helmfile.yaml
+++ b/e2e/postgres/helmfile.yaml
@@ -60,7 +60,7 @@ releases:
             enabled: false
           extraVolumeMounts:
             - name: data
-              mountPath: /bitnami/postgresql/data
+              mountPath: /bitnami/postgresql
 
   - name: cerbos
     namespace: '{{ requiredEnv "E2E_NS" }}'

--- a/e2e/postgres/helmfile.yaml
+++ b/e2e/postgres/helmfile.yaml
@@ -58,10 +58,9 @@ releases:
             scriptsConfigMap: postgres-init
           persistence:
             enabled: false
-          resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
+          extraVolumeMounts:
+            - name: data
+              mountPath: /bitnami/postgresql/data
 
   - name: cerbos
     namespace: '{{ requiredEnv "E2E_NS" }}'
@@ -97,11 +96,11 @@ releases:
           repository: '{{ env "E2E_CERBOS_IMG_REPO" | default "ghcr.io/cerbos/cerbos" }}'
           tag: '{{ env "E2E_CERBOS_IMG_TAG" | default "dev" }}'
       - volumes:
-        - name: cerbos-auditlog
-          emptyDir: {}
+          - name: cerbos-auditlog
+            emptyDir: {}
       - volumeMounts:
-        - name: cerbos-auditlog
-          mountPath: /audit
+          - name: cerbos-auditlog
+            mountPath: /audit
       - cerbos:
           tlsSecretName: 'cerbos-certs-{{ requiredEnv "E2E_CONTEXT_ID" }}'
           logLevel: DEBUG

--- a/e2e/postgres/helmfile.yaml
+++ b/e2e/postgres/helmfile.yaml
@@ -58,6 +58,10 @@ releases:
             scriptsConfigMap: postgres-init
           persistence:
             enabled: false
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
 
   - name: cerbos
     namespace: '{{ requiredEnv "E2E_NS" }}'
@@ -109,7 +113,7 @@ releases:
                 maxResourcesPerRequest: 5
               adminAPI:
                 enabled: true
-                adminCredentials: 
+                adminCredentials:
                   username: cerbos
                   passwordHash: JDJ5JDEwJC5BYjQyY2RJNG5QR2NWMmJPdnNtQU93c09RYVA0eFFGdHBrbmFEeXh1NnlIVTE1cHJNY05PCgo=
             auxData:
@@ -122,11 +126,11 @@ releases:
               accessLogsEnabled: true
               decisionLogsEnabled: true
               backend: local
-              local: 
+              local:
                 storagePath: /audit/cerbos
             storage:
               driver: "postgres"
-              postgres: 
+              postgres:
                 url: 'postgres://cerbos_user:changeme@{{ requiredEnv "E2E_CONTEXT_ID" }}.{{ requiredEnv "E2E_NS" }}.svc.cluster.local:5432/postgres?sslmode=disable&search_path=cerbos'
             telemetry:
               disabled: true

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -23,6 +23,10 @@ func Setup(ctx Ctx) error {
 		if err := CmdWithOutput(ctx, "kubectl", "describe", "pods", fmt.Sprintf("--namespace=%s", ctx.Namespace())); err != nil {
 			ctx.Logf("Failed to describe pods: %v", err)
 		}
+
+		if err := CmdWithOutput(ctx, "stern", ".*", fmt.Sprintf("--namespace=%s", ctx.Namespace()), "--no-follow"); err != nil {
+			ctx.Logf("Failed to grab logs: %v", err)
+		}
 		return err
 	}
 

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -20,6 +20,9 @@ func Setup(ctx Ctx) error {
 	// `helmfile apply` requires `helm diff`. `helmfile init` checks for required plugins
 	if err := Cmd(ctx, "helmfile", "apply"); err != nil {
 		ctx.Logf("Deployment failed: %v", err)
+		if err := CmdWithOutput(ctx, "kubectl", "describe", "pods", fmt.Sprintf("--namespace=%s", ctx.Namespace())); err != nil {
+			ctx.Logf("Failed to describe pods: %v", err)
+		}
 		return err
 	}
 


### PR DESCRIPTION
The new version of the Postgres Helm chart does not mount the data volume by default and causes the container to fail. This PR fixes the mount and also adds extra debug statements that would be useful in the future to investigate similar failures.