### PR TITLE
enhancement: Add user-agent to default allowed headers for CORS

### DIFF
--- a/docs/modules/configuration/pages/server.adoc
+++ b/docs/modules/configuration/pages/server.adoc
@@ -81,7 +81,7 @@ NOTE: For production use cases that require automatic certificate reloading, wor
 
 == CORS
 
-By default, link:https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[CORS] is enabled on the HTTP service with all origins allowed. You can disable CORS by setting `server.cors.disabled` to `true`. You can also restrict the list of allowed origins and headers by setting `server.cors.allowedOrigins` and `server.cors.allowedHeaders` respectively.
+By default, link:https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[CORS] is enabled on the HTTP service with all origins allowed. The default allowed headers are `accept`, `content-type`, `user-agent` and `x-requested-with`. You can disable CORS by setting `server.cors.disabled` to `true`. You can also restrict the list of allowed origins and headers by setting `server.cors.allowedOrigins` and `server.cors.allowedHeaders` respectively.
 
 [source,yaml,linenums]
 ----
@@ -91,7 +91,11 @@ server:
       - example.com
       - example.org
     allowedHeaders:
-      - X-CUSTOM
+      - accept
+      - content-type
+      - user-agent
+      - x-custom-header
+      - x-requested-with
 ----
 
 [#request-limits]

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -152,9 +152,15 @@ func withCORS(conf *Conf, handler http.Handler) http.Handler {
 		return handler
 	}
 
+	allowedHeaders := conf.CORS.AllowedHeaders
+	if len(allowedHeaders) == 0 {
+		// The cors library's defaults don't include user-agent so we explicitly add it here.
+		allowedHeaders = []string{"accept", "content-type", "user-agent", "x-requested-with"}
+	}
+
 	opts := cors.Options{
 		AllowedOrigins: conf.CORS.AllowedOrigins,
-		AllowedHeaders: conf.CORS.AllowedHeaders,
+		AllowedHeaders: allowedHeaders,
 		AllowedMethods: []string{
 			http.MethodHead,
 			http.MethodGet,


### PR DESCRIPTION
Most browsers send the `user-agent` header with CORS requests. The
default set of allowed headers baked into the library doesn't contain
that header.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
