### PR TITLE
fix: Include implicit `EFFECT_DENY` in test failure details

### DIFF
--- a/internal/test/testdata/verify/cases/case_019.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_019.yaml.golden
@@ -5,15 +5,15 @@
       "name": "Example test suite",
       "summary": {
         "overallResult": "RESULT_FAILED",
-        "testsCount": 2,
+        "testsCount": 4,
         "resultCounts": [
           {
             "result": "RESULT_PASSED",
-            "count": 1
+            "count": 2
           },
           {
             "result": "RESULT_FAILED",
-            "count": 1
+            "count": 2
           }
         ]
       },
@@ -30,10 +30,47 @@
                     {
                       "name": "create",
                       "details": {
+                        "result": "RESULT_PASSED",
+                        "success": {
+                          "effect": "EFFECT_ALLOW"
+                        }
+                      }
+                    },
+                    {
+                      "name": "update",
+                      "details": {
                         "result": "RESULT_FAILED",
                         "failure": {
-                          "expected": "EFFECT_ALLOW",
-                          "actual": "EFFECT_DENY"
+                          "expected": "EFFECT_DENY",
+                          "actual": "EFFECT_ALLOW"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "user",
+              "resources": [
+                {
+                  "name": "example",
+                  "actions": [
+                    {
+                      "name": "create",
+                      "details": {
+                        "result": "RESULT_FAILED",
+                        "failure": {
+                          "expected": "EFFECT_DENY",
+                          "actual": "EFFECT_DENY",
+                          "outputs": [
+                            {
+                              "src": "resource.account.vdefault#rule",
+                              "missing": {
+                                "expected": "foo"
+                              }
+                            }
+                          ]
                         }
                       }
                     },
@@ -42,7 +79,7 @@
                       "details": {
                         "result": "RESULT_PASSED",
                         "success": {
-                          "effect": "EFFECT_DENY"
+                          "effect": "EFFECT_ALLOW"
                         }
                       }
                     }
@@ -57,15 +94,15 @@
   ],
   "summary": {
     "overallResult": "RESULT_FAILED",
-    "testsCount": 2,
+    "testsCount": 4,
     "resultCounts": [
       {
         "result": "RESULT_PASSED",
-        "count": 1
+        "count": 2
       },
       {
         "result": "RESULT_FAILED",
-        "count": 1
+        "count": 2
       }
     ]
   }

--- a/internal/test/testdata/verify/cases/case_019.yaml.input
+++ b/internal/test/testdata/verify/cases/case_019.yaml.input
@@ -6,10 +6,14 @@ principals:
     id: admin
     roles:
       - admin
+  user:
+    id: user
+    roles:
+      - user
 
 resources:
   example:
-    kind: example
+    kind: account
     id: example
 
 tests:
@@ -17,6 +21,7 @@ tests:
     input:
       principals:
         - admin
+        - user
       resources:
         - example
       actions:
@@ -27,3 +32,12 @@ tests:
         resource: example
         actions:
           create: EFFECT_ALLOW
+      - principal: user
+        resource: example
+        actions:
+          update: EFFECT_ALLOW
+        outputs:
+          - action: create
+            expected:
+              - src: resource.account.vdefault#rule
+                val: foo

--- a/internal/verify/test_fixture.go
+++ b/internal/verify/test_fixture.go
@@ -289,7 +289,7 @@ func runTest(ctx context.Context, eng Checker, test *policyv1.Test, action strin
 		details.Result = policyv1.TestResults_RESULT_FAILED
 		details.Outcome = &policyv1.TestResults_Details_Failure{
 			Failure: &policyv1.TestResults_Failure{
-				Expected: test.Expected[action],
+				Expected: expectedEffect,
 				Actual:   actual[0].Actions[action].Effect,
 			},
 		}
@@ -334,7 +334,7 @@ func runTest(ctx context.Context, eng Checker, test *policyv1.Test, action strin
 			details.Result = policyv1.TestResults_RESULT_FAILED
 			details.Outcome = &policyv1.TestResults_Details_Failure{
 				Failure: &policyv1.TestResults_Failure{
-					Expected: test.Expected[action],
+					Expected: expectedEffect,
 					Actual:   actual[0].Actions[action].Effect,
 					Outputs:  failures,
 				},


### PR DESCRIPTION
https://github.com/cerbos/cerbos/pull/2116 defaulted the expectation to `EFFECT_DENY`, but didn't include the correct expected value in the failure details 🤦‍♂️ 