### PR TITLE
fix: Skip compile cache if first candidate doesn't exist

### DIFF
--- a/internal/test/policy.go
+++ b/internal/test/policy.go
@@ -126,6 +126,12 @@ func GenDisabledResourcePolicy(mod NameMod) *policyv1.Policy {
 	return p
 }
 
+func GenScopedResourcePolicy(scope string, mod NameMod) *policyv1.Policy {
+	p := GenResourcePolicy(mod)
+	p.GetResourcePolicy().Scope = scope
+	return p
+}
+
 // GenResourcePolicy generates a sample resource policy with some names modified by the NameMod.
 func GenResourcePolicy(mod NameMod) *policyv1.Policy {
 	return &policyv1.Policy{


### PR DESCRIPTION
When lenient scope search is enabled and we have a set of candidates to
search for, we incorrectly search the cache for all of those and return
the first one found. If we don't find the first candidate in the cache,
we should just hit the store because it could have been added to the
repo since we last looked for it.

Fixes #1846

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
