### PR TITLE
enhancement: Validate fixtures files with JSON schemas to improve error messages

### DIFF
--- a/internal/jsonschema/jsonschema.go
+++ b/internal/jsonschema/jsonschema.go
@@ -22,29 +22,50 @@ import (
 var (
 	ErrEmptyFile = errors.New("empty file")
 
-	policySchema *jsonschema.Schema
-	testSchema   *jsonschema.Schema
+	testSchema              *jsonschema.Schema
+	principalFixturesSchema *jsonschema.Schema
+	resourceFixturesSchema  *jsonschema.Schema
+	auxDataFixturesSchema   *jsonschema.Schema
 )
 
 func init() {
 	var err error
-	if policySchema, err = jsonschema.CompileString("Policy.schema.json", schema.PolicyJSONSchema); err != nil {
-		log.Fatalf("failed to compile policy schema: %v", err)
-	}
 
 	if testSchema, err = jsonschema.CompileString("TestSuite.schema.json", schema.TestSuiteJSONSchema); err != nil {
 		log.Fatalf("failed to compile test schema: %v", err)
 	}
-}
 
-// ValidatePolicy validates the policy in the fsys with the JSON schema.
-func ValidatePolicy(fsys fs.FS, path string) error {
-	return validate(policySchema, fsys, path)
+	if principalFixturesSchema, err = jsonschema.CompileString("Principals.schema.json", schema.PrincipalFixturesJSONSchema); err != nil {
+		log.Fatalf("failed to compile principal fixtures schema: %v", err)
+	}
+
+	if resourceFixturesSchema, err = jsonschema.CompileString("Resources.schema.json", schema.ResourceFixturesJSONSchema); err != nil {
+		log.Fatalf("failed to compile resource fixtures schema: %v", err)
+	}
+
+	if auxDataFixturesSchema, err = jsonschema.CompileString("AuxData.schema.json", schema.AuxDataFixturesJSONSchema); err != nil {
+		log.Fatalf("failed to compile aux data fixtures schema: %v", err)
+	}
 }
 
 // ValidateTest validates the test in the fsys with the JSON schema.
 func ValidateTest(fsys fs.FS, path string) error {
 	return validate(testSchema, fsys, path)
+}
+
+// ValidatePrincipalFixtures validates the principal fixtures file in the fsys with the JSON schema.
+func ValidatePrincipalFixtures(fsys fs.FS, path string) error {
+	return validate(principalFixturesSchema, fsys, path)
+}
+
+// ValidateResourceFixtures validates the resource fixtures file in the fsys with the JSON schema.
+func ValidateResourceFixtures(fsys fs.FS, path string) error {
+	return validate(resourceFixturesSchema, fsys, path)
+}
+
+// ValidatePrincipalFixtures validates the aux data fixtures file in the fsys with the JSON schema.
+func ValidateAuxDataFixtures(fsys fs.FS, path string) error {
+	return validate(auxDataFixturesSchema, fsys, path)
 }
 
 func validate(s *jsonschema.Schema, fsys fs.FS, path string) error {

--- a/internal/test/testdata/verify/cases/case_006.yaml.input
+++ b/internal/test/testdata/verify/cases/case_006.yaml.input
@@ -1,7 +1,3 @@
--- testdata/principals.yaml --
-principals:
-  invalid: {}
-
 -- suite_test.yaml --
 ---
 name: TestSuite

--- a/internal/test/testdata/verify/cases/case_025.yaml
+++ b/internal/test/testdata/verify/cases/case_025.yaml
@@ -1,0 +1,1 @@
+description: Invalid principal fixtures

--- a/internal/test/testdata/verify/cases/case_025.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_025.yaml.golden
@@ -6,7 +6,7 @@
       "summary": {
         "overallResult": "RESULT_ERRORED"
       },
-      "error": "failed to load test fixtures from testdata: failed to unmarshal JSON: proto: (line 1:119): invalid value for string field policyVersion: 20210210",
+      "error": "failed to load test fixtures from testdata: file is not valid: { /principals/john/policyVersion: [expected string, but got number] }",
       "description": "Tests for verifying something"
     }
   ],

--- a/internal/test/testdata/verify/cases/case_025.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_025.yaml.golden
@@ -6,7 +6,7 @@
       "summary": {
         "overallResult": "RESULT_ERRORED"
       },
