### PR TITLE
chore: Allow Renovate to update npm tests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "configMigration": true,
   "extends": [
-    "config:base",
     "group:allNonMajor",
     "schedule:weekly",
     ":automergeDisabled",
     ":combinePatchMinorReleases",
+    ":dependencyDashboard",
     ":gitSignOff",
     ":renovatePrefix",
     ":semanticCommitTypeAll(chore)",
@@ -44,6 +45,25 @@
       },
       "groupName": "Docker deps",
       "groupSlug": "docker-deps"
+    },
+    {
+      "matchManagers": ["nodenv", "npm"],
+      "groupName": "Node.js deps",
+      "groupSlug": "node-deps",
+      "rangeStrategy": "pin"
+    },
+    {
+      "description": "Don't update dependencies for npm test cases (they should be kept set to 'latest' because they're pulled from the private registry)",
+      "matchFileNames": ["npm/test/cases/*/package.json"],
+      "matchDepTypes": ["dependencies"],
+      "enabled": false
+    },
+    {
+      "description": "Don't do major version updates for package managers in npm test cases (each test case targets a specific major version)",
+      "matchFileNames": ["npm/test/cases/*/package.json"],
+      "matchDepTypes": ["packageManager"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "labels": [


### PR DESCRIPTION
The Renovate `config:base` preset includes the [`:ignoreModulesAndTests`](https://docs.renovatebot.com/presets-default/#ignoremodulesandtests) preset, which means that it's ignoring packages under `npm/test`.

This PR

- removes the `config:base` preset (which has been replaced by [`config:recommended`](https://docs.renovatebot.com/presets-config/#configrecommended) anyway) and inlines the only preset included in it that we actually need ([`:dependencyDashboard`](https://docs.renovatebot.com/presets-default/#dependencydashboard));
- enables the [`configMigration`](https://docs.renovatebot.com/configuration-options/#configmigration) setting so that we get PRs to keep the file up-to-date; and
- adds `packageRules` to configure the Node.js/npm updates.