### PR TITLE
fix: Maintain derived role mappings during policy updates

### DIFF
--- a/internal/engine/ruletable/rule_table.go
+++ b/internal/engine/ruletable/rule_table.go
@@ -973,7 +973,8 @@ func (rt *RuleTable) processPolicyEvent(ev storage.Event) {
 	// independently.
 	var modIDs []namer.ModuleID
 	if resourceModIDs, ok := rt.derivedRolePolicies[ev.PolicyID]; ok {
-		modIDs = make([]namer.ModuleID, 0, len(resourceModIDs))
+		modIDs = make([]namer.ModuleID, 1, len(resourceModIDs)+1)
+		modIDs[0] = ev.PolicyID
 		for id := range resourceModIDs {
 			modIDs = append(modIDs, id)
 		}
@@ -983,7 +984,8 @@ func (rt *RuleTable) processPolicyEvent(ev storage.Event) {
 	if ev.OldPolicyID != nil {
 		var oldModIDs []namer.ModuleID
 		if resourceModIDs, ok := rt.derivedRolePolicies[*ev.OldPolicyID]; ok {
-			oldModIDs = make([]namer.ModuleID, 0, len(resourceModIDs))
+			oldModIDs = make([]namer.ModuleID, 1, len(resourceModIDs)+1)
+			oldModIDs[0] = *ev.OldPolicyID
 			for id := range resourceModIDs {
 				oldModIDs = append(oldModIDs, id)
 			}

--- a/internal/engine/ruletable/rule_table.go
+++ b/internal/engine/ruletable/rule_table.go
@@ -1005,7 +1005,7 @@ func (rt *RuleTable) processPolicyEvent(ev storage.Event) {
 			// an immediate ADD/UPDATE. We need the `derivedRolePolicies` record to hang around after the
 			// DELETE otherwise we have no reference to the dependent resource policies that are needed, to
 			// invalidate the query register on the subsequent event.
-			// Symantically, this is correct--the only time we need to worry about purging the derivedRolePolicies
+			// Semantically, this is correct--the only time we need to worry about purging the derivedRolePolicies
 			// cache is when we're guaranteed to set it again. We invalidate here in the knowledge that future
 			// lazy-loads will correctly set the derivedRolePolicies again.
 			delete(rt.derivedRolePolicies, modID)


### PR DESCRIPTION
Preserves derived role policy mappings until explicitly invalidated to ensure proper handling of dependent resource policies during policy updates. This is especially important for certain stores that send DELETE followed by ADD/UPDATE events.