### PR TITLE
fix: Correctly handle GlobMap creation

### DIFF
--- a/internal/engine/ruletable/rule_table.go
+++ b/internal/engine/ruletable/rule_table.go
@@ -285,13 +285,13 @@ func (rt *RuleTable) insertRule(r *row) {
 			scopeMap[r.Scope] = roleMap
 		}
 
-		actionMap, ok := roleMap.Get(r.Role)
+		actionMap, ok := roleMap.GetLiteral(r.Role)
 		if !ok {
 			actionMap = util.NewGlobMap(make(map[string][]*row))
 			roleMap.Set(r.Role, actionMap)
 		}
 
-		rows, _ := actionMap.Get(r.Action)
+		rows, _ := actionMap.GetLiteral(r.Action)
 		rows = append(rows, r)
 		actionMap.Set(r.Action, rows)
 	}

--- a/internal/engine/ruletable/rule_table.go
+++ b/internal/engine/ruletable/rule_table.go
@@ -285,13 +285,13 @@ func (rt *RuleTable) insertRule(r *row) {
 			scopeMap[r.Scope] = roleMap
 		}
 
-		actionMap, ok := roleMap.GetLiteral(r.Role)
+		actionMap, ok := roleMap.GetWithLiteral(r.Role)
 		if !ok {
 			actionMap = util.NewGlobMap(make(map[string][]*row))
 			roleMap.Set(r.Role, actionMap)
 		}
 
-		rows, _ := actionMap.GetLiteral(r.Action)
+		rows, _ := actionMap.GetWithLiteral(r.Action)
 		rows = append(rows, r)
 		actionMap.Set(r.Action, rows)
 	}

--- a/internal/util/globs.go
+++ b/internal/util/globs.go
@@ -126,7 +126,7 @@ func (gm *GlobMap[T]) Get(k string) (T, bool) {
 	return zero, false
 }
 
-func (gm *GlobMap[T]) GetLiteral(k string) (T, bool) {
+func (gm *GlobMap[T]) GetWithLiteral(k string) (T, bool) {
 	if v, ok := gm.literals[k]; ok {
 		return v, true
 	}

--- a/internal/util/globs.go
+++ b/internal/util/globs.go
@@ -126,6 +126,19 @@ func (gm *GlobMap[T]) Get(k string) (T, bool) {
 	return zero, false
 }
 
+func (gm *GlobMap[T]) GetLiteral(k string) (T, bool) {
+	if v, ok := gm.literals[k]; ok {
+		return v, true
+	}
+
+	if v, ok := gm.globs[k]; ok {
+		return v, true
+	}
+
+	var zero T
+	return zero, false
+}
+
 func (gm *GlobMap[T]) GetMerged(k string) map[string]T {
 	merged := make(map[string]any)
 


### PR DESCRIPTION
We don't want to match glob patterns when building the rule table index as this leads to non-deterministic outputs and confused developers. Glob matching is only required at eval time.

The feature branch will be good to go after this!