### PR TITLE
chore: Specify service when checking health via HTTP

### DIFF
--- a/cmd/cerbos/healthcheck/healthcheck.go
+++ b/cmd/cerbos/healthcheck/healthcheck.go
@@ -235,7 +235,7 @@ func newHTTPCheck(hostPort string, tlsConf *tls.Config) httpCheck {
 		protocol = "https"
 	}
 
-	url := fmt.Sprintf("%s://%s/_cerbos/health", protocol, hostPort)
+	url := fmt.Sprintf("%s://%s/_cerbos/health?service=%s", protocol, hostPort, svcv1.CerbosService_ServiceDesc.ServiceName)
 	return httpCheck{url: url, tlsConf: tlsConf}
 }
 

--- a/cmd/cerbos/healthcheck/healthcheck_test.go
+++ b/cmd/cerbos/healthcheck/healthcheck_test.go
@@ -70,7 +70,7 @@ func TestBuildFromServerConf(t *testing.T) {
 					Key:  keyPath,
 				},
 			},
-			wantAddr: "https://127.0.0.1:3592/_cerbos/health",
+			wantAddr: "https://127.0.0.1:3592/_cerbos/health?service=cerbos.svc.v1.CerbosService",
 		},
 		{
 			name: "http/tls/insecure",
@@ -83,7 +83,7 @@ func TestBuildFromServerConf(t *testing.T) {
 					Key:  keyPath,
 				},
 			},
-			wantAddr: "https://127.0.0.1:3592/_cerbos/health",
+			wantAddr: "https://127.0.0.1:3592/_cerbos/health?service=cerbos.svc.v1.CerbosService",
 		},
 		{
 			name: "http/no-tls",
@@ -92,7 +92,7 @@ func TestBuildFromServerConf(t *testing.T) {
 				HTTPListenAddr: ":3592",
 				GRPCListenAddr: ":3593",
 			},
-			wantAddr: "http://127.0.0.1:3592/_cerbos/health",
+			wantAddr: "http://127.0.0.1:3592/_cerbos/health?service=cerbos.svc.v1.CerbosService",
 		},
 		{
 			name: "http/specific-host",
@@ -101,7 +101,7 @@ func TestBuildFromServerConf(t *testing.T) {
 				HTTPListenAddr: "10.0.1.5:3592",
 				GRPCListenAddr: ":3593",
 			},
-			wantAddr: "http://10.0.1.5:3592/_cerbos/health",
+			wantAddr: "http://10.0.1.5:3592/_cerbos/health?service=cerbos.svc.v1.CerbosService",
 		},
 	}
 
@@ -168,18 +168,18 @@ func TestBuildManual(t *testing.T) {
 			name:     "http/tls/secure",
 			cmd:      &Cmd{Kind: "http"},
 			wantTLS:  true,
-			wantAddr: "https://127.0.0.1:3592/_cerbos/health",
+			wantAddr: "https://127.0.0.1:3592/_cerbos/health?service=cerbos.svc.v1.CerbosService",
 		},
 		{
 			name:     "http/tls/insecure",
 			cmd:      &Cmd{Kind: "http", Insecure: true, HostPort: "10.0.1.5:3592"},
 			wantTLS:  true,
-			wantAddr: "https://10.0.1.5:3592/_cerbos/health",
+			wantAddr: "https://10.0.1.5:3592/_cerbos/health?service=cerbos.svc.v1.CerbosService",
 		},
 		{
 			name:     "http/no-tls",
 			cmd:      &Cmd{Kind: "http", NoTLS: true},
-			wantAddr: "http://127.0.0.1:3592/_cerbos/health",
+			wantAddr: "http://127.0.0.1:3592/_cerbos/health?service=cerbos.svc.v1.CerbosService",
 		},
 	}
 


### PR DESCRIPTION
I noticed that the `cerbos healthcheck` command specifies `cerbos.svc.v1.CerbosService` when checking health via gRPC but not via HTTP. I'm not sure it really matters, but this PR makes it consistent.