### PR TITLE
chore(tooling): Fix confdocs not being able to parse examples consisting of an array

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -46,7 +46,7 @@ generate-confdocs:
     set -euo pipefail
     cd {{ justfile_directory() }}
     mkdir -p ./internal/confdocs
-    go run ./hack/tools/confdocs/confdocs.go > ./internal/confdocs/generated.go
+    go run -tags confdocs ./hack/tools/confdocs/confdocs.go > ./internal/confdocs/generated.go
     CGO_ENABLED=0 go run ./internal/confdocs/generated.go
     rm -rf ./internal/confdocs
 

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -48,7 +48,7 @@ audit:
     brokers: ['localhost:9092'] # Required. Brokers list to seed the Kafka client.
     clientID: cerbos # ClientID reported in Kafka connections.
     closeTimeout: 30s # CloseTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
-    compression: ['zstd', 'snappy', 'none'] # Compression sets the compression algorithm to use in order of priority. Valid values are "none", "gzip", "snappy","lz4", "zstd". Default is ["snappy", "none"].
+    compression: ['snappy', 'none'] # Compression sets the compression algorithm to use in order of priority. Valid values are "none", "gzip", "snappy","lz4", "zstd". Default is ["snappy", "none"].
     encoding: json # Encoding format. Valid values are "json" (default) or "protobuf".
     maxBufferedRecords: 1000 # MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.
     produceSync: false # ProduceSync forces the client to produce messages to Kafka synchronously. This can have a significant impact on performance.

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -48,7 +48,7 @@ audit:
     brokers: ['localhost:9092'] # Required. Brokers list to seed the Kafka client.
     clientID: cerbos # ClientID reported in Kafka connections.
     closeTimeout: 30s # CloseTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
-    compression: ['snappy'] # Compression sets the compression algorithm to use in order of priority. Valid values are "none", "gzip", "snappy","lz4", "zstd". Default is ["snappy", "none"].
+    compression: ['zstd', 'snappy', 'none'] # Compression sets the compression algorithm to use in order of priority. Valid values are "none", "gzip", "snappy","lz4", "zstd". Default is ["snappy", "none"].
     encoding: json # Encoding format. Valid values are "json" (default) or "protobuf".
     maxBufferedRecords: 1000 # MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.
     produceSync: false # ProduceSync forces the client to produce messages to Kafka synchronously. This can have a significant impact on performance.

