### PR TITLE
chore(docs): Update cloud-platforms.adoc

### DIFF
--- a/docs/modules/deployment/pages/cloud-platforms.adoc
+++ b/docs/modules/deployment/pages/cloud-platforms.adoc
@@ -63,6 +63,8 @@ primary_region = '<REGION>' <2>
 
 The example above launches a Cerbos instance with the xref:configuration:index.adoc#minimal-configuration[minimal configuration] using an empty link:https://fly.io/docs/reference/volumes/[Fly volume] mounted as the policy directory. For production use cases, consider using one of the following methods for policy storage.
 
+TIP: Your host or service for an application should be listening on the right address within the VM: Fly Proxy reaches services through a private IPv4 address on each VM, so the process should listen on `0.0.0.0:<port>` (link:https://fly.io/docs/networking/app-services/#a-note-on-ipv4-and-ipv6-wildcards[but see A note on IPv4 and IPv6 wildcards]).
+
 - Cerbos xref:configuration:storage.adoc#git-driver[`git` driver] with a Git provider such as GitHub or GitLab
 - Cerbos xref:configuration:storage.adoc#blob-driver[`blob` driver] with link:https://fly.io/docs/reference/tigris/#create-and-manage-a-tigris-storage-bucket[Tigris]
 - Cerbos xref:configuration:storage.adoc#sqlite3[`sqlite3` driver] with a standalone SQLite database or link:https://fly.io/docs/litefs/#litefs-cloud[LiteFS]


### PR DESCRIPTION
Topic: Fly listens only on "0.0.0.0"
Changes: Tip added

> Services to be routed to using Fly Proxy need to bind to IPv4 addresses, and services to be reached over 6PN need to bind to IPv6, as described above. However, you may find that your service works even if you haven’t used the addresses we specified. IPv4-mapped IPv6 addresses, if enabled on the VM, can allow IPv4 (and thus Fly Proxy) connections to a service bound on [::]. Further, the wildcard syntax [::] or 0.0.0.0 sometimes covers both IPv4 and IPv6, depending on the language, library, or application.

#### Description

<!-- Thank you for contributing Cerbos! Please describe the changes made in this PR here and provide any other useful information for reviewers. Make sure that you included some automated tests (e.g unit tests) to verify your changes.  If there is a requirement for user input for testing, please include the instructions as well. -->

Fixes #<!-- Link the relevant issue here -->

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
