### PR TITLE
chore(ci): Clear disk space for upload workflow

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -176,6 +176,17 @@ jobs:
       - name: Check test results
         run: test "${{ needs.test.result }}" = "success"
 
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false # this might remove tools that are actually needed, if set to "true" but frees about 6 GB
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Seems like GitHub has shrunk the disks on runners recently
🤷🏽‍♂️ 

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
