### PR TITLE
enhancement: Make `now` fully deterministic

### DIFF
--- a/cmd/cerbos/repl/internal/repl.go
+++ b/cmd/cerbos/repl/internal/repl.go
@@ -17,7 +17,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 	"unicode"
 
 	"github.com/alecthomas/participle/v2"
@@ -411,7 +410,7 @@ func (r *REPL) evalExpr(expr string) (ref.Val, *exprpb.Type, error) {
 		return nil, nil, errSilent
 	}
 
-	val, _, err := conditions.Eval(env, ast, r.vars, time.Now)
+	val, _, err := conditions.Eval(env, ast, r.vars, conditions.Now())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/cerbosctl/put/put_test.go
+++ b/cmd/cerbosctl/put/put_test.go
@@ -111,6 +111,7 @@ func testPutCmd(clientCtx *cmdclient.Context, globals *flagset.Globals) func(*te
 					"resource.leave_request.vdefault/acme.hr.uk",
 					"resource.leave_request.vstaging",
 					"resource.missing_attr.vdefault",
+					"resource.output_now.vdefault",
 					"resource.products.vdefault",
 					"resource.purchase_order.vdefault",
 					"resource.runtime_effective_derived_roles.vdefault",

--- a/internal/conditions/cerbos_lib_test.go
+++ b/internal/conditions/cerbos_lib_test.go
@@ -106,7 +106,7 @@ func TestCerbosLib(t *testing.T) {
 			ast, issues := env.Compile(tc.expr)
 			is.NoError(issues.Err())
 
-			have, _, err := conditions.Eval(env, ast, cel.NoVars(), time.Now)
+			have, _, err := conditions.Eval(env, ast, cel.NoVars(), conditions.Now())
 			if tc.wantErr {
 				is.Error(err)
 			} else {

--- a/internal/engine/evaluator.go
+++ b/internal/engine/evaluator.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"time"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
@@ -41,7 +40,7 @@ var ErrPolicyNotExecutable = errors.New("policy not executable")
 
 type evalParams struct {
 	globals              map[string]any
-	nowFunc              func() time.Time
+	nowFunc              conditions.NowFunc
 	defaultPolicyVersion string
 	lenientScopeSearch   bool
 }
@@ -49,7 +48,6 @@ type evalParams struct {
 func defaultEvalParams(conf *Conf) evalParams {
 	return evalParams{
 		globals:              conf.Globals,
-		nowFunc:              time.Now,
 		defaultPolicyVersion: conf.DefaultPolicyVersion,
 		lenientScopeSearch:   conf.LenientScopeSearch,
 	}

--- a/internal/storage/index/builder_test.go
+++ b/internal/storage/index/builder_test.go
@@ -45,7 +45,7 @@ func TestBuildIndexWithDisk(t *testing.T) {
 
 	t.Run("check_contents", func(t *testing.T) {
 		data := idxImpl.Inspect()
-		require.Len(t, data, 38)
+		require.Len(t, data, 39)
 
 		rp1 := filepath.Join("resource_policies", "policy_01.yaml")
 		rp2 := filepath.Join("resource_policies", "policy_02.yaml")

--- a/internal/test/testdata/store/resource_policies/policy_15.yaml
+++ b/internal/test/testdata/store/resource_policies/policy_15.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=../../../../../schema/jsonschema/cerbos/policy/v1/Policy.schema.json
+---
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: output_now
+  rules:
+    - name: a
+      actions:
+        - a
+      effect: EFFECT_ALLOW
+      roles:
+        - user
+      output:
+        when:
+          ruleActivated: now()
+
+    - name: b
+      actions:
+        - b
+      effect: EFFECT_ALLOW
+      roles:
+        - user
+      output:
+        when:
+          ruleActivated: now()
+
+    - name: c
+      actions:
+        - c
+      effect: EFFECT_ALLOW
+      roles:
+        - user
+      output:
+        when:
+          ruleActivated: now()

--- a/private/verify/verify.go
+++ b/private/verify/verify.go
@@ -94,6 +94,7 @@ func Bundle(ctx context.Context, params BundleParams) (*policyv1.TestResults, er
 type CheckOptions interface {
 	Globals() map[string]any
 	NowFunc() func() time.Time
+	DefaultPolicyVersion() string
 	LenientScopeSearch() bool
 }
 


### PR DESCRIPTION
At the moment, `now` is deterministic within a CEL expression. However, within a single check, it varies between conditions of different rules in a policy.

This PR fixes the value of `now` at the time the check (or plan) is initiated instead of the time each expression is evaluated, so that the results are guaranteed to be consistent even between separate evaluations.