### PR TITLE
docs: Spell Datadog properly

### DIFF
--- a/docs/modules/configuration/pages/audit.adoc
+++ b/docs/modules/configuration/pages/audit.adoc
@@ -96,7 +96,7 @@ CAUTION: If requests contain sensitive data such as authorization tokens, they w
 [#file]
 == File backend
 
-The `file` backend writes audit records as newline-delimited JSON to a file or stdout/stderr. With this backend you can use your existing log aggregation system (DataDog agent, Elastic agent, Fluentd, Graylog -- to name a few) to collect, process and archive the audit data from all Cerbos instances.
+The `file` backend writes audit records as newline-delimited JSON to a file or stdout/stderr. With this backend you can use your existing log aggregation system (Datadog agent, Elastic agent, Fluentd, Graylog -- to name a few) to collect, process and archive the audit data from all Cerbos instances.
 
 
 NOTE: This backend cannot be queried using the Admin API, `cerbosctl audit` or `cerbosctl decisions`.


### PR DESCRIPTION
#### Description

`s/DataDog/Datadog/;`

Source: I worked there for five years and had to correct this _constantly_, even by our own employees.

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
