### PR TITLE
fix: Use correct filterDebug type in e2e query planner test

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -45,6 +45,7 @@ type testParam struct {
 	store        storage.Store
 	policyLoader policyloader.PolicyLoader
 	schemaMgr    schema.Manager
+	ruletable    *ruletable.RuleTable
 }
 
 type testParamGen func(*testing.T) testParam
@@ -65,10 +66,19 @@ func TestServer(t *testing.T) {
 			schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
 			policyLoader := compile.NewManagerFromDefaultConf(ctx, store, schemaMgr)
 
+			rt := ruletable.NewRuleTable().WithPolicyLoader(policyLoader)
+
+			rps, err := policyLoader.GetAll(ctx)
+			require.NoError(t, err, "Failed to get all policies")
+
+			err = rt.LoadPolicies(rps)
+			require.NoError(t, err, "Failed to load policies into rule table")
+
 			tp := testParam{
 				store:        store,
 				policyLoader: policyLoader,
 				schemaMgr:    schemaMgr,
+				ruletable:    rt,
 			}
 			return tp
 		}
@@ -98,11 +108,20 @@ func TestServer(t *testing.T) {
 			store, err := hubstore.NewStore(ctx, conf)
 			require.NoError(t, err)
 
+			rt := ruletable.NewRuleTable().WithPolicyLoader(store)
+
+			rps, err := store.GetAll(ctx)
+			require.NoError(t, err, "Failed to get all policies")
+
+			err = rt.LoadPolicies(rps)
+			require.NoError(t, err, "Failed to load policies into rule table")
+
 			schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
 			tp := testParam{
 				store:        store,
 				policyLoader: store,
 				schemaMgr:    schemaMgr,
+				ruletable:    rt,
 			}
 			return tp
 		}
@@ -307,17 +326,9 @@ func startServer(t *testing.T, conf *Conf, tpg testParamGen) {
 		},
 	}})
 
-	rt := ruletable.NewRuleTable().WithPolicyLoader(tp.policyLoader)
-
-	rps, err := tp.policyLoader.GetAll(ctx)
-	require.NoError(t, err, "Failed to get all policies")
-
-	err = rt.LoadPolicies(rps)
-	require.NoError(t, err, "Failed to load policies into rule table")
-
 	eng, err := engine.New(ctx, engine.Components{
 		PolicyLoader:      tp.policyLoader,
-		RuleTable:         rt,
+		RuleTable:         tp.ruletable,
 		SchemaMgr:         tp.schemaMgr,
 		AuditLog:          auditLog,
 		MetadataExtractor: audit.NewMetadataExtractorFromConf(&audit.Conf{}),

--- a/internal/test/testdata/server/plan_resources/plan_case_03.yaml
+++ b/internal/test/testdata/server/plan_resources/plan_case_03.yaml
@@ -34,4 +34,4 @@ planResources:
     filter:
       kind: KIND_ALWAYS_DENIED
     meta:
-      filterDebug: NO_MATCH
+      filterDebug: "(false)"


### PR DESCRIPTION
Should solve [this e2e test failure](https://github.com/cerbos/cerbos/actions/runs/12759334544/job/35562917228).

Looks like there's a minor discrepancy between precompiled rule tables and dynamically generated ones--I'll investigate in another issue.