### PR TITLE
fix: Stop blocking Kafka audit publishing when an outage occurs

### DIFF
--- a/internal/audit/kafka/publisher.go
+++ b/internal/audit/kafka/publisher.go
@@ -68,7 +68,7 @@ func init() {
 type Client interface {
 	Close()
 	Flush(context.Context) error
-	Produce(context.Context, *kgo.Record, func(*kgo.Record, error))
+	TryProduce(context.Context, *kgo.Record, func(*kgo.Record, error))
 	ProduceSync(context.Context, ...*kgo.Record) kgo.ProduceResults
 }
 
@@ -199,7 +199,9 @@ func (p *Publisher) write(ctx context.Context, msg *kgo.Record) error {
 
 	// detach the context from the caller so the request can return
 	// without cancelling any async kafka operations
-	p.Client.Produce(context.Background(), msg, func(r *kgo.Record, err error) {
+	ctx = context.WithoutCancel(ctx)
+
+	p.Client.TryProduce(ctx, msg, func(r *kgo.Record, err error) {
 		if err == nil {
 			return
 		}

--- a/internal/audit/kafka/publisher_test.go
+++ b/internal/audit/kafka/publisher_test.go
@@ -193,7 +193,7 @@ func (m *mockClient) Flush(_ context.Context) error {
 	return nil
 }
 
-func (m *mockClient) Produce(_ context.Context, record *kgo.Record, _ func(*kgo.Record, error)) {
+func (m *mockClient) TryProduce(_ context.Context, record *kgo.Record, _ func(*kgo.Record, error)) {
 	m.Records = append(m.Records, record)
 }
 


### PR DESCRIPTION
#### Description

`TryProduce` is similar to the previous `Produce` call, but rather than blocking if the Kafka client currently has MaxBufferedRecords or MaxBufferedBytes buffered, this fails immediately.

https://pkg.go.dev/github.com/twmb/franz-go/pkg/kgo#Client.TryProduce

Cerbos when configured with `produceSync: false` should handle an outage at the Kafka layer by continuing but reporting the problem through metrics & logs.

Fixes #2123 

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
