### PR TITLE
chore: Remove deprecated audit log fields from filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,8 @@ install-cerbos:
 				echo "aborting install"; \
 			exit -1; \
 		fi; \
+	else \
+		go install -ldflags '$(LDFLAGS)' ./cmd/cerbos; \
 	fi; \
 
 .PHONY: install-cerbosctl
@@ -164,6 +166,8 @@ install-cerbosctl:
 				echo "aborting install"; \
 			exit -1; \
 		fi; \
+	else \
+		go install -ldflags '$(LDFLAGS)' ./cmd/cerbosctl; \
 	fi; \
 
 .PHONY: warm-cache

--- a/internal/audit/hub/filter.go
+++ b/internal/audit/hub/filter.go
@@ -22,9 +22,8 @@ const (
 	peerPrefix        = unionedPathPrefix + ".peer"
 	metadataPrefix    = unionedPathPrefix + ".metadata"
 
-	checkResourcesDeprecatedPrefix = "entries[*].decisionLogEntry"
-	checkResourcesPrefix           = "entries[*].decisionLogEntry.checkResources"
-	planResourcesPrefix            = "entries[*].decisionLogEntry.planResources"
+	checkResourcesPrefix = "entries[*].decisionLogEntry.checkResources"
+	planResourcesPrefix  = "entries[*].decisionLogEntry.planResources"
 )
 
 type tokenType int8
@@ -95,10 +94,6 @@ func parseJSONPathExprs(conf MaskConf) (ast *Token, outErr error) {
 
 	for _, r := range conf.CheckResources {
 		if err := parse(checkResourcesPrefix + "." + r); err != nil {
-			outErr = multierr.Append(outErr, err)
-		}
-
-		if err := parse(checkResourcesDeprecatedPrefix + "." + r); err != nil {
 			outErr = multierr.Append(outErr, err)
 		}
 	}

--- a/internal/audit/hub/hub.go
+++ b/internal/audit/hub/hub.go
@@ -40,7 +40,7 @@ func init() {
 
 		logger := zap.L().Named("auditlog").With(zap.String("backend", Backend))
 
-		syncer, err := NewIngestSyncer(conf, logger)
+		syncer, err := NewIngestSyncer(&conf.Ingest, logger)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/audit/hub/ingest.go
+++ b/internal/audit/hub/ingest.go
@@ -38,22 +38,22 @@ type Impl struct {
 	log    *zap.Logger
 }
 
-func NewIngestSyncer(conf *Conf, logger *zap.Logger) (*Impl, error) {
-	pdpID := util.PDPIdentifier(conf.Ingest.Credentials.PDPID)
+func NewIngestSyncer(conf *IngestConf, logger *zap.Logger) (*Impl, error) {
+	pdpID := util.PDPIdentifier(conf.Credentials.PDPID)
 
 	logger = logger.Named("ingest").With(zap.String("instance", pdpID.Instance))
 
-	creds, err := conf.Ingest.Credentials.ToCredentials()
+	creds, err := conf.Credentials.ToCredentials()
 	if err != nil {
 		return nil, errors.New("failed to generate credentials from config")
 	}
 
 	tlsConf := &tls.Config{
 		MinVersion: tls.VersionTLS13,
-		ServerName: conf.Ingest.Connection.TLS.Authority,
+		ServerName: conf.Connection.TLS.Authority,
 	}
 
-	caCertPath := conf.Ingest.Connection.TLS.CACert
+	caCertPath := conf.Connection.TLS.CACert
 	if caCertPath != "" {
 		caCert, err := os.ReadFile(caCertPath)
 		if err != nil {
@@ -72,12 +72,12 @@ func NewIngestSyncer(conf *Conf, logger *zap.Logger) (*Impl, error) {
 			PDPIdentifier:     pdpID,
 			TLS:               tlsConf,
 			Credentials:       creds,
-			APIEndpoint:       conf.Ingest.Connection.APIEndpoint,
-			BootstrapEndpoint: conf.Ingest.Connection.BootstrapEndpoint,
-			RetryWaitMin:      conf.Ingest.Connection.MinRetryWait,
-			RetryWaitMax:      conf.Ingest.Connection.MaxRetryWait,
-			RetryMaxAttempts:  int(conf.Ingest.Connection.NumRetries),
-			HeartbeatInterval: conf.Ingest.Connection.HeartbeatInterval,
+			APIEndpoint:       conf.Connection.APIEndpoint,
+			BootstrapEndpoint: conf.Connection.BootstrapEndpoint,
+			RetryWaitMin:      conf.Connection.MinRetryWait,
+			RetryWaitMax:      conf.Connection.MaxRetryWait,
+			RetryMaxAttempts:  int(conf.Connection.NumRetries),
+			HeartbeatInterval: conf.Connection.HeartbeatInterval,
 		},
 	}
 


### PR DESCRIPTION
Any version of Cerbos which can be used with Hub does not support the deprecated form of the audit log, so the handling for that particular JSONPath prefix can be removed.

This commit also encompasses other minor changes:

* Only pass relevant cfg type to Syncer
* Fix Make recipe