### PR TITLE
fix(helm): Allow overriding listen addresses

### DIFF
--- a/deploy/charts/cerbos/templates/_helpers.tpl
+++ b/deploy/charts/cerbos/templates/_helpers.tpl
@@ -124,9 +124,11 @@ Configuration derived from values provided by the user
 */}}
 {{- define "cerbos.derivedConfig" -}}
 {{- $tlsDisabled := (eq (include "cerbos.tlsSecretName" .) "None") -}}
+{{- $defaultHTTPListenAddr := (toString .Values.cerbos.httpPort | printf ":%s") -}}
+{{- $defaultGRPCListenAddr := (toString .Values.cerbos.grpcPort | printf ":%s") -}}
 server:
-  httpListenAddr: ":{{ .Values.cerbos.httpPort }}"
-  grpcListenAddr: ":{{ .Values.cerbos.grpcPort }}"
+  httpListenAddr: "{{ dig "config" "server" "httpListenAddr" $defaultHTTPListenAddr .Values.cerbos }}"
+  grpcListenAddr: "{{ dig "config" "server" "grpcListenAddr" $defaultGRPCListenAddr .Values.cerbos }}"
   {{- if not $tlsDisabled }}
   tls:
     cert: /certs/tls.crt


### PR DESCRIPTION
We currently ignore `cerbos.config.server.httpListenAddr` and
`cerbos.config.server.grpcListenAddr` values and override them
with `cerbos.httpPort` and `cerbos.grpcPort` values. This is problematic
if the users want to set the listen address to a particular IP range.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
