### PR TITLE
fix: Correctly handle partial rule table and event subscription

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -158,7 +158,7 @@ func Start(ctx context.Context) error {
 		return ErrInvalidStore
 	}
 
-	rt := ruletable.NewRuleTable().WithPolicyLoader(policyLoader)
+	var rt *ruletable.RuleTable
 
 	// Populate rule table for non-mutable stores.
 	if _, ok := store.(storage.MutableStore); !ok {
@@ -167,13 +167,15 @@ func Start(ctx context.Context) error {
 			return fmt.Errorf("failed to retrieve runnable policy sets: %w", err)
 		}
 
+		rt = ruletable.NewRuleTable().WithPolicyLoader(policyLoader)
+
 		if err := rt.LoadPolicies(rps); err != nil {
 			return fmt.Errorf("failed to load policies into rule table: %w", err)
 		}
-	}
 
-	if ss, ok := policyLoader.(storage.Subscribable); ok {
-		ss.Subscribe(rt)
+		if ss, ok := policyLoader.(storage.Subscribable); ok {
+			ss.Subscribe(rt)
+		}
 	}
 
 	// create engine


### PR DESCRIPTION
Previously, the code determining whether or not to generate a partial rule table was incorrect, as the rule table could never be nil (so it would always look for the precompiled table).

We don't subscribe the rule table to change events unless we're precompiling the full rule table at start time, as the evaluator builds a partial rule table from underlying store state at evaluation time.

This seems to fix the broken tests for the JS and Go SDKs when run locally. I'm having some trouble with the E2E test suite so have been unable to confirm those.

This'll hopefully fix the broken Admin API tests for now. In general, I think maintaining partial rule table generation is confusing--I'll look at unifying (all stores using a full rule table) in a follow up item.