### PR TITLE
enhancement: Display attributes in the cerbosctl inspect policies command

### DIFF
--- a/cmd/cerbosctl/inspect/internal/print.go
+++ b/cmd/cerbosctl/inspect/internal/print.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	separator = ","
+	width     = 80
 )
 
 func Print(w io.Writer, format flagset.Format, response *responsev1.InspectPoliciesResponse) error {
@@ -86,6 +87,7 @@ func printJSON(w io.Writer, results []*responsev1.InspectPoliciesResponse_Result
 }
 
 func printTable(w io.Writer, noHeaders bool, results []*responsev1.InspectPoliciesResponse_Result) {
+	rowSeparator := strings.Repeat("-", width)
 	for _, result := range results {
 		attributes := make([]string, len(result.Attributes))
 		for idx, attribute := range result.Attributes {
@@ -104,25 +106,27 @@ func printTable(w io.Writer, noHeaders bool, results []*responsev1.InspectPolici
 			variables[idx] = variable.Name
 		}
 
-		var row string
 		if noHeaders {
-			row = fmt.Sprintf(
-				"%s\n%s\n%s\n%s",
+			fmt.Fprintf(w,
+				"%s\n%s\n%s\n%s\n%s\n",
 				result.PolicyId,
 				strings.Join(result.Actions, separator),
 				strings.Join(attributes, separator),
 				strings.Join(variables, separator),
+				rowSeparator,
 			)
 		} else {
-			row = fmt.Sprintf(
-				"%s\n%s\n%s\n%s",
-				fmt.Sprintf("POLICY ID : %s", result.PolicyId),
-				fmt.Sprintf("ACTIONS   : %s", strings.Join(result.Actions, separator)),
-				fmt.Sprintf("ATTRIBUTES: %s", strings.Join(attributes, separator)),
-				fmt.Sprintf("VARIABLES : %s", strings.Join(variables, separator)),
-			)
+			fmt.Fprintf(w, "POLICY ID : %s\n", result.PolicyId)
+			if len(result.Actions) > 0 {
+				fmt.Fprintf(w, "ACTIONS   : %s\n", strings.Join(result.Actions, separator))
+			}
+			if len(attributes) > 0 {
+				fmt.Fprintf(w, "ATTRIBUTES: %s\n", strings.Join(attributes, separator))
+			}
+			if len(variables) > 0 {
+				fmt.Fprintf(w, "VARIABLES : %s\n", strings.Join(variables, separator))
+			}
+			fmt.Fprintf(w, "%s\n", rowSeparator)
 		}
-
-		fmt.Fprintf(w, "%s\n-------------------\n", row)
 	}
 }

--- a/cmd/cerbosctl/inspect/internal/print.go
+++ b/cmd/cerbosctl/inspect/internal/print.go
@@ -13,7 +13,6 @@ import (
 
 	responsev1 "github.com/cerbos/cerbos/api/genpb/cerbos/response/v1"
 	"github.com/cerbos/cerbos/cmd/cerbosctl/inspect/internal/flagset"
-	"github.com/cerbos/cerbos/cmd/cerbosctl/internal/printer"
 	"github.com/cerbos/cerbos/internal/conditions"
 	"github.com/cerbos/cerbos/internal/util"
 )
@@ -87,11 +86,6 @@ func printJSON(w io.Writer, results []*responsev1.InspectPoliciesResponse_Result
 }
 
 func printTable(w io.Writer, noHeaders bool, results []*responsev1.InspectPoliciesResponse_Result) {
-	tw := printer.NewTableWriter(w)
-	if !noHeaders {
-		tw.SetHeader([]string{"POLICY ID", "ACTIONS", "ATTRIBUTES", "VARIABLES"})
-	}
-
 	for _, result := range results {
 		attributes := make([]string, len(result.Attributes))
 		for idx, attribute := range result.Attributes {
@@ -110,13 +104,25 @@ func printTable(w io.Writer, noHeaders bool, results []*responsev1.InspectPolici
 			variables[idx] = variable.Name
 		}
 
-		tw.Append([]string{
-			result.PolicyId,
-			strings.Join(result.Actions, separator),
-			strings.Join(attributes, separator),
-			strings.Join(variables, separator),
-		})
-	}
+		var row string
+		if noHeaders {
+			row = fmt.Sprintf(
+				"%s\n%s\n%s\n%s",
+				result.PolicyId,
+				strings.Join(result.Actions, separator),
+				strings.Join(attributes, separator),
+				strings.Join(variables, separator),
+			)
+		} else {
+			row = fmt.Sprintf(
+				"%s\n%s\n%s\n%s",
+				fmt.Sprintf("POLICY ID : %s", result.PolicyId),
+				fmt.Sprintf("ACTIONS   : %s", strings.Join(result.Actions, separator)),
+				fmt.Sprintf("ATTRIBUTES: %s", strings.Join(attributes, separator)),
+				fmt.Sprintf("VARIABLES : %s", strings.Join(variables, separator)),
+			)
+		}
 
-	tw.Render()
+		fmt.Fprintf(w, "%s\n-------------------\n", row)
+	}
 }

--- a/cmd/cerbosctl/inspect/internal/print.go
+++ b/cmd/cerbosctl/inspect/internal/print.go
@@ -106,15 +106,18 @@ func printTable(w io.Writer, noHeaders bool, results []*responsev1.InspectPolici
 			variables[idx] = variable.Name
 		}
 
+		//nolint:nestif
 		if noHeaders {
-			fmt.Fprintf(w,
-				"%s\n%s\n%s\n%s\n%s\n",
-				result.PolicyId,
-				strings.Join(result.Actions, separator),
-				strings.Join(attributes, separator),
-				strings.Join(variables, separator),
-				rowSeparator,
-			)
+			fmt.Fprintf(w, "%s\n", result.PolicyId)
+			if len(result.Actions) > 0 {
+				fmt.Fprintf(w, "%s\n", strings.Join(result.Actions, separator))
+			}
+			if len(attributes) > 0 {
+				fmt.Fprintf(w, "%s\n", strings.Join(attributes, separator))
+			}
+			if len(variables) > 0 {
+				fmt.Fprintf(w, "%s\n", strings.Join(variables, separator))
+			}
 		} else {
 			fmt.Fprintf(w, "POLICY ID : %s\n", result.PolicyId)
 			if len(result.Actions) > 0 {
@@ -126,7 +129,7 @@ func printTable(w io.Writer, noHeaders bool, results []*responsev1.InspectPolici
 			if len(variables) > 0 {
 				fmt.Fprintf(w, "VARIABLES : %s\n", strings.Join(variables, separator))
 			}
-			fmt.Fprintf(w, "%s\n", rowSeparator)
 		}
+		fmt.Fprintf(w, "%s\n", rowSeparator)
 	}
 }


### PR DESCRIPTION
Displaying attributes in the existing command `cerbosctl inspect policies` seems to work visually.

```
$ cerbosctl inspect policies
POLICY ID : derived_roles/common_roles.yaml
ACTIONS   : 
ATTRIBUTES: R.attr.flagged,R.attr.owner
VARIABLES : 
-------------------
POLICY ID : resource_policies/policy_05_acme.hr.uk.yaml
ACTIONS   : defer,delete
ATTRIBUTES: R.attr.geography
VARIABLES : principal_location
-------------------
```

```
$ cerbosctl inspect policies --no-headers
derived_roles/common_roles.yaml

R.attr.flagged,R.attr.owner

-------------------
resource_policies/policy_05_acme.hr.uk.yaml
defer,delete                                                
R.attr.geography                                                      
principal_location  
-------------------
```