### PR TITLE
fix: Purge rule table on index build failure

### DIFF
--- a/internal/compile/manager.go
+++ b/internal/compile/manager.go
@@ -156,6 +156,7 @@ func (c *Manager) recompile(evt storage.Event) error {
 			// log and remove the module that failed to compile.
 			c.log.Errorw("Failed to recompile", "id", modID, "error", err)
 			c.evict(modID)
+			// triggered by mutable stores
 			c.NotifySubscribers(storage.Event{Kind: storage.EventDisableRuleTable})
 		}
 	}

--- a/internal/compile/manager.go
+++ b/internal/compile/manager.go
@@ -94,10 +94,12 @@ func (c *Manager) processUpdateQueue(ctx context.Context) {
 				c.cache.Purge()
 				c.NotifySubscribers(evt)
 			case storage.EventDisableRuleTable:
+				// passed through from blob store
 				c.NotifySubscribers(evt)
 			case storage.EventAddOrUpdatePolicy, storage.EventDeleteOrDisablePolicy:
 				if err := c.recompile(evt); err != nil {
 					c.log.Warnw("Error while processing storage event", "event", evt, "error", err)
+					// triggered by disk/git store build failures
 					c.NotifySubscribers(storage.Event{Kind: storage.EventDisableRuleTable})
 				}
 			default:

--- a/internal/compile/manager.go
+++ b/internal/compile/manager.go
@@ -93,9 +93,12 @@ func (c *Manager) processUpdateQueue(ctx context.Context) {
 				c.log.Info("Purging compile cache")
 				c.cache.Purge()
 				c.NotifySubscribers(evt)
+			case storage.EventDisableRuleTable:
+				c.NotifySubscribers(evt)
 			case storage.EventAddOrUpdatePolicy, storage.EventDeleteOrDisablePolicy:
 				if err := c.recompile(evt); err != nil {
 					c.log.Warnw("Error while processing storage event", "event", evt, "error", err)
+					c.NotifySubscribers(storage.Event{Kind: storage.EventDisableRuleTable})
 				}
 			default:
 				c.log.Debugw("Ignoring storage event", "event", evt)

--- a/internal/compile/manager.go
+++ b/internal/compile/manager.go
@@ -156,6 +156,7 @@ func (c *Manager) recompile(evt storage.Event) error {
 			// log and remove the module that failed to compile.
 			c.log.Errorw("Failed to recompile", "id", modID, "error", err)
 			c.evict(modID)
+			c.NotifySubscribers(storage.Event{Kind: storage.EventDisableRuleTable})
 		}
 	}
 
@@ -273,6 +274,10 @@ func (c *Manager) GetAllMatching(ctx context.Context, modIDs []namer.ModuleID) (
 			continue
 		}
 		missed[id] = struct{}{}
+	}
+
+	if len(missed) == 0 {
+		return res, nil
 	}
 
 	toResolve := make([]namer.ModuleID, len(missed))

