### PR TITLE
enhancement: Context for YAML syntax errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -301,4 +301,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/goccy/go-yaml => github.com/cerbos/go-yaml v0.0.0-20240502082720-ab3470c47ed6
+replace github.com/goccy/go-yaml => github.com/cerbos/go-yaml v0.0.0-20240513133213-0c54559a0516

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/cerbos/cerbos/api/genpb v0.36.0 h1:jKfzDLbmyXIBXMoWoeX1Y0TXaDTL9swTdF
 github.com/cerbos/cerbos/api/genpb v0.36.0/go.mod h1:7rrCyoC3hAvGrvQIrXZswaWjWwpwfF4oXvsVqDYIZQ8=
 github.com/cerbos/cloud-api v0.1.19 h1:Wz/4h5BHVg2ul+gtoAZyQRaDfDTkgv639Blv1ejwblQ=
 github.com/cerbos/cloud-api v0.1.19/go.mod h1:vpBUoQV1XVR2zV+xI9aK2cBlwL//a7i3RiQBWRe6AZ0=
-github.com/cerbos/go-yaml v0.0.0-20240502082720-ab3470c47ed6 h1:GR4sGAsS8QtShlU7sGm2fNr7HXsnRUEXLVlkn21yjs4=
-github.com/cerbos/go-yaml v0.0.0-20240502082720-ab3470c47ed6/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
+github.com/cerbos/go-yaml v0.0.0-20240513133213-0c54559a0516 h1:G+IeeyI8JYGQYpr1W45hKT5ppZmddT/jNAiZgKgo+gA=
+github.com/cerbos/go-yaml v0.0.0-20240513133213-0c54559a0516/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/internal/test/testdata/parser/case_023.json
+++ b/internal/test/testdata/parser/case_023.json
@@ -1,0 +1,13 @@
+{
+    "description": "Invalid key",
+    "wantErrors": [
+        {
+            "kind": "KIND_PARSE_ERROR",
+            "position": {
+                "line": 9,
+                "column": 7
+            },
+            "message": "unexpected key name"
+        }
+    ]
+}

--- a/internal/test/testdata/parser/case_023.json.input
+++ b/internal/test/testdata/parser/case_023.json.input
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../../../../schema/jsonschema/cerbos/policy/v1/Policy.schema.json
+---
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: "20210210"
+  resource: leave_request
+  rules:
+    - actions: ['*']
+      effect! EFFECT_ALLOW
+      roles:
+        - admin
+      name: wildcard


### PR DESCRIPTION
The upstream YAML parser doesn't expose syntax errors in a way that we
could easily obtain information about the context. I've updated our fork
to make this easier and enable us to report syntax errors in the same
way as other errors.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
