### PR TITLE
fix: Reduce memory usage in badger stream for hub audit backend

### DIFF
--- a/internal/audit/hub/hub.go
+++ b/internal/audit/hub/hub.go
@@ -287,8 +287,12 @@ func (l *Log) streamPrefix(ctx context.Context, kind logsv1.IngestBatch_EntryKin
 				return err
 			}
 
-			clear(keys[i])
-			keys[i] = kv.Key
+			if keys[i] == nil {
+				keys[i] = make([]byte, len(kv.Key))
+			} else {
+				clear(keys[i])
+			}
+			copy(keys[i], kv.Key)
 
 			i++
 			if i == l.maxBatchSize {

--- a/internal/audit/hub/hub.go
+++ b/internal/audit/hub/hub.go
@@ -275,7 +275,7 @@ func (l *Log) streamPrefix(ctx context.Context, kind logsv1.IngestBatch_EntryKin
 		if keysIface := keysPool.Get(); keysIface == nil {
 			keys = make([][]byte, l.maxBatchSize)
 		} else {
-			keys = *(keysIface.(*[][]byte))
+			keys = *(keysIface.(*[][]byte)) //nolint:forcetypeassert
 		}
 		defer keysPool.Put(&keys)
 


### PR DESCRIPTION
We observe high memory usage in Cerbos instances which have a `hub` audit backend configured. This is an attempt to reduce memory usage by lazily evaluating buffers produced by the DB scan, and by reusing types which we use as unmarshal targets.