### PR TITLE
chore: Revert Coveralls GitHub workflow bypass

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -158,7 +158,6 @@ jobs:
           path-to-profile: unit.cover
           flag-name: unit-${{ strategy.job-index }}
           parallel: true
-          fail-on-error: false # TODO remove temp bypass
 
       - name: Upload integration coverage to Coveralls
         uses: shogo82148/actions-goveralls@v1

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -61,7 +61,6 @@ jobs:
         with:
           path-to-profile: unit.cover
           flag-name: unit-main
-          fail-on-error: false # TODO remove temp bypass
 
       - name: Upload integration coverage to Coveralls
         uses: shogo82148/actions-goveralls@v1

--- a/internal/engine/planner/ast.go
+++ b/internal/engine/planner/ast.go
@@ -415,7 +415,7 @@ func buildExprImpl(cur *exprpb.Expr, acc *enginev1.PlanResourcesFilter_Expressio
 		if ok { // only values in list, so acc.Node is a list of values
 			listValue := structpb.ListValue{Values: make([]*structpb.Value, len(x.Elements))}
 			for i, e := range x.Elements {
-				value, err := visitConst(e.ExprKind.(*exprpb.Expr_ConstExpr).ConstExpr)
+				value, err := visitConst(e.ExprKind.(*exprpb.Expr_ConstExpr).ConstExpr) //nolint:forcetypeassert
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This reverts commit 5926145fda94a97fdeb4684af4a983207147a946.

The issue was [supposedly resolved 15 hours ago](https://status.coveralls.io/incidents/0nz347snpb16), so we should be safe to re-enable Coveralls.