### PR TITLE
chore(ci): Clear disk space for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,17 @@ jobs:
       contents: write
       packages: write
     steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The worker is running out of disk space during the release.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
