### PR TITLE
chore: Initialise protovalidate lazily

### DIFF
--- a/internal/policy/io.go
+++ b/internal/policy/io.go
@@ -48,7 +48,7 @@ func ReadPolicyWithSourceContext(fsys fs.FS, path string) (*policyv1.Policy, par
 }
 
 func ReadPolicyWithSourceContextFromReader(src io.Reader) (*policyv1.Policy, parser.SourceCtx, error) {
-	policies, contexts, err := parser.Unmarshal(src, func() *policyv1.Policy { return &policyv1.Policy{} }, parser.WithValidator(validator.Validator))
+	policies, contexts, err := parser.Unmarshal(src, func() *policyv1.Policy { return &policyv1.Policy{} }, parser.WithValidator(validator.Validator()))
 	switch len(policies) {
 	case 0:
 		return nil, parser.SourceCtx{}, err

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -446,14 +446,14 @@ func (s *Server) mkGRPCServer(log *zap.Logger, auditLog audit.Log) (*grpc.Server
 		grpc.ChainStreamInterceptor(
 			grpc_recovery.StreamServerInterceptor(),
 			telemetryInt.StreamServerInterceptor(),
-			grpc_validator.StreamServerInterceptor(validator.Validator),
+			grpc_validator.StreamServerInterceptor(validator.Validator()),
 			grpc_logging.StreamServerInterceptor(RequestLogger(log, "Handled request")),
 			grpc_logging.StreamServerInterceptor(PayloadLogger(s.conf), grpc_logging.WithLogOnEvents(grpc_logging.PayloadReceived, grpc_logging.PayloadSent)),
 		),
 		grpc.ChainUnaryInterceptor(
 			grpc_recovery.UnaryServerInterceptor(),
 			telemetryInt.UnaryServerInterceptor(),
-			grpc_validator.UnaryServerInterceptor(validator.Validator),
+			grpc_validator.UnaryServerInterceptor(validator.Validator()),
 			RequestMetadataUnaryServerInterceptor,
 			auditInterceptor,
 			grpc_logging.UnaryServerInterceptor(RequestLogger(log, "Handled request")),

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -4,6 +4,8 @@
 package validator
 
 import (
+	"sync"
+
 	"github.com/bufbuild/protovalidate-go"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -12,20 +14,20 @@ import (
 	requestv1 "github.com/cerbos/cerbos/api/genpb/cerbos/request/v1"
 )
 
-var Validator protovalidate.Validator
-
-func init() {
-	var err error
-	if Validator, err = protovalidate.New(
+var Validator = sync.OnceValue(func() protovalidate.Validator {
+	validator, err := protovalidate.New(
 		protovalidate.WithMessages(
 			&policyv1.Policy{},
 			&requestv1.CheckResourcesRequest{},
 			&requestv1.PlanResourcesRequest{}),
-	); err != nil {
+	)
+	if err != nil {
 		zap.L().Fatal(err.Error())
 	}
-}
+
+	return validator
+})
 
 func Validate(msg proto.Message) error {
-	return Validator.Validate(msg)
+	return Validator().Validate(msg)
 }


### PR DESCRIPTION
Eager initialisation results in unnecessary memory usage even when the
validator is not used.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
