### PR TITLE
fix: Inspect policy output expressions

### DIFF
--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -69,9 +69,15 @@ func TestInspect(t *testing.T) {
 				idx, err := index.Build(ctx, os.DirFS(dir))
 				var haveIdxBuildErr *index.BuildError
 				if errors.As(err, &haveIdxBuildErr) {
+					var wantIdxBuildErrs *runtimev1.IndexBuildErrors
+					expectedIdxBuildErrs, ok := expectedErrors.(*privatev1.InspectTestCase_PolicySetsExpectation_IndexBuildErrors)
+					if ok {
+						wantIdxBuildErrs = expectedIdxBuildErrs.IndexBuildErrors
+					}
+
 					require.Empty(t,
 						cmp.Diff(
-							expectedErrors.(*privatev1.InspectTestCase_PolicySetsExpectation_IndexBuildErrors).IndexBuildErrors,
+							wantIdxBuildErrs,
 							haveIdxBuildErr.IndexBuildErrors,
 							protocmp.Transform(),
 							protocmp.IgnoreFields(&sourcev1.Error{}, "context"),
@@ -86,12 +92,19 @@ func TestInspect(t *testing.T) {
 					rps, err := compile.Compile(unit, mgr)
 					var haveCompileErrSet *compile.ErrorSet
 					if errors.As(err, &haveCompileErrSet) {
+						var wantCompileErrs []*runtimev1.CompileErrors_Err
+						expectedCompileErrs, ok := expectedErrors.(*privatev1.InspectTestCase_PolicySetsExpectation_CompileErrors_)
+						if ok {
+							wantCompileErrs = expectedCompileErrs.CompileErrors.CompileErrors
+						}
+
 						for _, err := range haveCompileErrSet.CompileErrors {
 							t.Log(protojson.Format(err))
 						}
+
 						require.Empty(t,
 							cmp.Diff(
-								compileErrorsMap(expectedErrors.(*privatev1.InspectTestCase_PolicySetsExpectation_CompileErrors_).CompileErrors.CompileErrors),
+								compileErrorsMap(wantCompileErrs),
 								haveCompileErrSet.CompileErrors,
 								protocmp.Transform(),
 								protocmp.IgnoreFields(&runtimev1.CompileErrors_Err{}, "context"),

--- a/internal/inspect/policyset.go
+++ b/internal/inspect/policyset.go
@@ -51,7 +51,7 @@ func (ps *PolicySet) Results() (map[string]*responsev1.InspectPoliciesResponse_R
 	return ps.results, nil
 }
 
-// inspectDefinitionsAndRules inspects the definitions and rules in the given policy set to find references to the attributes.
+// listReferencedAttributes inspects the definitions and rules in the given policy set to find references to the attributes.
 func (ps *PolicySet) listReferencedAttributes(pset *runtimev1.RunnablePolicySet) ([]*responsev1.InspectPoliciesResponse_Attribute, error) {
 	attrs := make(map[string]*responsev1.InspectPoliciesResponse_Attribute)
 	if err := visitCompiledPolicySet(pset, attributeVisitor(attrs)); err != nil {

--- a/internal/test/testdata/inspect/outputs.yaml
+++ b/internal/test/testdata/inspect/outputs.yaml
@@ -1,0 +1,152 @@
+# yaml-language-server: $schema=../.jsonschema/InspectTestCase.schema.json
+inputs:
+  - apiVersion: api.cerbos.dev/v1
+    metadata:
+      storeIdentifier: a.yaml
+    principalPolicy:
+      version: default
+      principal: john
+      constants:
+        local:
+          x: 1
+      variables:
+        local:
+          x: "1"
+      rules:
+        - resource: leave_request
+          actions:
+            - action: x
+              effect: EFFECT_ALLOW
+              output:
+                expr: C.x + V.x + P.attr.x
+
+  - apiVersion: api.cerbos.dev/v1
+    metadata:
+      storeIdentifier: b.yaml
+    resourcePolicy:
+      version: default
+      resource: leave_request
+      constants:
+        local:
+          "y": 2
+          z: 3
+      variables:
+        local:
+          "y": "2"
+          z: "3"
+      rules:
+        - actions:
+            - "y"
+            - z
+          roles:
+            - foo
+          effect: EFFECT_ALLOW
+          output:
+            when:
+              ruleActivated: C.y + V.y + R.attr.y
+              conditionNotMet: C.z + V.z + R.attr.z
+
+
+policiesExpectation:
+  policies:
+      principal.john.vdefault:
+        policyId: a.yaml
+        actions:
+          - x
+        attributes:
+          - kind: KIND_PRINCIPAL_ATTRIBUTE
+            name: x
+        constants:
+          - kind: KIND_LOCAL
+            name: x
+            value: 1
+            source: principal.john.vdefault
+            used: true
+        variables:
+          - kind: KIND_LOCAL
+            name: x
+            value: "1"
+            source: principal.john.vdefault
+            used: true
+
+      resource.leave_request.vdefault:
+        policyId: b.yaml
+        actions:
+          - "y"
+          - z
+        attributes:
+          - kind: KIND_RESOURCE_ATTRIBUTE
+            name: "y"
+          - kind: KIND_RESOURCE_ATTRIBUTE
+            name: z
+        constants:
+          - kind: KIND_LOCAL
+            name: "y"
+            value: 2
+            source: resource.leave_request.vdefault
+            used: true
+          - kind: KIND_LOCAL
+            name: z
+            value: 3
+            source: resource.leave_request.vdefault
+            used: true
+        variables:
+          - kind: KIND_LOCAL
+            name: "y"
+            value: "2"
+            source: resource.leave_request.vdefault
+            used: true
+          - kind: KIND_LOCAL
+            name: z
+            value: "3"
+            source: resource.leave_request.vdefault
+            used: true
+
+policySetsExpectation:
+  policySets:
+      principal.john.vdefault:
+        policyId: principal.john.vdefault
+        actions:
+          - x
+        attributes:
+          - kind: KIND_PRINCIPAL_ATTRIBUTE
+            name: x
+        constants:
+          - kind: KIND_UNKNOWN
+            name: x
+            value: 1
+            used: true
+        variables:
+          - kind: KIND_UNKNOWN
+            name: x
+            value: "1"
+            used: true
+
+      resource.leave_request.vdefault:
+        policyId: resource.leave_request.vdefault
+        actions:
+          - "y"
+          - z
+        attributes:
+          - kind: KIND_RESOURCE_ATTRIBUTE
+            name: "y"
+          - kind: KIND_RESOURCE_ATTRIBUTE
+            name: z
+        constants:
+          - kind: KIND_UNKNOWN
+            name: "y"
+            value: 2
+            used: true
+          - kind: KIND_UNKNOWN
+            name: z
+            value: 3
+            used: true
+        variables:
+          - kind: KIND_UNKNOWN
+            name: "y"
+            value: "2"
+            used: true
+          - kind: KIND_UNKNOWN
+            name: z
+            value: "3"
+            used: true


### PR DESCRIPTION
Currently we don't inspect policy output expressions, so attributes might not be listed and constants/variables are incorrectly marked as unused.

This PR fixes that.