### PR TITLE
docs(backport): Remove policy version from .NET quickstart (#2065)

### DIFF
--- a/docs/modules/ROOT/examples/quickstart/example.cs
+++ b/docs/modules/ROOT/examples/quickstart/example.cs
@@ -27,7 +27,6 @@ internal class Program
 
                 ResourceEntry
                     .NewInstance("album:object", "DAFFY002")
-                    .WithPolicyVersion("20210210")
                     .WithAttribute("owner", AttributeValue.StringValue("daffy_duck"))
                     .WithAttribute("public", AttributeValue.BoolValue(true))
                     .WithAttribute("flagged", AttributeValue.BoolValue(false))


### PR DESCRIPTION
Backport of #2065