### PR TITLE
fix: Eagerly establish gRPC connection to avoid initial delay

### DIFF
--- a/cmd/cerbos/healthcheck/healthcheck.go
+++ b/cmd/cerbos/healthcheck/healthcheck.go
@@ -203,7 +203,7 @@ func (gc grpcCheck) check(ctx context.Context, out io.Writer) error {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(gc.tlsConf)))
 	}
 
-	conn, err := grpc.NewClient(gc.addr, dialOpts...)
+	conn, err := util.EagerGRPCClient(gc.addr, dialOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to connect to gRPC service at %q: %w", gc.addr, err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -573,7 +573,7 @@ func (s *Server) mkGRPCConn() (*grpc.ClientConn, error) {
 		opts = append(opts, grpc.WithTransportCredentials(local.NewCredentials()))
 	}
 
-	grpcConn, err := grpc.NewClient(s.conf.GRPCListenAddr, opts...)
+	grpcConn, err := util.EagerGRPCClient(s.conf.GRPCListenAddr, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial gRPC: %w", err)
 	}

--- a/internal/server/tests.go
+++ b/internal/server/tests.go
@@ -118,7 +118,7 @@ func mkGRPCConn(t *testing.T, addr string, opts ...grpc.DialOption) *grpc.Client
 
 	dialOpts := append(defaultGRPCDialOpts(), opts...)
 
-	grpcConn, err := grpc.NewClient(addr, dialOpts...)
+	grpcConn, err := util.EagerGRPCClient(addr, dialOpts...)
 	require.NoError(t, err, "Failed to dial gRPC server")
 
 	return grpcConn

--- a/internal/util/network.go
+++ b/internal/util/network.go
@@ -5,9 +5,12 @@ package util
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
+
+	"google.golang.org/grpc"
 )
 
 // ParseListenAddress parses an address and returns the network type and the address to dial.
@@ -72,4 +75,15 @@ func GetFreePort() (int, error) {
 	}
 
 	return strconv.Atoi(p)
+}
+
+// EagerGRPCClient creates a gRPC client and establishes a connection immediately.
+func EagerGRPCClient(target string, dialOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	client, err := grpc.NewClient("passthrough:///"+target, dialOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gRPC client: %w", err)
+	}
+
+	client.Connect()
+	return client, nil
 }


### PR DESCRIPTION
The Go gRPC library has changed its behaviour to lazily establish a
connection when the first request is sent. This makes the first request
to Cerbos quite slow to return a response.

Before:

```
  DNS Lookup   TCP Connection   Server Processing   Content Transfer
[     0ms    |       0ms      |      20023ms      |        0ms       ]
             |                |                   |                  |
    namelookup:0ms            |                   |                  |
                        connect:0ms               |                  |
                                      starttransfer:20038ms          |
                                                                 total:20038ms

```

After:

```
  DNS Lookup   TCP Connection   Server Processing   Content Transfer
[     0ms    |       0ms      |        1ms        |        0ms       ]
             |                |                   |                  |
    namelookup:0ms            |                   |                  |
                        connect:0ms               |                  |
                                      starttransfer:7ms              |
                                                                 total:7ms
```

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
