### PR TITLE
chore: Temporarily disable fail-on-error behaviour for Coveralls unit test coverable uploads in GitHub workflow

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -158,6 +158,7 @@ jobs:
           path-to-profile: unit.cover
           flag-name: unit-${{ strategy.job-index }}
           parallel: true
+          fail-on-error: false # TODO remove temp bypass
 
       - name: Upload integration coverage to Coveralls
         uses: shogo82148/actions-goveralls@v1

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -61,6 +61,7 @@ jobs:
         with:
           path-to-profile: unit.cover
           flag-name: unit-main
+          fail-on-error: false # TODO remove temp bypass
 
       - name: Upload integration coverage to Coveralls
         uses: shogo82148/actions-goveralls@v1


### PR DESCRIPTION
At time of writing, an [outage at Coveralls](https://status.coveralls.io/incidents/0nz347snpb16) has been ongoing for 19 hours. This impacts our `pr-test` and `snapshop` workflows. Disabling will enable us to continue to merge PRs--we can reenable once the incident is resolved.

We'll (ironically) need to bypass PR protection rules to merge this PR.