### PR TITLE
chore: Share Hub base client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cerbos/cerbos-sdk-go v0.2.8
 	github.com/cerbos/cerbos/api/genpb v0.37.0
-	github.com/cerbos/cloud-api v0.1.21
+	github.com/cerbos/cloud-api v0.1.22
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cloudflare/certinel v0.4.1
 	github.com/dgraph-io/badger/v4 v4.2.0

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,6 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.5 h1:K/NXvIftO
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.5/go.mod h1:cl9HGLV66EnCmMNzq4sYOti+/xo8w34CsgzVtm2GgsY=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.3 h1:4t+QEX7BsXz98W8W1lNvMAG+NX8qHz2CjLBxQKku40g=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.3/go.mod h1:oFcjjUq5Hm09N9rpxTdeMeLeQcxS7mIkBkL8qUKng+A=
-github.com/aws/aws-sdk-go-v2/service/marketplacemetering v1.23.3 h1:ZkaFS2PmZFk710zqw7Yki2douIA6fL5JVvy7rP4q9qg=
-github.com/aws/aws-sdk-go-v2/service/marketplacemetering v1.23.3/go.mod h1:ZK5KBD+u8g1Frfqe1atGaH19dSnY9SbHuSUimYv1cy0=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.51.4 h1:lW5xUzOPGAMY7HPuNF4FdyBwRc3UJ/e8KsapbesVeNU=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.51.4/go.mod h1:MGTaf3x/+z7ZGugCGvepnx2DS6+caCYYqKhzVoLNYPk=
 github.com/aws/aws-sdk-go-v2/service/sso v1.20.2 h1:XOPfar83RIRPEzfihnp+U6udOveKZJvPQ76SKWrLRHc=

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.5 h1:K/NXvIftO
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.5/go.mod h1:cl9HGLV66EnCmMNzq4sYOti+/xo8w34CsgzVtm2GgsY=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.3 h1:4t+QEX7BsXz98W8W1lNvMAG+NX8qHz2CjLBxQKku40g=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.3/go.mod h1:oFcjjUq5Hm09N9rpxTdeMeLeQcxS7mIkBkL8qUKng+A=
+github.com/aws/aws-sdk-go-v2/service/marketplacemetering v1.23.3 h1:ZkaFS2PmZFk710zqw7Yki2douIA6fL5JVvy7rP4q9qg=
+github.com/aws/aws-sdk-go-v2/service/marketplacemetering v1.23.3/go.mod h1:ZK5KBD+u8g1Frfqe1atGaH19dSnY9SbHuSUimYv1cy0=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.51.4 h1:lW5xUzOPGAMY7HPuNF4FdyBwRc3UJ/e8KsapbesVeNU=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.51.4/go.mod h1:MGTaf3x/+z7ZGugCGvepnx2DS6+caCYYqKhzVoLNYPk=
 github.com/aws/aws-sdk-go-v2/service/sso v1.20.2 h1:XOPfar83RIRPEzfihnp+U6udOveKZJvPQ76SKWrLRHc=
@@ -158,8 +160,8 @@ github.com/cerbos/cerbos-sdk-go v0.2.8 h1:+pPSsH9yh2EP1y+z+9Md9s5ArdiEuge3T2ZIBn
 github.com/cerbos/cerbos-sdk-go v0.2.8/go.mod h1:YfMDWB/AUIEVoufmg4bfhCF0P3YXPrnA2UUxP4SlEEA=
 github.com/cerbos/cerbos/api/genpb v0.37.0 h1:dTtlElLVx3utwYEWT0b3b1cff3GGg/Q8nXFTFbfIdFY=
 github.com/cerbos/cerbos/api/genpb v0.37.0/go.mod h1:/oEYro8MlnD3cUwoKwUWB136sVj3hlm2Yoyuiue56d0=
-github.com/cerbos/cloud-api v0.1.21 h1:8Ybluj+QjcIe/jjUE/Zix3H2sCOibkmoGmk5LlMb6UY=
-github.com/cerbos/cloud-api v0.1.21/go.mod h1:euVuPCb5K7Ofejf3xLgaHw/+AdSfVvXyHFZ/ctAL8Iw=
+github.com/cerbos/cloud-api v0.1.22 h1:qFzi29K3RmUHSuSBgNn6pSr19oV9OgOca4ujFKhV8U4=
+github.com/cerbos/cloud-api v0.1.22/go.mod h1:euVuPCb5K7Ofejf3xLgaHw/+AdSfVvXyHFZ/ctAL8Iw=
 github.com/cerbos/go-yaml v0.0.0-20240514093850-321c98b4c50b h1:YFaRF8eTUO15ZJuX8tE3KmWRoNaYAZMFreQYcYGHVmo=
 github.com/cerbos/go-yaml v0.0.0-20240514093850-321c98b4c50b/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/internal/audit/hub/conf.go
