### PR TITLE
enhancement: Lazy rule table

### DIFF
--- a/cmd/cerbosctl/put/put_test.go
+++ b/cmd/cerbosctl/put/put_test.go
@@ -102,6 +102,7 @@ func testPutCmd(clientCtx *cmdclient.Context, globals *flagset.Globals) func(*te
 					"resource.account.vdefault",
 					"resource.album_object.vdefault",
 					"resource.arn:aws:sns:us-east-1:123456789012:topic-a.vdefault",
+					"resource.calendar_entry.vdefault",
 					"resource.equipment_request.vdefault",
 					"resource.equipment_request.vdefault/acme",
 					"resource.example.vdefault",

--- a/internal/compile/manager.go
+++ b/internal/compile/manager.go
@@ -256,6 +256,11 @@ func (c *Manager) GetAll(ctx context.Context) ([]*runtimev1.RunnablePolicySet, e
 
 func (c *Manager) GetAllMatching(ctx context.Context, modIDs []namer.ModuleID) ([]*runtimev1.RunnablePolicySet, error) {
 	res := []*runtimev1.RunnablePolicySet{}
+
+	if len(modIDs) == 0 {
+		return res, nil
+	}
+
 	missed := make(map[namer.ModuleID]struct{})
 	for _, id := range modIDs {
 		if rps, ok := c.cache.Get(id); ok && rps != nil {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -185,7 +185,7 @@ func NewEphemeral(conf *Conf, policyLoader policyloader.PolicyLoader, schemaMgr 
 		conf.SetDefaults()
 	}
 
-	return newEngine(conf, Components{PolicyLoader: policyLoader, SchemaMgr: schemaMgr, AuditLog: audit.NewNopLog()})
+	return newEngine(conf, Components{PolicyLoader: policyLoader, SchemaMgr: schemaMgr, AuditLog: audit.NewNopLog(), RuleTable: ruletable.NewRuleTable(policyLoader)})
 }
 
 func newEngine(conf *Conf, c Components) *Engine {
@@ -283,24 +283,17 @@ func (engine *Engine) doPlanResources(ctx context.Context, input *enginev1.PlanR
 		policyVersion = opts.DefaultPolicyVersion()
 	}
 
-	ruleTable := engine.ruleTable
-	if ruleTable == nil {
-		var err error
-		ruleTable, err = engine.getPartialRuleTable(ctx, input.Resource.Kind, policyVersion, input.Resource.Scope, input.Principal.Roles)
-		if err != nil {
-			return nil, nil, err
-		}
+	if err := engine.ruleTable.LazyLoad(ctx, input.Resource.Kind, policyVersion, input.Resource.Scope, input.Principal.Roles); err != nil {
+		return nil, nil, err
 	}
 
-	if ruleTable != nil {
-		ruleTableResult, err := planner.EvaluateRuleTableQueryPlan(ctx, ruleTable, input, policyVersion, engine.schemaMgr, opts.NowFunc(), opts.Globals())
-		if err != nil {
-			return nil, nil, err
-		}
-
-		maps.Copy(auditTrail.EffectivePolicies, ruleTableResult.EffectivePolicies)
-		result = planner.CombinePlans(result, ruleTableResult)
+	ruleTableResult, err := planner.EvaluateRuleTableQueryPlan(ctx, engine.ruleTable, input, policyVersion, engine.schemaMgr, opts.NowFunc(), opts.Globals())
+	if err != nil {
+		return nil, nil, err
 	}
+
+	maps.Copy(auditTrail.EffectivePolicies, ruleTableResult.EffectivePolicies)
+	result = planner.CombinePlans(result, ruleTableResult)
 
 	if result.AllowIsEmpty() && !result.DenyIsEmpty() { // reset an conditional DENY to an unconditional one
 		result.ResetToUnconditionalDeny()
@@ -562,93 +555,11 @@ func (engine *Engine) buildEvaluationCtx(ctx context.Context, eparams evalParams
 }
 
 func (engine *Engine) getRuleTableEvaluator(ctx context.Context, eparams evalParams, resource, policyVer, scope string, inputRoles []string) (Evaluator, error) {
-	ruleTable := engine.ruleTable
-	if ruleTable == nil {
-		var err error
-		ruleTable, err = engine.getPartialRuleTable(ctx, resource, policyVer, scope, inputRoles)
-		if err != nil {
-			return nil, err
-		}
-		if ruleTable == nil {
-			return nil, nil
-		}
-	}
-
-	return NewRuleTableEvaluator(ruleTable, engine.schemaMgr, eparams), nil
-}
-
-func (engine *Engine) getPartialRuleTable(ctx context.Context, resource, policyVer, scope string, inputRoles []string) (*ruletable.RuleTable, error) {
-	// A matching scope must have at least one resource or role policy or a mixture of both.
-
-	ruleTable := ruletable.NewRuleTable()
-	// Add rules for policies at all scope levels.
-	// We duplicate rows for all role policy parent roles recursively.
-	//
-	// Rule table resource policies are added as individual units rather than as compilation units.
-	// Therefore, we need to retrieve the compilation unit for each scope, remove all bar the first policy,
-	// and pass all individually to the LoadPolicies method.
-	toLoad := []*runtimev1.RunnablePolicySet{}
-	// we force lenientScopeSearch when retrieving resource policy sets as lenient scope search is enforced
-	// in the evaluator function. Therefore, to prevent duplicate rows in the rule table, we check the returned
-	// policy scope before adding to `toLoad`
-	addedResourceScopes := make(map[string]struct{})
-	addScopedPolicyRules := func(scope string) error {
-		rps, err := engine.getResourcePolicySet(ctx, resource, policyVer, scope, true)
-		if err != nil {
-			return err
-		}
-
-		if rps != nil {
-			// check the first policy scope
-			p := rps.GetResourcePolicy().GetPolicies()[0]
-			if _, ok := addedResourceScopes[p.Scope]; !ok {
-				toLoad = append(toLoad, rps)
-				addedResourceScopes[p.Scope] = struct{}{}
-			}
-		}
-
-		rlps, err := engine.getRolePolicySets(ctx, scope, inputRoles)
-		if err != nil {
-			return err
-		}
-
-		if (rps == nil || len(rps.GetResourcePolicy().GetPolicies()) == 0) && len(rlps) == 0 {
-			return errNoPoliciesMatched
-		}
-
-		toLoad = append(toLoad, rlps...)
-
-		return nil
-	}
-
-	if err := addScopedPolicyRules(scope); err != nil {
-		if errors.Is(err, errNoPoliciesMatched) {
-			return nil, nil
-		}
+	if err := engine.ruleTable.LazyLoad(ctx, resource, policyVer, scope, inputRoles); err != nil {
 		return nil, err
 	}
 
-	for i := len(scope) - 1; i >= 0; i-- {
-		if scope[i] == '.' || i == 0 {
-			partialScope := scope[:i]
-			if err := addScopedPolicyRules(partialScope); err != nil {
-				if errors.Is(err, errNoPoliciesMatched) {
-					return nil, nil
-				}
-				return nil, err
-			}
-		}
-	}
-
-	if len(toLoad) == 0 {
-		return nil, nil
-	}
-
-	if err := ruleTable.LoadPolicies(toLoad); err != nil {
-		return nil, err
-	}
-
-	return ruleTable, nil
+	return NewRuleTableEvaluator(engine.ruleTable, engine.schemaMgr, eparams), nil
 }
 
 func (engine *Engine) getPrincipalPolicyEvaluator(ctx context.Context, eparams evalParams, principal, policyVer, scope string) (Evaluator, error) {
@@ -677,84 +588,6 @@ func (engine *Engine) getPrincipalPolicySet(ctx context.Context, principal, poli
 	}
 
 	return rps, nil
-}
-
-func (engine *Engine) getResourcePolicySet(ctx context.Context, resource, policyVer, scope string, lenientScopeSearch bool) (*runtimev1.RunnablePolicySet, error) {
-	ctx, span := tracing.StartSpan(ctx, "engine.GetResourcePolicy")
-	defer span.End()
-	span.SetAttributes(tracing.PolicyName(resource), tracing.PolicyVersion(policyVer), tracing.PolicyScope(scope))
-
-	resourceModIDs := namer.ScopedResourcePolicyModuleIDs(resource, policyVer, scope, lenientScopeSearch)
-	rps, err := engine.policyLoader.GetFirstMatch(ctx, resourceModIDs)
-	if err != nil {
-		tracing.MarkFailed(span, http.StatusInternalServerError, err)
-		return nil, err
-	}
-
-	return rps, nil
-}
-
-func (engine *Engine) getRolePolicySets(ctx context.Context, scope string, roles []string) ([]*runtimev1.RunnablePolicySet, error) {
-	ctx, span := tracing.StartSpan(ctx, "engine.GetRolePolicies")
-	defer span.End()
-	span.SetAttributes(tracing.PolicyScope(scope))
-
-	var requireParentalConsent, overrideParent int
-	processedRoles := make(map[string]struct{})
-	sets := []*runtimev1.RunnablePolicySet{}
-
-	// we recursively retrieve all role policies defined within parent roles
-	// (parent roles can be base level or role policy roles)
-	//
-	// TODO: to avoid repeat unconstrained (and potentially expensive) recursions,
-	// we could cache the result here and invalidate if the index changes. This might
-	// not be relevant if we rethink how the index is implemented down the line
-	var getPolicies func([]string, map[string]struct{}) error
-
-	getPolicies = func(roles []string, processedRoles map[string]struct{}) error {
-		roleModIDs := make([]namer.ModuleID, 0, len(roles))
-		for _, r := range roles {
-			if _, ok := processedRoles[r]; !ok {
-				roleModIDs = append(roleModIDs, namer.RolePolicyModuleID(r, scope))
-				processedRoles[r] = struct{}{}
-			}
-		}
-
-		currSets, err := engine.policyLoader.GetAllMatching(ctx, roleModIDs)
-		if err != nil {
-			tracing.MarkFailed(span, http.StatusInternalServerError, err)
-			return err
-		}
-
-		for _, r := range currSets {
-			rp := r.GetRolePolicy()
-
-			err := getPolicies(rp.GetParentRoles(), processedRoles)
-			if err != nil {
-				return err
-			}
-
-			switch rp.ScopePermissions { //nolint:exhaustive
-			case policyv1.ScopePermissions_SCOPE_PERMISSIONS_REQUIRE_PARENTAL_CONSENT_FOR_ALLOWS:
-				requireParentalConsent++
-			case policyv1.ScopePermissions_SCOPE_PERMISSIONS_OVERRIDE_PARENT:
-				overrideParent++
-			}
-
-			if requireParentalConsent > 0 && overrideParent > 0 {
-				return errors.New("invalid scope permissions: role policies cannot combine different scope permissions within the same scope")
-			}
-
-			sets = append(sets, r)
-		}
-		return nil
-	}
-
-	if err := getPolicies(roles, processedRoles); err != nil {
-		return nil, err
-	}
-
-	return sets, nil
 }
 
 func (engine *Engine) policyAttr(name, version, scope string, params evalParams) (pName, pVersion, pScope string) {

--- a/internal/engine/evaluator.go
+++ b/internal/engine/evaluator.go
@@ -101,10 +101,6 @@ func NewPrincipalPolicyEvaluator(pps *runtimev1.RunnablePrincipalPolicySet, epar
 }
 
 func NewRuleTableEvaluator(rt *ruletable.RuleTable, schemaMgr schema.Manager, eparams evalParams) Evaluator {
-	if rt.Len() == 0 {
-		return noopEvaluator{}
-	}
-
 	return &ruleTableEvaluator{
 		RuleTable:  rt,
 		schemaMgr:  schemaMgr,
@@ -180,7 +176,7 @@ func (rte *ruleTableEvaluator) Evaluate(ctx context.Context, tctx tracer.Context
 		return result, nil
 	}
 
-	allRoles := rte.GetParentRoles(input.Principal.Roles)
+	allRoles := rte.GetParentRoles(input.Resource.Scope, input.Principal.Roles)
 	includingParentRoles := make(map[string]struct{})
 	for _, r := range allRoles {
 		includingParentRoles[r] = struct{}{}
@@ -208,7 +204,7 @@ func (rte *ruleTableEvaluator) Evaluate(ctx context.Context, tctx tracer.Context
 				Policy: policyKey,
 			}
 
-			parentRoles := rte.GetParentRoles([]string{role})
+			parentRoles := rte.GetParentRoles(input.Resource.Scope, []string{role})
 
 		scopesLoop:
 			for _, scope := range scopes {

--- a/internal/engine/ruletable/rule_table.go
+++ b/internal/engine/ruletable/rule_table.go
@@ -506,7 +506,7 @@ func getCelProgramsFromExpressions(vars []*runtimev1.Variable) ([]*CelProgram, e
 func (rt *RuleTable) addRolePolicy(p *runtimev1.RunnableRolePolicySet) {
 	rt.scopeScopePermissions[p.Scope] = p.ScopePermissions
 
-	version := "default"
+	version := "default" //nolint:goconst
 	moduleID := namer.GenModuleIDFromFQN(p.Meta.Fqn)
 	rt.meta[moduleID] = &runtimev1.RuleTableMetadata{
 		Fqn:              p.Meta.Fqn,

--- a/internal/engine/ruletable/rule_table.go
+++ b/internal/engine/ruletable/rule_table.go
@@ -599,9 +599,9 @@ func (rt *RuleTable) deletePolicy(moduleID namer.ModuleID) {
 		return
 	}
 
-	delete(rt.storeQueryRegister, moduleID)
-
 	rt.log.Debugf("Deleting policy %s", meta.GetFqn())
+
+	delete(rt.storeQueryRegister, moduleID)
 
 	for version, scopeMap := range rt.primaryIdx {
 		for scope, roleMap := range scopeMap {
@@ -609,9 +609,6 @@ func (rt *RuleTable) deletePolicy(moduleID namer.ModuleID) {
 			scopedParentRoles := rt.parentRoles[scope]
 
 			for role, actionMap := range roleMap.GetAll() {
-				delete(scopedParentRoleAncestors, role)
-				delete(scopedParentRoles, role)
-
 				for action, rules := range actionMap.GetAll() {
 					newRules := make([]*Row, 0, len(rules))
 					for _, r := range rules {
@@ -631,6 +628,8 @@ func (rt *RuleTable) deletePolicy(moduleID namer.ModuleID) {
 
 				if actionMap.Len() == 0 {
 					roleMap.DeleteLiteral(role)
+					delete(scopedParentRoleAncestors, role)
+					delete(scopedParentRoles, role)
 				}
 			}
 

--- a/internal/engine/ruletable/rule_table.go
+++ b/internal/engine/ruletable/rule_table.go
@@ -146,7 +146,7 @@ func (rt *RuleTable) LazyLoad(ctx context.Context, resource, policyVer, scope st
 		resourceModID := namer.ResourcePolicyModuleID(resource, policyVer, partialScope)
 
 		// Check to see if the store has already been queried for the given parameters.
-		if policyExists, isQueried := rt.storeQueryRegister[resourceModID]; !isQueried {
+		if policyExists, isQueried := rt.storeQueryRegister[resourceModID]; !isQueried { //nolint:nestif
 			var err error
 			rps, err = rt.getResourcePolicySet(ctx, resource, policyVer, partialScope, true)
 			if err != nil {
@@ -851,9 +851,7 @@ func (rt *RuleTable) OnStorageEvent(events ...storage.Event) {
 			}
 		case storage.EventAddOrUpdatePolicy, storage.EventDeleteOrDisablePolicy:
 			rt.log.Debugw("Processing storage event", "event", evt)
-			if err := rt.processPolicyEvent(evt); err != nil {
-				rt.log.Warnw("Error while processing storage event", "event", evt, "error", err)
-			}
+			rt.processPolicyEvent(evt)
 		default:
 			rt.log.Debugw("Ignoring storage event", "event", evt)
 		}
@@ -874,11 +872,9 @@ func (rt *RuleTable) triggerReload() error {
 	return rt.loadPolicies(rpss)
 }
 
-func (rt *RuleTable) processPolicyEvent(ev storage.Event) error {
+func (rt *RuleTable) processPolicyEvent(ev storage.Event) {
 	rt.deletePolicy(ev.PolicyID)
 	if ev.OldPolicyID != nil {
 		rt.deletePolicy(*ev.OldPolicyID)
 	}
-
-	return nil
 }

--- a/internal/engine/ruletable/rule_table_test.go
+++ b/internal/engine/ruletable/rule_table_test.go
@@ -1,0 +1,200 @@
+// Copyright 2021-2025 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package ruletable
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
+	"github.com/cerbos/cerbos/internal/compile"
+	"github.com/cerbos/cerbos/internal/namer"
+	"github.com/cerbos/cerbos/internal/schema"
+	"github.com/cerbos/cerbos/internal/storage/disk"
+	"github.com/cerbos/cerbos/internal/test"
+)
+
+func TestRuleTable(t *testing.T) {
+	dir := test.PathToDir(t, "store")
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
+	store, err := disk.NewStore(ctx, &disk.Conf{Directory: dir})
+	require.NoError(t, err)
+
+	schemaConf := schema.NewConf(schema.EnforcementNone)
+	schemaMgr := schema.NewFromConf(ctx, store, schemaConf)
+
+	compiler := compile.NewManagerFromDefaultConf(ctx, store, schemaMgr)
+
+	rt := NewRuleTable(compiler)
+
+	t.Run("add and delete resource policy", func(t *testing.T) {
+		t.Cleanup(func() {
+			rt.purge()
+		})
+
+		resource := "leave_request"
+		version := "default"
+		scope := ""
+		role := "admin"
+
+		nonexistentRolePolicyModID := namer.RolePolicyModuleID(role, scope)
+
+		modID := namer.ResourcePolicyModuleID(resource, version, scope)
+
+		rps, err := compiler.GetFirstMatch(ctx, []namer.ModuleID{modID})
+		require.NoError(t, err)
+
+		require.NoError(t, rt.addPolicy(rps))
+
+		// version -> scope -> role -> action -> []rows
+		require.Contains(t, rt.primaryIdx, version)
+		require.Contains(t, rt.primaryIdx[version], scope)
+		actionMap, exists := rt.primaryIdx[version][scope].GetWithLiteral(role)
+		require.True(t, exists)
+		rows, exists := actionMap.GetWithLiteral("*")
+		require.True(t, exists)
+		require.Len(t, rows, 1)
+
+		require.Contains(t, rt.scopedResourceIdx, version)
+		require.Contains(t, rt.scopedResourceIdx[version], scope)
+		_, exists = rt.scopedResourceIdx[version][scope].GetWithLiteral("leave_request")
+		require.True(t, exists)
+
+		require.Contains(t, rt.schemas, modID)
+		require.Contains(t, rt.meta, modID)
+
+		require.Contains(t, rt.policyDerivedRoles, modID)
+		require.Empty(t, rt.policyDerivedRoles[modID])
+		// require.Contains(t, rt.policyDerivedRoles[modID], "alpha")
+		// require.Contains(t, rt.policyDerivedRoles[modID], "beta")
+
+		require.Contains(t, rt.scopeMap, scope)
+		scopePermissions, exists := rt.scopeScopePermissions[scope]
+		require.True(t, exists)
+		require.Equal(t, scopePermissions, policyv1.ScopePermissions_SCOPE_PERMISSIONS_OVERRIDE_PARENT)
+
+		exists, queried := rt.storeQueryRegister[modID]
+		require.False(t, queried)
+		require.False(t, exists)
+
+		// Registry stores the modID after LazyLoads
+		require.NoError(t, rt.LazyLoad(ctx, resource, version, scope, []string{role}))
+		exists, queried = rt.storeQueryRegister[modID]
+		require.True(t, queried)
+		require.True(t, exists)
+		exists, queried = rt.storeQueryRegister[nonexistentRolePolicyModID]
+		require.True(t, queried)
+		require.False(t, exists)
+
+		rt.deletePolicy(modID)
+
+		require.Empty(t, rt.primaryIdx)
+		require.Empty(t, rt.scopedResourceIdx)
+		require.Empty(t, rt.schemas)
+		require.Empty(t, rt.meta)
+		require.Empty(t, rt.policyDerivedRoles)
+		require.Empty(t, rt.scopeMap)
+		require.Empty(t, rt.scopeScopePermissions)
+		// we keep the registry entry but set it to `false`
+		require.Len(t, rt.storeQueryRegister, 2)
+		exists, queried = rt.storeQueryRegister[modID]
+		require.True(t, queried)
+		require.False(t, exists)
+		require.Contains(t, rt.storeQueryRegister, nonexistentRolePolicyModID)
+	})
+
+	t.Run("add and delete role policy", func(t *testing.T) {
+		t.Cleanup(func() {
+			rt.purge()
+		})
+
+		role := "acme_london_employee"
+		version := "default"
+		scope := "acme.hr.uk.london"
+		resource := "*"
+
+		modID := namer.RolePolicyModuleID(role, scope)
+
+		rps, err := compiler.GetFirstMatch(ctx, []namer.ModuleID{modID})
+		require.NoError(t, err)
+
+		require.NoError(t, rt.addPolicy(rps))
+
+		// version -> scope -> role -> action -> []rows
+		require.Contains(t, rt.primaryIdx, version)
+		require.Contains(t, rt.primaryIdx[version], scope)
+		actionMap, exists := rt.primaryIdx[version][scope].GetWithLiteral(role)
+		require.True(t, exists)
+		rows, exists := actionMap.GetWithLiteral("create")
+		require.True(t, exists)
+		require.Len(t, rows, 1)
+
+		require.Contains(t, rt.scopedResourceIdx, version)
+		require.Contains(t, rt.scopedResourceIdx[version], scope)
+		_, exists = rt.scopedResourceIdx[version][scope].GetWithLiteral(resource)
+		require.True(t, exists)
+
+		require.Contains(t, rt.meta, modID)
+
+		require.Contains(t, rt.scopeMap, scope)
+		scopePermissions, exists := rt.scopeScopePermissions[scope]
+		require.True(t, exists)
+		require.Equal(t, scopePermissions, policyv1.ScopePermissions_SCOPE_PERMISSIONS_REQUIRE_PARENTAL_CONSENT_FOR_ALLOWS)
+
+		// warm up the parent roles cache
+		rt.GetParentRoles(scope, []string{role})
+		require.Contains(t, rt.parentRoles, scope)
+		require.Contains(t, rt.parentRoles[scope], role)
+		require.Contains(t, rt.parentRoleAncestorsCache, scope)
+		require.Contains(t, rt.parentRoleAncestorsCache[scope], role)
+
+		exists, queried := rt.storeQueryRegister[modID]
+		require.False(t, queried)
+		require.False(t, exists)
+
+		// Registry stores the modID after LazyLoads
+		require.NoError(t, rt.LazyLoad(ctx, resource, version, scope, []string{role}))
+		// A store miss for the resource policy with lenientScopeSearch allows pre-optimised assertion that no
+		// resource policies exist in any scopes, hence the extra keys in the storeQueryRegister.
+		require.Len(t, rt.storeQueryRegister, 7)
+		exists, queried = rt.storeQueryRegister[modID]
+		require.True(t, queried)
+		require.True(t, exists)
+		// all nonexistent resource policy FQN
+		exists, queried = rt.storeQueryRegister[namer.ResourcePolicyModuleID(resource, version, scope)]
+		require.True(t, queried)
+		require.False(t, exists)
+		for s := range namer.ScopeParents(scope) {
+			exists, queried = rt.storeQueryRegister[namer.ResourcePolicyModuleID(resource, version, s)]
+			require.True(t, queried)
+			require.False(t, exists)
+		}
+		// Missing role policy in first parent scope (the search breaks after this with "not found")
+		exists, queried = rt.storeQueryRegister[namer.RolePolicyModuleID(role, "acme.hr.uk")]
+		require.True(t, queried)
+		require.False(t, exists)
+
+		rt.deletePolicy(modID)
+
+		require.Empty(t, rt.primaryIdx)
+		require.Empty(t, rt.scopedResourceIdx)
+		require.Empty(t, rt.schemas)
+		require.Empty(t, rt.meta)
+		require.Empty(t, rt.policyDerivedRoles)
+		require.Empty(t, rt.scopeMap)
+		require.Empty(t, rt.scopeScopePermissions)
+		require.Empty(t, rt.parentRoles)
+		require.Empty(t, rt.parentRoleAncestorsCache)
+		// not deleted, just set to `false`
+		require.Len(t, rt.storeQueryRegister, 7)
+		exists, queried = rt.storeQueryRegister[modID]
+		require.True(t, queried)
+		require.False(t, exists)
+	})
+}

--- a/internal/namer/namer.go
+++ b/internal/namer/namer.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"iter"
 	"regexp"
 	"strconv"
 	"strings"
@@ -157,6 +158,18 @@ func buildFQNTree[T any](fqn, scope string, elementFn func(string) T) []T {
 	fqnTree = append(fqnTree, elementFn(fqn))
 
 	return fqnTree
+}
+
+func ScopeParents(scope string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for i := len(scope) - 1; i >= 0; i-- {
+			if scope[i] == '.' || i == 0 {
+				if !yield(scope[:i]) {
+					return
+				}
+			}
+		}
+	}
 }
 
 func ScopeFromFQN(fqn string) string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -158,24 +158,10 @@ func Start(ctx context.Context) error {
 		return ErrInvalidStore
 	}
 
-	var rt *ruletable.RuleTable
+	rt := ruletable.NewRuleTable(policyLoader)
 
-	// Populate rule table for non-mutable stores.
-	if _, ok := store.(storage.MutableStore); !ok {
-		rps, err := policyLoader.GetAll(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to retrieve runnable policy sets: %w", err)
-		}
-
-		rt = ruletable.NewRuleTable().WithPolicyLoader(policyLoader)
-
-		if err := rt.LoadPolicies(rps); err != nil {
-			return fmt.Errorf("failed to load policies into rule table: %w", err)
-		}
-
-		if ss, ok := policyLoader.(storage.Subscribable); ok {
-			ss.Subscribe(rt)
-		}
+	if ss, ok := policyLoader.(storage.Subscribable); ok {
+		ss.Subscribe(rt)
 	}
 
 	// create engine

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -46,7 +46,6 @@ type testParam struct {
 	store        storage.Store
 	policyLoader policyloader.PolicyLoader
 	schemaMgr    schema.Manager
-	ruletable    *ruletable.RuleTable
 }
 
 type testParamGen func(*testing.T) testParam
@@ -67,19 +66,10 @@ func TestServer(t *testing.T) {
 			schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
 			policyLoader := compile.NewManagerFromDefaultConf(ctx, store, schemaMgr)
 
-			rt := ruletable.NewRuleTable().WithPolicyLoader(policyLoader)
-
-			rps, err := policyLoader.GetAll(ctx)
-			require.NoError(t, err, "Failed to get all policies")
-
-			err = rt.LoadPolicies(rps)
-			require.NoError(t, err, "Failed to load policies into rule table")
-
 			tp := testParam{
 				store:        store,
 				policyLoader: policyLoader,
 				schemaMgr:    schemaMgr,
-				ruletable:    rt,
 			}
 			return tp
 		}
@@ -122,20 +112,11 @@ func TestServer(t *testing.T) {
 				store, err := hubstore.NewStore(ctx, conf)
 				require.NoError(t, err)
 
-				rt := ruletable.NewRuleTable().WithPolicyLoader(store)
-
-				rps, err := store.GetAll(ctx)
-				require.NoError(t, err, "Failed to get all policies")
-
-				err = rt.LoadPolicies(rps)
-				require.NoError(t, err, "Failed to load policies into rule table")
-
 				schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
 				return testParam{
 					store:        store,
 					policyLoader: store,
 					schemaMgr:    schemaMgr,
-					ruletable:    rt,
 				}
 			}
 		}
@@ -345,7 +326,7 @@ func startServer(t *testing.T, conf *Conf, tpg testParamGen) {
 
 	eng, err := engine.New(ctx, engine.Components{
 		PolicyLoader:      tp.policyLoader,
-		RuleTable:         tp.ruletable,
+		RuleTable:         ruletable.NewRuleTable(tp.policyLoader),
 		SchemaMgr:         tp.schemaMgr,
 		AuditLog:          auditLog,
 		MetadataExtractor: audit.NewMetadataExtractorFromConf(&audit.Conf{}),

--- a/internal/storage/index/builder_test.go
+++ b/internal/storage/index/builder_test.go
@@ -45,7 +45,7 @@ func TestBuildIndexWithDisk(t *testing.T) {
 
 	t.Run("check_contents", func(t *testing.T) {
 		data := idxImpl.Inspect()
-		require.Len(t, data, 44)
+		require.Len(t, data, 45)
 
 		rp1 := filepath.Join("resource_policies", "policy_01.yaml")
 		rp2 := filepath.Join("resource_policies", "policy_02.yaml")

--- a/internal/test/testdata/engine/case_26.yaml
+++ b/internal/test/testdata/engine/case_26.yaml
@@ -9,6 +9,7 @@ inputs:
         "create", # exists, falls through, allow
         "delete", # exists, falls through, no match
         "nonaction", # doesn't exist, falls through, no match
+        "acme_action" # doesn't exist, falls through, match (implicit DENY)
       ],
       "principal":
         {
@@ -44,7 +45,14 @@ wantOutputs:
           "nonaction":
             {
               "effect": "EFFECT_DENY",
-              "policy": "NO_MATCH"
+              "policy": "NO_MATCH_FOR_SCOPE_PERMISSIONS",
+              "scope": "acme.sales"
+            },
+          "acme_action":
+            {
+              "effect": "EFFECT_DENY",
+              "policy": "NO_MATCH_FOR_SCOPE_PERMISSIONS",
+              "scope": "acme.sales"
             },
         }
     },
@@ -71,7 +79,7 @@ wantDecisionLogs:
                     "roles": ["employee"],
                     "scope": "acme.sales",
                   },
-                "actions": ["create", "delete", "nonaction"],
+                "actions": ["create", "delete", "nonaction", "acme_action"],
               },
             ],
           "outputs":
@@ -95,7 +103,14 @@ wantDecisionLogs:
                     "nonaction":
                       {
                         "effect": "EFFECT_DENY",
-                        "policy": "NO_MATCH"
+                        "policy": "NO_MATCH_FOR_SCOPE_PERMISSIONS",
+                        "scope": "acme.sales"
+                      },
+                    "acme_action":
+                      {
+                        "effect": "EFFECT_DENY",
+                        "policy": "NO_MATCH_FOR_SCOPE_PERMISSIONS",
+                        "scope": "acme.sales"
                       },
                   },
               },

--- a/internal/test/testdata/engine/case_26.yaml
+++ b/internal/test/testdata/engine/case_26.yaml
@@ -8,7 +8,7 @@ inputs:
       "actions": [
         "create", # exists, falls through, allow
         "delete", # exists, falls through, no match
-        "nonaction", # doesn't exist, falls through, no match
+        "nonaction", # doesn't exist, falls through, no match (even with matching rule in rule table)
         "acme_action" # doesn't exist, falls through, match (implicit DENY)
       ],
       "principal":

--- a/internal/test/testdata/server/plan_resources/plan_case_03.yaml
+++ b/internal/test/testdata/server/plan_resources/plan_case_03.yaml
@@ -34,4 +34,4 @@ planResources:
     filter:
       kind: KIND_ALWAYS_DENIED
     meta:
-      filterDebug: "(false)"
+      filterDebug: "NO_MATCH"

--- a/internal/test/testdata/server/plan_resources/plan_case_04.yaml
+++ b/internal/test/testdata/server/plan_resources/plan_case_04.yaml
@@ -31,4 +31,4 @@ planResources:
     filter:
       kind: KIND_ALWAYS_DENIED
     meta:
-      filterDebug: "(false)" 
+      filterDebug: "NO_MATCH" 

--- a/internal/test/testdata/server/playground/proxy/pgp_rqp_case_05.yaml
+++ b/internal/test/testdata/server/playground/proxy/pgp_rqp_case_05.yaml
@@ -68,7 +68,7 @@ playgroundProxy:
         "kind": "KIND_ALWAYS_DENIED"
       },
       "meta": {
-        "filterDebug": "(false)"
+        "filterDebug": "NO_MATCH"
       }
     }
   }

--- a/internal/test/testdata/store/principal_policies/policy_02_acme.yaml
+++ b/internal/test/testdata/store/principal_policies/policy_02_acme.yaml
@@ -31,3 +31,5 @@ principalPolicy:
       actions:
         - action: "create"
           effect: EFFECT_ALLOW
+        - action: "acme_action"
+          effect: EFFECT_ALLOW

--- a/internal/test/testdata/store/resource_policies/policy_17.yaml
+++ b/internal/test/testdata/store/resource_policies/policy_17.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  resource: calendar_entry
+  version: default
+  rules:
+    - actions:
+        - nonaction
+      effect: EFFECT_ALLOW
+      roles:
+        - employee

--- a/internal/util/globs.go
+++ b/internal/util/globs.go
@@ -139,6 +139,30 @@ func (gm *GlobMap[T]) GetWithLiteral(k string) (T, bool) {
 	return zero, false
 }
 
+func (gm *GlobMap[T]) DeleteLiteral(k string) {
+	if _, ok := gm.literals[k]; ok {
+		delete(gm.literals, k)
+	}
+
+	if _, ok := gm.globs[k]; ok {
+		delete(gm.globs, k)
+	}
+}
+
+func (gm *GlobMap[T]) GetAll() map[string]T {
+	res := make(map[string]T, gm.Len())
+
+	for k, v := range gm.literals {
+		res[k] = v
+	}
+
+	for k, v := range gm.globs {
+		res[k] = v
+	}
+
+	return res
+}
+
 func (gm *GlobMap[T]) GetMerged(k string) map[string]T {
 	merged := make(map[string]any)
 

--- a/internal/util/globs.go
+++ b/internal/util/globs.go
@@ -140,13 +140,8 @@ func (gm *GlobMap[T]) GetWithLiteral(k string) (T, bool) {
 }
 
 func (gm *GlobMap[T]) DeleteLiteral(k string) {
-	if _, ok := gm.literals[k]; ok {
-		delete(gm.literals, k)
-	}
-
-	if _, ok := gm.globs[k]; ok {
-		delete(gm.globs, k)
-	}
+	delete(gm.literals, k)
+	delete(gm.globs, k)
 }
 
 func (gm *GlobMap[T]) GetAll() map[string]T {

--- a/internal/verify/junit/junit_test.go
+++ b/internal/verify/junit/junit_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cerbos/cerbos/internal/audit"
 	"github.com/cerbos/cerbos/internal/compile"
 	"github.com/cerbos/cerbos/internal/engine"
+	"github.com/cerbos/cerbos/internal/engine/ruletable"
 	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage/disk"
 	"github.com/cerbos/cerbos/internal/test"
@@ -139,8 +140,11 @@ func mkEngine(t *testing.T) *engine.Engine {
 	schemaMgr, err := schema.New(ctx, store)
 	require.NoError(t, err)
 
+	mgr := compile.NewManagerFromDefaultConf(ctx, store, schemaMgr)
+
 	eng, err := engine.New(ctx, engine.Components{
-		PolicyLoader:      compile.NewManagerFromDefaultConf(ctx, store, schemaMgr),
+		PolicyLoader:      mgr,
+		RuleTable:         ruletable.NewRuleTable(mgr),
 		SchemaMgr:         schemaMgr,
 		AuditLog:          audit.NewNopLog(),
 		MetadataExtractor: audit.NewMetadataExtractorFromConf(&audit.Conf{}),

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cerbos/cerbos/internal/audit"
 	"github.com/cerbos/cerbos/internal/compile"
 	"github.com/cerbos/cerbos/internal/engine"
+	"github.com/cerbos/cerbos/internal/engine/ruletable"
 	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage/disk"
 	"github.com/cerbos/cerbos/internal/test"
@@ -380,8 +381,11 @@ func mkEngine(t *testing.T) *engine.Engine {
 	schemaMgr, err := schema.New(ctx, store)
 	require.NoError(t, err)
 
+	mgr := compile.NewManagerFromDefaultConf(ctx, store, schemaMgr)
+
 	eng, err := engine.New(ctx, engine.Components{
-		PolicyLoader:      compile.NewManagerFromDefaultConf(ctx, store, schemaMgr),
+		PolicyLoader:      mgr,
+		RuleTable:         ruletable.NewRuleTable(mgr),
 		SchemaMgr:         schemaMgr,
 		AuditLog:          audit.NewNopLog(),
 		MetadataExtractor: audit.NewMetadataExtractorFromConf(&audit.Conf{}),


### PR DESCRIPTION
Introduce a single rule table implementation which is empty on start and lazily loads required policies as they're queried. Enables this rule table for all store types.

Also solves some other issues:

* Makes query planner empty-case output consistent
* Fixes E2E tests
* Fixes principal policy `scopePermissions: *REQUIRES_PARENTAL_CONSENT` fall through behaviour