### PR TITLE
chore(docs): Redirect old versions with correct status code

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  publish = "docs/build"
+publish = "docs/build"
 
 # Only required until Antora LFS support lands. https://gitlab.com/antora/antora/-/issues/185
 
@@ -108,4 +108,4 @@ force = true
 [[redirects]]
 from = "/cerbos/:version/*"
 to = "/cerbos/latest/:splat"
-status = 404
+status = 301


### PR DESCRIPTION
Netlify documentation is not clear about how to handle 404 errors and I
wrongly assumed it needed to have the status code parameter set to 404.
It actually sends a 404 back to the user :man_facepalming:

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
