### PR TITLE
feat: Add public API for running a PDP in-process

### DIFF
--- a/pkg/cerbos/serve.go
+++ b/pkg/cerbos/serve.go
@@ -1,0 +1,154 @@
+// Copyright 2021-2024 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package cerbos
+
+import (
+	"context"
+	"os"
+
+	"github.com/google/gops/agent"
+	"go.uber.org/automaxprocs/maxprocs"
+	"go.uber.org/zap"
+
+	"github.com/cerbos/cerbos/internal/config"
+	"github.com/cerbos/cerbos/internal/integrations"
+	"github.com/cerbos/cerbos/internal/observability/logging"
+	"github.com/cerbos/cerbos/internal/observability/otel"
+	"github.com/cerbos/cerbos/internal/server"
+)
+
+type LogLevel string
+
+const (
+	LogLevelDebug LogLevel = "debug"
+	LogLevelInfo  LogLevel = "info"
+	LogLevelWarn  LogLevel = "warn"
+	LogLevelError LogLevel = "error"
+)
+
+type serveOptions struct {
+	configFilePath  string
+	configOverrides map[string]any
+	debugListenAddr string
+	logLevel        LogLevel
+}
+
+// ServeOption defines options for [Serve].
+type ServeOption func(*serveOptions)
+
+// WithConfigFile sets the path to the [server configuration file].
+//
+// [server configuration file]: https://docs.cerbos.dev/cerbos/latest/configuration/
+func WithConfigFile(path string) ServeOption {
+	return func(opts *serveOptions) {
+		opts.configFilePath = path
+	}
+}
+
+// WithConfig sets [server configuration], overriding any values present in the configuration file.
+//
+// [server configuration]: https://docs.cerbos.dev/cerbos/latest/configuration/
+func WithConfig(overrides map[string]any) ServeOption {
+	return func(opts *serveOptions) {
+		opts.configOverrides = overrides
+	}
+}
+
+// WithDebug enables the [gops] agent listening on the given host:port.
+//
+// [gops]: https://github.com/google/gops
+func WithDebug(addr string) ServeOption {
+	return func(opts *serveOptions) {
+		opts.debugListenAddr = addr
+	}
+}
+
+// WithLogLevel sets the minimum level at which logs will be emitted.
+func WithLogLevel(level LogLevel) ServeOption {
+	return func(opts *serveOptions) {
+		opts.logLevel = level
+	}
+}
+
+// Serve runs the Cerbos policy decision point server, stopping it when the context is canceled.
+func Serve(ctx context.Context, options ...ServeOption) error {
+	opts := serveOptions{logLevel: LogLevelInfo}
+	for _, option := range options {
+		option(&opts)
+	}
+
+	logging.InitLogging(ctx, string(opts.logLevel))
+	defer zap.L().Sync() //nolint:errcheck
+
+	log := zap.S().Named("server")
+
+	undo, err := maxprocs.Set(maxprocs.Logger(log.Infof))
+	defer undo()
+	if err != nil {
+		log.Warnw("Failed to adjust GOMAXPROCS", "error", err)
+	}
+
+	// initialize metrics
+	metricsDone, err := otel.InitMetrics(ctx, otel.Env(os.LookupEnv))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := metricsDone(); err != nil {
+			log.Warnw("Metrics exporter did not shutdown cleanly", "error", err)
+		}
+	}()
+
+	if opts.debugListenAddr != "" {
+		startDebugListener(opts.debugListenAddr)
+		defer agent.Close()
+	}
+
+	// load configuration
+	if opts.configFilePath == "" {
+		log.Info("Loading default configuration")
+	} else {
+		log.Infof("Loading configuration from %s", opts.configFilePath)
+	}
+	if err := config.Load(opts.configFilePath, opts.configOverrides); err != nil {
+		log.Errorw("Failed to load configuration", "error", err)
+		return err
+	}
+
+	// initialize tracing
+	tracingDone, err := otel.InitTraces(ctx, otel.Env(os.LookupEnv))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := tracingDone(); err != nil {
+			log.Warnw("Trace exporter did not shutdown cleanly", "error", err)
+		}
+	}()
+
+	if err := integrations.Init(ctx); err != nil {
+		return err
+	}
+
+	if err := server.Start(ctx); err != nil {
+		log.Errorw("Failed to start server", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+func startDebugListener(listenAddr string) {
+	log := zap.S().Named("debug")
+	log.Infof("Starting debug listener at %s", listenAddr)
+
+	err := agent.Listen(agent.Options{
+		Addr:                   listenAddr,
+		ShutdownCleanup:        false,
+		ReuseSocketAddrAndPort: true,
+	})
+	if err != nil {
+		log.Errorw("Failed to start debug agent", "error", err)
+	}
+}

--- a/pkg/cerbos/serve_test.go
+++ b/pkg/cerbos/serve_test.go
@@ -1,0 +1,68 @@
+// Copyright 2021-2024 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package cerbos_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/local"
+
+	"github.com/cerbos/cerbos/internal/server"
+	"github.com/cerbos/cerbos/internal/test"
+	"github.com/cerbos/cerbos/internal/util"
+	"github.com/cerbos/cerbos/pkg/cerbos"
+)
+
+func TestServe(t *testing.T) {
+	// run twice to make sure that global state initialization is idempotent
+	for run := 0; run < 2; run++ {
+		t.Run(fmt.Sprintf("run_%d", run), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			grpcListenAddr, err := util.GetFreeListenAddr()
+			require.NoError(t, err, "Failed to get free port")
+
+			httpListenAddr, err := util.GetFreeListenAddr()
+			require.NoError(t, err, "Failed to get free port")
+
+			config := map[string]any{
+				"schema": map[string]any{
+					"enforcement": "reject",
+				},
+				"server": map[string]any{
+					"grpcListenAddr": grpcListenAddr,
+					"httpListenAddr": httpListenAddr,
+					"requestLimits": map[string]any{
+						"maxActionsPerResource":  5,
+						"maxResourcesPerRequest": 5,
+					},
+				},
+				"storage": map[string]any{
+					"driver": "disk",
+					"disk": map[string]any{
+						"directory": test.PathToDir(t, "store"),
+					},
+				},
+			}
+
+			serveErr := make(chan error)
+			go func() {
+				serveErr <- cerbos.Serve(ctx, cerbos.WithConfig(config))
+			}()
+
+			testRunner := server.LoadTestCases(t, "checks/check_resources")
+
+			t.Run("grpc", testRunner.RunGRPCTests(grpcListenAddr, grpc.WithTransportCredentials(local.NewCredentials())))
+			t.Run("http", testRunner.RunHTTPTests(fmt.Sprintf("http://%s", httpListenAddr), nil))
+
+			cancel()
+			require.NoError(t, <-serveErr)
+		})
+	}
+}


### PR DESCRIPTION
This PR extracts the `cerbos server` command internals to a public `cerbos.Serve` function that runs the PDP server in the current process.