### PR TITLE
chore: Update deprecated `brews.folder` setting in GoReleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -293,7 +293,7 @@ brews:
         base:
           branch: main
 
-    folder: Formula
+    directory: Formula
     ids:
       - cerbos
     homepage: "https://cerbos.dev"


### PR DESCRIPTION
https://goreleaser.com/deprecations/#brewsfolder
