### PR TITLE
chore(ci): Clear disk space for npm build

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,7 @@
     ":semanticCommitTypeAll(chore)",
     ":separateMultipleMajorReleases"
   ],
+  "ignoreDeps": ["github.com/cerbos/go-yaml"],
   "packageRules": [
     {
       "matchManagers": ["helmfile"],
@@ -34,7 +35,8 @@
       "groupName": "Go deps",
       "groupSlug": "go-deps",
       "postUpdateOptions": [
-        "gomodTidy1.17"
+        "gomodTidy",
+        "gomodUpdateImportPaths"
       ]
     },
     {

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -265,6 +265,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Check out code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       contents: write
       packages: write
     steps:
-      - name: Free Disk Space
+      - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false


### PR DESCRIPTION
Also includes a tweak to Renovate to ignore the go-yaml replacement and
update import paths on major module version updates.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