--- a/go.mod
+++ b/go.mod
@@ -23,10 +23,10 @@ require (
 	github.com/dgraph-io/badger/v4 v4.3.0
 	github.com/doug-martin/goqu/v9 v9.19.0
 	github.com/fatih/color v1.17.0
-	github.com/fatih/structtag v1.2.0
 	github.com/fergusstrange/embedded-postgres v1.29.0
 	github.com/gdamore/tcell/v2 v2.7.4
 	github.com/ghodss/yaml v1.0.0
+	github.com/go-andiamo/splitter v1.2.5
 	github.com/go-cmd/cmd v1.4.3
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/go-logr/zapr v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,6 @@ github.com/envoyproxy/protoc-gen-validate v1.1.0 h1:tntQDh69XqOCOZsDz0lVJQez/2L6
 github.com/envoyproxy/protoc-gen-validate v1.1.0/go.mod h1:sXRDRVmzEbkM7CVcM06s9shE/m23dg3wzjl0UWqJ2q4=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
-github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
-github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fergusstrange/embedded-postgres v1.29.0 h1:Uv8hdhoiaNMuH0w8UuGXDHr60VoAQPFdgx7Qf3bzXJM=
@@ -250,6 +248,8 @@ github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.3.7 h1:iV3Bqi942d9huXnzEF2Mt+CY9gLu8DNM4Obd+8bODRE=
 github.com/gliderlabs/ssh v0.3.7/go.mod h1:zpHEXBstFnQYtGnB8k8kQLol82umzn/2/snG7alWVD8=
+github.com/go-andiamo/splitter v1.2.5 h1:P3NovWMY2V14TJJSolXBvlOmGSZo3Uz+LtTl2bsV/eY=
+github.com/go-andiamo/splitter v1.2.5/go.mod h1:8WHU24t9hcMKU5FXDQb1hysSEC/GPuivIp0uKY1J8gw=
 github.com/go-cmd/cmd v1.4.3 h1:6y3G+3UqPerXvPcXvj+5QNPHT02BUw7p6PsqRxLNA7Y=
 github.com/go-cmd/cmd v1.4.3/go.mod h1:u3hxg/ry+D5kwh8WvUkHLAMe2zQCaXd00t35WfQaOFk=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=

--- a/hack/tools/confdocs/confdocs.go
+++ b/hack/tools/confdocs/confdocs.go
@@ -20,16 +20,16 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"text/template"
 
-	"github.com/go-andiamo/splitter"
 	"github.com/mattn/go-isatty"
 	"go.elastic.co/ecszap"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/tools/go/packages"
+
+	"github.com/cerbos/cerbos/hack/tools/confdocs/structtag"
 )
 
 const (
@@ -399,7 +399,7 @@ func parseTag(tag string) (*TagInfo, error) {
 		return nil, errTagNotExists
 	}
 
-	t, err := Parse(tag[1 : len(tag)-1])
+	t, err := structtag.Parse(tag[1 : len(tag)-1])
 	if err != nil {
 		return nil, fmt.Errorf("structtag failed to parse tags: %w", err)
 	}
@@ -542,123 +542,4 @@ func doInitLogging(level string) {
 	zap.RedirectStdLog(l.Named("stdlog"))
 
 	logger = l.Sugar()
-}
-
-var (
-	errTagSyntax      = errors.New("bad syntax for struct tag pair")
-	errTagKeySyntax   = errors.New("bad syntax for struct tag key")
-	errTagValueSyntax = errors.New("bad syntax for struct tag value")
-	errTagNotExist    = errors.New("tag does not exist")
-)
-
-type Tags struct {
-	tags []*Tag
-}
-
-type Tag struct {
-	// Key is the tag key, such as json, xml, etc..
-	// i.e: `json:"foo,omitempty". Here key is: "json"
-	Key string
-
-	// Name is a part of the value
-	// i.e: `json:"foo,omitempty". Here name is: "foo"
-	Name string
-
-	// Options is a part of the value. It contains a slice of tag options i.e:
-	// `json:"foo,omitempty". Here options is: ["omitempty"]
-	Options []string
-}
-
-// Parse and others are from https://github.com/fatih/structtag/blob/2977b8db49bbf5ae2e0ae2be55e43d2c1798fc03/tags.go#L42-L125
-func Parse(tag string) (*Tags, error) {
-	var tags []*Tag
-
-	hasTag := tag != ""
-	for tag != "" {
-		i := 0
-		for i < len(tag) && tag[i] == ' ' {
-			i++
-		}
-		tag = tag[i:]
-		if tag == "" {
-			break
-		}
-
-		i = 0
-		for i < len(tag) && tag[i] > ' ' && tag[i] != ':' && tag[i] != '"' && tag[i] != 0x7f {
-			i++
-		}
-
-		if i == 0 {
-			return nil, errTagKeySyntax
-		}
-		if i+1 >= len(tag) || tag[i] != ':' {
-			return nil, errTagSyntax
-		}
-		if tag[i+1] != '"' {
-			return nil, errTagValueSyntax
-		}
-
-		key := tag[:i]
-		tag = tag[i+1:]
-
-		i = 1
-		for i < len(tag) && tag[i] != '"' {
-			if tag[i] == '\\' {
-				i++
-			}
-			i++
-		}
-		if i >= len(tag) {
-			return nil, errTagValueSyntax
-		}
-
-		qvalue := tag[:i+1]
-		tag = tag[i+1:]
-
-		value, err := strconv.Unquote(qvalue)
-		if err != nil {
-			return nil, errTagValueSyntax
-		}
-
-		split, err := splitter.NewSplitter(',', splitter.SquareBrackets)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create a new splitter: %w", err)
-		}
-
-		res, err := split.Split(value)
-		if err != nil {
-			return nil, fmt.Errorf("failed to split value %s: %w", value, err)
-		}
-
-		name := res[0]
-		options := res[1:]
-		if len(options) == 0 {
-			options = nil
-		}
-
-		tags = append(tags, &Tag{
-			Key:     key,
-			Name:    name,
-			Options: options,
-		})
-	}
-
-	if hasTag && len(tags) == 0 {
-		return nil, nil
-	}
-
-	return &Tags{
-		tags: tags,
-	}, nil
-}
-
-func (t *Tags) Get(key string) (*Tag, error) {
-	for _, tag := range t.tags {
-		if tag.Key == key {
-			return tag, nil
-		}
-	}
-
-	return nil, errTagNotExist
 }

--- a/hack/tools/confdocs/confdocs.go
+++ b/hack/tools/confdocs/confdocs.go
@@ -20,10 +20,11 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 
-	"github.com/fatih/structtag"
+	"github.com/go-andiamo/splitter"
 	"github.com/mattn/go-isatty"
 	"go.elastic.co/ecszap"
 	"go.uber.org/zap"
