### PR TITLE
chore!: REQUIRE_PARENTAL_CONSENT refinements for resource and principal policies

### DIFF
--- a/internal/engine/evaluator.go
+++ b/internal/engine/evaluator.go
@@ -472,6 +472,11 @@ func (ppe *principalPolicyEvaluator) Evaluate(ctx context.Context, tctx tracer.C
 										result.Outputs = append(result.Outputs, output)
 										octx.ComputedOutput(output)
 									}
+
+									if p.ScopePermissions == policyv1.ScopePermissions_SCOPE_PERMISSIONS_REQUIRE_PARENTAL_CONSENT_FOR_ALLOWS && rule.Effect == effectv1.Effect_EFFECT_ALLOW {
+										result.setEffect(action, EffectInfo{Effect: effectv1.Effect_EFFECT_DENY, Policy: policyKey, Scope: p.Scope})
+									}
+
 									continue
 								}
 

--- a/internal/engine/evaluator.go
+++ b/internal/engine/evaluator.go
@@ -470,11 +470,8 @@ func (ppe *principalPolicyEvaluator) Evaluate(ctx context.Context, tctx tracer.C
 								}
 
 								if p.ScopePermissions == policyv1.ScopePermissions_SCOPE_PERMISSIONS_REQUIRE_PARENTAL_CONSENT_FOR_ALLOWS && rule.Effect == effectv1.Effect_EFFECT_ALLOW {
-									implicitlyAllowedActions[action] = struct{}{}
 									continue
 								}
-
-								delete(implicitlyAllowedActions, action)
 
 								result.setEffect(action, EffectInfo{Effect: rule.Effect, Policy: policyKey, Scope: p.Scope})
 								actx.AppliedEffect(rule.Effect, "")
@@ -503,19 +500,6 @@ func (ppe *principalPolicyEvaluator) Evaluate(ctx context.Context, tctx tracer.C
 						}
 					}
 				})
-
-				if p.ScopePermissions == policyv1.ScopePermissions_SCOPE_PERMISSIONS_REQUIRE_PARENTAL_CONSENT_FOR_ALLOWS {
-					for _, a := range result.unresolvedActions() {
-						if _, ok := implicitlyAllowedActions[a]; !ok {
-							result.setEffect(a, EffectInfo{
-								Effect: effectv1.Effect_EFFECT_DENY,
-								Policy: noMatchScopePermissions,
-								Scope:  p.Scope,
-							})
-							delete(implicitlyAllowedActions, a)
-						}
-					}
-				}
 
 				return nil
 			})

--- a/internal/test/testdata/engine/case_25.yaml
+++ b/internal/test/testdata/engine/case_25.yaml
@@ -14,6 +14,7 @@ inputs:
         "defer", # ALLOW in resource policy for a role that `acme_creator` recursively narrows. However, because the named role is
                  # defined in a role policy, it narrows the permissions of `employee` rather than assuming them, even if they share
                  # the same scope. If the principal explicitly had the role `employee`, this would be allowed. 
+        "party_plan", # Rule with non-matching condition in target scope which implicitly DENYs (even with ALLOW in parent scope)
         ],
       "principal":
         {
@@ -21,6 +22,7 @@ inputs:
           "roles": [
             "acme_creator", # narrows `acme_jr_admin`, which itself narrows `employee`
             "boss",
+            "organiser",
           ],
           "attr":
             {
@@ -89,6 +91,11 @@ wantOutputs:
               "policy": "NO_MATCH_FOR_SCOPE_PERMISSIONS",
               "scope": "acme.hr.uk.brighton"
             },
+          "party_plan":
+            {
+              "effect": "EFFECT_DENY",
+              "policy": "resource.leave_request.vdefault/acme.hr.uk.brighton",
+            },
         },
       "effectiveDerivedRoles":
         ["any_employee", "employee_that_owns_the_record"],