-      "error": "Failed to load the test suite: invalid test \"John and his leave request\": principal \"john\" not found",
+      "error": "failed to load test fixtures from testdata: failed to unmarshal JSON: proto: (line 1:119): invalid value for string field policyVersion: 20210210",
       "description": "Tests for verifying something"
     }
   ],

--- a/internal/test/testdata/verify/cases/case_025.yaml.input
+++ b/internal/test/testdata/verify/cases/case_025.yaml.input
@@ -1,0 +1,59 @@
+-- testdata/principals.yaml --
+---
+principals:
+  john:
+    id: john
+    policyVersion: 20210210
+    roles:
+      - employee
+    attr:
+      department: marketing
+      geography: GB
+      team: design
+
+-- testdata/resources.yaml --
+---
+resources:
+  john_leave_request:
+    kind: leave_request
+    policyVersion: '20210210'
+    id: XX125
+    attr:
+      department: marketing
+      geography: GB
+      id: XX125
+      owner: john
+      team: design
+
+-- testdata/auxdata.yaml --
+---
+auxData:
+  myJWT:
+    jwt:
+      iss: cerbos-test-suite
+      aud: [cerbos-jwt-tests]
+      customArray: [A, B]
+
+-- suite_test.yaml --
+---
+name: TestSuite
+description: Tests for verifying something
+tests:
+  - name: John and his leave request
+    input:
+      principals:
+        - john
+      resources:
+        - john_leave_request
+      actions:
+        - view:public
+        - approve
+        - defer
+      auxData: myJWT
+    expected:
+      - principal: john
+        resource: john_leave_request
+        actions:
+          view:public: EFFECT_ALLOW
+          approve: EFFECT_DENY
+          defer: EFFECT_ALLOW

--- a/internal/test/testdata/verify/cases/case_026.yaml
+++ b/internal/test/testdata/verify/cases/case_026.yaml
@@ -1,0 +1,1 @@
+description: Invalid resource fixtures

--- a/internal/test/testdata/verify/cases/case_026.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_026.yaml.golden
@@ -6,7 +6,7 @@
       "summary": {
         "overallResult": "RESULT_ERRORED"
       },
-      "error": "failed to load test fixtures from testdata: validation error:\n - resources[\"john_leave_request\"].kind: value is required [required]",
+      "error": "failed to load test fixtures from testdata: file is not valid: { /resources/john_leave_request: [missing properties: 'kind'] }",
       "description": "Tests for verifying something"
     }
   ],

--- a/internal/test/testdata/verify/cases/case_026.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_026.yaml.golden
@@ -6,7 +6,7 @@
       "summary": {
         "overallResult": "RESULT_ERRORED"
       },
-      "error": "Failed to load the test suite: invalid test \"John and his leave request\": principal \"john\" not found",
+      "error": "failed to load test fixtures from testdata: validation error:\n - resources[\"john_leave_request\"].kind: value is required [required]",
       "description": "Tests for verifying something"
     }
   ],

--- a/internal/test/testdata/verify/cases/case_026.yaml.input
+++ b/internal/test/testdata/verify/cases/case_026.yaml.input
@@ -1,0 +1,58 @@
+-- testdata/principals.yaml --
+---
+principals:
+  john:
+    id: john
+    policyVersion: '20210210'
+    roles:
+      - employee
+    attr:
+      department: marketing
+      geography: GB
+      team: design
+
+-- testdata/resources.yaml --
+---
+resources:
+  john_leave_request:
+    policyVersion: '20210210'
+    id: XX125
+    attr:
+      department: marketing
+      geography: GB
+      id: XX125
+      owner: john
+      team: design
+
+-- testdata/auxdata.yaml --
+---
+auxData:
+  myJWT:
+    jwt:
+      iss: cerbos-test-suite
+      aud: [cerbos-jwt-tests]
+      customArray: [A, B]
+
+-- suite_test.yaml --
+---
+name: TestSuite
+description: Tests for verifying something
+tests:
+  - name: John and his leave request
+    input:
+      principals:
+        - john
+      resources:
+        - john_leave_request
+      actions:
+        - view:public
+        - approve
+        - defer
+      auxData: myJWT
+    expected:
+      - principal: john
+        resource: john_leave_request
+        actions:
+          view:public: EFFECT_ALLOW
+          approve: EFFECT_DENY
+          defer: EFFECT_ALLOW

