### PR TITLE
chore: Make ephemeral engine configurable

### DIFF
--- a/cmd/cerbos/compile/compile.go
+++ b/cmd/cerbos/compile/compile.go
@@ -133,10 +133,7 @@ func (c *Cmd) Run(k *kong.Kong) error {
 		}
 
 		compiler := compile.NewManagerFromDefaultConf(ctx, store, schemaMgr)
-		eng, err := engine.NewEphemeral(compiler, schemaMgr)
-		if err != nil {
-			return fmt.Errorf("failed to create engine to run tests: %w", err)
-		}
+		eng := engine.NewEphemeral(nil, compiler, schemaMgr)
 
 		testFsys, testDir, err := c.testsDir()
 		if err != nil {

--- a/hack/tools/confdocs/confdocs.go
+++ b/hack/tools/confdocs/confdocs.go
@@ -196,6 +196,11 @@ func implementsIface(iface *types.Interface, obj types.Object) bool {
 		return false
 	}
 
+	name, ok := obj.(*types.TypeName)
+	if !ok || name.IsAlias() {
+		return false
+	}
+
 	t := obj.Type()
 	if types.Implements(t, iface) {
 		return true

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -179,13 +179,13 @@ func NewFromConf(ctx context.Context, conf *Conf, components Components) *Engine
 	return engine
 }
 
-func NewEphemeral(policyLoader policyloader.PolicyLoader, schemaMgr schema.Manager) (*Engine, error) {
-	conf, err := GetConf()
-	if err != nil {
-		return nil, fmt.Errorf("failed to read engine configuration: %w", err)
+func NewEphemeral(conf *Conf, policyLoader policyloader.PolicyLoader, schemaMgr schema.Manager) *Engine {
+	if conf == nil {
+		conf = &Conf{}
+		conf.SetDefaults()
 	}
 
-	return newEngine(conf, Components{PolicyLoader: policyLoader, SchemaMgr: schemaMgr, AuditLog: audit.NewNopLog()}), nil
+	return newEngine(conf, Components{PolicyLoader: policyLoader, SchemaMgr: schemaMgr, AuditLog: audit.NewNopLog()})
 }
 
 func newEngine(conf *Conf, c Components) *Engine {

--- a/internal/svc/playground_svc.go
+++ b/internal/svc/playground_svc.go
@@ -454,5 +454,5 @@ func (c *components) mkEngine(ctx context.Context) (*engine.Engine, error) {
 		return nil, err
 	}
 
-	return engine.NewEphemeral(cm, c.schemaMgr)
+	return engine.NewEphemeral(nil, cm, c.schemaMgr), nil
 }

--- a/private/check/check.go
+++ b/private/check/check.go
@@ -9,12 +9,13 @@ import (
 
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	internalcompile "github.com/cerbos/cerbos/internal/compile"
-	"github.com/cerbos/cerbos/internal/engine"
+	internalengine "github.com/cerbos/cerbos/internal/engine"
 	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage/disk"
 	"github.com/cerbos/cerbos/internal/util"
 	"github.com/cerbos/cerbos/internal/verify"
 	"github.com/cerbos/cerbos/private/compile"
+	"github.com/cerbos/cerbos/private/engine"
 )
 
 type TestFixtureGetter struct {
@@ -80,14 +81,10 @@ func (g *TestFixtureGetter) GetAllTestFixtures() []*TestFixtureCtx {
 	return fixtures
 }
 
-func Check(ctx context.Context, idx compile.Index, inputs []*enginev1.CheckInput) ([]*enginev1.CheckOutput, error) {
+func Check(ctx context.Context, conf *engine.Conf, idx compile.Index, inputs []*enginev1.CheckInput) ([]*enginev1.CheckOutput, error) {
 	store := disk.NewFromIndexWithConf(idx, &disk.Conf{})
 	schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
 	compiler := internalcompile.NewManagerFromDefaultConf(ctx, store, schemaMgr)
-	eng, err := engine.NewEphemeral(compiler, schemaMgr)
-	if err != nil {
-		return nil, err
-	}
-
+	eng := internalengine.NewEphemeral(conf, compiler, schemaMgr)
 	return eng.Check(ctx, inputs)
 }

--- a/private/engine/engine.go
+++ b/private/engine/engine.go
@@ -1,0 +1,8 @@
+// Copyright 2021-2025 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package engine
+
+import "github.com/cerbos/cerbos/internal/engine"
+
+type Conf = engine.Conf

--- a/private/plan/plan.go
+++ b/private/plan/plan.go
@@ -8,20 +8,17 @@ import (
 
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	internalcompile "github.com/cerbos/cerbos/internal/compile"
-	"github.com/cerbos/cerbos/internal/engine"
+	internalengine "github.com/cerbos/cerbos/internal/engine"
 	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage/disk"
 	"github.com/cerbos/cerbos/private/compile"
+	"github.com/cerbos/cerbos/private/engine"
 )
 
-func Resources(ctx context.Context, idx compile.Index, input *enginev1.PlanResourcesInput) (*enginev1.PlanResourcesOutput, error) {
+func Resources(ctx context.Context, conf *engine.Conf, idx compile.Index, input *enginev1.PlanResourcesInput) (*enginev1.PlanResourcesOutput, error) {
 	store := disk.NewFromIndexWithConf(idx, &disk.Conf{})
 	schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
 	compiler := internalcompile.NewManagerFromDefaultConf(ctx, store, schemaMgr)
-	eng, err := engine.NewEphemeral(compiler, schemaMgr)
-	if err != nil {
-		return nil, err
-	}
-
+	eng := internalengine.NewEphemeral(conf, compiler, schemaMgr)
 	return eng.PlanResources(ctx, input)
 }

--- a/private/verify/verify.go
+++ b/private/verify/verify.go
@@ -48,10 +48,7 @@ func Files(ctx context.Context, fsys fs.FS, idx compile.Index) (*policyv1.TestRe
 	store := disk.NewFromIndexWithConf(idx, &disk.Conf{})
 	schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
 	compiler := internalcompile.NewManagerFromDefaultConf(ctx, store, schemaMgr)
-	eng, err := engine.NewEphemeral(compiler, schemaMgr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create engine: %w", err)
-	}
+	eng := engine.NewEphemeral(nil, compiler, schemaMgr)
 
 	results, err := verify.Verify(ctx, fsys, eng, verify.Config{Trace: true})
 	if err != nil {
@@ -78,10 +75,7 @@ func Bundle(ctx context.Context, params BundleParams) (*policyv1.TestResults, er
 	}
 
 	schemaMgr := schema.NewFromConf(ctx, bundleSrc, schema.NewConf(schema.EnforcementReject))
-	eng, err := engine.NewEphemeral(bundleSrc, schemaMgr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create engine: %w", err)
-	}
+	eng := engine.NewEphemeral(nil, bundleSrc, schemaMgr)
 
 	results, err := verify.Verify(ctx, os.DirFS(params.TestsDir), eng, verify.Config{Trace: true})
 	if err != nil {


### PR DESCRIPTION
This PR changes the `engine.NewEphemeral` function to accept an `*engine.Conf` parameter, so that a non-default configuration can be applied in the Hub playground.