### PR TITLE
chore: Replace `golang.org/x/exp/maps` with stdlib `maps`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,6 @@ require (
 	go.uber.org/zap v1.27.0
 	gocloud.dev v0.40.0
 	golang.org/x/crypto v0.35.0
-	golang.org/x/exp v0.0.0-20250228200357-dead58393ab7
 	golang.org/x/net v0.35.0
 	golang.org/x/sync v0.11.0
 	golang.org/x/tools v0.30.0
@@ -276,6 +275,7 @@ require (
 	go.opentelemetry.io/contrib/propagators/ot v1.34.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20250228200357-dead58393ab7 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.23.0 // indirect
 	golang.org/x/oauth2 v0.26.0 // indirect

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math/rand"
 	"net/http"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	auditv1 "github.com/cerbos/cerbos/api/genpb/cerbos/audit/v1"

--- a/internal/engine/evaluator.go
+++ b/internal/engine/evaluator.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"sort"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/multierr"
-	"golang.org/x/exp/maps"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	"google.golang.org/protobuf/types/known/structpb"
 

--- a/internal/storage/util.go
+++ b/internal/storage/util.go
@@ -11,13 +11,6 @@ import (
 
 const MaxPoliciesInBatch = 25
 
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func BatchLoadPolicy(
 	ctx context.Context,
 	maxPoliciesInBatch int,
@@ -27,7 +20,7 @@ func BatchLoadPolicy(
 ) error {
 	for idx := range ids {
 		if idx%maxPoliciesInBatch == 0 {
-			idxEnd := minInt(idx+maxPoliciesInBatch, len(ids))
+			idxEnd := min(idx+maxPoliciesInBatch, len(ids))
 			var err error
 			policies, err := loadPolicyFn(ctx, ids[idx:idxEnd]...)
 			if err != nil {


### PR DESCRIPTION
#### Description

<!-- Thank you for contributing Cerbos! Please describe the changes made in this PR here and provide any other useful information for reviewers. Make sure that you included some automated tests (e.g unit tests) to verify your changes.  If there is a requirement for user input for testing, please include the instructions as well. -->

The experimental functions in `golang.org/x/exp/maps` are now available in the standard library in Go 1.21.

Reference: https://go.dev/doc/go1.21#maps

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
