### PR TITLE
fix(helm): Remove whitespace chomp for priorityClassName so valid yaml is rendered

### DIFF
--- a/deploy/charts/cerbos/templates/deployment.yaml
+++ b/deploy/charts/cerbos/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.priorityClassName }}
-      priorityClassName: {{- .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
#### Description

This PR removes the whitespace [chomping](https://helm.sh/docs/chart_template_guide/control_structures/#controlling-whitespace) (`{{- `)  on the `priorityClassName` value to allow the chart to render valid YAML when the `priorityClassName` value is set.

Fixes https://github.com/cerbos/cerbos/issues/2336

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
