### PR TITLE
fix: Kafka TLS using system CA

### DIFF
--- a/internal/audit/kafka/tls.go
+++ b/internal/audit/kafka/tls.go
@@ -26,14 +26,20 @@ func NewTLSConfig(ctx context.Context, reloadInterval time.Duration, insecureSki
 		return nil, errors.New("certPath and keyPath must both be empty or both be non-empty")
 	}
 
-	caCert, err := os.ReadFile(caPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
-	}
+	var caCertPool *x509.CertPool
+	if caPath != "" {
+		caCert, err := os.ReadFile(caPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+		}
 
-	caCertPool := x509.NewCertPool()
-	if !caCertPool.AppendCertsFromPEM(caCert) {
-		return nil, fmt.Errorf("failed to append CA certificate")
+		caCertPool, err = x509.SystemCertPool()
+		if err != nil {
+			caCertPool = x509.NewCertPool()
+		}
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to append CA certificate")
+		}
 	}
 
 	// #nosec G402

--- a/internal/audit/kafka/tls.go
+++ b/internal/audit/kafka/tls.go
@@ -18,10 +18,6 @@ import (
 )
 
 func NewTLSConfig(ctx context.Context, reloadInterval time.Duration, insecureSkipVerify bool, caPath, certPath, keyPath string) (*tls.Config, error) {
-	if caPath == "" {
-		return nil, errors.New("CA path cannot be empty")
-	}
-
 	if certPath != "" && keyPath == "" || certPath == "" && keyPath != "" {
 		return nil, errors.New("certPath and keyPath must both be empty or both be non-empty")
 	}

--- a/internal/audit/kafka/tls_test.go
+++ b/internal/audit/kafka/tls_test.go
@@ -15,12 +15,8 @@ func TestNewTLSConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	// caPath is required
-	_, err := kafka.NewTLSConfig(ctx, 0, false, "", "path/to/cert", "path/to/key")
-	require.EqualError(t, err, "CA path cannot be empty")
-
 	// certPath or keyPath are required if either one are set
-	_, err = kafka.NewTLSConfig(ctx, 0, false, "path/to/ca", "path/to/cert", "")
+	_, err := kafka.NewTLSConfig(ctx, 0, false, "path/to/ca", "path/to/cert", "")
 	require.EqualError(t, err, "certPath and keyPath must both be empty or both be non-empty")
 
 	_, err = kafka.NewTLSConfig(ctx, 0, false, "path/to/ca", "", "path/to/key")


### PR DESCRIPTION
#### Description

Fixes the follow: 
- allow not setting path to CA to fallback to system
- when supplying own CA, append to system CA

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