--- a/internal/test/testdata/verify/cases/case_027.yaml
+++ b/internal/test/testdata/verify/cases/case_027.yaml
@@ -1,0 +1,1 @@
+description: Invalid aux data fixtures

--- a/internal/test/testdata/verify/cases/case_027.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_027.yaml.golden
@@ -6,7 +6,7 @@
       "summary": {
         "overallResult": "RESULT_ERRORED"
       },
-      "error": "Failed to load the test suite: invalid test \"John and his leave request\": principal \"john\" not found",
+      "error": "failed to load test fixtures from testdata: failed to unmarshal JSON: proto: (line 1:22): unknown field \"jort\"",
       "description": "Tests for verifying something"
     }
   ],

--- a/internal/test/testdata/verify/cases/case_027.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_027.yaml.golden
@@ -6,7 +6,7 @@
       "summary": {
         "overallResult": "RESULT_ERRORED"
       },
-      "error": "failed to load test fixtures from testdata: failed to unmarshal JSON: proto: (line 1:22): unknown field \"jort\"",
+      "error": "failed to load test fixtures from testdata: file is not valid: { /auxData/myJWT: [additionalProperties 'jort' not allowed] }",
       "description": "Tests for verifying something"
     }
   ],

--- a/internal/test/testdata/verify/cases/case_027.yaml.input
+++ b/internal/test/testdata/verify/cases/case_027.yaml.input
@@ -1,0 +1,59 @@
+-- testdata/principals.yaml --
+---
+principals:
+  john:
+    id: john
+    policyVersion: '20210210'
+    roles:
+      - employee
+    attr:
+      department: marketing
+      geography: GB
+      team: design
+
+-- testdata/resources.yaml --
+---
+resources:
+  john_leave_request:
+    kind: leave_request
+    policyVersion: '20210210'
+    id: XX125
+    attr:
+      department: marketing
+      geography: GB
+      id: XX125
+      owner: john
+      team: design
+
+-- testdata/auxdata.yaml --
+---
+auxData:
+  myJWT:
+    jort:
+      iss: cerbos-test-suite
+      aud: [cerbos-jwt-tests]
+      customArray: [A, B]
+
+-- suite_test.yaml --
+---
+name: TestSuite
+description: Tests for verifying something
+tests:
+  - name: John and his leave request
+    input:
+      principals:
+        - john
+      resources:
+        - john_leave_request
+      actions:
+        - view:public
+        - approve
+        - defer
+      auxData: myJWT
+    expected:
+      - principal: john
+        resource: john_leave_request
+        actions:
+          view:public: EFFECT_ALLOW
+          approve: EFFECT_DENY
+          defer: EFFECT_ALLOW

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -21,11 +21,17 @@ var svcSwaggerRaw []byte
 //go:embed assets/ui.html
 var rapidocHTML []byte
 
-//go:embed jsonschema/cerbos/policy/v1/Policy.schema.json
-var PolicyJSONSchema string
-
 //go:embed jsonschema/cerbos/policy/v1/TestSuite.schema.json
 var TestSuiteJSONSchema string
+
+//go:embed jsonschema/cerbos/policy/v1/TestFixture/Principals.schema.json
+var PrincipalFixturesJSONSchema string
+
+//go:embed jsonschema/cerbos/policy/v1/TestFixture/Resources.schema.json
+var ResourceFixturesJSONSchema string
+
+//go:embed jsonschema/cerbos/policy/v1/TestFixture/AuxData.schema.json
+var AuxDataFixturesJSONSchema string
 
 func ServeSvcSwagger(w http.ResponseWriter, r *http.Request) {
 	defer cleanup(r)


### PR DESCRIPTION
https://github.com/cerbos/cerbos/pull/1526 only covered policy and test files; fixtures files are still prone to cryptic "failed to unmarshal JSON" error messages like

```
failed to load test fixtures from testdata: failed to unmarshal JSON: proto: (line 1:119): invalid value for string field policyVersion: 20210210
```

This PR adds JSON schema validation for fixtures files so that this error is now

```
failed to load test fixtures from testdata: file is not valid: { /principals/john/policyVersion: [expected string, but got number] }
```