### PR TITLE
enhancement: Pre-compile rule table CEL programs

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -643,7 +643,9 @@ func (engine *Engine) getPartialRuleTable(ctx context.Context, resource, policyV
 		return nil, nil
 	}
 
-	ruleTable.LoadPolicies(toLoad)
+	if err := ruleTable.LoadPolicies(toLoad); err != nil {
+		return nil, err
+	}
 
 	return ruleTable, nil
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -340,7 +340,7 @@ func mkEngine(tb testing.TB, p param) (*Engine, context.CancelFunc) {
 		rps, err := compiler.GetAll(ctx)
 		require.NoError(tb, err)
 
-		rt.LoadPolicies(rps)
+		require.NoError(tb, rt.LoadPolicies(rps))
 	}
 
 	var auditLog audit.Log

--- a/internal/engine/ruletable/rule_table.go
+++ b/internal/engine/ruletable/rule_table.go
@@ -82,9 +82,9 @@ func (r *row) Matches(scope, action string, roles []string) bool {
 
 type rowParams struct {
 	Key         string
-	Constants   map[string]any        // conditions can be converted to Go native types at build time
-	CelPrograms []*CelProgram         // these need to be ordered for self referential variables at eval time
-	Variables   []*runtimev1.Variable // only used in the query planner
+	Constants   map[string]any // conditions can be converted to Go native types at build time
+	CelPrograms []*CelProgram  // these need to be ordered for self referential variables at eval time
+	Variables   []*runtimev1.Variable
 }
 
 type CelProgram struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -168,7 +168,9 @@ func Start(ctx context.Context) error {
 			return fmt.Errorf("failed to retrieve runnable policy sets: %w", err)
 		}
 
-		rt.LoadPolicies(rps)
+		if err := rt.LoadPolicies(rps); err != nil {
+			return fmt.Errorf("failed to load policies into rule table: %w", err)
+		}
 
 		if ss, ok := store.(storage.Subscribable); ok {
 			ss.Subscribe(rt)


### PR DESCRIPTION
Expressions are now checked and compiled to CEL programs at build time rather than at evaluation time, thus reducing hot-path CPU pressure.

This is now more performant than the original, pre ruletable engine (for relevant engine test cases 0-23):

- `sec/op`: -15%
- `allocs/op`: -16%
- `b/ops`: -18%

And the current rule table implementation:

- `sec/op`: -24%
- `allocs/op`: -20%
- `b/ops`: -22%