@@ -122,17 +129,16 @@ wantDecisionLogs:
                 "principal":
                   {
                     "id": "john",
-                    # "roles": ["employee", "acme_creator", "boss"],
-                    "roles": ["acme_creator", "boss"],
+                    "roles": ["acme_creator", "boss", "organiser"],
                     "attr":
                       {
                         "department": "marketing",
                         "geography": "GB",
-                        "ip_address": "10.20.0.13",
                         "team": "design",
+                        "ip_address": "10.20.0.13",
                       },
                   },
-                "actions": ["create", "delete", "view:public", "deny", "block", "defer"],
+                "actions": ["create", "delete", "view:public", "deny", "block", "defer", "party_plan"],
               },
             ],
           "outputs":
@@ -177,6 +183,11 @@ wantDecisionLogs:
                         "effect": "EFFECT_DENY",
                         "policy": "NO_MATCH_FOR_SCOPE_PERMISSIONS",
                         "scope": "acme.hr.uk.brighton"
+                      },
+                    "party_plan":
+                      {
+                        "effect": "EFFECT_DENY",
+                        "policy": "resource.leave_request.vdefault/acme.hr.uk.brighton",
                       },
                   },
                 "effectiveDerivedRoles":

--- a/internal/test/testdata/engine/case_26.yaml
+++ b/internal/test/testdata/engine/case_26.yaml
@@ -6,10 +6,11 @@ inputs:
     {
       "requestId": "test",
       "actions": [
-        "create", # exists, falls through, allow
-        "delete", # exists, falls through, no match
-        "nonaction", # doesn't exist, falls through, no match (even with matching rule in rule table)
-        "acme_action" # doesn't exist, falls through, match (implicit DENY)
+        "create", # ALLOW in target scope, ALLOW in parent
+        "delete", # ALLOW in target scope, no match is parent principal scopes or resource scopes
+        "plan", # ALLOW in target scope, no match in parent principal scopes, match in resource policy scope
+        "nonaction", # no match in target scope, no match in principal policies, match in resource policy scope
+        "acme_action" # no match in target scope, match in principal policies
       ],
       "principal":
         {
@@ -40,19 +41,23 @@ wantOutputs:
           "delete":
             {
               "effect": "EFFECT_DENY",
-              "policy": "NO_MATCH"
+              "policy": "resource.calendar_entry.vdefault"
+            },
+          "plan":
+            {
+              "effect": "EFFECT_ALLOW",
+              "policy": "resource.calendar_entry.vdefault",
             },
           "nonaction":
             {
-              "effect": "EFFECT_DENY",
-              "policy": "NO_MATCH_FOR_SCOPE_PERMISSIONS",
-              "scope": "acme.sales"
+              "effect": "EFFECT_ALLOW",
+              "policy": "resource.calendar_entry.vdefault",
             },
           "acme_action":
             {
-              "effect": "EFFECT_DENY",
-              "policy": "NO_MATCH_FOR_SCOPE_PERMISSIONS",
-              "scope": "acme.sales"
+              "effect": "EFFECT_ALLOW",
+              "policy": "principal.donald_duck.vdefault/acme.sales",
+              "scope": "acme"
             },
         }
     },
@@ -79,7 +84,7 @@ wantDecisionLogs:
                     "roles": ["employee"],
                     "scope": "acme.sales",
                   },
-                "actions": ["create", "delete", "nonaction", "acme_action"],
+                "actions": ["create", "delete", "plan", "nonaction", "acme_action"],
               },
             ],
           "outputs":
