### PR TITLE
chore(ci): Update storage type for Jaeger chart

### DIFF
--- a/e2e/otlp/helmfile.yaml
+++ b/e2e/otlp/helmfile.yaml
@@ -47,7 +47,7 @@ releases:
       - provisionDataStore:
           cassandra: false
       - storage:
-          type: none
+          type: memory
       - agent:
           enabled: false
       - allInOne:


### PR DESCRIPTION
The chart's been changed recently to support both Badger and memory as
storage types for the all-in-one deployment.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