@@ -398,7 +399,7 @@ func parseTag(tag string) (*TagInfo, error) {
 		return nil, errTagNotExists
 	}
 
-	t, err := structtag.Parse(tag[1 : len(tag)-1])
+	t, err := Parse(tag[1 : len(tag)-1])
 	if err != nil {
 		return nil, fmt.Errorf("structtag failed to parse tags: %w", err)
 	}
@@ -541,4 +542,123 @@ func doInitLogging(level string) {
 	zap.RedirectStdLog(l.Named("stdlog"))
 
 	logger = l.Sugar()
+}
+
+var (
+	errTagSyntax      = errors.New("bad syntax for struct tag pair")
+	errTagKeySyntax   = errors.New("bad syntax for struct tag key")
+	errTagValueSyntax = errors.New("bad syntax for struct tag value")
+	errTagNotExist    = errors.New("tag does not exist")
+)
+
+type Tags struct {
+	tags []*Tag
+}
+
+type Tag struct {
+	// Key is the tag key, such as json, xml, etc..
+	// i.e: `json:"foo,omitempty". Here key is: "json"
+	Key string
+
+	// Name is a part of the value
+	// i.e: `json:"foo,omitempty". Here name is: "foo"
+	Name string
+
+	// Options is a part of the value. It contains a slice of tag options i.e:
+	// `json:"foo,omitempty". Here options is: ["omitempty"]
+	Options []string
+}
+
+// Parse and others are from https://github.com/fatih/structtag/blob/2977b8db49bbf5ae2e0ae2be55e43d2c1798fc03/tags.go#L42-L125
+func Parse(tag string) (*Tags, error) {
+	var tags []*Tag
+
+	hasTag := tag != ""
+	for tag != "" {
+		i := 0
+		for i < len(tag) && tag[i] == ' ' {
+			i++
+		}
+		tag = tag[i:]
+		if tag == "" {
+			break
+		}
+
+		i = 0
+		for i < len(tag) && tag[i] > ' ' && tag[i] != ':' && tag[i] != '"' && tag[i] != 0x7f {
+			i++
+		}
+
+		if i == 0 {
+			return nil, errTagKeySyntax
+		}
+		if i+1 >= len(tag) || tag[i] != ':' {
+			return nil, errTagSyntax
+		}
+		if tag[i+1] != '"' {
+			return nil, errTagValueSyntax
+		}
+
+		key := tag[:i]
+		tag = tag[i+1:]
+
+		i = 1
+		for i < len(tag) && tag[i] != '"' {
+			if tag[i] == '\\' {
+				i++
+			}
+			i++
+		}
+		if i >= len(tag) {
+			return nil, errTagValueSyntax
+		}
+
+		qvalue := tag[:i+1]
+		tag = tag[i+1:]
+
+		value, err := strconv.Unquote(qvalue)
+		if err != nil {
+			return nil, errTagValueSyntax
+		}
+
+		split, err := splitter.NewSplitter(',', splitter.SquareBrackets)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create a new splitter: %w", err)
+		}
+
+		res, err := split.Split(value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to split value %s: %w", value, err)
+		}
+
+		name := res[0]
+		options := res[1:]
+		if len(options) == 0 {
+			options = nil
+		}
+
+		tags = append(tags, &Tag{
+			Key:     key,
+			Name:    name,
+			Options: options,
+		})
+	}
+
+	if hasTag && len(tags) == 0 {
+		return nil, nil
+	}
+
+	return &Tags{
+		tags: tags,
+	}, nil
+}
+
+func (t *Tags) Get(key string) (*Tag, error) {
+	for _, tag := range t.tags {
+		if tag.Key == key {
+			return tag, nil
+		}
+	}
+
+	return nil, errTagNotExist
 }

--- a/hack/tools/confdocs/structtag/LICENSE
+++ b/hack/tools/confdocs/structtag/LICENSE
@@ -1,0 +1,60 @@
+Copyright (c) 2017, Fatih Arslan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of structtag nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+This software includes some portions from Go. Go is used under the terms of the
+BSD like license.
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The Go gopher was designed by Renee French. http://reneefrench.blogspot.com/ The design is licensed under the Creative Commons 3.0 Attributions license. Read this article for more details: https://blog.golang.org/gopher

