### PR TITLE
chore: Replace deprecated `snapshot.name_template` field in GoReleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,7 @@
 version: 2
 
 snapshot:
-  name_template: "{{ incminor .Version }}-prerelease"
+  version_template: "{{ incminor .Version }}-prerelease"
 
 git:
   ignore_tags:


### PR DESCRIPTION
https://goreleaser.com/deprecations/#snapshotname_template
