### PR TITLE
enhancement: Correctly set GOMAXPROCS on ECS

### DIFF
--- a/cmd/cerbos/run/run.go
+++ b/cmd/cerbos/run/run.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/alecthomas/kong"
 	"github.com/go-cmd/cmd"
+	gomaxecs "github.com/rdforte/gomaxecs/maxprocs"
 	"go.uber.org/automaxprocs/maxprocs"
 	"go.uber.org/zap"
 	"helm.sh/helm/v3/pkg/strvals"
@@ -90,7 +91,12 @@ func (c *Cmd) Run(k *kong.Kong) error {
 
 	log := zap.S().Named("run")
 
-	undo, _ := maxprocs.Set(maxprocs.Logger(log.Infof))
+	var undo func()
+	if gomaxecs.IsECS() {
+		undo, _ = gomaxecs.Set(gomaxecs.WithLogger(log.Infof))
+	} else {
+		undo, _ = maxprocs.Set(maxprocs.Logger(log.Infof))
+	}
 	defer undo()
 
 	if err := c.loadConfig(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20241121165744-79df5c4772f2
 	github.com/prometheus/client_golang v1.20.5
 	github.com/pterm/pterm v0.12.80
+	github.com/rdforte/gomaxecs v1.1.1
 	github.com/rivo/tview v0.0.0-20241227133733-17b7edb88c57
 	github.com/rjeczalik/notify v0.9.3
 	github.com/rogpeppe/go-internal v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -599,6 +599,8 @@ github.com/pterm/pterm v0.12.36/go.mod h1:NjiL09hFhT/vWjQHSj1athJpx6H8cjpHXNAK5b
 github.com/pterm/pterm v0.12.40/go.mod h1:ffwPLwlbXxP+rxT0GsgDTzS3y3rmpAO1NMjUkGTYf8s=
 github.com/pterm/pterm v0.12.80 h1:mM55B+GnKUnLMUSqhdINe4s6tOuVQIetQ3my8JGyAIg=
 github.com/pterm/pterm v0.12.80/go.mod h1:c6DeF9bSnOSeFPZlfs4ZRAFcf5SCoTwvwQ5xaKGQlHo=
+github.com/rdforte/gomaxecs v1.1.1 h1:Eq5WZN5jfR1wI7UkblWgOhjFo1j8ypCx+GWGjPmBGh8=
+github.com/rdforte/gomaxecs v1.1.1/go.mod h1:8agrawOmcvb+oBa6EnV2oADDtnDtkVx1Q0H/Ht7GiFc=
 github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
 github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
 github.com/redis/rueidis v1.0.19 h1:s65oWtotzlIFN8eMPhyYwxlwLR1lUdhza2KtWprKYSo=


### PR DESCRIPTION
Apparently, the cgroups are not correctly set on ECS and the CFS quota
cannot be determined by automaxprocs. See uber-go/automaxprocs#66.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
