### PR TITLE
fix: Kafka TLS does not load system CA certs

### DIFF
--- a/internal/audit/kafka/tls.go
+++ b/internal/audit/kafka/tls.go
@@ -31,7 +31,10 @@ func NewTLSConfig(ctx context.Context, reloadInterval time.Duration, insecureSki
 		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
 	}
 
-	caCertPool := x509.NewCertPool()
+	caCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		caCertPool = x509.NewCertPool()
+	}
 	if !caCertPool.AppendCertsFromPEM(caCert) {
 		return nil, fmt.Errorf("failed to append CA certificate")
 	}


### PR DESCRIPTION
#### Description

Instead of starting with an empty pool, attempt to load system certificates. Fixes an issue where TLS certs signed by well known authorities will fail.

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