--- a/hack/tools/confdocs/structtag/tags.go
+++ b/hack/tools/confdocs/structtag/tags.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2017, Fatih Arslan
+
+//go:build confdocs
+// +build confdocs
+
+package structtag
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/go-andiamo/splitter"
+)
+
+var (
+	errTagSyntax      = errors.New("bad syntax for struct tag pair")
+	errTagKeySyntax   = errors.New("bad syntax for struct tag key")
+	errTagValueSyntax = errors.New("bad syntax for struct tag value")
+	errTagNotExist    = errors.New("tag does not exist")
+)
+
+type Tags struct {
+	tags []*Tag
+}
+
+type Tag struct {
+	Key     string
+	Name    string
+	Options []string
+}
+
+func Parse(tag string) (*Tags, error) {
+	var tags []*Tag
+
+	hasTag := tag != ""
+	for tag != "" {
+		i := 0
+		for i < len(tag) && tag[i] == ' ' {
+			i++
+		}
+		tag = tag[i:]
+		if tag == "" {
+			break
+		}
+
+		i = 0
+		for i < len(tag) && tag[i] > ' ' && tag[i] != ':' && tag[i] != '"' && tag[i] != 0x7f {
+			i++
+		}
+
+		if i == 0 {
+			return nil, errTagKeySyntax
+		}
+		if i+1 >= len(tag) || tag[i] != ':' {
+			return nil, errTagSyntax
+		}
+		if tag[i+1] != '"' {
+			return nil, errTagValueSyntax
+		}
+
+		key := tag[:i]
+		tag = tag[i+1:]
+
+		i = 1
+		for i < len(tag) && tag[i] != '"' {
+			if tag[i] == '\\' {
+				i++
+			}
+			i++
+		}
+		if i >= len(tag) {
+			return nil, errTagValueSyntax
+		}
+
+		qvalue := tag[:i+1]
+		tag = tag[i+1:]
+
+		value, err := strconv.Unquote(qvalue)
+		if err != nil {
+			return nil, errTagValueSyntax
+		}
+
+		split, err := splitter.NewSplitter(',', splitter.SquareBrackets)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create a new splitter: %w", err)
+		}
+
+		res, err := split.Split(value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to split value %s: %w", value, err)
+		}
+
+		name := res[0]
+		options := res[1:]
+		if len(options) == 0 {
+			options = nil
+		}
+
+		tags = append(tags, &Tag{
+			Key:     key,
+			Name:    name,
+			Options: options,
+		})
+	}
+
+	if hasTag && len(tags) == 0 {
+		return nil, nil
+	}
+
+	return &Tags{
+		tags: tags,
+	}, nil
+}
+
+func (t *Tags) Get(key string) (*Tag, error) {
+	for _, tag := range t.tags {
+		if tag.Key == key {
+			return tag, nil
+		}
+	}
+
+	return nil, errTagNotExist
+}

--- a/internal/audit/kafka/conf.go
+++ b/internal/audit/kafka/conf.go
@@ -55,7 +55,7 @@ type Conf struct {
 	// Brokers list to seed the Kafka client.
 	Brokers []string `yaml:"brokers" conf:"required,example=['localhost:9092']"`
 	// Compression sets the compression algorithm to use in order of priority. Valid values are "none", "gzip", "snappy","lz4", "zstd". Default is ["snappy", "none"].
-	Compression []string `yaml:"compression" conf:",example=['zstd', 'snappy', 'none']"`
+	Compression []string `yaml:"compression" conf:",example=['snappy', 'none']"`
 	// CloseTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
 	CloseTimeout time.Duration `yaml:"closeTimeout" conf:",example=30s"`
 	// MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.

--- a/internal/audit/kafka/conf.go
+++ b/internal/audit/kafka/conf.go
@@ -55,7 +55,7 @@ type Conf struct {
 	// Brokers list to seed the Kafka client.
 	Brokers []string `yaml:"brokers" conf:"required,example=['localhost:9092']"`
 	// Compression sets the compression algorithm to use in order of priority. Valid values are "none", "gzip", "snappy","lz4", "zstd". Default is ["snappy", "none"].
-	Compression []string `yaml:"compression" conf:",example=['snappy']"`
+	Compression []string `yaml:"compression" conf:",example=['zstd', 'snappy', 'none']"`
 	// CloseTimeout sets how long when closing the client to wait for any remaining messages to be flushed.
 	CloseTimeout time.Duration `yaml:"closeTimeout" conf:",example=30s"`
 	// MaxBufferedRecords sets the maximum number of records the client should buffer in memory in async mode.


### PR DESCRIPTION
Parsing logic from `structtag` doesn't have a way to configure whether we want to ignore a `,` character inside of square brackets while splitting the tag value such as;
```
Compression []string `conf:",example=['zstd', 'snappy', 'none']"`
```
This makes us unable to parse array examples such as: `['zstd', 'snappy', 'none']`

One possible solution to this was copying the implementation (or maybe we should fork it?) from `structtag` and modifying it to use [go-andiamo/splitter](github.com/go-andiamo/splitter), which I did for this PR.

fixes #1638