### PR TITLE
fix: Purge schema cache on store reload

### DIFF
--- a/hack/dev/plan.hurl
+++ b/hack/dev/plan.hurl
@@ -54,7 +54,7 @@ jsonpath "$.action" == "view"
 jsonpath "$.resourceKind" == "album:object"
 jsonpath "$.policyVersion" == "nonexistent"
 jsonpath "$.filter.kind" == "KIND_ALWAYS_DENIED"
-jsonpath "$.meta.filterDebug" == "(false)"
+jsonpath "$.meta.filterDebug" == "NO_MATCH"
 jsonpath "$.cerbosCallId" exists
 
 

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -269,6 +269,9 @@ func (m *manager) OnStorageEvent(events ...storage.Event) {
 			cacheKey := fmt.Sprintf("%s:///%s", URLScheme, event.SchemaFile)
 			_ = m.cache.Remove(cacheKey)
 			m.log.Warn("Handled schema delete event", zap.String("schema", cacheKey))
+		case storage.EventReload:
+			m.cache.Purge()
+			m.log.Debug("Handled store reload event")
 		}
 	}
 }


### PR DESCRIPTION
The schema manager should handle store reload events by purging its
cache.

Fixes #2519

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
