### PR TITLE
fix: Detect incorrectly indented YAML

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -301,4 +301,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/goccy/go-yaml => github.com/cerbos/go-yaml v0.0.0-20240513133213-0c54559a0516
+replace github.com/goccy/go-yaml => github.com/cerbos/go-yaml v0.0.0-20240514093850-321c98b4c50b

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/cerbos/cerbos/api/genpb v0.36.0 h1:jKfzDLbmyXIBXMoWoeX1Y0TXaDTL9swTdF
 github.com/cerbos/cerbos/api/genpb v0.36.0/go.mod h1:7rrCyoC3hAvGrvQIrXZswaWjWwpwfF4oXvsVqDYIZQ8=
 github.com/cerbos/cloud-api v0.1.19 h1:Wz/4h5BHVg2ul+gtoAZyQRaDfDTkgv639Blv1ejwblQ=
 github.com/cerbos/cloud-api v0.1.19/go.mod h1:vpBUoQV1XVR2zV+xI9aK2cBlwL//a7i3RiQBWRe6AZ0=
-github.com/cerbos/go-yaml v0.0.0-20240513133213-0c54559a0516 h1:G+IeeyI8JYGQYpr1W45hKT5ppZmddT/jNAiZgKgo+gA=
-github.com/cerbos/go-yaml v0.0.0-20240513133213-0c54559a0516/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
+github.com/cerbos/go-yaml v0.0.0-20240514093850-321c98b4c50b h1:YFaRF8eTUO15ZJuX8tE3KmWRoNaYAZMFreQYcYGHVmo=
+github.com/cerbos/go-yaml v0.0.0-20240514093850-321c98b4c50b/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -80,6 +80,8 @@ func TestUnmarshal(t *testing.T) {
 						requireErrorsEqual(t, want.Errors, haveSrc[i].Errors)
 					}
 				}
+			} else {
+				require.Empty(t, haveMsg)
 			}
 		})
 	}

--- a/internal/test/testdata/parser/case_024.json
+++ b/internal/test/testdata/parser/case_024.json
@@ -1,0 +1,14 @@
+{
+    "description": "Invalid indentation (#2146)",
+    "want": [],
+    "wantErrors": [
+        {
+            "kind": "KIND_PARSE_ERROR",
+            "position": {
+                "line": 12,
+                "column": 11
+            },
+            "message": "invalid indentation"
+        }
+    ]
+}

--- a/internal/test/testdata/parser/case_024.json.input
+++ b/internal/test/testdata/parser/case_024.json.input
@@ -1,0 +1,17 @@
+---
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: "20210210"
+  resource: leave_request
+  rules:
+    - actions: ['*']
+      condition:
+        match:
+          expr: > 
+            foo
+          bar
+      name: wildcard
+      effect: EFFECT_ALLOW
+      roles:
+        - admin
+


### PR DESCRIPTION
The bug was patched in the parser (cerbos/go-yaml#3). This PR adds a
test for it.

Fixes #2146

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
