### PR TITLE
fix(helm): Fix schema definition of initContainers

### DIFF
--- a/deploy/charts/cerbos/values.schema.json
+++ b/deploy/charts/cerbos/values.schema.json
@@ -276,8 +276,9 @@
     "initContainers": {
       "description": "Init containers to inject into the deployment. See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#containers.",
       "items": {
+        "additionalProperties": true,
         "required": [],
-        "type": "array"
+        "type": "object"
       },
       "required": [],
       "title": "initContainers",

--- a/deploy/charts/cerbos/values.yaml
+++ b/deploy/charts/cerbos/values.yaml
@@ -59,6 +59,9 @@ imagePullSecrets: []
 
 # @schema
 # type: [array, null]
+# items:
+#   type: object
+#   additionalProperties: true
 # @schema
 # Init containers to inject into the deployment. See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#containers.
 initContainers: []


### PR DESCRIPTION
Helm refuses to work because the schema definition for `initContainers`
doesn't allow items that are objects.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
