### PR TITLE
chore(ci): Check results of npm package tests

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -333,3 +333,13 @@ jobs:
       - name: Test npm packages
         working-directory: npm
         run: corepack npm test
+
+  test-npm-results:
+    name: Check results of npm package tests
+    runs-on: ubuntu-latest
+    if: always() && needs.test-npm.result != 'skipped'
+    needs:
+      - test-npm
+    steps:
+      - name: Check test results
+        run: test "${{ needs.test-npm.result }}" = "success"


### PR DESCRIPTION
This PR adds a job to the CI workflow to allow us to add the npm package tests as a required check in the branch protection rules, because it's not possible to do so with a matrix job.