### PR TITLE
chore: Remove deprecated linters and fix linter errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,6 +33,10 @@ linters-settings:
     replace-allow-list:
       - github.com/goccy/go-yaml
 
+  gosec:
+    excludes:
+      - G115 # integer overflow conversion
+
   govet:
     enable-all: true
     disable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -55,11 +55,11 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - copyloopvar
     - dupl
     - durationcheck
     - errorlint
     - exhaustive
-    - exportloopref
     - forbidigo
     - forcetypeassert
     - goconst

--- a/cmd/cerbos/healthcheck/healthcheck_test.go
+++ b/cmd/cerbos/healthcheck/healthcheck_test.go
@@ -106,7 +106,6 @@ func TestBuildFromServerConf(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			have, err := tc.cmd.doBuildCheckFromConf(tc.conf)
 			if tc.wantErr {
@@ -185,7 +184,6 @@ func TestBuildManual(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			have, err := tc.cmd.doBuildCheckManual()
 			if tc.wantErr {

--- a/cmd/cerbos/repl/internal/directive_test.go
+++ b/cmd/cerbos/repl/internal/directive_test.go
@@ -212,7 +212,6 @@ func TestDirectiveParser(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.directive, func(t *testing.T) {
 			have, err := parser.ParseString("", tc.directive)
 			if tc.wantErr {

--- a/cmd/cerbos/repl/internal/repl_test.go
+++ b/cmd/cerbos/repl/internal/repl_test.go
@@ -407,7 +407,6 @@ func TestREPL(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			mockOut := &mockOutput{}
 			repl, err := NewREPL(nil, mockOut)

--- a/internal/audit/decision_filter_test.go
+++ b/internal/audit/decision_filter_test.go
@@ -93,7 +93,6 @@ func TestDecisionLogEntryFilter(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			f := NewDecisionLogEntryFilterFromConf(&Conf{
 				confHolder: confHolder{DecisionLogFilters: tc.filters},

--- a/internal/audit/file/log.go
+++ b/internal/audit/file/log.go
@@ -53,7 +53,6 @@ func NewLog(conf *Conf, decisionFilter audit.DecisionLogEntryFilter) (*Log, erro
 	outputSyncers := make([]zapcore.WriteSyncer, len(outputPaths))
 
 	for i, path := range outputPaths {
-		path := path
 		switch path {
 		case "stdout":
 			outputSyncers[i] = zapcore.AddSync(syncErrIgnorer{WriteSyncer: os.Stdout})

--- a/internal/audit/metadata_test.go
+++ b/internal/audit/metadata_test.go
@@ -55,7 +55,6 @@ func TestMetadataExtractor(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			conf := &Conf{
 				confHolder: confHolder{

--- a/internal/auxdata/conf_test.go
+++ b/internal/auxdata/conf_test.go
@@ -146,7 +146,6 @@ func TestConfigValidate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require.NoError(t, config.LoadMap(tc.conf))
 

--- a/internal/auxdata/jwt.go
+++ b/internal/auxdata/jwt.go
@@ -59,7 +59,6 @@ func newJWTHelper(ctx context.Context, conf *JWTConf) *jwtHelper {
 
 		var jwkCache *jwk.Cache
 		for _, ks := range conf.KeySets {
-			ks := ks
 			var opts []any
 			if ks.Insecure.OptionalAlg {
 				log.Warn("[INSECURE CONFIG] Enabling optional alg field for key set", zap.String("keySetID", ks.ID))

--- a/internal/auxdata/jwt_test.go
+++ b/internal/auxdata/jwt_test.go
@@ -37,7 +37,6 @@ func TestKeySet(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	for _, k := range keys {
-		k := k
 		isPEM := filepath.Ext(k) == ".pem"
 
 		t.Run(fmt.Sprintf("local/file/%s", filepath.Base(k)), func(t *testing.T) {
@@ -194,7 +193,6 @@ func TestExtract_MultipleKeySets(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		for _, keySetID := range []string{"remote", "local_file", "local_data", "remote_insecure", "local_file_insecure", "local_data_insecure"} {
 			ksID := keySetID
 			t.Run(fmt.Sprintf("%s/%s", tc.name, ksID), func(t *testing.T) {
@@ -287,7 +285,6 @@ func TestExtract_SingleKeySet(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			want := mkExpectedTokenData(t, tc.expiry)
 			input := &requestv1.AuxData_JWT{
@@ -331,7 +328,6 @@ func TestExtract_NoKeySets(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			input := &requestv1.AuxData_JWT{
 				Token: mkSignedToken(t, tc.expiry),

--- a/internal/compile/compile_test.go
+++ b/internal/compile/compile_test.go
@@ -48,7 +48,6 @@ func TestCompile(t *testing.T) {
 	}
 
 	for _, tcase := range testCases {
-		tcase := tcase
 		t.Run(tcase.Name, func(t *testing.T) {
 			tc, archive := readTestCase(t, tcase)
 			cu := mkCompilationUnit(t, tc.MainDef, archive)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -196,7 +196,6 @@ func TestStrictParsing(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require.NoError(t, config.LoadMap(tc.conf))
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -46,7 +46,6 @@ func TestCheck(t *testing.T) {
 	testCases := test.LoadTestCases(t, "engine")
 
 	for _, tcase := range testCases {
-		tcase := tcase
 		t.Run(tcase.Name, func(t *testing.T) {
 			tc := readTestCase(t, tcase.Input)
 			mockAuditLog.clear()
@@ -88,7 +87,6 @@ func TestCheckWithLenientScopeSearch(t *testing.T) {
 	testCases = append(testCases, test.LoadTestCases(t, "engine_lenient_scope_search")...)
 
 	for _, tcase := range testCases {
-		tcase := tcase
 		t.Run(tcase.Name, func(t *testing.T) {
 			tc := readTestCase(t, tcase.Input)
 			mockAuditLog.clear()
@@ -123,7 +121,6 @@ func TestCheckWithLenientScopeSearch(t *testing.T) {
 
 func TestSchemaValidation(t *testing.T) {
 	for _, enforcement := range []string{"warn", "reject"} {
-		enforcement := enforcement
 		t.Run(fmt.Sprintf("enforcement=%s", enforcement), func(t *testing.T) {
 			p := param{schemaEnforcement: schema.Enforcement(enforcement)}
 
@@ -133,7 +130,6 @@ func TestSchemaValidation(t *testing.T) {
 			testCases := test.LoadTestCases(t, filepath.Join("engine_schema_enforcement", enforcement))
 
 			for _, tcase := range testCases {
-				tcase := tcase
 				t.Run(tcase.Name, func(t *testing.T) {
 					tc := readTestCase(t, tcase.Input)
 
@@ -194,7 +190,6 @@ func runBenchmarks(b *testing.B, eng *Engine, testCases []test.Case) {
 	b.Helper()
 
 	for _, tcase := range testCases {
-		tcase := tcase
 		b.Run(tcase.Name, func(b *testing.B) {
 			tc := readTestCase(b, tcase.Input)
 

--- a/internal/engine/evaluator_test.go
+++ b/internal/engine/evaluator_test.go
@@ -29,7 +29,6 @@ func TestSatisfiesCondition(t *testing.T) {
 	eparams := evalParams{nowFunc: func() time.Time { return timeNow }}
 
 	for _, tcase := range testCases {
-		tcase := tcase
 		t.Run(tcase.Name, func(t *testing.T) {
 			tc := readCELTestCase(t, tcase.Input)
 			cond, err := compile.Condition(&policyv1.Condition{Condition: &policyv1.Condition_Match{Match: tc.Condition}})

--- a/internal/engine/internal/utils_test.go
+++ b/internal/engine/internal/utils_test.go
@@ -46,7 +46,6 @@ func TestSetIntersects(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/engine/planner/planner.go
+++ b/internal/engine/planner/planner.go
@@ -242,7 +242,6 @@ func (rpe *ResourcePolicyEvaluator) EvaluateResourcesQueryPlan(ctx context.Conte
 		derivedRolesList := mkDerivedRolesList(nil)
 		evalCtx := rpe.evalContext()
 		for drName, dr := range p.DerivedRoles {
-			dr := dr
 			if !internal.SetIntersects(dr.ParentRoles, effectiveRoles) {
 				continue
 			}

--- a/internal/engine/planner/planner_test.go
+++ b/internal/engine/planner/planner_test.go
@@ -442,7 +442,6 @@ func TestNormaliseFilter(t *testing.T) {
 	tcases := test.LoadTestCases(t, "query_planner_filter")
 
 	for _, tcase := range tcases {
-		tcase := tcase
 		t.Run(tcase.Name, func(t *testing.T) {
 			tc := readQPFilterTestCase(t, tcase.Input)
 			haveFilter := normaliseFilter(tc.Input)

--- a/internal/namer/namer_test.go
+++ b/internal/namer/namer_test.go
@@ -125,7 +125,6 @@ func TestFQNTree(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			have := namer.FQNTree(tc.policy())
 			require.Equal(t, tc.want, have)
@@ -177,12 +176,10 @@ func TestScopedModuleIDs(t *testing.T) {
 	)
 
 	for _, fn := range fns {
-		fn := fn
 		t.Run(fn.kind, func(t *testing.T) {
 			t.Parallel()
 
 			for _, tc := range testCases {
-				tc := tc
 				t.Run(fmt.Sprintf("scope=%s/genTree=false", tc.scope), func(t *testing.T) {
 					t.Parallel()
 
@@ -271,7 +268,6 @@ func TestFQNSpecialChars(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.policyName, func(t *testing.T) {
 			haveFQN := tc.fqnFunc(tc.policyName, "default", "a.b.c")
 			require.Equal(t, tc.wantFQN, haveFQN)

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -108,7 +108,6 @@ func TestAncestors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("scope=%q", tc.scope), func(t *testing.T) {
 			p := test.GenResourcePolicy(test.NoMod())
 			p.GetResourcePolicy().Scope = tc.scope
@@ -151,7 +150,6 @@ func TestRequiredAncestors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("scope=%q", tc.scope), func(t *testing.T) {
 			p := test.GenResourcePolicy(test.NoMod())
 			p.GetResourcePolicy().Scope = tc.scope

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -72,7 +72,6 @@ func TestLoad(t *testing.T) {
 	for storeName, mgr := range mgrs {
 		t.Run(storeName, func(t *testing.T) {
 			for _, tc := range testCases {
-				tc := tc
 				t.Run(tc.name, func(t *testing.T) {
 					err := mgr.CheckSchema(context.Background(), tc.url)
 					if tc.wantErr {
@@ -90,14 +89,12 @@ func TestValidate(t *testing.T) {
 	testCases := test.LoadTestCases(t, filepath.Join("schema", "test_cases"))
 
 	for _, enforcement := range []schema.Enforcement{schema.EnforcementWarn, schema.EnforcementReject} {
-		enforcement := enforcement
 		t.Run(fmt.Sprintf("enforcement=%s", enforcement), func(t *testing.T) {
 			store := mkStore(t)
 			conf := schema.NewConf(enforcement)
 			mgr := schema.NewFromConf(context.Background(), store, conf)
 
 			for _, tcase := range testCases {
-				tcase := tcase
 				t.Run(tcase.Name, func(t *testing.T) {
 					tc := readTestCase(t, tcase.Input)
 
@@ -127,7 +124,6 @@ func TestValidate(t *testing.T) {
 
 	t.Run(fmt.Sprintf("enforcement=%s", schema.EnforcementNone), func(t *testing.T) {
 		for _, tcase := range testCases {
-			tcase := tcase
 			t.Run(tcase.Name, func(t *testing.T) {
 				tc := readTestCase(t, tcase.Input)
 				store := mkStore(t)

--- a/internal/server/conf_test.go
+++ b/internal/server/conf_test.go
@@ -123,7 +123,6 @@ func TestConfigValidate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := config.LoadMap(tc.conf)
 			if tc.wantLoadErr {
@@ -190,7 +189,6 @@ func TestAdminAPICredentials(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require.NoError(t, config.LoadMap(tc.conf))
 

--- a/internal/server/tests.go
+++ b/internal/server/tests.go
@@ -363,10 +363,8 @@ func (tr *TestRunner) checkCORS(c *http.Client, hostAddr string) func(*testing.T
 	//nolint:thelper
 	return func(t *testing.T) {
 		for _, path := range paths {
-			path := path
 			t.Run(path, func(t *testing.T) {
 				for _, method := range methods {
-					method := method
 					t.Run(method, func(t *testing.T) {
 						ctx, cancelFunc := context.WithTimeout(context.Background(), tr.Timeout)
 						defer cancelFunc()

--- a/internal/storage/db/internal/funcs_test.go
+++ b/internal/storage/db/internal/funcs_test.go
@@ -77,10 +77,8 @@ func TestConcatWithSep(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("args=%d", len(tc.args)), func(t *testing.T) {
 			for d, w := range tc.want {
-				d, w := d, w
 				t.Run(d, func(t *testing.T) {
 					concat := internal.ConcatWithSepFunc(d)
 					dialect := goqu.Dialect(d)

--- a/internal/storage/db/internal/tests.go
+++ b/internal/storage/db/internal/tests.go
@@ -210,7 +210,6 @@ func TestSuite(store DBStorage) func(*testing.T) {
 
 		t.Run("get_policy", func(t *testing.T) {
 			for _, want := range policyList {
-				want := want
 				t.Run(want.FQN, func(t *testing.T) {
 					haveRes, err := store.LoadPolicy(ctx, namer.PolicyKeyFromFQN(want.FQN))
 					require.NoError(t, err)
@@ -298,7 +297,6 @@ func TestSuite(store DBStorage) func(*testing.T) {
 			}
 
 			for _, tc := range testCases {
-				tc := tc
 				t.Run("should be able to filter policies "+tc.name, func(t *testing.T) {
 					have, err := store.ListPolicyIDs(ctx, tc.params)
 					require.NoError(t, err)

--- a/internal/storage/db/mysql/conf_test.go
+++ b/internal/storage/db/mysql/conf_test.go
@@ -105,7 +105,6 @@ func TestConf(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			have, err := buildDSN(tc.conf)
 			if tc.wantErr {

--- a/internal/storage/git/conf_test.go
+++ b/internal/storage/git/conf_test.go
@@ -74,7 +74,6 @@ func TestGitProtocolAndURL(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			wrapper, err := config.WrapperFromMap(tc.config)
 			require.NoError(t, err)

--- a/internal/storage/git/store_test.go
+++ b/internal/storage/git/store_test.go
@@ -669,7 +669,6 @@ func TestNormalizePath(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("subDir=%s,path=%s", tc.subDir, tc.path), func(t *testing.T) {
 			store := &Store{subDir: tc.subDir}
 

--- a/internal/storage/hub/conf_test.go
+++ b/internal/storage/hub/conf_test.go
@@ -192,7 +192,6 @@ func doTestConfig(driver string) func(*testing.T) {
 		}
 
 		for _, tc := range testCases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				for k, v := range tc.env {
 					t.Setenv(k, v)

--- a/internal/storage/index/builder.go
+++ b/internal/storage/index/builder.go
@@ -214,7 +214,6 @@ func (idx *indexBuilder) addLoadFailure(file string, err error) {
 
 func (idx *indexBuilder) addErrors(file string, errs []*sourcev1.Error) {
 	for _, e := range errs {
-		e := e
 		idx.loadFailures = append(idx.loadFailures, &runtimev1.IndexBuildErrors_LoadFailure{File: file, Error: e.Message, ErrorDetails: e})
 	}
 }

--- a/internal/storage/index/builder_test.go
+++ b/internal/storage/index/builder_test.go
@@ -173,7 +173,6 @@ func TestBuildIndex(t *testing.T) {
 	testCases := test.LoadTestCases(t, "index")
 
 	for _, tcase := range testCases {
-		tcase := tcase
 		t.Run(tcase.Name, func(t *testing.T) {
 			tc := readTestCase(t, tcase.Input)
 			fs := toFS(t, tc)

--- a/internal/storage/index/index_test.go
+++ b/internal/storage/index/index_test.go
@@ -206,7 +206,6 @@ func TestIndexGetFirstMatch(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/util/serdeio_test.go
+++ b/internal/util/serdeio_test.go
@@ -44,7 +44,6 @@ func TestReadJSONOrYAML(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
 			f, err := os.Open(filepath.Join("testdata", tc.input))
 			require.NoError(t, err)


### PR DESCRIPTION
`exportloopref` linter is deprecated with `go1.22` and replaced by the `copyloopvar` linter.