### PR TITLE
chore: Expose `plan.Resources` from `private` package

### DIFF
--- a/private/check/check.go
+++ b/private/check/check.go
@@ -12,9 +12,9 @@ import (
 	"github.com/cerbos/cerbos/internal/engine"
 	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage/disk"
-	"github.com/cerbos/cerbos/internal/storage/index"
 	"github.com/cerbos/cerbos/internal/util"
 	"github.com/cerbos/cerbos/internal/verify"
+	"github.com/cerbos/cerbos/private/compile"
 )
 
 type TestFixtureGetter struct {
@@ -80,7 +80,7 @@ func (g *TestFixtureGetter) GetAllTestFixtures() []*TestFixtureCtx {
 	return fixtures
 }
 
-func Check(ctx context.Context, idx index.Index, inputs []*enginev1.CheckInput) ([]*enginev1.CheckOutput, error) {
+func Check(ctx context.Context, idx compile.Index, inputs []*enginev1.CheckInput) ([]*enginev1.CheckOutput, error) {
 	store := disk.NewFromIndexWithConf(idx, &disk.Conf{})
 	schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
 	compiler := internalcompile.NewManagerFromDefaultConf(ctx, store, schemaMgr)

--- a/private/plan/plan.go
+++ b/private/plan/plan.go
@@ -1,0 +1,27 @@
+// Copyright 2021-2024 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package plan
+
+import (
+	"context"
+
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
+	internalcompile "github.com/cerbos/cerbos/internal/compile"
+	"github.com/cerbos/cerbos/internal/engine"
+	"github.com/cerbos/cerbos/internal/schema"
+	"github.com/cerbos/cerbos/internal/storage/disk"
+	"github.com/cerbos/cerbos/private/compile"
+)
+
+func Resources(ctx context.Context, idx compile.Index, input *enginev1.PlanResourcesInput) (*enginev1.PlanResourcesOutput, error) {
+	store := disk.NewFromIndexWithConf(idx, &disk.Conf{})
+	schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
+	compiler := internalcompile.NewManagerFromDefaultConf(ctx, store, schemaMgr)
+	eng, err := engine.NewEphemeral(compiler, schemaMgr)
+	if err != nil {
+		return nil, err
+	}
+
+	return eng.PlanResources(ctx, input)
+}


### PR DESCRIPTION
For use in the Hub playground.