### PR TITLE
fix: Correctly handle defaultPolicyVersion engine config

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -41,7 +41,6 @@ var errNoPoliciesMatched = errors.New("no matching policies")
 const (
 	defaultEffect        = effectv1.Effect_EFFECT_DENY
 	noPolicyMatch        = "NO_MATCH"
-	defaultVersion       = "default"
 	parallelismThreshold = 5
 	workerQueueSize      = 4
 	workerResetJitter    = 1 << 4
@@ -283,9 +282,6 @@ func (engine *Engine) doPlanResources(ctx context.Context, input *enginev1.PlanR
 	if ruleTable == nil {
 		var err error
 		version := input.Resource.PolicyVersion
-		if version == "" {
-			version = defaultVersion
-		}
 		ruleTable, err = engine.getPartialRuleTable(ctx, input.Resource.Kind, version, input.Resource.Scope, input.Principal.Roles)
 		if err != nil {
 			return nil, nil, err
@@ -293,7 +289,7 @@ func (engine *Engine) doPlanResources(ctx context.Context, input *enginev1.PlanR
 	}
 
 	if ruleTable != nil {
-		ruleTableResult, err := planner.EvaluateRuleTableQueryPlan(ctx, ruleTable, input, engine.schemaMgr, opts.NowFunc(), opts.Globals())
+		ruleTableResult, err := planner.EvaluateRuleTableQueryPlan(ctx, ruleTable, input, engine.schemaMgr, opts.NowFunc(), opts.Globals(), opts.DefaultPolicyVersion())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/engine/evaluator.go
+++ b/internal/engine/evaluator.go
@@ -127,7 +127,7 @@ type ruleTableEvaluator struct {
 func (rte *ruleTableEvaluator) Evaluate(ctx context.Context, tctx tracer.Context, input *enginev1.CheckInput) (*PolicyEvalResult, error) {
 	version := input.Resource.PolicyVersion
 	if version == "" {
-		version = defaultVersion
+		version = rte.evalParams.defaultPolicyVersion
 	}
 
 	trail := newAuditTrail(make(map[string]*policyv1.SourceAttributes))

--- a/internal/engine/planner/planner.go
+++ b/internal/engine/planner/planner.go
@@ -264,10 +264,10 @@ func (ppe *PrincipalPolicyEvaluator) EvaluateResourcesQueryPlan(ctx context.Cont
 	return acc, nil
 }
 
-func EvaluateRuleTableQueryPlan(ctx context.Context, ruleTable *ruletable.RuleTable, input *enginev1.PlanResourcesInput, schemaMgr schema.Manager, nowFunc conditions.NowFunc, globals map[string]any) (*PolicyPlanResult, error) {
+func EvaluateRuleTableQueryPlan(ctx context.Context, ruleTable *ruletable.RuleTable, input *enginev1.PlanResourcesInput, schemaMgr schema.Manager, nowFunc conditions.NowFunc, globals map[string]any, defaultPolicyVersion string) (*PolicyPlanResult, error) {
 	version := input.Resource.PolicyVersion
 	if version == "" {
-		version = "default"
+		version = defaultPolicyVersion
 	}
 
 	fqn := namer.ResourcePolicyFQN(input.Resource.Kind, version, input.Resource.Scope)

--- a/internal/test/testdata/verify/cases/case_033.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_033.yaml.golden
@@ -4,16 +4,12 @@
       "file": "suite_test.yaml",
       "name": "TestSuite",
       "summary": {
-        "overallResult": "RESULT_FAILED",
+        "overallResult": "RESULT_PASSED",
         "testsCount": 3,
         "resultCounts": [
           {
             "result": "RESULT_PASSED",
-            "count": 1
-          },
-          {
-            "result": "RESULT_FAILED",
-            "count": 2
+            "count": 3
           }
         ]
       },
@@ -30,10 +26,9 @@
                     {
                       "name": "view:public",
                       "details": {
-                        "result": "RESULT_FAILED",
-                        "failure": {
-                          "expected": "EFFECT_ALLOW",
-                          "actual": "EFFECT_DENY"
+                        "result": "RESULT_PASSED",
+                        "success": {
+                          "effect": "EFFECT_ALLOW"
                         }
                       }
                     },
@@ -49,10 +44,9 @@
                     {
                       "name": "defer",
                       "details": {
-                        "result": "RESULT_FAILED",
-                        "failure": {
-                          "expected": "EFFECT_ALLOW",
-                          "actual": "EFFECT_DENY"
+                        "result": "RESULT_PASSED",
+                        "success": {
+                          "effect": "EFFECT_ALLOW"
                         }
                       }
                     }
@@ -67,16 +61,12 @@
     }
   ],
   "summary": {
-    "overallResult": "RESULT_FAILED",
+    "overallResult": "RESULT_PASSED",
     "testsCount": 3,
     "resultCounts": [
       {
         "result": "RESULT_PASSED",
-        "count": 1
-      },
-      {
-        "result": "RESULT_FAILED",
-        "count": 2
+        "count": 3
       }
     ]
   }

--- a/internal/test/testdata/verify/cases/case_034.yaml.golden
+++ b/internal/test/testdata/verify/cases/case_034.yaml.golden
@@ -4,16 +4,12 @@
       "file": "suite_test.yaml",
       "name": "TestSuite",
       "summary": {
-        "overallResult": "RESULT_FAILED",
+        "overallResult": "RESULT_PASSED",
         "testsCount": 3,
         "resultCounts": [
           {
             "result": "RESULT_PASSED",
-            "count": 1
-          },
-          {
-            "result": "RESULT_FAILED",
-            "count": 2
+            "count": 3
           }
         ]
       },
@@ -30,10 +26,9 @@
                     {
                       "name": "view:public",
                       "details": {
-                        "result": "RESULT_FAILED",
-                        "failure": {
-                          "expected": "EFFECT_ALLOW",
-                          "actual": "EFFECT_DENY"
+                        "result": "RESULT_PASSED",
+                        "success": {
+                          "effect": "EFFECT_ALLOW"
                         }
                       }
                     },
@@ -49,10 +44,9 @@
                     {
                       "name": "defer",
                       "details": {
-                        "result": "RESULT_FAILED",
-                        "failure": {
-                          "expected": "EFFECT_ALLOW",
-                          "actual": "EFFECT_DENY"
+                        "result": "RESULT_PASSED",
+                        "success": {
+                          "effect": "EFFECT_ALLOW"
                         }
                       }
                     }
@@ -67,16 +61,12 @@
     }
   ],
   "summary": {
-    "overallResult": "RESULT_FAILED",
+    "overallResult": "RESULT_PASSED",
     "testsCount": 3,
     "resultCounts": [
       {
         "result": "RESULT_PASSED",
-        "count": 1
-      },
-      {
-        "result": "RESULT_FAILED",
-        "count": 2
+        "count": 3
       }
     ]
   }


### PR DESCRIPTION
Rather embarrassingly, there were previously working tests covering this case but I erroneously changed them as part of the original [rule table PR](https://github.com/cerbos/cerbos/pull/2442/files):

<img width="441" alt="image" src="https://github.com/user-attachments/assets/9c765887-48cc-4fb0-95f2-b04325014c05" />

This PR fixes the issue whereby engine settings were ignored, and correctly reinstates the valid test expectations.