### PR TITLE
docs: Remove policy version from .NET quickstart

### DIFF
--- a/docs/modules/ROOT/examples/quickstart/example.cs
+++ b/docs/modules/ROOT/examples/quickstart/example.cs
@@ -27,7 +27,6 @@ internal class Program
 
                 ResourceEntry
                     .NewInstance("album:object", "DAFFY002")
-                    .WithPolicyVersion("20210210")
                     .WithAttribute("owner", AttributeValue.StringValue("daffy_duck"))
                     .WithAttribute("public", AttributeValue.BoolValue(true))
                     .WithAttribute("flagged", AttributeValue.BoolValue(false))


### PR DESCRIPTION
Specifying a policy version for the resource "DAFFY002" in the .NET SDK version of the quickstart docs causes the final step to not work as described.

Removing this policy version specification fixes the issue, and the quickstart works as intended.

Fixes #2064

- [X] The PR title has the correct prefix 
- [X] PR is linked to the corresponding issue
- [X] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
