### PR TITLE
docs: Fix missing default value for `storage.hub.remote.disableAutoUpdate`

### DIFF
--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -170,7 +170,7 @@ storage:
     remote: # Remote holds configuration for remote bundle source. Takes precedence over local if both are defined.
       bundleLabel: latest # Required. BundleLabel to fetch from the server.
       cacheDir: ${XDG_CACHE_DIR} # CacheDir is the directory to use for caching downloaded bundles.
-      disableAutoUpdate: <DEFAULT_VALUE_NOT_SET> # DisableAutoUpdate sets whether new bundles should be automatically downloaded and applied.
+      disableAutoUpdate: false # DisableAutoUpdate sets whether new bundles should be automatically downloaded and applied.
       tempDir: ${TEMP} # TempDir is the directory to use for temporary files.
   mysql:
     # This section is required only if storage.driver is mysql.

--- a/hack/tools/confdocs/confdocs.go
+++ b/hack/tools/confdocs/confdocs.go
@@ -318,7 +318,7 @@ func doGenDocs(out io.Writer, si *StructInfo, indent int) error {
 func walkFields(out io.Writer, fields []FieldInfo, indent int) error {
 	for _, field := range fields {
 		name := field.Name
-		defaultValue := "<DEFAULT_VALUE_NOT_SET>"
+		defaultValue := ""
 		docs := ""
 
 		tag, err := parseTag(field.Tag)
@@ -370,6 +370,10 @@ func walkFields(out io.Writer, fields []FieldInfo, indent int) error {
 			}
 
 			continue
+		}
+
+		if defaultValue == "" {
+			return fmt.Errorf("field %q lacks a default value, specify one with `conf:\",example=...\"`", name)
 		}
 
 		if err := indentf(out, indent, "%s: %s %s\n", name, defaultValue, docs); err != nil {

--- a/internal/storage/hub/conf.go
+++ b/internal/storage/hub/conf.go
@@ -57,7 +57,7 @@ type RemoteSourceConf struct {
 	// TempDir is the directory to use for temporary files.
 	TempDir string `yaml:"tempDir" conf:",example=${TEMP}"`
 	// DisableAutoUpdate sets whether new bundles should be automatically downloaded and applied.
-	DisableAutoUpdate bool `yaml:"disableAutoUpdate"`
+	DisableAutoUpdate bool `yaml:"disableAutoUpdate" conf:",example=false"`
 }
 
 func (conf *Conf) Key() string {


### PR DESCRIPTION
We're currently showing `<DEFAULT_VALUE_NOT_SET>` for `storage.hub.remote.disableAutoUpdate` rather than the actual default of `false`.

This PR fixes that and prevents it from happening in future by failing to generate confdocs if an example value is not set on a struct field.