@@ -98,19 +103,23 @@ wantDecisionLogs:
                     "delete":
                       {
                         "effect": "EFFECT_DENY",
-                        "policy": "NO_MATCH",
+                        "policy": "resource.calendar_entry.vdefault"
+                      },
+                    "plan":
+                      {
+                        "effect": "EFFECT_ALLOW",
+                        "policy": "resource.calendar_entry.vdefault",
                       },
                     "nonaction":
                       {
-                        "effect": "EFFECT_DENY",
-                        "policy": "NO_MATCH_FOR_SCOPE_PERMISSIONS",
-                        "scope": "acme.sales"
+                        "effect": "EFFECT_ALLOW",
+                        "policy": "resource.calendar_entry.vdefault",
                       },
                     "acme_action":
                       {
-                        "effect": "EFFECT_DENY",
-                        "policy": "NO_MATCH_FOR_SCOPE_PERMISSIONS",
-                        "scope": "acme.sales"
+                        "effect": "EFFECT_ALLOW",
+                        "policy": "principal.donald_duck.vdefault/acme.sales",
+                        "scope": "acme"
                       },
                   },
               },
@@ -142,6 +151,14 @@ wantDecisionLogs:
                     {
                       "driver": "disk",
                       "source": "principal_policies/policy_02_acme.sales.yaml",
+                    },
+                },
+              "resource.calendar_entry.vdefault":
+                {
+                  "attributes":
+                    {
+                      "driver": "disk",
+                      "source": "resource_policies/policy_17.yaml",
                     },
                 },
             },

--- a/internal/test/testdata/engine/case_26.yaml
+++ b/internal/test/testdata/engine/case_26.yaml
@@ -10,7 +10,8 @@ inputs:
         "delete", # ALLOW in target scope, no match is parent principal scopes or resource scopes
         "plan", # ALLOW in target scope, no match in parent principal scopes, match in resource policy scope
         "nonaction", # no match in target scope, no match in principal policies, match in resource policy scope
-        "acme_action" # no match in target scope, match in principal policies
+        "acme_action", # no match in target scope, match in principal policies
+        "duplicate"  # Matching rule but condition not satisfied in target scope, ALLOW in parent, still DENY
       ],
       "principal":
         {
@@ -59,6 +60,12 @@ wantOutputs:
               "policy": "principal.donald_duck.vdefault/acme.sales",
               "scope": "acme"
             },
+          "duplicate":
+            {
+              "effect": "EFFECT_DENY",
+              "policy": "principal.donald_duck.vdefault/acme.sales",
+              "scope": "acme.sales"
+            },
         }
     },
   ]
@@ -84,7 +91,7 @@ wantDecisionLogs:
                     "roles": ["employee"],
                     "scope": "acme.sales",
                   },
-                "actions": ["create", "delete", "plan", "nonaction", "acme_action"],
+                "actions": ["create", "delete", "plan", "nonaction", "acme_action", "duplicate"],
               },
             ],
           "outputs":
@@ -120,6 +127,12 @@ wantDecisionLogs:
                         "effect": "EFFECT_ALLOW",
                         "policy": "principal.donald_duck.vdefault/acme.sales",
                         "scope": "acme"
+                      },
+                    "duplicate":
+                      {
+                        "effect": "EFFECT_DENY",
+                        "policy": "principal.donald_duck.vdefault/acme.sales",
+                        "scope": "acme.sales"
                       },
                   },
               },

