### PR TITLE
chore(release): Update generated API module version before tagging

### DIFF
--- a/hack/scripts/prep-release.sh
+++ b/hack/scripts/prep-release.sh
@@ -70,6 +70,10 @@ set_branch() {
 
 # Generate NOTICE.txt
 just generate-notice
+# Because of go.work, the build works correctly by ignoring the version of the API module from go.mod.
+# However, when we create the tag, we should ensure that the go.mod version reflects what's actually
+# being used for the build. This also helps workspace-unaware tools such as Nix to build from a tag.
+go get -u github.com/cerbos/cerbos/api/genpb@main && go mod tidy
 # Set release version and tag
 update_version $VERSION
 # Create netlify redirects


### PR DESCRIPTION
Because we have a `go.work` file, the version of `api/genpb` submodule
in `go.mod` is ignored in workspace-aware builds. This is generally what
we want because it makes it much easier to test changes to the
protobufs. However, when we tag a release, we should make sure that the
`go.mod` points to the actual version of the submodule used. This is
important for reproducible builds because Go workspaces are considered a
development aid by some tools and they disable workspace mode when
building from source.

I am currently having trouble building Cerbos 0.39 with Nix because the
tagged version uses v0.38.1 of `api/genpb` which doesn't contain some of
the protobuf definitions used in 0.39.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
