### PR TITLE
chore: InspectPolicies returns FQN instead of policy key

### DIFF
--- a/internal/storage/bundle/bundle.go
+++ b/internal/storage/bundle/bundle.go
@@ -258,7 +258,7 @@ func (b *Bundle) InspectPolicies(ctx context.Context, listParams storage.ListPol
 
 		actions := policy.ListPolicySetActions(pset)
 		if len(actions) > 0 {
-			results[pset.Fqn] = &responsev1.InspectPoliciesResponse_Result{
+			results[namer.PolicyKeyFromFQN(pset.Fqn)] = &responsev1.InspectPoliciesResponse_Result{
 				Actions: actions,
 			}
 		}

--- a/internal/storage/bundle/local_source_test.go
+++ b/internal/storage/bundle/local_source_test.go
@@ -59,8 +59,8 @@ func runTests(have *bundle.LocalSource, manifest *bundlev1.Manifest) func(*testi
 			results, err := have.InspectPolicies(context.Background(), storage.ListPolicyIDsParams{IncludeDisabled: true})
 			require.NoError(t, err)
 
-			for fqn, h := range results {
-				mID := namer.GenModuleIDFromFQN(fqn)
+			for policyKey, h := range results {
+				mID := namer.GenModuleIDFromFQN(namer.FQNFromPolicyKey(policyKey))
 				ps, err := have.GetFirstMatch(context.Background(), []namer.ModuleID{mID})
 				require.NoError(t, err)
 

--- a/internal/storage/db/internal/db.go
+++ b/internal/storage/db/internal/db.go
@@ -668,7 +668,7 @@ func (s *dbStorage) InspectPolicies(ctx context.Context, listParams storage.List
 	if err := storage.BatchLoadPolicy(ctx, storage.MaxPoliciesInBatch, s.LoadPolicy, func(p *policy.Wrapper) error {
 		actions := policy.ListActions(p.Policy)
 		if len(actions) > 0 {
-			results[p.FQN] = &responsev1.InspectPoliciesResponse_Result{
+			results[namer.PolicyKeyFromFQN(p.FQN)] = &responsev1.InspectPoliciesResponse_Result{
 				Actions: actions,
 			}
 		}

--- a/internal/storage/db/internal/tests.go
+++ b/internal/storage/db/internal/tests.go
@@ -64,7 +64,7 @@ func TestSuite(store DBStorage) func(*testing.T) {
 		policyList := []policy.Wrapper{rp, pp, dr, ev, rpx, drx, rpAcme, rpAcmeHR, rpAcmeHRUK, ppAcme, ppAcmeHR, drImportVariables, rpImportDerivedRolesThatImportVariables, rpDupe1, ppDupe1, drDupe1, evDupe1}
 		policyMap := make(map[string]policy.Wrapper)
 		for _, p := range policyList {
-			policyMap[p.FQN] = p
+			policyMap[namer.PolicyKeyFromFQN(p.FQN)] = p
 		}
 
 		sch := test.ReadSchemaFromFile(t, test.PathToDir(t, "store/_schemas/resources/leave_request.json"))

--- a/internal/storage/index/index.go
+++ b/internal/storage/index/index.go
@@ -462,7 +462,7 @@ func (idx *index) InspectPolicies(ctx context.Context) (map[string]*responsev1.I
 	if err := storage.BatchLoadPolicy(ctx, 1, idx.LoadPolicy, func(p *policy.Wrapper) error {
 		actions := policy.ListActions(p.Policy)
 		if len(actions) > 0 {
-			results[p.FQN] = &responsev1.InspectPoliciesResponse_Result{
+			results[namer.PolicyKeyFromFQN(p.FQN)] = &responsev1.InspectPoliciesResponse_Result{
 				Actions: actions,
 			}
 		}


### PR DESCRIPTION
`cerbos.resource.leave_request.vdefault/regional` to `resource.leave_request.vdefault/regional`