### PR TITLE
chore(ci): Fix duplicate volume mount for postgres in E2E tests

### DIFF
--- a/e2e/overlay/helmfile.yaml
+++ b/e2e/overlay/helmfile.yaml
@@ -58,9 +58,6 @@ releases:
             scriptsConfigMap: postgres-init
           persistence:
             enabled: false
-          extraVolumeMounts:
-            - name: data
-              mountPath: /bitnami/postgresql
 
   - name: cerbos
     namespace: '{{ requiredEnv "E2E_NS" }}'

--- a/e2e/postgres/helmfile.yaml
+++ b/e2e/postgres/helmfile.yaml
@@ -58,9 +58,6 @@ releases:
             scriptsConfigMap: postgres-init
           persistence:
             enabled: false
-          extraVolumeMounts:
-            - name: data
-              mountPath: /bitnami/postgresql
 
   - name: cerbos
     namespace: '{{ requiredEnv "E2E_NS" }}'


### PR DESCRIPTION
Previously an update to the `bitnami/postgres` chart broke E2E tests because a data volume wasn't mounted which cerbos/cerbos#2061 fixed. With the recent update, it is now mounted and we get a duplicate entry error:
```
Events:
  Type     Reason        Age                  From                    Message
  ----     ------        ----                 ----                    -------
  Warning  FailedCreate  25s (x15 over 107s)  statefulset-controller  create Pod postgres-0 in StatefulSet postgres failed error: Pod "postgres-0" is invalid: spec.containers[0].volumeMounts[7].mountPath: Invalid value: "/bitnami/postgresql": must be unique
```

This PR removes the previously added volume mount entry to solve the problem.