### PR TITLE
chore: Handle empty policies in the parser

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -127,15 +127,11 @@ func UnmarshalBytes[T proto.Message](contents []byte, factory func() T, opts ...
 	}
 
 	if len(f.Docs) == 0 {
-		if contentLen > 0 {
-			// Special case for unterminated strings. See test case 20.
-			return nil, nil, NewUnmarshalError(&sourcev1.Error{
-				Kind:     sourcev1.Error_KIND_PARSE_ERROR,
-				Message:  "invalid document: contents are not valid YAML or JSON",
-				Position: &sourcev1.Position{Line: 1, Column: 1, Path: "$"},
-			})
-		}
-		return nil, nil, nil
+		return nil, nil, NewUnmarshalError(&sourcev1.Error{
+			Kind:     sourcev1.Error_KIND_PARSE_ERROR,
+			Message:  "invalid document: contents are not valid YAML or JSON",
+			Position: &sourcev1.Position{Line: 1, Column: 1, Path: "$"},
+		})
 	}
 
 	u := &unmarshaler[T]{unmarshalOpts: unmarshalOpts{}}

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -12,6 +12,8 @@ import (
 	"github.com/cerbos/cerbos/internal/parser"
 )
 
+var errEmptyPolicy = errors.New("policy is empty")
+
 type ValidationError struct {
 	Err *sourcev1.Error
 }
@@ -30,7 +32,11 @@ func (ve ValidationError) Error() string {
 }
 
 func Validate(p *policyv1.Policy, sc parser.SourceCtx) error {
-	switch pt := p.PolicyType.(type) {
+	if p == nil {
+		return errEmptyPolicy
+	}
+
+	switch pt := p.GetPolicyType().(type) {
 	case *policyv1.Policy_ResourcePolicy:
 		return validateResourcePolicy(pt.ResourcePolicy, sc)
 	case *policyv1.Policy_PrincipalPolicy:


### PR DESCRIPTION
Return an error instead of nil when a file is empty.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
