### PR TITLE
enhancement: Fail tests with unreachable output expectations

### DIFF
--- a/cmd/cerbosctl/put/put_test.go
+++ b/cmd/cerbosctl/put/put_test.go
@@ -104,6 +104,7 @@ func testPutCmd(clientCtx *cmdclient.Context, globals *flagset.Globals) func(*te
 					"resource.arn:aws:sns:us-east-1:123456789012:topic-a.vdefault",
 					"resource.equipment_request.vdefault",
 					"resource.equipment_request.vdefault/acme",
+					"resource.example.vdefault",
 					"resource.global.vdefault",
 					"resource.import_derived_roles_that_import_variables.vdefault",
 					"resource.import_variables.vdefault",

--- a/internal/storage/index/builder_test.go
+++ b/internal/storage/index/builder_test.go
@@ -45,7 +45,7 @@ func TestBuildIndexWithDisk(t *testing.T) {
 
 	t.Run("check_contents", func(t *testing.T) {
 		data := idxImpl.Inspect()
-		require.Len(t, data, 43)
+		require.Len(t, data, 44)
 
 		rp1 := filepath.Join("resource_policies", "policy_01.yaml")
 		rp2 := filepath.Join("resource_policies", "policy_02.yaml")

--- a/internal/test/testdata/store/resource_policies/policy_16.yaml
+++ b/internal/test/testdata/store/resource_policies/policy_16.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  resource: example
+  version: default
+  rules:
+    - actions:
+        - view
+      effect: EFFECT_ALLOW
+      roles:
+        - user
+      condition:
+        match:
+          expr: request.principal.attr.ip.inIPAddrRange("10.20.0.0/16")
+      output:
+        when:
+          ruleActivated: R

--- a/internal/test/testdata/verify/cases/case_037.yaml
+++ b/internal/test/testdata/verify/cases/case_037.yaml
@@ -1,0 +1,1 @@
+description: "Output matching failure (#1455)"

--- a/internal/test/testdata/verify/cases/case_037.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_037.yaml.golden
@@ -1,0 +1,15 @@
+{
+  "suites": [
+    {
+      "file": "example_test.yaml",
+      "name": "Example test suite",
+      "summary": {
+        "overallResult": "RESULT_ERRORED"
+      },
+      "error": "Failed to load the test suite: invalid test \"Example test\": found output expectations for actions that are not in the input actions list: [edit]"
+    }
+  ],
+  "summary": {
+    "overallResult": "RESULT_ERRORED"
+  }
+}

--- a/internal/test/testdata/verify/cases/case_037.yaml.input
+++ b/internal/test/testdata/verify/cases/case_037.yaml.input
@@ -1,0 +1,54 @@
+-- example.yaml --
+---
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  resource: example
+  version: default
+  rules:
+    - actions:
+        - view
+      effect: EFFECT_ALLOW
+      roles:
+        - user
+      condition:
+        match:
+          expr: `request.principal.attr.ip == "10.20.2.2"`
+      output:
+        when:
+          ruleActivated: R
+
+-- example_test.yaml --
+---
+name: Example test suite
+principals:
+  exampleUser:
+    id: example.user@yourapp.example.com
+    roles:
+      - user
+    attr:
+      ip: 10.20.2.2
+resources:
+  exampleResource:
+    kind: example
+    id: example-001
+    attr:
+      owner: example.user@yourapp.example.com
+tests:
+  - name: Example test
+    input:
+      principals:
+        - exampleUser
+      resources:
+        - exampleResource
+      actions:
+        - view
+    expected:
+      - principal: exampleUser
+        resource: exampleResource
+        actions:
+          view: EFFECT_ALLOW
+        outputs:
+          - action: edit
+            expected:
+              - src: x
+                val: x

--- a/internal/verify/test_matrix.go
+++ b/internal/verify/test_matrix.go
@@ -80,6 +80,17 @@ func (r *testSuiteRun) buildExpectationLookup(table *policyv1.TestTable) (map[te
 	for _, expectation := range table.Expected {
 		outputs := outputExpectations(expectation)
 
+		var unreachableOutputs []string
+		for action := range outputs {
+			if _, ok := inputActionsMap[action]; !ok {
+				unreachableOutputs = append(unreachableOutputs, action)
+			}
+		}
+
+		if len(unreachableOutputs) > 0 {
+			return nil, fmt.Errorf("found output expectations for actions that are not in the input actions list: [%s]", strings.Join(unreachableOutputs, ","))
+		}
+
 		principals, err := r.collectFixtures(expectation.Principal, expectation.Principals, expectation.PrincipalGroups, r.lookupPrincipalGroup)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
If a test defines an output expectation for an action that doesn't exist
in the input actions list, fail the test.



Signed-off-by: Charith Ellawala <charith@cerbos.dev>
