### PR TITLE
chore(ci): Remove AWS dev and latest container tags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -239,8 +239,6 @@ dockers:
     dockerfile: Dockerfile.cerbos
     image_templates:
       - "{{ .Env.AWS_CONTAINER_REPO }}:{{ .Version }}-amd64"
-      - "{{ .Env.AWS_CONTAINER_REPO }}:latest-amd64"
-      - "{{ .Env.AWS_CONTAINER_REPO }}:dev-amd64"
     ids:
       - cerbos-aws
     goarch: amd64
@@ -258,8 +256,6 @@ dockers:
     dockerfile: Dockerfile.cerbos
     image_templates:
       - "{{ .Env.AWS_CONTAINER_REPO }}:{{ .Version }}-arm64"
-      - "{{ .Env.AWS_CONTAINER_REPO }}:latest-arm64"
-      - "{{ .Env.AWS_CONTAINER_REPO }}:dev-arm64"
     ids:
       - cerbos-aws
     goarch: arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -339,16 +339,6 @@ docker_manifests:
       - "{{ .Env.AWS_CONTAINER_REPO }}:{{ .Version }}-amd64"
       - "{{ .Env.AWS_CONTAINER_REPO }}:{{ .Version }}-arm64"
 
-  - name_template: "{{ .Env.AWS_CONTAINER_REPO }}:latest"
-    image_templates:
-      - "{{ .Env.AWS_CONTAINER_REPO }}:latest-amd64"
-      - "{{ .Env.AWS_CONTAINER_REPO }}:latest-arm64"
-
-  - name_template: "{{ .Env.AWS_CONTAINER_REPO }}:dev"
-    image_templates:
-      - "{{ .Env.AWS_CONTAINER_REPO }}:dev-amd64"
-      - "{{ .Env.AWS_CONTAINER_REPO }}:dev-arm64"
-
 docker_signs:
   - id: sign-images
     cmd: cosign


### PR DESCRIPTION
Can't push dev and latest tags because the registry is immutable.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
