### PR TITLE
chore(docs): Replace broken links in documentation

### DIFF
--- a/docs/modules/api/pages/index.adoc
+++ b/docs/modules/api/pages/index.adoc
@@ -553,7 +553,7 @@ docker run --rm -v $(pwd):/oas openapitools/openapi-generator-cli generate -i /o
 
 **Any language**
 
-You can access the Cerbos protobuf definitions from the link:https://github.com/cerbos/cerbos/tree/main/api/cerbos[Cerbos source tree]. However, the easiest way to generate client code for your preferred language is to use the link:https://docs.buf.build[Buf build tool] to obtain the published API definitions from the link:https://buf.build/cerbos/cerbos-api[Buf schema registry (BSR)].
+You can access the Cerbos protobuf definitions from the link:https://github.com/cerbos/cerbos/tree/main/api[Cerbos source tree]. However, the easiest way to generate client code for your preferred language is to use the link:https://docs.buf.build[Buf build tool] to obtain the published API definitions from the link:https://buf.build/cerbos/cerbos-api[Buf schema registry (BSR)].
 
 * Run `buf export buf.build/cerbos/cerbos-api -o proto` to download the API definitions with dependencies to the `proto` directory.
 
@@ -572,7 +572,7 @@ The link:https://pkg.go.dev/github.com/cerbos/cerbos/client[Cerbos Go SDK] uses 
 go get github.com/cerbos/cerbos/api
 ----
 
-You can also make use of the link:https://docs.buf.build/tour/use-remote-generation[remote generation feature of Buf schema registry] to pull down the Cerbos gRPC API as a Go module:
+You can also make use of the link:https://docs.buf.build/generate/remote-plugins[remote plugins feature of Buf schema registry] or the link:https://buf.build/cerbos[generated SDKs] to pull down the Cerbos gRPC API as a Go module:
 
 [source,sh]
 ----


### PR DESCRIPTION
#### Description

Fix broken link in documentation. 
For [remote generation feature of Buf schema registry](https://docs.buf.build/tour/use-remote-generation) link, the remote generation was [deprecated](https://buf.build/docs/migration-guides/migrate-remote-generation-alpha/?h=remote+generation), and in Buf's doc it was suggested to migrate to [remote plugins](https://buf.build/docs/bsr/remote-plugins/overview/) or [generated SDKs](https://buf.build/docs/bsr/generated-sdks/overview/). Thus replace it with these 2 links. 



<!-- Thank you for contributing Cerbos! Please describe the changes made in this PR here and provide any other useful information for reviewers. Make sure that you included some automated tests (e.g unit tests) to verify your changes.  If there is a requirement for user input for testing, please include the instructions as well. -->

Fixes #<!-- Link the relevant issue here -->

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