--- a/internal/test/testdata/engine/case_28.yaml
+++ b/internal/test/testdata/engine/case_28.yaml
@@ -38,7 +38,6 @@ wantOutputs:
             {
               "effect": "EFFECT_DENY",
               "policy": "resource.leave_request.vdefault/acme.hr.uk.london",
-              "scope": "acme.hr.uk.london",
             },
           "view":
             {
@@ -97,7 +96,6 @@ wantDecisionLogs:
                       {
                         "effect": "EFFECT_DENY",
                         "policy": "resource.leave_request.vdefault/acme.hr.uk.london",
-                        "scope": "acme.hr.uk.london",
                       },
                     "view":
                       {

--- a/internal/test/testdata/query_planner/suite/basics_scoped.yaml
+++ b/internal/test/testdata/query_planner/suite/basics_scoped.yaml
@@ -50,12 +50,12 @@ tests:
                   operator: eq
                   operands:
                     - variable: request.resource.attr.status
-                    - value: PENDING_STATUS 
+                    - value: PENDING_STATUS
               - expression:
                   operator: eq
                   operands:
                     - variable: request.resource.attr.status
-                    - value: APPROVED 
+                    - value: APPROVED
     - action: debug
       resource:
         kind: x

--- a/internal/test/testdata/store/principal_policies/policy_02_acme.sales.yaml
+++ b/internal/test/testdata/store/principal_policies/policy_02_acme.sales.yaml
@@ -17,3 +17,9 @@ principalPolicy:
 
       - action: "plan"
         effect: EFFECT_ALLOW
+
+      - action: "duplicate"
+        effect: EFFECT_ALLOW
+        condition:
+          match:
+            expr: P.attr.copy_cat == true

--- a/internal/test/testdata/store/principal_policies/policy_02_acme.sales.yaml
+++ b/internal/test/testdata/store/principal_policies/policy_02_acme.sales.yaml
@@ -14,3 +14,6 @@ principalPolicy:
 
       - action: "delete"
         effect: EFFECT_ALLOW
+
+      - action: "plan"
+        effect: EFFECT_ALLOW

--- a/internal/test/testdata/store/principal_policies/policy_02_acme.yaml
+++ b/internal/test/testdata/store/principal_policies/policy_02_acme.yaml
@@ -33,3 +33,5 @@ principalPolicy:
           effect: EFFECT_ALLOW
         - action: "acme_action"
           effect: EFFECT_ALLOW
+        - action: "duplicate"
+          effect: EFFECT_ALLOW

--- a/internal/test/testdata/store/resource_policies/policy_05_acme.hr.uk.brighton.yaml
+++ b/internal/test/testdata/store/resource_policies/policy_05_acme.hr.uk.brighton.yaml
@@ -12,3 +12,11 @@ resourcePolicy:
         - defer
         - invite
       effect: EFFECT_ALLOW
+
+    - roles: ["organiser"]
+      actions:
+        - party_plan
+      effect: EFFECT_ALLOW
+      condition:
+        match:
+          expr: P.attr.in_party_committee == true

--- a/internal/test/testdata/store/resource_policies/policy_05_acme.hr.uk.yaml
+++ b/internal/test/testdata/store/resource_policies/policy_05_acme.hr.uk.yaml
@@ -32,3 +32,8 @@ resourcePolicy:
       effect: EFFECT_ALLOW
       roles:
         - boss
+
+    - actions: ["party_plan"]
+      effect: EFFECT_ALLOW
+      roles:
+        - organiser

--- a/internal/test/testdata/store/resource_policies/policy_17.yaml
+++ b/internal/test/testdata/store/resource_policies/policy_17.yaml
@@ -6,6 +6,7 @@ resourcePolicy:
   rules:
     - actions:
         - nonaction
+        - plan
       effect: EFFECT_ALLOW
       roles:
         - employee


### PR DESCRIPTION
This PR encompasses two notable changes.

#### Principal policies are now consistent with resource policies:

Principal policies with `scopePermissions: REQUIRE_PARENTAL_CONSENT` are now consistent with resource policy behaviour:
- If a rule is not matched for a given resource and action, it now falls through to parent scopes instead of instantly (implicitly) issuing a `DENY`.
- If a rule matches but the condition is not satisfied, the action is issued a `DENY`.

Unresolved resource/action pairs from a `REQUIRE_PARENTAL_CONSENT` principal policy scope can also fall through to the resource policy evaluator.

#### Conditional resource policy rules with `REQUIRE_PARENTAL_CONSENT` now implicitly narrow permissions:

Rules defined within resource policies with `scopePermissions: REQUIRE_PARENTAL_CONSENT` now implicitly DENY actions for matching roles if a condition is defined and not satisfied. This differs from default `scopePermissions: OVERRIDE_PARENT` behaviour, which will not evaluate the rule if the condition is not satisfied.

For the query planner, it was necessary to UN-inverse `REQUIRE_PARENTAL_CONSENT` conditional resource policy rules (back to the original conditional `ALLOW` rules) so that they could be logically `AND`ed with the parent rules.