### PR TITLE
chore(ci): Output signature from cosign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,7 @@
 ---
 name: Release
 on:
+  workflow_dispatch:
   push:
     tags:
       - v*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -117,6 +117,7 @@ signs:
       - --rekor-url
       - https://rekor.sigstore.dev/
       - "--bundle=${artifact}.bundle"
+      - "--output-signature=${signature}"
       - "${artifact}"
     artifacts: all
 
@@ -302,6 +303,8 @@ brews:
 checksum:
   name_template: 'checksums.txt'
 release:
+  extra_files:
+    - glob: '**/*.bundle'
   header: |-
     Cerbos {{ .Version }}
     ---------------------


### PR DESCRIPTION
GoReleaser is hard-coded to look for a `.sig` file for each artifact.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