+++ b/internal/audit/hub/conf.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cerbos/cerbos/internal/audit"
 	"github.com/cerbos/cerbos/internal/audit/local"
-	"github.com/cerbos/cerbos/internal/hub"
 	"go.uber.org/multierr"
 )
 
@@ -32,17 +31,13 @@ var (
 )
 
 type Conf struct {
-	Ingest IngestConf `yaml:"ingest" conf:",ignore"`
 	// Mask defines a list of attributes to exclude from the audit logs, specified as lists of JSONPaths
 	Mask       MaskConf `yaml:"mask"`
 	local.Conf `yaml:",inline"`
+	Ingest     IngestConf `yaml:"ingest" conf:",ignore"`
 }
 
 type IngestConf struct {
-	// Credentials holds Cerbos Hub credentials.
-	Credentials *hub.CredentialsConf `yaml:"credentials" conf:",ignore"`
-	// Connection defines settings for the remote server connection.
-	Connection *hub.ConnectionConf `yaml:"connection" conf:",ignore"`
 	// MaxBatchSize defines the max number of log entries to send in each Ingest request.
 	MaxBatchSize uint `yaml:"maxBatchSize" conf:",example=32"`
 	// MinFlushInterval is the minimal duration between Ingest requests.
@@ -92,29 +87,6 @@ func (c *Conf) Validate() (outErr error) {
 
 	if c.Ingest.MinFlushInterval >= c.Conf.Advanced.FlushInterval {
 		outErr = multierr.Append(outErr, errors.New("ingest.minFlushInterval must be less than advanced.flushInterval"))
-	}
-
-	if err := c.loadHubConf(); err != nil {
-		outErr = multierr.Append(outErr, err)
-	}
-
-	return outErr
-}
-
-func (c *Conf) loadHubConf() (outErr error) {
-	hubConf, err := hub.GetConf()
-	if err != nil {
-		outErr = multierr.Append(outErr, fmt.Errorf("failed to read Cerbos Hub configuration: %w", err))
-	}
-
-	c.Ingest.Connection = &hubConf.Connection
-	if err := c.Ingest.Connection.Validate(); err != nil {
-		outErr = multierr.Append(outErr, err)
-	}
-
-	c.Ingest.Credentials = &hubConf.Credentials
-	if err := c.Ingest.Credentials.Validate(); err != nil {
-		outErr = multierr.Append(outErr, err)
 	}
 
 	return outErr

--- a/internal/audit/hub/hub.go
+++ b/internal/audit/hub/hub.go
@@ -42,7 +42,7 @@ func init() {
 
 		logger := zap.L().Named("auditlog").With(zap.String("backend", Backend))
 
-		syncer, err := NewIngestSyncer(&conf.Ingest, logger)
+		syncer, err := NewIngestSyncer(logger)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/audit/hub/hub_test.go
+++ b/internal/audit/hub/hub_test.go
@@ -113,16 +113,16 @@ func TestHubLog(t *testing.T) {
 	}
 
 	conf := &hub.Conf{
-		hub.IngestConf{
+		Ingest: hub.IngestConf{
 			MaxBatchSize:     batchSize,
 			MinFlushInterval: 2 * time.Second,
 			FlushTimeout:     1 * time.Second,
 			NumGoRoutines:    8,
 		},
-		hub.MaskConf{
+		Mask: hub.MaskConf{
 			Peer: []string{"address"},
 		},
-		local.Conf{
+		Conf: local.Conf{
 			StoragePath:     t.TempDir(),
 			RetentionPeriod: 24 * time.Hour,
 			Advanced: local.AdvancedConf{

--- a/internal/audit/hub/ingest.go
+++ b/internal/audit/hub/ingest.go
@@ -5,19 +5,14 @@ package hub
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"errors"
 	"fmt"
-	"os"
 	"time"
 
-	"github.com/cerbos/cerbos/internal/util"
-	"github.com/cerbos/cloud-api/base"
+	"go.uber.org/zap"
+
+	"github.com/cerbos/cerbos/internal/hub"
 	logsv1 "github.com/cerbos/cloud-api/genpb/cerbos/cloud/logs/v1"
 	"github.com/cerbos/cloud-api/logcap"
-	"github.com/go-logr/zapr"
-	"go.uber.org/zap"
 )
 
 type ErrIngestBackoff struct {
@@ -38,50 +33,13 @@ type Impl struct {
 	log    *zap.Logger
 }
 
-func NewIngestSyncer(conf *IngestConf, logger *zap.Logger) (*Impl, error) {
-	pdpID := util.PDPIdentifier(conf.Credentials.PDPID)
-
-	logger = logger.Named("ingest").With(zap.String("instance", pdpID.Instance))
-
-	creds, err := conf.Credentials.ToCredentials()
+func NewIngestSyncer(logger *zap.Logger) (*Impl, error) {
+	hubInstance, err := hub.Get()
 	if err != nil {
-		return nil, errors.New("failed to generate credentials from config")
+		return nil, fmt.Errorf("failed to establish Cerbos Hub connection: %w", err)
 	}
 
-	tlsConf := &tls.Config{
-		MinVersion: tls.VersionTLS13,
-		ServerName: conf.Connection.TLS.Authority,
-	}
-
-	caCertPath := conf.Connection.TLS.CACert
-	if caCertPath != "" {
-		caCert, err := os.ReadFile(caCertPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read CA cert from %q: %w", caCertPath, err)
-		}
-
-		tlsConf.RootCAs = x509.NewCertPool()
-		if !tlsConf.RootCAs.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("failed to parse CA certs")
-		}
-	}
-
-	clientConf := logcap.ClientConf{
-		ClientConf: base.ClientConf{
-			Logger:            zapr.NewLogger(logger),
-			PDPIdentifier:     pdpID,
-			TLS:               tlsConf,
-			Credentials:       creds,
-			APIEndpoint:       conf.Connection.APIEndpoint,
-			BootstrapEndpoint: conf.Connection.BootstrapEndpoint,
-			RetryWaitMin:      conf.Connection.MinRetryWait,
-			RetryWaitMax:      conf.Connection.MaxRetryWait,
-			RetryMaxAttempts:  int(conf.Connection.NumRetries),
-			HeartbeatInterval: conf.Connection.HeartbeatInterval,
-		},
-	}
-
-	client, err := logcap.NewClient(clientConf)
+	client, err := hubInstance.LogCapClient()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -1,0 +1,67 @@
+// Copyright 2021-2024 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package hub
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/cerbos/cerbos/internal/util"
+	"github.com/cerbos/cloud-api/base"
+	"github.com/cerbos/cloud-api/hub"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+)
+
+var Get = sync.OnceValues(getInstance)
+
+func getInstance() (*hub.Hub, error) {
+	conf, err := GetConf()
+	if err != nil {
+		return nil, err
+	}
+
+	pdpID := util.PDPIdentifier(conf.Credentials.PDPID)
+	logger := zap.L().Named("hub").With(zap.String("instance", pdpID.Instance))
+
+	creds, err := conf.Credentials.ToCredentials()
+	if err != nil {
+		return nil, errors.New("failed to generate credentials from config")
+	}
+
+	tlsConf := &tls.Config{
+		MinVersion: tls.VersionTLS13,
+		ServerName: conf.Connection.TLS.Authority,
+	}
+
+	caCertPath := conf.Connection.TLS.CACert
+	if caCertPath != "" {
+		caCert, err := os.ReadFile(caCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA cert from %q: %w", caCertPath, err)
+		}
+
+		tlsConf.RootCAs = x509.NewCertPool()
+		if !tlsConf.RootCAs.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to parse CA certs")
+		}
+	}
+
+	return hub.Get(base.ClientConf{
+		Logger:            zapr.NewLogger(logger),
+		PDPIdentifier:     pdpID,
+		TLS:               tlsConf,
+		Credentials:       creds,
+		APIEndpoint:       conf.Connection.APIEndpoint,
+		BootstrapEndpoint: conf.Connection.BootstrapEndpoint,
+		RetryWaitMin:      conf.Connection.MinRetryWait,
+		RetryWaitMax:      conf.Connection.MaxRetryWait,
+		RetryMaxAttempts:  int(conf.Connection.NumRetries),
+		HeartbeatInterval: conf.Connection.HeartbeatInterval,
+	})
+}

--- a/internal/storage/hub/conf.go
+++ b/internal/storage/hub/conf.go
@@ -95,8 +95,7 @@ func (conf *Conf) Validate() (outErr error) {
 func (conf *Conf) validateCredentials() error {
 	if conf.Credentials != nil {
 		util.DeprecationWarning("storage.bundle.credentials section", "hub.credentials")
-		conf.Credentials.LoadFromEnv()
-		return conf.Credentials.Validate()
+		return errors.New("storage.bundle.credentials section is no longer supported")
 	}
 
 	hubConf, err := hub.GetConf()
@@ -191,7 +190,7 @@ func (rc *RemoteSourceConf) setDefaultsForUnsetFields() error {
 
 	if rc.Connection != nil {
 		util.DeprecationWarning("storage.bundle.remote.connection section", "hub.connection")
-		return rc.Connection.Validate()
+		return errors.New("storage.bundle.remote.connection configuration is no longer supported")
 	}
 
 	hubConf, err := hub.GetConf()

--- a/internal/storage/hub/conf_test.go
+++ b/internal/storage/hub/conf_test.go
@@ -33,7 +33,7 @@ func doTestConfig(driver string) func(*testing.T) {
 			wantErr bool
 		}{
 			{
-				name: "file/valid-config",
+				name: "file/legacy-config",
 				conf: map[string]any{
 					"storage": map[string]any{
 						driver: map[string]any{
@@ -48,55 +48,6 @@ func doTestConfig(driver string) func(*testing.T) {
 								"bundleLabel": "latest",
 								"tempDir":     "/tmp",
 								"cacheDir":    "/tmp",
-								"connection": map[string]any{
-									"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
-									"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
-								},
-							},
-						},
-					},
-				},
-			},
-			{
-				name: "file/valid-legacy-config",
-				conf: map[string]any{
-					"storage": map[string]any{
-						driver: map[string]any{
-							"cacheSize": 1024,
-							"credentials": map[string]any{
-								"instanceID":   "pdp-id",
-								"clientID":     "client-id",
-								"clientSecret": "client-secret",
-								"secretKey":    "workspace-secret",
-							},
-							"remote": map[string]any{
-								"bundleLabel": "latest",
-								"tempDir":     "/tmp",
-								"cacheDir":    "/tmp",
-								"connection": map[string]any{
-									"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
-									"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
-								},
-							},
-						},
-					},
-				},
-			},
-			{
-				name: "file/invalid-config-missing-bundle-label",
-				conf: map[string]any{
-					"storage": map[string]any{
-						driver: map[string]any{
-							"cacheSize": 1024,
-							"credentials": map[string]any{
-								"pdpID":           "pdp-id",
-								"clientID":        "client-id",
-								"clientSecret":    "client-secret",
-								"workspaceSecret": "workspace-secret",
-							},
-							"remote": map[string]any{
-								"tempDir":  "/tmp",
-								"cacheDir": "/tmp",
 								"connection": map[string]any{
 									"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
 									"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
@@ -135,15 +86,9 @@ func doTestConfig(driver string) func(*testing.T) {
 				},
 			},
 			{
-				name: "file/duplicate-credentials",
+				name: "env/valid-config",
 				conf: map[string]any{
 					"hub": map[string]any{
-						"credentials": map[string]any{
-							"pdpID":           "Xpdp-id",
-							"clientID":        "Xclient-id",
-							"clientSecret":    "Xclient-secret",
-							"workspaceSecret": "Xworkspace-secret",
-						},
 						"connection": map[string]any{
 							"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
 							"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
@@ -152,65 +97,9 @@ func doTestConfig(driver string) func(*testing.T) {
 					"storage": map[string]any{
 						driver: map[string]any{
 							"cacheSize": 1024,
-							"credentials": map[string]any{
-								"pdpID":           "pdp-id",
-								"clientID":        "client-id",
-								"clientSecret":    "client-secret",
-								"workspaceSecret": "workspace-secret",
-							},
-							"remote": map[string]any{
-								"bundleLabel": "latest",
-								"tempDir":     "/tmp",
-								"cacheDir":    "/tmp",
-							},
-						},
-					},
-				},
-			},
-			{
-				name: "file/duplicate-connection",
-				conf: map[string]any{
-					"hub": map[string]any{
-						"credentials": map[string]any{
-							"pdpID":           "pdp-id",
-							"clientID":        "client-id",
-							"clientSecret":    "client-secret",
-							"workspaceSecret": "workspace-secret",
-						},
-						"connection": map[string]any{
-							"apiEndpoint":       "Xhttps://api.stg-spitfire.cerbos.tech",
-							"bootstrapEndpoint": "Xhttps://cdn.stg-spitfire.cerbos.tech",
-						},
-					},
-					"storage": map[string]any{
-						driver: map[string]any{
-							"cacheSize": 1024,
-							"remote": map[string]any{
-								"bundleLabel": "latest",
-								"tempDir":     "/tmp",
-								"cacheDir":    "/tmp",
-								"connection": map[string]any{
-									"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
-									"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
-								},
-							},
-						},
-					},
-				},
-			},
-			{
-				name: "env/valid-config",
-				conf: map[string]any{
-					"storage": map[string]any{
-						driver: map[string]any{
-							"cacheSize": 1024,
 							"remote": map[string]any{
 								"tempDir":  "/tmp",
 								"cacheDir": "/tmp",
-								"connection": map[string]any{
-									"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
-									"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
-								},
 							},
 						},
 					},
@@ -226,16 +115,18 @@ func doTestConfig(driver string) func(*testing.T) {
 			{
 				name: "env/valid-legacy-config",
 				conf: map[string]any{
+					"hub": map[string]any{
+						"connection": map[string]any{
+							"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
+							"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
+						},
+					},
 					"storage": map[string]any{
 						driver: map[string]any{
 							"cacheSize": 1024,
 							"remote": map[string]any{
 								"tempDir":  "/tmp",
 								"cacheDir": "/tmp",
-								"connection": map[string]any{
-									"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
-									"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
-								},
 							},
 						},
 					},
@@ -251,16 +142,18 @@ func doTestConfig(driver string) func(*testing.T) {
 			{
 				name: "env/invalid-config-missing-bundle-label",
 				conf: map[string]any{
+					"hub": map[string]any{
+						"connection": map[string]any{
+							"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
+							"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
+						},
+					},
 					"storage": map[string]any{
 						driver: map[string]any{
 							"cacheSize": 1024,
 							"remote": map[string]any{
 								"tempDir":  "/tmp",
 								"cacheDir": "/tmp",
-								"connection": map[string]any{
-									"apiEndpoint":       "https://api.stg-spitfire.cerbos.tech",
-									"bootstrapEndpoint": "https://cdn.stg-spitfire.cerbos.tech",
-								},
 							},
 						},
 					},

--- a/internal/storage/hub/remote_source_test.go
+++ b/internal/storage/hub/remote_source_test.go
@@ -348,7 +348,6 @@ func withDisableAutoUpdate() confOption {
 
 func withPlayground() confOption {
 	return func(conf *hubstore.Conf) {
-		conf.Credentials.WorkspaceSecret = ""
 		conf.Remote.BundleLabel = playgroundLabel
 	}
 }

--- a/internal/test/mocks/CloudAPIClient.go
+++ b/internal/test/mocks/CloudAPIClient.go
@@ -10,6 +10,8 @@ import (
 
 	bundle "github.com/cerbos/cloud-api/bundle"
 
+	credentials "github.com/cerbos/cloud-api/credentials"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -192,6 +194,53 @@ func (_c *CloudAPIClient_GetCachedBundle_Call) Return(_a0 string, _a1 error) *Cl
 }
 
 func (_c *CloudAPIClient_GetCachedBundle_Call) RunAndReturn(run func(string) (string, error)) *CloudAPIClient_GetCachedBundle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// HubCredentials provides a mock function with given fields:
+func (_m *CloudAPIClient) HubCredentials() *credentials.Credentials {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for HubCredentials")
+	}
+
+	var r0 *credentials.Credentials
+	if rf, ok := ret.Get(0).(func() *credentials.Credentials); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*credentials.Credentials)
+		}
+	}
+
+	return r0
+}
+
+// CloudAPIClient_HubCredentials_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HubCredentials'
+type CloudAPIClient_HubCredentials_Call struct {
+	*mock.Call
+}
+
+// HubCredentials is a helper method to define mock.On call
+func (_e *CloudAPIClient_Expecter) HubCredentials() *CloudAPIClient_HubCredentials_Call {
+	return &CloudAPIClient_HubCredentials_Call{Call: _e.mock.On("HubCredentials")}
+}
+
+func (_c *CloudAPIClient_HubCredentials_Call) Run(run func()) *CloudAPIClient_HubCredentials_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *CloudAPIClient_HubCredentials_Call) Return(_a0 *credentials.Credentials) *CloudAPIClient_HubCredentials_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *CloudAPIClient_HubCredentials_Call) RunAndReturn(run func() *credentials.Credentials) *CloudAPIClient_HubCredentials_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Use a singleton Hub base client to share the authentication token
between different APIs.

Requires cerbos/cloud-api#186

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
