### PR TITLE
chore(ci): Trust SQL Server certificate

### DIFF
--- a/e2e/sqlserver/helmfile.yaml
+++ b/e2e/sqlserver/helmfile.yaml
@@ -141,6 +141,6 @@ releases:
             storage:
               driver: "sqlserver"
               sqlserver:
-                url: 'sqlserver://cerbos_user:ChangeMe(1!!)@{{ requiredEnv "E2E_CONTEXT_ID" }}.{{ requiredEnv "E2E_NS" }}.svc.cluster.local:1433?database=cerbos'
+                url: 'sqlserver://cerbos_user:ChangeMe(1!!)@{{ requiredEnv "E2E_CONTEXT_ID" }}.{{ requiredEnv "E2E_NS" }}.svc.cluster.local:1433?database=cerbos&TrustServerCertificate=true'
             telemetry:
               disabled: true

--- a/e2e/sqlserver/sqlserver_test.go
+++ b/e2e/sqlserver/sqlserver_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 Zenauth Ltd.
+// Copyright 2020-2024 Zenauth Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build e2e

--- a/internal/storage/db/sqlserver/sqlserver_test.go
+++ b/internal/storage/db/sqlserver/sqlserver_test.go
@@ -58,7 +58,7 @@ func TestSqlServer(t *testing.T) {
 
 	port := resource.GetPort("1433/tcp")
 	getConnString := func(dbname string) string {
-		return fmt.Sprintf("sqlserver://sa:%s@127.0.0.1:%s?database=%s", password, port, dbname)
+		return fmt.Sprintf("sqlserver://sa:%s@127.0.0.1:%s?database=%s&TrustServerCertificate=true", password, port, dbname)
 	}
 
 	if err := pool.Retry(func() error {


### PR DESCRIPTION
The SQL Server TLS issue still springs up during E2E tests. This is
another attempt to work around it.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
