### PR TITLE
chore(ci): Remove unmaintained Netlify action

### DIFF
--- a/.github/actions/publish-docs/action.yaml
+++ b/.github/actions/publish-docs/action.yaml
@@ -1,0 +1,28 @@
+name: Publish docs
+
+description: Publish docs to Netlify
+
+inputs:
+  auth_token:
+    description: Netlify authentication token
+    required: true
+
+  site_id:
+    description: Netlify site ID
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Install Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: .node-version
+
+    - name: Publish docs to Netlify
+      shell: bash
+      run: npx --package=netlify-cli -- netlify deploy --prod
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ inputs.auth_token }}
+        NETLIFY_SITE_ID: ${{ inputs.site_id }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,13 +23,10 @@ jobs:
 
       - name: Generate docs
         uses: ./.github/actions/antora-docs
-        id: docs
 
       - name: Publish to Netlify
-        uses: netlify/actions/cli@master
+        uses: ./.github/actions/publish-docs
         with:
-          args: deploy --prod
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          auth_token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          site_id: ${{ secrets.NETLIFY_SITE_ID }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -143,15 +143,12 @@ jobs:
 
       - name: Generate docs
         uses: ./.github/actions/antora-docs
-        id: docs
 
       - name: Publish to Netlify
-        uses: netlify/actions/cli@master
+        uses: ./.github/actions/publish-docs
         with:
-          args: deploy --prod
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          auth_token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          site_id: ${{ secrets.NETLIFY_SITE_ID }}
 
   publishHelm:
     name: Publish Helm chart


### PR DESCRIPTION
The [Netlify CLI action](https://github.com/netlify/actions) is unmaintained and using an EOL Node.js version (which it complains about on install) as well as the deprecated `set-output` syntax. This PR removes the action in favour of installing the CLI ourselves.