### PR TITLE
enhancement: Stop logging attribute values as JSON-encoded strings in decision logs

### DIFF
--- a/internal/audit/file/log.go
+++ b/internal/audit/file/log.go
@@ -4,8 +4,8 @@
 package file
 
 import (
-	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -175,8 +175,8 @@ func encodeSingular(enc zapcore.ObjectEncoder, fieldName string, fd protoreflect
 		// output readbale timestamps and values
 		switch msg.Descriptor().FullName() {
 		case "google.protobuf.Timestamp", "google.protobuf.Value":
-			if tsVal, err := protojson.Marshal(msg.Interface()); err == nil {
-				enc.AddByteString(fieldName, bytes.Trim(tsVal, `"`))
+			if val, err := protojson.Marshal(msg.Interface()); err == nil {
+				_ = enc.AddReflected(fieldName, json.RawMessage(val))
 				return
 			}
 		default:


### PR DESCRIPTION
Currently the file audit log backend prints arrays and objects within resource or principal attributes as JSON-encoded strings, e.g.

```json
"attr":{"claims":"[\"foo\",\"bar\"]"}
```

This PR changes the encoder to produce the expected nested JSON structures, e.g.

```json
"attr":{"claims":["foo","bar"]}
```