### PR TITLE
chore: Remove usage of deprecated MySQL native authentication plugin

### DIFF
--- a/internal/storage/db/mysql/schema.sql
+++ b/internal/storage/db/mysql/schema.sql
@@ -3,7 +3,7 @@ CREATE DATABASE IF NOT EXISTS cerbos CHARACTER SET utf8mb4;
 USE cerbos;
 
 CREATE TABLE IF NOT EXISTS policy (
-    id BIGINT PRIMARY KEY, 
+    id BIGINT PRIMARY KEY,
     kind VARCHAR(128) NOT NULL,
     name VARCHAR(1024) NOT NULL,
     version VARCHAR(128) NOT NULL,
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS policy_revision (
     version VARCHAR(128),
     scope VARCHAR(512),
     description TEXT,
-    disabled BOOLEAN, 
+    disabled BOOLEAN,
     definition BLOB,
     update_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP);
 
@@ -43,28 +43,28 @@ CREATE TABLE IF NOT EXISTS attr_schema_defs (
 
 DROP TRIGGER IF EXISTS policy_on_insert;
 
-CREATE TRIGGER policy_on_insert AFTER INSERT ON policy 
+CREATE TRIGGER policy_on_insert AFTER INSERT ON policy
 FOR EACH ROW
 INSERT INTO policy_revision(action, id, kind, name, version, scope, description, disabled, definition)
 VALUES('INSERT', NEW.id, NEW.kind, NEW.name, NEW.version, NEW.scope, NEW.description, NEW.disabled, NEW.definition);
 
 DROP TRIGGER IF EXISTS policy_on_update;
 
-CREATE TRIGGER policy_on_update AFTER UPDATE ON policy 
+CREATE TRIGGER policy_on_update AFTER UPDATE ON policy
 FOR EACH ROW
 INSERT INTO policy_revision(action, id, kind, name, version, scope, description, disabled, definition)
 VALUES('UPDATE', NEW.id, NEW.kind, NEW.name, NEW.version, NEW.scope, NEW.description, NEW.disabled, NEW.definition);
 
 DROP TRIGGER IF EXISTS policy_on_delete;
 
-CREATE TRIGGER policy_on_delete AFTER DELETE ON policy 
+CREATE TRIGGER policy_on_delete AFTER DELETE ON policy
 FOR EACH ROW
 INSERT INTO policy_revision(action, id, kind, name, version, scope, description, disabled, definition)
 VALUES('DELETE', OLD.id, OLD.kind, OLD.name, OLD.version, OLD.scope, OLD.description, OLD.disabled, OLD.definition);
 
-CREATE USER IF NOT EXISTS cerbos_user IDENTIFIED WITH mysql_native_password BY 'changeme';
-GRANT SELECT,INSERT,UPDATE,DELETE ON cerbos.policy TO cerbos_user; 
+CREATE USER IF NOT EXISTS cerbos_user IDENTIFIED BY 'changeme';
+GRANT SELECT,INSERT,UPDATE,DELETE ON cerbos.policy TO cerbos_user;
 GRANT SELECT,INSERT,UPDATE,DELETE ON cerbos.attr_schema_defs TO cerbos_user;
 GRANT SELECT,INSERT,UPDATE,DELETE ON cerbos.policy_dependency TO cerbos_user;
 GRANT SELECT,INSERT,UPDATE,DELETE ON cerbos.policy_ancestor TO cerbos_user;
-GRANT SELECT,INSERT ON cerbos.policy_revision TO cerbos_user; 
+GRANT SELECT,INSERT ON cerbos.policy_revision TO cerbos_user;


### PR DESCRIPTION
The `mysql_native_password` plugin is deprecated and not available on
latest MySQL container images.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
