### PR TITLE
fix: Populate path field of validation errors

### DIFF
--- a/internal/schema/error.go
+++ b/internal/schema/error.go
@@ -31,8 +31,13 @@ func (e ErrSource) toProto() schemav1.ValidationError_Source {
 }
 
 func newValidationError(err *jsonschema.ValidationError, source ErrSource) ValidationError {
+	path := "/"
+	if err.InstanceLocation != "" {
+		path = err.InstanceLocation
+	}
+
 	return ValidationError{
-		Path:    err.InstanceLocation,
+		Path:    path,
 		Message: err.Message,
 		Source:  source,
 	}

--- a/internal/test/testdata/schema/fs/_schemas/complex_object.json
+++ b/internal/test/testdata/schema/fs/_schemas/complex_object.json
@@ -1,115 +1,118 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
-  "required": [
-    "stringField",
-    "intField"
-  ],
-  "properties": {
-    "stringField": {
-      "type": "string",
-      "minLength": 5
-    },
-    "intField": {
-      "type": "integer",
-      "minimum": 20
-    },
-    "floatField": {
-      "type": "number",
-      "maximum": 400
-    },
-    "boolField": {
-      "type": "boolean"
-    },
-    "dateField": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "stringList": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "intList": {
-      "type": "array",
-      "items": {
-        "type": "integer"
-      }
-    },
-    "floatList": {
-      "type": "array",
-      "items": {
-        "type": "number"
-      }
-    },
-    "boolList": {
-      "type": "array",
-      "items": {
-        "type": "boolean"
-      }
-    },
-    "nestedList": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "stringField": {
-            "type": "string"
-          },
-          "floatField": {
-            "type": "number"
-          },
-          "intListField": {
-            "type": "array",
-            "items": {
-              "type": "integer"
-            }
-          }
-        }
-      }
-    },
-    "simpleObject": {
-      "type": "object",
-      "properties": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": [
+        "stringField",
+        "intField"
+    ],
+    "properties": {
         "stringField": {
-          "type": "string"
+            "type": "string",
+            "minLength": 5
+        },
+        "intField": {
+            "type": "integer",
+            "minimum": 20
         },
         "floatField": {
-          "type": "number"
-        }
-      }
-    },
-    "nestedObject": {
-      "type": "object",
-      "properties": {
-        "key1": {
-          "type": "object",
-          "properties": {
-            "stringField": {
-              "type": "string"
-            },
-            "floatField": {
-              "type": "number"
-            },
-            "intListField": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              }
+            "type": "number",
+            "maximum": 400
+        },
+        "boolField": {
+            "type": "boolean"
+        },
+        "dateField": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "stringList": {
+            "type": "array",
+            "items": {
+                "type": "string"
             }
-          }
         },
-        "key2": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        "intList": {
+            "type": "array",
+            "items": {
+                "type": "integer"
+            }
         },
-        "key3": {
-          "type": "boolean"
+        "floatList": {
+            "type": "array",
+            "items": {
+                "type": "number"
+            }
+        },
+        "boolList": {
+            "type": "array",
+            "items": {
+                "type": "boolean"
+            }
+        },
+        "nestedList": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "stringField": {
+                        "type": "string"
+                    },
+                    "floatField": {
+                        "type": "number"
+                    },
+                    "intListField": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "simpleObject": {
+            "type": "object",
+            "properties": {
+                "stringField": {
+                    "type": "string"
+                },
+                "floatField": {
+                    "type": "number"
+                }
+            }
+        },
+        "nestedObject": {
+            "type": "object",
+            "properties": {
+                "key1": {
+                    "type": "object",
+                    "required": [
+                        "stringField"
+                    ],
+                    "properties": {
+                        "stringField": {
+                            "type": "string"
+                        },
+                        "floatField": {
+                            "type": "number"
+                        },
+                        "intListField": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                },
+                "key2": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "key3": {
+                    "type": "boolean"
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/internal/test/testdata/schema/test_cases/check_input_01.yaml
+++ b/internal/test/testdata/schema/test_cases/check_input_01.yaml
@@ -7,13 +7,16 @@ schemaRefs:
   resourceSchema:
     ref: cerbos:///complex_object.json
 checkInput:
-  actions: [ "view:public" ]
+  actions: ["view:public"]
   principal:
     id: "john"
     policyVersion: "20210210"
-    roles: [ "employee" ]
+    roles: ["employee"]
     attr: &myAttr
       stringField: 1
+      nestedObject:
+        key1:
+          float_field: 0.1
   resource:
     kind: "leave_request"
     policyVersion: "20210210"
@@ -24,12 +27,22 @@ wantValidationErrors:
     message: "expected string, but got number"
     source: SOURCE_PRINCIPAL
 
-  - message: "missing properties: 'intField'"
+  - path: "/"
+    message: "missing properties: 'intField'"
+    source: SOURCE_PRINCIPAL
+
+  - path: "/nestedObject/key1"
+    message: "missing properties: 'stringField'"
     source: SOURCE_PRINCIPAL
 
   - path: "/stringField"
     message: "expected string, but got number"
     source: SOURCE_RESOURCE
 
-  - message: "missing properties: 'intField'"
+  - path: "/"
+    message: "missing properties: 'intField'"
+    source: SOURCE_RESOURCE
+
+  - path: "/nestedObject/key1"
+    message: "missing properties: 'stringField'"
     source: SOURCE_RESOURCE

--- a/internal/test/testdata/schema/test_cases/check_input_03.yaml
+++ b/internal/test/testdata/schema/test_cases/check_input_03.yaml
@@ -7,11 +7,11 @@ schemaRefs:
   resourceSchema:
     ref: cerbos:///blah.json
 checkInput:
-  actions: [ "view:public" ]
+  actions: ["view:public"]
   principal:
     id: "john"
     policyVersion: "20210210"
-    roles: [ "employee" ]
+    roles: ["employee"]
     attr: &myAttr
       stringField: hello
   resource:
@@ -20,8 +20,9 @@ checkInput:
     id: "XX125"
     attr: *myAttr
 wantValidationErrors:
-  - message: "Failed to load schema \"cerbos:///blah.json\""
+  - message: 'Failed to load schema "cerbos:///blah.json"'
     source: SOURCE_RESOURCE
 
-  - message: "missing properties: 'intField'"
+  - path: /
+    message: "missing properties: 'intField'"
     source: SOURCE_PRINCIPAL

--- a/internal/test/testdata/schema/test_cases/check_input_07.yaml
+++ b/internal/test/testdata/schema/test_cases/check_input_07.yaml
@@ -11,11 +11,11 @@ schemaRefs:
     ignoreWhen:
       actions: ["view:public"]
 checkInput:
-  actions: [ "view:public", "defer"]
+  actions: ["view:public", "defer"]
   principal:
     id: "john"
     policyVersion: "20210210"
-    roles: [ "employee" ]
+    roles: ["employee"]
     attr: &myAttr
       stringField: 1
   resource:
@@ -28,12 +28,14 @@ wantValidationErrors:
     message: "expected string, but got number"
     source: SOURCE_PRINCIPAL
 
-  - message: "missing properties: 'intField'"
+  - path: "/"
+    message: "missing properties: 'intField'"
     source: SOURCE_PRINCIPAL
 
   - path: "/stringField"
     message: "expected string, but got number"
     source: SOURCE_RESOURCE
 
-  - message: "missing properties: 'intField'"
+  - path: "/"
+    message: "missing properties: 'intField'"
     source: SOURCE_RESOURCE

--- a/internal/test/testdata/schema/test_cases/check_input_08.yaml
+++ b/internal/test/testdata/schema/test_cases/check_input_08.yaml
@@ -9,11 +9,11 @@ schemaRefs:
   resourceSchema:
     ref: cerbos:///complex_object.json
 checkInput:
-  actions: [ "view:public" ]
+  actions: ["view:public"]
   principal:
     id: "john"
     policyVersion: "20210210"
-    roles: [ "employee" ]
+    roles: ["employee"]
     attr: &myAttr
       stringField: 1
   resource:
@@ -26,5 +26,6 @@ wantValidationErrors:
     message: "expected string, but got number"
     source: SOURCE_RESOURCE
 
-  - message: "missing properties: 'intField'"
+  - path: "/"
+    message: "missing properties: 'intField'"
     source: SOURCE_RESOURCE

--- a/internal/test/testdata/schema/test_cases/plan_resources_input_01.yaml
+++ b/internal/test/testdata/schema/test_cases/plan_resources_input_01.yaml
@@ -11,7 +11,7 @@ planResourcesInput:
   principal:
     id: "john"
     policyVersion: "20210210"
-    roles: [ "employee" ]
+    roles: ["employee"]
     attr: &myAttr
       stringField: 1
   resource:
@@ -23,7 +23,8 @@ wantValidationErrors:
     message: "expected string, but got number"
     source: SOURCE_PRINCIPAL
 
-  - message: "missing properties: 'intField'"
+  - path: /
+    message: "missing properties: 'intField'"
     source: SOURCE_PRINCIPAL
 
   - path: "/stringField"

--- a/internal/test/testdata/schema/test_cases/plan_resources_input_02.yaml
+++ b/internal/test/testdata/schema/test_cases/plan_resources_input_02.yaml
@@ -11,7 +11,7 @@ planResourcesInput:
   principal:
     id: "john"
     policyVersion: "20210210"
-    roles: [ "employee" ]
+    roles: ["employee"]
     attr: &customer
       billing_address:
         street_address: 20 W 34th St
@@ -21,7 +21,8 @@ planResourcesInput:
     policyVersion: "20210210"
     attr: *customer
 wantValidationErrors:
-  - message: "missing properties: 'first_name', 'last_name', 'shipping_address'"
+  - path: /
+    message: "missing properties: 'first_name', 'last_name', 'shipping_address'"
     source: SOURCE_PRINCIPAL
 
   - path: /billing_address


### PR DESCRIPTION
The validation library doesn't populate the path field for top-level
required fields that are missing. This PR handles that case.

Fixes #2362

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
