### PR TITLE
fix: Return validation errors and effective policies in query planner responses

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -298,6 +298,7 @@ func (engine *Engine) doPlanResources(ctx context.Context, input *enginev1.PlanR
 			return nil, nil, err
 		}
 
+		maps.Copy(auditTrail.EffectivePolicies, ruleTableResult.EffectivePolicies)
 		result = planner.CombinePlans(result, ruleTableResult)
 	}
 


### PR DESCRIPTION
These issues were picked up in the JS SDK tests: https://github.com/cerbos/cerbos-sdk-javascript/actions/runs/12745231739

I've been able to partially verify locally with manual requests against a PDP and JS SDK tests but am struggling to do so like for like with the CI environment (I'm seeing other unrelated failures etc). The fixes seem simple enough so it's probably more time efficient to merge these and see if they resolve errors in the SDK.

I need to add query planner tests, but I'll do that in a separate follow-up item as it seems fairly involved and I'm away for the latter part of this week--I'm keen to get these fixes in ASAP.