### PR TITLE
fix(plan): A policy with only conditional DENY rule must produce `ALWAYS_DENIED`

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -336,6 +336,10 @@ func (engine *Engine) doPlanResources(ctx context.Context, input *enginev1.PlanR
 		}
 	}
 
+	if result.AllowIsEmpty() {
+		result = planner.NewAlwaysDenied(result.Scope)
+	}
+
 	output, err := result.ToPlanResourcesOutput(input)
 	if err != nil {
 		return nil, nil, err

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -336,7 +336,7 @@ func (engine *Engine) doPlanResources(ctx context.Context, input *enginev1.PlanR
 		}
 	}
 
-	if result.AllowIsEmpty() {
+	if result.AllowIsEmpty() && !result.DenyIsEmpty() { // reset an conditional DENY to an unconditional one
 		result = planner.NewAlwaysDenied(result.Scope)
 	}
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -337,7 +337,7 @@ func (engine *Engine) doPlanResources(ctx context.Context, input *enginev1.PlanR
 	}
 
 	if result.AllowIsEmpty() && !result.DenyIsEmpty() { // reset an conditional DENY to an unconditional one
-		result = planner.NewAlwaysDenied(result.Scope)
+		result.ResetToUnconditionalDeny()
 	}
 
 	output, err := result.ToPlanResourcesOutput(input)

--- a/internal/engine/planner/planner.go
+++ b/internal/engine/planner/planner.go
@@ -73,6 +73,10 @@ func CombinePlans(principalPolicyPlan, resourcePolicyPlan *PolicyPlanResult) *Po
 		return principalPolicyPlan
 	}
 
+	if resourcePolicyPlan.AllowIsEmpty() && principalPolicyPlan.AllowIsEmpty() {
+		return resourcePolicyPlan // short-circuiting
+	}
+
 	return &PolicyPlanResult{
 		Scope:            fmt.Sprintf("principal: %q; resource: %q", principalPolicyPlan.Scope, resourcePolicyPlan.Scope),
 		AllowFilter:      append(principalPolicyPlan.AllowFilter, resourcePolicyPlan.toAST()),

--- a/internal/engine/planner/planner.go
+++ b/internal/engine/planner/planner.go
@@ -221,6 +221,10 @@ func (p *PolicyPlanResult) Complete() bool {
 	return false
 }
 
+func (p *PolicyPlanResult) ResetToUnconditionalDeny() {
+	p.DenyFilter = []*qpN{mkFalseNode()}
+}
+
 func (ppe *PrincipalPolicyEvaluator) evalContext() *evalContext {
 	return &evalContext{ppe.NowFn}
 }

--- a/internal/test/testdata/query_planner/policies/resource_policies/basics.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policies/basics.yaml
@@ -39,3 +39,11 @@ resourcePolicy:
       condition:
         match:
           expr: now() == timestamp("2024-01-16T10:18:27.395716+13:00") && now() == now()
+    - actions:
+        - lecture
+      effect: EFFECT_DENY
+      roles:
+        - USER
+      condition:
+        match:
+          expr: R.attr.degree != "master's"

--- a/internal/test/testdata/query_planner/policies/resource_policies/leave_request.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policies/leave_request.yaml
@@ -110,19 +110,25 @@ resourcePolicy:
             of:
               - expr: R.attr.status == "PENDING_APPROVAL"
               - expr: R.attr.owner != request.principal.id
-    - actions: ["report:deny-deny"]
+    - actions: ["report:allow-deny-deny"]
+      roles: ["manager"]
+      effect: EFFECT_ALLOW
+    - actions: ["report:allow-deny-deny"]
       roles: ["manager"]
       effect: EFFECT_DENY
       condition:
         match:
           expr: R.attr.deleted
-    - actions: ["report:deny-deny"]
+    - actions: ["report:allow-deny-deny"]
       roles: ["manager"]
       effect: EFFECT_DENY
       condition:
         match:
           expr: R.attr.hidden
-    - actions: ["report:deny"]
+    - actions: ["report:allow-deny"]
+      roles: ["manager"]
+      effect: EFFECT_ALLOW
+    - actions: ["report:allow-deny"]
       roles: ["manager"]
       effect: EFFECT_DENY
       condition:

--- a/internal/test/testdata/query_planner/policies/resource_policies/top.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policies/top.yaml
@@ -15,4 +15,4 @@ resourcePolicy:
             of:
               - expr: R.attr.custAnal in P.attr.custAllowedValues
               - expr: R.attr.salhAnal in P.attr.salhAllowedValues
-      effect: EFFECT_DENY
+      effect: EFFECT_ALLOW

--- a/internal/test/testdata/query_planner/suite/basics.yaml
+++ b/internal/test/testdata/query_planner/suite/basics.yaml
@@ -51,3 +51,9 @@ tests:
         policyVersion: default
       want:
         kind: KIND_ALWAYS_ALLOWED
+    - action: lecture
+      resource:
+        kind: x
+        policyVersion: default
+      want:
+        kind: KIND_ALWAYS_DENIED

--- a/internal/test/testdata/query_planner/suite/maggie.yaml
+++ b/internal/test/testdata/query_planner/suite/maggie.yaml
@@ -50,7 +50,7 @@ tests:
                                       - variable: request.resource.attr.owner
                                       - value: "maggie"
 
-    - action: "report:deny-deny"
+    - action: "report:allow-deny-deny"
       resource:
         kind: leave_request
         policyVersion: default
@@ -69,7 +69,7 @@ tests:
                   operands:
                     - variable: request.resource.attr.hidden
 
-    - action: "report:deny"
+    - action: "report:allow-deny"
       resource:
         kind: leave_request
         policyVersion: default

--- a/internal/test/testdata/query_planner/suite/wrong_attr_data_type.yaml
+++ b/internal/test/testdata/query_planner/suite/wrong_attr_data_type.yaml
@@ -18,18 +18,15 @@ tests:
         kind: KIND_CONDITIONAL
         condition:
           expression:
-            operator: not
+            operator: or
             operands:
               - expression:
-                  operator: or
+                  operator: eq
                   operands:
-                    - expression:
-                        operator: eq
-                        operands:
-                          - variable: request.resource.attr.custAnal
-                          - value: VALUE1
-                    - expression:
-                        operator: eq
-                        operands:
-                          - variable: request.resource.attr.salhAnal
-                          - value: VALUE2
+                    - variable: request.resource.attr.custAnal
+                    - value: VALUE1
+              - expression:
+                  operator: eq
+                  operands:
+                    - variable: request.resource.attr.salhAnal
+                    - value: VALUE2


### PR DESCRIPTION
When the policy does not have an 'ALLOW' rule and has an unconditional 'DENY' rule, the query planner correctly returns an `ALWAYS_DENIED` response.

```yaml
apiVersion: "api.cerbos.dev/v1"
resourcePolicy:
  version: default
  resource: x
  rules:
    - actions:
        - write
      roles:
        - USER
      effect: EFFECT_DENY
```

When the policy does not have an 'ALLOW' rule and has a conditional 'DENY' rule:
```yaml
apiVersion: "api.cerbos.dev/v1"
resourcePolicy:
  version: default
  resource: x
  rules:
    - actions:
        - write
      roles:
        - USER
      effect: EFFECT_DENY
      condition:
        match:
          expr: R.attr.environment == "production"
```

The query planner should also return `ALWAYS_DENIED` response, but instead returns: `AST: (not (eq request.resource.attr.environment "production"))`
