### PR TITLE
chore: Add Hub overrides to cerbos server launch

### DIFF
--- a/cmd/cerbos/server/server.go
+++ b/cmd/cerbos/server/server.go
@@ -44,8 +44,14 @@ type Cmd struct {
 	DebugListenAddr string       `help:"Address to start the gops listener" placeholder:":6666"`
 	LogLevel        LogLevelFlag `help:"Log level (${enum})" default:"info" enum:"debug,info,warn,error"`
 	Config          string       `help:"Path to config file" optional:"" placeholder:".cerbos.yaml" env:"CERBOS_CONFIG"`
-	HubBundle       string       `help:"Use Cerbos Hub to pull the policy bundle with the given label. Overrides the store defined in the configuration." optional:"" env:"CERBOS_HUB_BUNDLE,CERBOS_CLOUD_BUNDLE"`
+	HubBundle       string       `help:"[Legacy] Use Cerbos Hub to pull the policy bundle with the given label. Overrides the store defined in the configuration." optional:"" env:"CERBOS_HUB_BUNDLE,CERBOS_CLOUD_BUNDLE" group:"hubv1" xor:"hub.deployment-id,hub.playground-id"`
+	Hub             hubFlags     `embed:"" prefix:"hub."`
 	Set             []string     `help:"Config overrides" placeholder:"server.adminAPI.enabled=true"`
+}
+
+type hubFlags struct {
+	DeploymentID string `help:"Use Cerbos Hub to pull the policy bundle for the given deployment ID. Overrides the store defined in the configuration." optional:"" env:"CERBOS_HUB_DEPLOYMENT_ID" group:"hubv2" xor:"hub-bundle,hub.playground-id"`
+	PlaygroundID string `help:"Use Cerbos Hub to pull the policy bundle for the given playground ID. Overrides the store defined in the configuration." optional:"" env:"CERBOS_HUB_PLAYGROUND_ID" group:"hubv2" xor:"hub-bundle,hub.deployment-id"`
 }
 
 func (c *Cmd) Run() error {
@@ -59,14 +65,29 @@ func (c *Cmd) Run() error {
 		}
 	}
 
-	if c.HubBundle != "" {
-		for _, override := range []string{
+	var hubOverrides []string
+	switch {
+	case c.Hub.DeploymentID != "":
+		hubOverrides = []string{
+			"storage.driver=hub",
+			"storage.hub.bundleVersion=2",
+			fmt.Sprintf("storage.hub.remote.deploymentID=%s", c.Hub.DeploymentID),
+		}
+	case c.Hub.PlaygroundID != "":
+		hubOverrides = []string{
+			"storage.driver=hub",
+			"storage.hub.bundleVersion=2",
+			fmt.Sprintf("storage.hub.remote.playgroundID=%s", c.Hub.PlaygroundID),
+		}
+	case c.HubBundle != "":
+		hubOverrides = []string{
 			"storage.driver=hub",
 			fmt.Sprintf("storage.hub.remote.bundleLabel=%s", c.HubBundle),
-		} {
-			if err := strvals.ParseInto(override, confOverrides); err != nil {
-				return fmt.Errorf("failed to parse Cerbos Hub override [%s]: %w", override, err)
-			}
+		}
+	}
+	for _, hubOverride := range hubOverrides {
+		if err := strvals.ParseInto(hubOverride, confOverrides); err != nil {
+			return fmt.Errorf("failed to parse Cerbos Hub override [%s]: %w", hubOverride, err)
 		}
 	}
 

--- a/internal/storage/hub/remote_source.go
+++ b/internal/storage/hub/remote_source.go
@@ -172,7 +172,7 @@ func NewRemoteSourceWithHub(conf *Conf, hub ClientProvider) (*RemoteSource, erro
 		conf:      conf,
 		hub:       hub,
 		healthy:   false,
-		log:       zap.L().Named(DriverName).With(zap.String("label", conf.Remote.BundleLabel)),
+		log:       zap.L().Named(DriverName),
 		scratchFS: afero.NewBasePathFs(afero.NewOsFs(), conf.Remote.TempDir),
 	}, nil
 }
@@ -195,6 +195,8 @@ func (s *RemoteSource) Init(ctx context.Context) error {
 			bundleLabel: s.conf.Remote.BundleLabel,
 			playground:  playgroundLabelPattern.MatchString(s.conf.Remote.BundleLabel),
 		}
+		s.log = s.log.With(zap.String("label", s.conf.Remote.BundleLabel))
+
 	case bundleapi.Version2:
 		clientv2, err := s.hub.V2(clientConf)
 		if err != nil {
@@ -212,6 +214,7 @@ func (s *RemoteSource) Init(ctx context.Context) error {
 		}
 
 		s.client = &cloudAPIv2{client: clientv2, source: source}
+		s.log = s.log.With(zap.Stringer("source", source))
 	default:
 		return fmt.Errorf("unsupported bundle version: %d", s.conf.BundleVersion)
 	}


### PR DESCRIPTION
Adds support for launching Cerbos with a deployment or playground from Hub.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