--- a/internal/engine/ruletable/rule_table.go
+++ b/internal/engine/ruletable/rule_table.go
@@ -233,10 +233,9 @@ func (rt *RuleTable) LazyLoad(ctx context.Context, resource, policyVer, scope st
 	}
 
 	if err := addScopedPolicyRules(scope); err != nil {
-		if errors.Is(err, errNoPoliciesMatched) {
-			return nil
+		if !errors.Is(err, errNoPoliciesMatched) {
+			return err
 		}
-		return err
 	}
 
 	for s := range namer.ScopeParents(scope) {
@@ -249,6 +248,7 @@ func (rt *RuleTable) LazyLoad(ctx context.Context, resource, policyVer, scope st
 	}
 
 	if len(toLoad) == 0 {
+		maps.Copy(rt.storeQueryRegister, registryBuffer)
 		return nil
 	}
 

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -259,6 +259,9 @@ func (m *manager) SubscriberID() string {
 
 func (m *manager) OnStorageEvent(events ...storage.Event) {
 	for _, event := range events {
+		if event.IndexUnhealthy {
+			continue
+		}
 		//nolint:exhaustive
 		switch event.Kind {
 		case storage.EventAddOrUpdateSchema:

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -259,9 +259,6 @@ func (m *manager) SubscriberID() string {
 
 func (m *manager) OnStorageEvent(events ...storage.Event) {
 	for _, event := range events {
-		if event.IndexUnhealthy {
-			continue
-		}
 		//nolint:exhaustive
 		switch event.Kind {
 		case storage.EventAddOrUpdateSchema:

--- a/internal/storage/blob/store.go
+++ b/internal/storage/blob/store.go
@@ -202,7 +202,7 @@ func (s *Store) init(ctx context.Context) error {
 		return fmt.Errorf("failed to clone blob store: %w", err)
 	}
 
-	idx, dirName, _, err := s.buildIndex(ctx, cr.all)
+	idx, dirName, err := s.buildIndex(ctx, cr.all)
 	if err != nil {
 		return fmt.Errorf("failed to build index from the new set of files: %w", err)
 	}
@@ -394,18 +394,18 @@ func (e *indexBuildError) Error() string {
 // buildIndex creates a new work directory with its name set to current timestamp, creates symlinks targeted to
 // s.cacheDir according to the given map 'all' and tries to build a temporary index to see if there are any errors
 // with the incoming policies/schemas. If there are no errors returns the index built and the path to the new work directory.
-func (s *Store) buildIndex(ctx context.Context, all map[string][]string) (index.Index, string, int64, error) {
+func (s *Store) buildIndex(ctx context.Context, all map[string][]string) (index.Index, string, error) {
 	dir, dirName, ts, err := s.prepareWorkDir(ctx, all)
 	if err != nil {
-		return nil, "", 0, err
+		return nil, "", err
 	}
 
 	idx, err := s.buildIndexFromWorkDir(ctx, dir, dirName, ts)
 	if err != nil {
-		return nil, "", 0, err
+		return nil, "", err
 	}
 
-	return idx, dirName, ts, nil
+	return idx, dirName, nil
 }
 
 func (s *Store) prepareWorkDir(ctx context.Context, all map[string][]string) (dir, currDirName string, ts int64, err error) {
@@ -504,7 +504,7 @@ func (s *Store) Reload(ctx context.Context) error {
 		return fmt.Errorf("failed to clone blob store: %w", err)
 	}
 
-	idx, dirName, _, err := s.buildIndex(ctx, cr.all)
+	idx, dirName, err := s.buildIndex(ctx, cr.all)
 	if err != nil {
 		if errors.Is(err, &indexBuildError{}) {
 			s.log.Warnw("Remote store is in an invalid state", "error", err)

--- a/internal/storage/blob/store.go
+++ b/internal/storage/blob/store.go
@@ -218,7 +218,7 @@ func (s *Store) init(ctx context.Context) error {
 	return nil
 }
 
-func (s *Store) updateIndex(ctx context.Context) error {
+func (s *Store) updateIndex(ctx context.Context) (err error) {
 	s.log.Debug("Checking for updates")
 	cr, err := s.clone(ctx)
 	if err != nil {
@@ -232,11 +232,6 @@ func (s *Store) updateIndex(ctx context.Context) error {
 
 	s.log.Infof("Detected changes: added or updated (%d), deleted (%d)", len(cr.addedOrUpdated), len(cr.deleted))
 
-	idx, dirName, ts, err := s.buildIndex(ctx, cr.all)
-	if err != nil {
-		return fmt.Errorf("failed to build index from the new set of files: %w", err)
-	}
-
 	evts := make([]storage.Event, 0, len(cr.addedOrUpdated)+len(cr.deleted))
 	for _, i := range cr.deleted {
 		e, err := s.deleteEvent(i.file)
@@ -246,19 +241,39 @@ func (s *Store) updateIndex(ctx context.Context) error {
 		evts = append(evts, e)
 	}
 
-	oldDirName := s.currDirName
-	s.currDirName = dirName
-	s.idx = idx
+	dir, dirName, ts, err := s.prepareWorkDir(ctx, cr.all)
+	if err != nil {
+		return fmt.Errorf("failed to prepare temp directory from the new set of files: %w", err)
+	}
 
 	for _, i := range cr.addedOrUpdated {
-		e, err := s.addOrUpdateEvent(i.etag, i.file, ts)
+		e, err := s.addOrUpdateEvent(i.etag, i.file, dirName, ts)
 		if err != nil {
 			return fmt.Errorf("failed to create add or update event: %w", err)
 		}
 		evts = append(evts, e)
 	}
 
-	s.NotifySubscribers(evts...)
+	// we need to emit all events regardless of validity as some subscribers (such as the rule table)
+	// need to be kept in sync.
+	defer func() {
+		if err != nil {
+			for i := range evts {
+				evts[i].IndexUnhealthy = true
+			}
+		}
+		s.NotifySubscribers(evts...)
+	}()
+
+	idx, err := s.buildIndexFromWorkDir(ctx, dir, dirName, ts)
+	if err != nil {
+		return fmt.Errorf("failed to build index in new work directory: %w", err)
+	}
+
+	oldDirName := s.currDirName
+	s.currDirName = dirName
+	s.idx = idx
+
 	s.log.Info("Index updated")
 
 	if err := s.cloner.Clean(); err != nil {
@@ -272,12 +287,12 @@ func (s *Store) updateIndex(ctx context.Context) error {
 	return nil
 }
 
-func (s *Store) addOrUpdateEvent(etag, file string, ts int64) (storage.Event, error) {
+func (s *Store) addOrUpdateEvent(etag, file, currDirName string, ts int64) (storage.Event, error) {
 	if schemaFile, ok := util.RelativeSchemaPath(file); ok {
 		return storage.NewSchemaEvent(storage.EventAddOrUpdateSchema, schemaFile), nil
 	}
 
-	p, err := policy.ReadPolicyFromFile(newBlobFS(filepath.Join(s.workDir, s.currDirName)), file)
+	p, err := policy.ReadPolicyFromFile(newBlobFS(filepath.Join(s.workDir, currDirName)), file)
 	if err != nil {
 		return storage.Event{}, fmt.Errorf("failed to read policy from file %s: %w", file, err)
 	}
@@ -379,41 +394,60 @@ func (e *indexBuildError) Error() string {
 // buildIndex creates a new work directory with its name set to current timestamp, creates symlinks targeted to
 // s.cacheDir according to the given map 'all' and tries to build a temporary index to see if there are any errors
 // with the incoming policies/schemas. If there are no errors returns the index built and the path to the new work directory.
-func (s *Store) buildIndex(ctx context.Context, all map[string][]string) (idx index.Index, currDirName string, ts int64, err error) {
+func (s *Store) buildIndex(ctx context.Context, all map[string][]string) (index.Index, string, int64, error) {
+	dir, dirName, ts, err := s.prepareWorkDir(ctx, all)
+	if err != nil {
+		return nil, "", 0, err
+	}
+
+	idx, err := s.buildIndexFromWorkDir(ctx, dir, dirName, ts)
+	if err != nil {
+		return nil, "", 0, err
+	}
+
+	return idx, dirName, ts, nil
+}
+
+func (s *Store) prepareWorkDir(ctx context.Context, all map[string][]string) (dir, currDirName string, ts int64, err error) {
 	ts = time.Now().UnixMilli()
 	defer func() {
 		metrics.Inc(ctx, metrics.StorePollCount(), metrics.DriverKey(DriverName))
 		if err != nil {
 			metrics.Inc(ctx, metrics.StoreSyncErrorCount(), metrics.DriverKey(DriverName))
-			s.NotifySubscribers(storage.Event{Kind: storage.EventDisableRuleTable})
-		} else {
-			metrics.Record(ctx, metrics.StoreLastSuccessfulRefresh(), ts, metrics.DriverKey(DriverName))
 		}
 	}()
 
-	dir, err := os.MkdirTemp(s.workDir, fmt.Sprintf("cerbos-%s-%d-*", DriverName, ts))
+	dir, err = os.MkdirTemp(s.workDir, fmt.Sprintf("cerbos-%s-%d-*", DriverName, ts))
 	if err != nil {
-		return nil, "", 0, fmt.Errorf("failed to create new temporary storage directory: %w", err)
+		return "", "", 0, fmt.Errorf("failed to create new temporary storage directory: %w", err)
 	}
 
 	if currDirName, err = filepath.Rel(s.workDir, dir); err != nil {
-		return nil, "", 0, fmt.Errorf("failed to determine relative path of directory %s: %w", dir, err)
+		return "", "", 0, fmt.Errorf("failed to determine relative path of directory %s: %w", dir, err)
 	}
 
 	if err := s.createSymlinks(all, currDirName); err != nil {
-		return nil, "", 0, fmt.Errorf("failed to create symbolic links for the new work directory: %w", err)
+		return "", "", ts, fmt.Errorf("failed to create symbolic links for the new work directory: %w", err)
 	}
 
+	return dir, currDirName, ts, nil
+}
+
+func (s *Store) buildIndexFromWorkDir(ctx context.Context, dir, currDirName string, ts int64) (idx index.Index, err error) {
 	s.log.Debugw("Building index", "dir", dir)
 	if idx, err = index.Build(ctx, newBlobFS(dir), index.WithRootDir("."), index.WithSourceAttributes(driverSourceAttr)); err != nil {
+		metrics.Inc(ctx, metrics.StoreSyncErrorCount(), metrics.DriverKey(DriverName))
+
 		if rerr := s.workFS.RemoveAll(currDirName); rerr != nil && !errors.Is(rerr, fs.ErrNotExist) {
-			return nil, "", 0, errors.Join(err, fmt.Errorf("failed to remove directory %s: %w", dir, rerr))
+			return nil, errors.Join(err, fmt.Errorf("failed to remove directory %s: %w", dir, rerr))
 		}
 
-		return nil, "", 0, &indexBuildError{dir: dir, err: err}
+		return nil, &indexBuildError{dir: dir, err: err}
 	}
 
-	return idx, currDirName, ts, nil
+	metrics.Record(ctx, metrics.StoreLastSuccessfulRefresh(), ts, metrics.DriverKey(DriverName))
+
+	return idx, nil
 }
 
 func (s *Store) Driver() string {

--- a/internal/storage/blob/store.go
+++ b/internal/storage/blob/store.go
@@ -385,6 +385,7 @@ func (s *Store) buildIndex(ctx context.Context, all map[string][]string) (idx in
 		metrics.Inc(ctx, metrics.StorePollCount(), metrics.DriverKey(DriverName))
 		if err != nil {
 			metrics.Inc(ctx, metrics.StoreSyncErrorCount(), metrics.DriverKey(DriverName))
+			s.NotifySubscribers(storage.Event{Kind: storage.EventDisableRuleTable})
 		} else {
 			metrics.Record(ctx, metrics.StoreLastSuccessfulRefresh(), ts, metrics.DriverKey(DriverName))
 		}

--- a/internal/storage/db/internal/db.go
+++ b/internal/storage/db/internal/db.go
@@ -346,6 +346,10 @@ func (s *dbStorage) GetAllMatching(ctx context.Context, modIDs []namer.ModuleID)
 }
 
 func (s *dbStorage) GetCompilationUnits(ctx context.Context, ids ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	// Rather than writing a proper recursive query (which is pretty much impossible to do in a database-agnostic way), we're
 	// exploiting the fact that we have a maximum of two levels of dependency (resourcePolicy -> derivedRoles -> exportConstants/Variables).
 

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -208,6 +208,7 @@ const (
 	EventAddOrUpdateSchema
 	EventDeleteSchema
 	EventReload
+	EventDisableRuleTable
 	EventNop
 )
 
@@ -235,6 +236,8 @@ func (evt Event) String() string {
 		id = evt.SchemaFile
 	case EventReload:
 		kind = "RELOAD"
+	case EventDisableRuleTable:
+		kind = "DISABLE RULE TABLE"
 	case EventNop:
 		kind = "NOP"
 	default:

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -208,16 +208,16 @@ const (
 	EventAddOrUpdateSchema
 	EventDeleteSchema
 	EventReload
-	EventDisableRuleTable
 	EventNop
 )
 
 // Event is an event detected by the storage layer.
 type Event struct {
-	OldPolicyID *namer.ModuleID
-	SchemaFile  string
-	Kind        EventKind
-	PolicyID    namer.ModuleID
+	OldPolicyID    *namer.ModuleID
+	SchemaFile     string
+	Kind           EventKind
+	PolicyID       namer.ModuleID
+	IndexUnhealthy bool
 }
 
 func (evt Event) String() string {
@@ -236,8 +236,6 @@ func (evt Event) String() string {
 		id = evt.SchemaFile
 	case EventReload:
 		kind = "RELOAD"
-	case EventDisableRuleTable:
-		kind = "DISABLE RULE TABLE"
 	case EventNop:
 		kind = "NOP"
 	default:


### PR DESCRIPTION
When an index build fails, ensure the rule table is purged to avoid operating on stale data. Adds EventDisableRuleTable event type and makes rule table rebuild from scratch on next policy event.

Also handles an issue in mutable stores where intended no-ops were generating invalid queries and breaking evaluations.