### PR TITLE
chore: Add missing `continue` to ignore non-string keys in JWT claims

### DIFF
--- a/internal/auxdata/jwt.go
+++ b/internal/auxdata/jwt.go
@@ -183,6 +183,7 @@ func (j *jwtHelper) doExtract(ctx context.Context, auxJWT *requestv1.AuxData_JWT
 		if !ok {
 			logging.FromContext(ctx).Named("auxdata").
 				Warn("Ignoring JWT key-value pair because the key is not a string", zap.Any("pair", p), zap.Error(err))
+			continue
 		}
 
 		value, err := util.ToStructPB(p.Value)


### PR DESCRIPTION
I marked this as a chore rather than a fix because it should never happen since JSON objects are string-keyed, but anyway, it seemed like it should be there.