### PR TITLE
chore(ci): Set SQL Server image pull policy for E2E tests

### DIFF
--- a/e2e/sqlserver/chart/values.yaml
+++ b/e2e/sqlserver/chart/values.yaml
@@ -6,28 +6,25 @@ replicas: 1
 
 image:
   repository: mcr.microsoft.com/azure-sql-edge
-#  repository: mcr.microsoft.com/mssql/server
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-#  tag: "2019-latest"
+  pullPolicy: Always
   tag: latest
 
 ACCEPT_EULA:
-    value: "y"
+  value: "y"
 MSSQL_PID:
-    value: "Developer"
+  value: "Developer"
 MSSQL_AGENT_ENABLED:
-    value: "true"
+  value: "true"
 hostname: mssqllatest
 sa_password: "MyPassword1!"
 containers:
   ports:
-      containerPort: 1433
+    containerPort: 1433
 
 podAnnotations: {}
 
 podSecurityContext:
-   fsGroup: 10001
+  fsGroup: 10001
 
 service:
   type: ClusterIP

--- a/e2e/sqlserver/helmfile.yaml
+++ b/e2e/sqlserver/helmfile.yaml
@@ -83,19 +83,20 @@ releases:
       - nameOverride: '{{ requiredEnv "E2E_CONTEXT_ID" }}'
       - initContainers:
           - name: init-mssql
-            image: 'mcr.microsoft.com/azure-sql-edge:latest' 
+            image: "mcr.microsoft.com/azure-sql-edge:latest"
+            imagePullPolicy: Always
             command:
-              - '/opt/mssql-tools/bin/sqlcmd' 
-              - '-S'
+              - "/opt/mssql-tools/bin/sqlcmd"
+              - "-S"
               - '{{ requiredEnv "E2E_CONTEXT_ID" }}.{{ requiredEnv "E2E_NS" }}.svc.cluster.local'
-              - '-l'
-              - '60'
-              - '-U'
-              - 'SA'
-              - '-P'
-              - 'MyPassword1!' 
-              - '-i'
-              - '/initdb/schema.sql'
+              - "-l"
+              - "60"
+              - "-U"
+              - "SA"
+              - "-P"
+              - "MyPassword1!"
+              - "-i"
+              - "/initdb/schema.sql"
             volumeMounts:
               - name: mssql-init-script
                 mountPath: /initdb
@@ -103,14 +104,14 @@ releases:
           repository: '{{ env "E2E_CERBOS_IMG_REPO" | default "ghcr.io/cerbos/cerbos" }}'
           tag: '{{ env "E2E_CERBOS_IMG_TAG" | default "dev" }}'
       - volumes:
-        - name: cerbos-auditlog
-          emptyDir: {}
-        - name: mssql-init-script
-          configMap:
-            name: mssql-init
+          - name: cerbos-auditlog
+            emptyDir: {}
+          - name: mssql-init-script
+            configMap:
+              name: mssql-init
       - volumeMounts:
-        - name: cerbos-auditlog
-          mountPath: /audit
+          - name: cerbos-auditlog
+            mountPath: /audit
       - cerbos:
           tlsSecretName: 'cerbos-certs-{{ requiredEnv "E2E_CONTEXT_ID" }}'
           logLevel: DEBUG
@@ -122,7 +123,7 @@ releases:
                 maxResourcesPerRequest: 5
               adminAPI:
                 enabled: true
-                adminCredentials: 
+                adminCredentials:
                   username: cerbos
                   passwordHash: JDJ5JDEwJC5BYjQyY2RJNG5QR2NWMmJPdnNtQU93c09RYVA0eFFGdHBrbmFEeXh1NnlIVTE1cHJNY05PCgo=
             auxData:
@@ -135,7 +136,7 @@ releases:
               accessLogsEnabled: true
               decisionLogsEnabled: true
               backend: local
-              local: 
+              local:
                 storagePath: /audit/cerbos
             storage:
               driver: "sqlserver"


### PR DESCRIPTION
SQL Server container images don't have versioned labels and previously
cached images have an expired certificate that causes the E2E tests to
fail. This PR sets the image pull policy to make sure that the most
up-to-date image is used for tests.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
