### PR TITLE
chore(ci): Fix E2E tests combining the host address with extra colon

### DIFF
--- a/internal/server/tests.go
+++ b/internal/server/tests.go
@@ -104,7 +104,7 @@ func (tr *TestRunner) RunGRPCTests(addr string, opts ...grpc.DialOption) func(*t
 	return func(t *testing.T) {
 		grpcConn := mkGRPCConn(t, addr, opts...)
 		require.Eventually(t,
-			grpcHealthCheckPasses(grpcConn, tr.HealthPollInterval),
+			grpcHealthCheckPasses(t, grpcConn, tr.HealthPollInterval),
 			tr.Timeout, tr.HealthPollInterval, "Server did not come up on time")
 
 		for _, tc := range tr.Cases {
@@ -443,7 +443,7 @@ func cmpOutputs(a, b *enginev1.OutputEntry) bool {
 	return a.Src < b.Src
 }
 
-func grpcHealthCheckPasses(grpcConn *grpc.ClientConn, reqTimeout time.Duration) func() bool {
+func grpcHealthCheckPasses(t *testing.T, grpcConn *grpc.ClientConn, reqTimeout time.Duration) func() bool {
 	return func() bool {
 		client := healthpb.NewHealthClient(grpcConn)
 
@@ -452,6 +452,7 @@ func grpcHealthCheckPasses(grpcConn *grpc.ClientConn, reqTimeout time.Duration) 
 
 		resp, err := client.Check(ctx, &healthpb.HealthCheckRequest{})
 		if err != nil {
+			t.Errorf("gRPC health check failed: %s", err.Error())
 			return false
 		}
 

--- a/internal/test/e2e/ctx.go
+++ b/internal/test/e2e/ctx.go
@@ -130,7 +130,7 @@ func (c Ctx) Namespace() string {
 }
 
 func (c Ctx) GRPCAddr() string {
-	return fmt.Sprintf("dns:///%s:%d", c.CerbosHost(), GRPCPort)
+	return fmt.Sprintf("%s:%d", c.CerbosHost(), GRPCPort)
 }
 
 func (c Ctx) HTTPAddr() string {


### PR DESCRIPTION
Due to a previous [commit](https://github.com/cerbos/cerbos/commit/4929745082e4e82794e87acce30d8d6de79cbb28), the E2E tests have been combining a host address with an extra colon.
This PR fixes the problem and adds an extra log for the gRPC health checks which made it easier to debug this problem.