### PR TITLE
feat: Add principal policy support to rule table

### DIFF
--- a/api/genpb/cerbos/runtime/v1/hashpb_helpers.pb.go
+++ b/api/genpb/cerbos/runtime/v1/hashpb_helpers.pb.go
@@ -354,6 +354,8 @@ func cerbos_runtime_v1_RuleTableMetadata_hashpb_sum(m *RuleTableMetadata, hasher
 				_, _ = hasher.Write(protowire.AppendString(nil, t.Resource))
 			case *RuleTableMetadata_Role:
 				_, _ = hasher.Write(protowire.AppendString(nil, t.Role))
+			case *RuleTableMetadata_Principal:
+				_, _ = hasher.Write(protowire.AppendString(nil, t.Principal))
 			}
 		}
 	}
@@ -444,6 +446,9 @@ func cerbos_runtime_v1_RuleTable_RuleRow_hashpb_sum(m *RuleTable_RuleRow, hasher
 	}
 	if _, ok := ignore["cerbos.runtime.v1.RuleTable.RuleRow.name"]; !ok {
 		_, _ = hasher.Write(protowire.AppendString(nil, m.GetName()))
+	}
+	if _, ok := ignore["cerbos.runtime.v1.RuleTable.RuleRow.principal"]; !ok {
+		_, _ = hasher.Write(protowire.AppendString(nil, m.GetPrincipal()))
 	}
 }
 

--- a/api/genpb/cerbos/runtime/v1/runtime.pb.go
+++ b/api/genpb/cerbos/runtime/v1/runtime.pb.go
@@ -231,6 +231,7 @@ type RuleTableMetadata struct {
 	//
 	//	*RuleTableMetadata_Resource
 	//	*RuleTableMetadata_Role
+	//	*RuleTableMetadata_Principal
 	Name             isRuleTableMetadata_Name        `protobuf_oneof:"name"`
 	Version          string                          `protobuf:"bytes,4,opt,name=version,proto3" json:"version,omitempty"`
 	SourceAttributes map[string]*v1.SourceAttributes `protobuf:"bytes,5,rep,name=source_attributes,json=sourceAttributes,proto3" json:"source_attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
@@ -301,6 +302,15 @@ func (x *RuleTableMetadata) GetRole() string {
 	return ""
 }
 
+func (x *RuleTableMetadata) GetPrincipal() string {
+	if x != nil {
+		if x, ok := x.Name.(*RuleTableMetadata_Principal); ok {
+			return x.Principal
+		}
+	}
+	return ""
+}
+
 func (x *RuleTableMetadata) GetVersion() string {
 	if x != nil {
 		return x.Version
@@ -334,9 +344,15 @@ type RuleTableMetadata_Role struct {
 	Role string `protobuf:"bytes,3,opt,name=role,proto3,oneof"`
 }
 
+type RuleTableMetadata_Principal struct {
+	Principal string `protobuf:"bytes,7,opt,name=principal,proto3,oneof"`
+}
+
 func (*RuleTableMetadata_Resource) isRuleTableMetadata_Name() {}
 
 func (*RuleTableMetadata_Role) isRuleTableMetadata_Name() {}
+
+func (*RuleTableMetadata_Principal) isRuleTableMetadata_Name() {}
 
 type RunnableRolePolicySet struct {
 	state protoimpl.MessageState          `protogen:"open.v1"`
@@ -1266,6 +1282,7 @@ type RuleTable_RuleRow struct {
 	OriginDerivedRole    string                        `protobuf:"bytes,11,opt,name=origin_derived_role,json=originDerivedRole,proto3" json:"origin_derived_role,omitempty"`
 	EmitOutput           *Output                       `protobuf:"bytes,12,opt,name=emit_output,json=emitOutput,proto3" json:"emit_output,omitempty"`
 	Name                 string                        `protobuf:"bytes,13,opt,name=name,proto3" json:"name,omitempty"`
+	Principal            string                        `protobuf:"bytes,14,opt,name=principal,proto3" json:"principal,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -1405,6 +1422,13 @@ func (x *RuleTable_RuleRow) GetEmitOutput() *Output {
 func (x *RuleTable_RuleRow) GetName() string {
 	if x != nil {
 		return x.Name
+	}
+	return ""
+}
+
+func (x *RuleTable_RuleRow) GetPrincipal() string {
+	if x != nil {
+		return x.Principal
 	}
 	return ""
 }
@@ -2874,9 +2898,9 @@ const file_cerbos_runtime_v1_runtime_proto_rawDesc = "" +
 	"rolePolicy\x12)\n" +
 	"\x10compiler_version\x18\x06 \x01(\rR\x0fcompilerVersionB\f\n" +
 	"\n" +
-	"policy_set\"\xa6\a\n" +
+	"policy_set\"\xc4\a\n" +
 	"\tRuleTable\x12:\n" +
-	"\x05rules\x18\x01 \x03(\v2$.cerbos.runtime.v1.RuleTable.RuleRowR\x05rules\x1a\xdc\x06\n" +
+	"\x05rules\x18\x01 \x03(\v2$.cerbos.runtime.v1.RuleTable.RuleRowR\x05rules\x1a\xfa\x06\n" +
 	"\aRuleRow\x12\x1d\n" +
 	"\n" +
 	"origin_fqn\x18\x01 \x01(\tR\toriginFqn\x12\x1a\n" +
@@ -2894,18 +2918,20 @@ const file_cerbos_runtime_v1_runtime_proto_rawDesc = "" +
 	"\x13origin_derived_role\x18\v \x01(\tR\x11originDerivedRole\x12:\n" +
 	"\vemit_output\x18\f \x01(\v2\x19.cerbos.runtime.v1.OutputR\n" +
 	"emitOutput\x12\x12\n" +
-	"\x04name\x18\r \x01(\tR\x04name\x1a\xbc\x01\n" +
+	"\x04name\x18\r \x01(\tR\x04name\x12\x1c\n" +
+	"\tprincipal\x18\x0e \x01(\tR\tprincipal\x1a\xbc\x01\n" +
 	"\fAllowActions\x12X\n" +
 	"\aactions\x18\x01 \x03(\v2>.cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntryR\aactions\x1aR\n" +
 	"\fActionsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
 	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.EmptyR\x05value:\x028\x01B\f\n" +
 	"\n" +
-	"action_set\"\xe6\x03\n" +
+	"action_set\"\x86\x04\n" +
 	"\x11RuleTableMetadata\x12\x10\n" +
 	"\x03fqn\x18\x01 \x01(\tR\x03fqn\x12\x1c\n" +
 	"\bresource\x18\x02 \x01(\tH\x00R\bresource\x12\x14\n" +
-	"\x04role\x18\x03 \x01(\tH\x00R\x04role\x12\x18\n" +
+	"\x04role\x18\x03 \x01(\tH\x00R\x04role\x12\x1e\n" +
+	"\tprincipal\x18\a \x01(\tH\x00R\tprincipal\x12\x18\n" +
 	"\aversion\x18\x04 \x01(\tR\aversion\x12g\n" +
 	"\x11source_attributes\x18\x05 \x03(\v2:.cerbos.runtime.v1.RuleTableMetadata.SourceAttributesEntryR\x10sourceAttributes\x12W\n" +
 	"\vannotations\x18\x06 \x03(\v25.cerbos.runtime.v1.RuleTableMetadata.AnnotationsEntryR\vannotations\x1ag\n" +
@@ -3378,6 +3404,7 @@ func file_cerbos_runtime_v1_runtime_proto_init() {
 	file_cerbos_runtime_v1_runtime_proto_msgTypes[2].OneofWrappers = []any{
 		(*RuleTableMetadata_Resource)(nil),
 		(*RuleTableMetadata_Role)(nil),
+		(*RuleTableMetadata_Principal)(nil),
 	}
 	file_cerbos_runtime_v1_runtime_proto_msgTypes[12].OneofWrappers = []any{
 		(*Condition_All)(nil),

--- a/api/genpb/cerbos/runtime/v1/runtime_vtproto.pb.go
+++ b/api/genpb/cerbos/runtime/v1/runtime_vtproto.pb.go
@@ -290,6 +290,13 @@ func (m *RuleTable_RuleRow) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		}
 		i -= size
 	}
+	if len(m.Principal) > 0 {
+		i -= len(m.Principal)
+		copy(dAtA[i:], m.Principal)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Principal)))
+		i--
+		dAtA[i] = 0x72
+	}
 	if len(m.Name) > 0 {
 		i -= len(m.Name)
 		copy(dAtA[i:], m.Name)
@@ -599,6 +606,20 @@ func (m *RuleTableMetadata_Role) MarshalToSizedBufferVT(dAtA []byte) (int, error
 	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Role)))
 	i--
 	dAtA[i] = 0x1a
+	return len(dAtA) - i, nil
+}
+func (m *RuleTableMetadata_Principal) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *RuleTableMetadata_Principal) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.Principal)
+	copy(dAtA[i:], m.Principal)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Principal)))
+	i--
+	dAtA[i] = 0x3a
 	return len(dAtA) - i, nil
 }
 func (m *RunnableRolePolicySet_Metadata) MarshalVT() (dAtA []byte, err error) {
@@ -3475,6 +3496,10 @@ func (m *RuleTable_RuleRow) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	l = len(m.Principal)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -3584,6 +3609,16 @@ func (m *RuleTableMetadata_Role) SizeVT() (n int) {
 	var l int
 	_ = l
 	l = len(m.Role)
+	n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	return n
+}
+func (m *RuleTableMetadata_Principal) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Principal)
 	n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	return n
 }
@@ -5683,6 +5718,38 @@ func (m *RuleTable_RuleRow) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Name = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 14:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Principal", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Principal = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		case 15:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field AllowActions", wireType)
@@ -6251,6 +6318,38 @@ func (m *RuleTableMetadata) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Annotations[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Principal", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = &RuleTableMetadata_Principal{Principal: string(dAtA[iNdEx:postIndex])}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/api/private/cerbos/runtime/v1/runtime.proto
+++ b/api/private/cerbos/runtime/v1/runtime.proto
@@ -48,6 +48,7 @@ message RuleTable {
     string origin_derived_role = 11;
     Output emit_output = 12;
     string name = 13;
+    string principal = 14;
   }
 
   repeated RuleRow rules = 1;
@@ -58,6 +59,7 @@ message RuleTableMetadata {
   oneof name {
     string resource = 2;
     string role = 3;
+    string principal = 7;
   }
   string version = 4;
   map<string, cerbos.policy.v1.SourceAttributes> source_attributes = 5;

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -21,7 +21,6 @@ import (
 	effectv1 "github.com/cerbos/cerbos/api/genpb/cerbos/effect/v1"
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
-	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
 	schemav1 "github.com/cerbos/cerbos/api/genpb/cerbos/schema/v1"
 	"github.com/cerbos/cerbos/internal/audit"
 	"github.com/cerbos/cerbos/internal/conditions"
@@ -29,7 +28,6 @@ import (
 	"github.com/cerbos/cerbos/internal/engine/policyloader"
 	"github.com/cerbos/cerbos/internal/engine/ruletable"
 	"github.com/cerbos/cerbos/internal/engine/tracer"
-	"github.com/cerbos/cerbos/internal/namer"
 	"github.com/cerbos/cerbos/internal/observability/logging"
 	"github.com/cerbos/cerbos/internal/observability/metrics"
 	"github.com/cerbos/cerbos/internal/observability/tracing"
@@ -259,41 +257,21 @@ func (engine *Engine) doPlanResources(ctx context.Context, input *enginev1.PlanR
 		return nil, nil, err
 	}
 
-	// get the principal policy check
 	ppName, ppVersion, ppScope := engine.policyAttr(input.Principal.Id, input.Principal.PolicyVersion, input.Principal.Scope, opts.evalParams)
-	policySet, err := engine.getPrincipalPolicySet(ctx, ppName, ppVersion, ppScope, opts.LenientScopeSearch())
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get check for [%s.%s]: %w", ppName, ppVersion, err)
+	rpName, rpVersion, rpScope := engine.policyAttr(input.Resource.Kind, input.Resource.PolicyVersion, input.Resource.Scope, opts.evalParams)
+
+	if err := engine.ruleTable.LazyLoadPrincipalPolicy(ctx, ppName, ppVersion, ppScope); err != nil {
+		return nil, nil, fmt.Errorf("failed to load principal policy [%s.%s]: %w", ppName, ppVersion, err)
 	}
 
-	result := new(planner.PolicyPlanResult)
-	auditTrail := &auditv1.AuditTrail{EffectivePolicies: make(map[string]*policyv1.SourceAttributes, 2)} //nolint:mnd
-	if policy := policySet.GetPrincipalPolicy(); policy != nil {
-		policyEvaluator := planner.PrincipalPolicyEvaluator{Policy: policy, Globals: opts.Globals(), NowFn: opts.NowFunc()}
-		result, err = policyEvaluator.EvaluateResourcesQueryPlan(ctx, input)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		maps.Copy(auditTrail.EffectivePolicies, policy.GetMeta().GetSourceAttributes())
+	if err := engine.ruleTable.LazyLoadResourcePolicy(ctx, rpName, rpVersion, rpScope, input.Principal.Roles); err != nil {
+		return nil, nil, fmt.Errorf("failed to load resource policy [%s.%s]: %w", rpName, rpVersion, err)
 	}
 
-	policyVersion := input.Resource.PolicyVersion
-	if policyVersion == "" {
-		policyVersion = opts.DefaultPolicyVersion()
-	}
-
-	if err := engine.ruleTable.LazyLoad(ctx, input.Resource.Kind, policyVersion, input.Resource.Scope, input.Principal.Roles); err != nil {
-		return nil, nil, err
-	}
-
-	ruleTableResult, err := planner.EvaluateRuleTableQueryPlan(ctx, engine.ruleTable, input, policyVersion, engine.schemaMgr, opts.NowFunc(), opts.Globals())
+	result, err := planner.EvaluateRuleTableQueryPlan(ctx, engine.ruleTable, input, ppVersion, rpVersion, engine.schemaMgr, opts.NowFunc(), opts.Globals())
 	if err != nil {
 		return nil, nil, err
 	}
-
-	maps.Copy(auditTrail.EffectivePolicies, ruleTableResult.EffectivePolicies)
-	result = planner.CombinePlans(result, ruleTableResult)
 
 	if result.AllowIsEmpty() && !result.DenyIsEmpty() { // reset an conditional DENY to an unconditional one
 		result.ResetToUnconditionalDeny()
@@ -307,6 +285,8 @@ func (engine *Engine) doPlanResources(ctx context.Context, input *enginev1.PlanR
 	if result.Empty() {
 		output.FilterDebug = noPolicyMatch
 	}
+
+	auditTrail := &auditv1.AuditTrail{EffectivePolicies: result.EffectivePolicies} //nolint:mnd
 
 	return output, auditTrail, nil
 }
@@ -487,12 +467,6 @@ func (engine *Engine) evaluate(ctx context.Context, input *enginev1.CheckInput, 
 		return nil, nil, err
 	}
 
-	output := &enginev1.CheckOutput{
-		RequestId:  input.RequestId,
-		ResourceId: input.Resource.Id,
-		Actions:    make(map[string]*enginev1.CheckOutput_ActionEffect, len(input.Actions)),
-	}
-
 	ec, err := engine.buildEvaluationCtx(ctx, checkOpts.evalParams, input)
 	if err != nil {
 		return nil, nil, err
@@ -505,6 +479,12 @@ func (engine *Engine) evaluate(ctx context.Context, input *enginev1.CheckInput, 
 	if err != nil {
 		logging.FromContext(ctx).Error("Failed to evaluate policies", zap.Error(err))
 		return nil, nil, fmt.Errorf("failed to evaluate policies: %w", err)
+	}
+
+	output := &enginev1.CheckOutput{
+		RequestId:  input.RequestId,
+		ResourceId: input.Resource.Id,
+		Actions:    make(map[string]*enginev1.CheckOutput_ActionEffect, len(input.Actions)),
 	}
 
 	// update the output
@@ -534,60 +514,27 @@ func (engine *Engine) evaluate(ctx context.Context, input *enginev1.CheckInput, 
 }
 
 func (engine *Engine) buildEvaluationCtx(ctx context.Context, eparams evalParams, input *enginev1.CheckInput) (*evaluationCtx, error) {
-	ec := &evaluationCtx{}
-
-	// get the principal policy check
 	ppName, ppVersion, ppScope := engine.policyAttr(input.Principal.Id, input.Principal.PolicyVersion, input.Principal.Scope, eparams)
-	ppCheck, err := engine.getPrincipalPolicyEvaluator(ctx, eparams, ppName, ppVersion, ppScope)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get check for [%s.%s]: %w", ppName, ppVersion, err)
-	}
-	ec.addCheck(ppCheck)
-
 	rpName, rpVersion, rpScope := engine.policyAttr(input.Resource.Kind, input.Resource.PolicyVersion, input.Resource.Scope, eparams)
-	pCheck, err := engine.getRuleTableEvaluator(ctx, eparams, rpName, rpVersion, rpScope, input.Principal.Roles)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get check for [%s.%s]: %w", rpName, rpVersion, err)
-	}
-	ec.addCheck(pCheck)
 
-	return ec, nil
+	check, err := engine.getRuleTableEvaluator(ctx, eparams, ppName, ppVersion, ppScope, rpName, rpVersion, rpScope, input.Principal.Roles)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get evaluator: %w", err)
+	}
+
+	return &evaluationCtx{check}, nil
 }
 
-func (engine *Engine) getRuleTableEvaluator(ctx context.Context, eparams evalParams, resource, policyVer, scope string, inputRoles []string) (Evaluator, error) {
-	if err := engine.ruleTable.LazyLoad(ctx, resource, policyVer, scope, inputRoles); err != nil {
-		return nil, err
+func (engine *Engine) getRuleTableEvaluator(ctx context.Context, eparams evalParams, principal, principalPolicyVer, principalScope, resource, policyVer, scope string, inputRoles []string) (Evaluator, error) {
+	if err := engine.ruleTable.LazyLoadPrincipalPolicy(ctx, principal, principalPolicyVer, principalScope); err != nil {
+		return nil, fmt.Errorf("failed to load principal policy [%s.%s]: %w", principal, principalPolicyVer, err)
+	}
+
+	if err := engine.ruleTable.LazyLoadResourcePolicy(ctx, resource, policyVer, scope, inputRoles); err != nil {
+		return nil, fmt.Errorf("failed to load resource policy [%s.%s]: %w", resource, policyVer, err)
 	}
 
 	return NewRuleTableEvaluator(engine.ruleTable, engine.schemaMgr, eparams), nil
-}
-
-func (engine *Engine) getPrincipalPolicyEvaluator(ctx context.Context, eparams evalParams, principal, policyVer, scope string) (Evaluator, error) {
-	rps, err := engine.getPrincipalPolicySet(ctx, principal, policyVer, scope, eparams.lenientScopeSearch)
-	if err != nil {
-		return nil, err
-	}
-
-	if rps == nil {
-		return nil, nil
-	}
-
-	return NewPrincipalPolicyEvaluator(rps.GetPrincipalPolicy(), eparams), nil
-}
-
-func (engine *Engine) getPrincipalPolicySet(ctx context.Context, principal, policyVer, scope string, lenientScopeSearch bool) (*runtimev1.RunnablePolicySet, error) {
-	ctx, span := tracing.StartSpan(ctx, "engine.GetPrincipalPolicy")
-	defer span.End()
-	span.SetAttributes(tracing.PolicyName(principal), tracing.PolicyVersion(policyVer), tracing.PolicyScope(scope))
-
-	principalModIDs := namer.ScopedPrincipalPolicyModuleIDs(principal, policyVer, scope, lenientScopeSearch)
-	rps, err := engine.policyLoader.GetFirstMatch(ctx, principalModIDs)
-	if err != nil {
-		tracing.MarkFailed(span, http.StatusInternalServerError, err)
-		return nil, err
-	}
-
-	return rps, nil
 }
 
 func (engine *Engine) policyAttr(name, version, scope string, params evalParams) (pName, pVersion, pScope string) {
@@ -603,57 +550,50 @@ func (engine *Engine) policyAttr(name, version, scope string, params evalParams)
 }
 
 type evaluationCtx struct {
-	checks    [2]Evaluator
-	numChecks int
-}
-
-func (ec *evaluationCtx) addCheck(eval Evaluator) {
-	if eval != nil {
-		ec.checks[ec.numChecks] = eval
-		ec.numChecks++
-	}
+	evaluator Evaluator
 }
 
 func (ec *evaluationCtx) evaluate(ctx context.Context, tctx tracer.Context, input *enginev1.CheckInput) (*evaluationResult, error) {
 	ctx, span := tracing.StartSpan(ctx, "engine.EvalCtxEvaluate")
 	defer span.End()
 
-	resp := &evaluationResult{
-		effectiveDerivedRoles: make(map[string]struct{}),
-		toResolve:             make(map[string]struct{}),
-	}
-	if len(ec.checks) == 0 {
+	if ec.evaluator == nil {
 		tracing.MarkFailed(span, http.StatusNotFound, errNoPoliciesMatched)
 
+		resp := &evaluationResult{
+			effectiveDerivedRoles: make(map[string]struct{}),
+			toResolve:             make(map[string]struct{}),
+		}
 		resp.setDefaultsForUnmatchedActions(tctx, input)
 		return resp, nil
 	}
 
-	for i := range ec.numChecks {
-		c := ec.checks[i]
-		result, err := c.Evaluate(ctx, tctx, input)
-		if err != nil {
-			logging.FromContext(ctx).Error("Failed to evaluate policy", zap.Error(err))
-			tracing.MarkFailed(span, http.StatusInternalServerError, err)
-
-			return nil, fmt.Errorf("failed to execute policy: %w", err)
-		}
-
-		incomplete := resp.merge(result)
-		if !incomplete {
-			return resp, nil
-		}
+	result, err := ec.evaluator.Evaluate(ctx, tctx, input)
+	if err != nil {
+		logging.FromContext(ctx).Error("Failed to evaluate policy", zap.Error(err))
+		tracing.MarkFailed(span, http.StatusInternalServerError, err)
+		return nil, fmt.Errorf("failed to execute policy: %w", err)
 	}
 
-	tracing.MarkFailed(span, http.StatusNotFound, errNoPoliciesMatched)
-	resp.setDefaultsForUnmatchedActions(tctx, input)
+	resp := &evaluationResult{
+		effects:               result.Effects,
+		auditTrail:            result.AuditTrail,
+		effectiveDerivedRoles: result.EffectiveDerivedRoles,
+		toResolve:             result.toResolve,
+		validationErrors:      result.ValidationErrors,
+		outputs:               result.Outputs,
+	}
 
-	for action := range resp.toResolve {
-		if _, ok := resp.effects[action]; !ok {
-			tctx.StartAction(action).AppliedEffect(defaultEffect, "No matching policies")
-			resp.effects[action] = EffectInfo{
-				Effect: defaultEffect,
-				Policy: noPolicyMatch,
+	if len(result.toResolve) > 0 {
+		tracing.MarkFailed(span, http.StatusNotFound, errNoPoliciesMatched)
+
+		for action := range result.toResolve {
+			if _, ok := resp.effects[action]; !ok {
+				tctx.StartAction(action).AppliedEffect(defaultEffect, "No matching policies")
+				resp.effects[action] = EffectInfo{
+					Effect: defaultEffect,
+					Policy: noPolicyMatch,
+				}
 			}
 		}
 	}
@@ -668,43 +608,6 @@ type evaluationResult struct {
 	toResolve             map[string]struct{}
 	validationErrors      []*schemav1.ValidationError
 	outputs               []*enginev1.OutputEntry
-}
-
-// merge the results by only updating the actions that have a no_match effect.
-func (er *evaluationResult) merge(res *PolicyEvalResult) bool {
-	er.auditTrail = mergeTrails(er.auditTrail, res.AuditTrail)
-
-	if er.effects == nil {
-		er.effects = make(map[string]EffectInfo, len(res.Effects))
-	}
-
-	if len(res.EffectiveDerivedRoles) > 0 {
-		for edr := range res.EffectiveDerivedRoles {
-			er.effectiveDerivedRoles[edr] = struct{}{}
-		}
-	}
-
-	if len(res.ValidationErrors) > 0 {
-		er.validationErrors = append(er.validationErrors, res.ValidationErrors...)
-	}
-
-	if len(res.Outputs) > 0 {
-		er.outputs = append(er.outputs, res.Outputs...)
-	}
-
-	for action, effect := range res.Effects {
-		// if the action doesn't already exist or if it has a no_match effect, update it.
-		if currEffect, ok := er.effects[action]; !ok ||
-			currEffect.Effect == effectv1.Effect_EFFECT_NO_MATCH {
-			er.effects[action] = effect
-		}
-	}
-
-	for a := range res.toResolve {
-		er.toResolve[a] = struct{}{}
-	}
-
-	return len(res.toResolve) > 0
 }
 
 func (er *evaluationResult) setDefaultsForUnmatchedActions(tctx tracer.Context, input *enginev1.CheckInput) {

--- a/internal/engine/evaluator.go
+++ b/internal/engine/evaluator.go
@@ -187,12 +187,13 @@ func (rte *ruleTableEvaluator) Evaluate(ctx context.Context, tctx tracer.Context
 	conditionCache := make(map[string]bool)
 
 	processedScopedDerivedRoles := make(map[string]struct{})
+	policyTypes := []policy.Kind{policy.PrincipalKind, policy.ResourceKind}
 	for _, action := range actionsToResolve {
 		actx := pctx.StartAction(action)
 
 		var actionEffectInfo EffectInfo
 		var mainPolicyKey string
-		for _, pt := range []policy.Kind{policy.PrincipalKind, policy.ResourceKind} {
+		for _, pt := range policyTypes {
 			if pt == policy.PrincipalKind {
 				mainPolicyKey = principalPolicyKey
 			} else {

--- a/internal/engine/ruletable/rule_table.go
+++ b/internal/engine/ruletable/rule_table.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"net/http"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/cerbos/cerbos/internal/engine/policyloader"
 	"github.com/cerbos/cerbos/internal/namer"
 	"github.com/cerbos/cerbos/internal/observability/tracing"
+	"github.com/cerbos/cerbos/internal/policy"
 	"github.com/cerbos/cerbos/internal/storage"
 	"github.com/cerbos/cerbos/internal/util"
 )
@@ -36,7 +38,6 @@ type RuleTable struct {
 	policyLoader policyloader.PolicyLoader
 	// version -> scope -> role -> action -> []rows
 	primaryIdx         map[string]map[string]*util.GlobMap[*util.GlobMap[[]*Row]]
-	scopedResourceIdx  map[string]map[string]*util.GlobMap[struct{}]
 	log                *zap.SugaredLogger
 	schemas            map[namer.ModuleID]*policyv1.Schemas
 	meta               map[namer.ModuleID]*runtimev1.RuleTableMetadata
@@ -44,7 +45,8 @@ type RuleTable struct {
 	// reverse mapping of derived role mod IDs to the resource policies it's referenced in
 	derivedRolePolicies   map[namer.ModuleID]map[namer.ModuleID]struct{}
 	storeQueryRegister    map[namer.ModuleID]bool
-	scopeMap              map[string]struct{}
+	principalScopeMap     map[string]struct{}
+	resourceScopeMap      map[string]struct{}
 	scopeScopePermissions map[string]policyv1.ScopePermissions
 	// role policies are per-scope, so the maps takes the form `map[scope]map[role][]roles`
 	parentRoles              map[string]map[string][]string
@@ -65,9 +67,19 @@ type Row struct {
 	EvaluationKey              string
 	OriginModuleID             namer.ModuleID
 	NoMatchForScopePermissions bool
+	FromRolePolicy             bool
+	PolicyKind                 policy.Kind
 }
 
-func (r *Row) Matches(scope, action string, roles []string) bool {
+func (r *Row) Matches(pt policy.Kind, scope, action, principalID string, roles []string) bool {
+	if r.PolicyKind != pt {
+		return false
+	}
+
+	if pt == policy.PrincipalKind && r.Principal != principalID {
+		return false
+	}
+
 	if scope != r.Scope {
 		return false
 	}
@@ -101,14 +113,14 @@ type CelProgram struct {
 func NewRuleTable(policyLoader policyloader.PolicyLoader) *RuleTable {
 	return &RuleTable{
 		primaryIdx:               make(map[string]map[string]*util.GlobMap[*util.GlobMap[[]*Row]]),
-		scopedResourceIdx:        make(map[string]map[string]*util.GlobMap[struct{}]),
 		log:                      zap.S().Named("ruletable"),
 		schemas:                  make(map[namer.ModuleID]*policyv1.Schemas),
 		meta:                     make(map[namer.ModuleID]*runtimev1.RuleTableMetadata),
 		policyDerivedRoles:       make(map[namer.ModuleID]map[string]*WrappedRunnableDerivedRole),
 		derivedRolePolicies:      make(map[namer.ModuleID]map[namer.ModuleID]struct{}),
 		storeQueryRegister:       make(map[namer.ModuleID]bool),
-		scopeMap:                 make(map[string]struct{}),
+		principalScopeMap:        make(map[string]struct{}),
+		resourceScopeMap:         make(map[string]struct{}),
 		scopeScopePermissions:    make(map[string]policyv1.ScopePermissions),
 		parentRoles:              make(map[string]map[string][]string),
 		parentRoleAncestorsCache: make(map[string]map[string][]string),
@@ -117,7 +129,7 @@ func NewRuleTable(policyLoader policyloader.PolicyLoader) *RuleTable {
 	}
 }
 
-func (rt *RuleTable) LazyLoad(ctx context.Context, resource, policyVer, scope string, inputRoles []string) error {
+func (rt *RuleTable) LazyLoadResourcePolicy(ctx context.Context, resource, policyVer, scope string, inputRoles []string) error {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 
@@ -262,6 +274,123 @@ func (rt *RuleTable) LazyLoad(ctx context.Context, resource, policyVer, scope st
 	return nil
 }
 
+func (rt *RuleTable) LazyLoadPrincipalPolicy(ctx context.Context, principal, policyVer, scope string) error {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	toLoad := []*runtimev1.RunnablePolicySet{}
+
+	// we don't want to add retrieved mod IDs to the cache until the rule table has been successfully updated
+	registryBuffer := make(map[namer.ModuleID]bool)
+
+	checkRegisters := func(modID namer.ModuleID) (bool, bool) {
+		if policyExists, isQueried := registryBuffer[modID]; isQueried {
+			return policyExists, isQueried
+		}
+
+		policyExists, isQueried := rt.storeQueryRegister[modID]
+		return policyExists, isQueried
+	}
+
+	// Process scopes from the most specific to the least specific
+	addScopedPrincipalPolicy := func(partialScope string) error {
+		principalModID := namer.PrincipalPolicyModuleID(principal, policyVer, partialScope)
+
+		// Check if we've already queried the store for this policy
+		if policyExists, isQueried := checkRegisters(principalModID); isQueried {
+			if policyExists {
+				return nil
+			}
+			return errNoPoliciesMatched
+		}
+
+		// Fetch the principal policy (always use lenient scope search)
+		pps, err := rt.getPrincipalPolicySet(ctx, principal, policyVer, partialScope, true)
+		if err != nil {
+			return err
+		}
+
+		if pps == nil {
+			registryBuffer[principalModID] = false
+			for s := range namer.ScopeParents(partialScope) {
+				registryBuffer[namer.PrincipalPolicyModuleID(principal, policyVer, s)] = false
+			}
+			return errNoPoliciesMatched
+		}
+
+		p := pps.GetPrincipalPolicy().GetPolicies()[0]
+
+		// lenientScopeSearch might return a parent policy which we've already added--don't load if this is the case
+		if p.Scope != partialScope {
+			registryBuffer[principalModID] = false
+			for s := range namer.ScopeParents(partialScope) {
+				if s == p.Scope {
+					break
+				}
+				registryBuffer[namer.PrincipalPolicyModuleID(principal, policyVer, s)] = false
+			}
+
+			principalModID = namer.PrincipalPolicyModuleID(principal, policyVer, p.Scope)
+
+			// check again to see if the parent scope policy has already been added
+			if policyExists, isQueried := checkRegisters(principalModID); isQueried {
+				if policyExists {
+					return nil
+				}
+				return errNoPoliciesMatched
+			}
+		}
+
+		toLoad = append(toLoad, pps)
+		registryBuffer[principalModID] = true
+
+		return nil
+	}
+
+	if err := addScopedPrincipalPolicy(scope); err != nil {
+		if !errors.Is(err, errNoPoliciesMatched) {
+			return err
+		}
+	}
+
+	for s := range namer.ScopeParents(scope) {
+		if err := addScopedPrincipalPolicy(s); err != nil {
+			if errors.Is(err, errNoPoliciesMatched) {
+				break
+			}
+			return err
+		}
+	}
+
+	if len(toLoad) == 0 {
+		maps.Copy(rt.storeQueryRegister, registryBuffer)
+		return nil
+	}
+
+	if err := rt.loadPolicies(toLoad); err != nil {
+		return err
+	}
+
+	maps.Copy(rt.storeQueryRegister, registryBuffer)
+
+	return nil
+}
+
+func (rt *RuleTable) getPrincipalPolicySet(ctx context.Context, principal, policyVer, scope string, lenientScopeSearch bool) (*runtimev1.RunnablePolicySet, error) {
+	ctx, span := tracing.StartSpan(ctx, "ruletable.GetPrincipalPolicy")
+	defer span.End()
+	span.SetAttributes(tracing.PolicyName(principal), tracing.PolicyVersion(policyVer), tracing.PolicyScope(scope))
+
+	principalModIDs := namer.ScopedPrincipalPolicyModuleIDs(principal, policyVer, scope, lenientScopeSearch)
+	rps, err := rt.policyLoader.GetFirstMatch(ctx, principalModIDs)
+	if err != nil {
+		tracing.MarkFailed(span, http.StatusInternalServerError, err)
+		return nil, err
+	}
+
+	return rps, nil
+}
+
 func (rt *RuleTable) getResourcePolicySet(ctx context.Context, resource, policyVer, scope string, lenientScopeSearch bool) (*runtimev1.RunnablePolicySet, error) {
 	ctx, span := tracing.StartSpan(ctx, "engine.GetResourcePolicy")
 	defer span.End()
@@ -344,6 +473,104 @@ func (rt *RuleTable) addPolicy(rps *runtimev1.RunnablePolicySet) error {
 		return rt.addResourcePolicy(rps.GetResourcePolicy())
 	case *runtimev1.RunnablePolicySet_RolePolicy:
 		rt.addRolePolicy(rps.GetRolePolicy())
+	case *runtimev1.RunnablePolicySet_PrincipalPolicy:
+		return rt.addPrincipalPolicy(rps.GetPrincipalPolicy())
+	}
+
+	return nil
+}
+
+func (rt *RuleTable) addPrincipalPolicy(rpps *runtimev1.RunnablePrincipalPolicySet) error {
+	principalID := rpps.Meta.Principal
+
+	policies := rpps.GetPolicies()
+	if len(policies) == 0 {
+		return nil
+	}
+
+	// We only process the first of principal policy sets as it's assumed parent scopes are handled in separate calls
+	p := policies[0]
+
+	moduleID := namer.GenModuleIDFromFQN(rpps.Meta.Fqn)
+	rt.meta[moduleID] = &runtimev1.RuleTableMetadata{
+		Fqn:              rpps.Meta.Fqn,
+		Name:             &runtimev1.RuleTableMetadata_Principal{Principal: principalID},
+		Version:          rpps.Meta.Version,
+		SourceAttributes: rpps.Meta.SourceAttributes,
+		Annotations:      rpps.Meta.Annotations,
+	}
+
+	progs, err := getCelProgramsFromExpressions(p.OrderedVariables)
+	if err != nil {
+		return err
+	}
+
+	policyParameters := &rowParams{
+		Key:         namer.PrincipalPolicyFQN(principalID, rpps.Meta.Version, p.Scope),
+		Variables:   p.OrderedVariables,
+		Constants:   (&structpb.Struct{Fields: p.Constants}).AsMap(),
+		CelPrograms: progs,
+	}
+
+	scopePermissions := p.ScopePermissions
+	if scopePermissions == policyv1.ScopePermissions_SCOPE_PERMISSIONS_UNSPECIFIED {
+		scopePermissions = policyv1.ScopePermissions_SCOPE_PERMISSIONS_OVERRIDE_PARENT
+	}
+	rt.scopeScopePermissions[p.Scope] = scopePermissions
+
+	for resource, resourceRules := range p.ResourceRules {
+		for _, rule := range resourceRules.ActionRules {
+			emitOutput := rule.EmitOutput
+			if emitOutput == nil && rule.Output != nil { //nolint:staticcheck
+				emitOutput = &runtimev1.Output{
+					When: &runtimev1.Output_When{
+						RuleActivated: rule.Output, //nolint:staticcheck
+					},
+				}
+			}
+
+			ruleFqn := namer.RuleFQN(rt.meta[moduleID], p.Scope, rule.Name)
+			evaluationKey := fmt.Sprintf("%s#%s", policyParameters.Key, ruleFqn)
+
+			row := &Row{
+				RuleTable_RuleRow: &runtimev1.RuleTable_RuleRow{
+					OriginFqn: rpps.Meta.Fqn,
+					Resource:  resource,
+					// Since principal policies don't have explicit roles, we use "*" to match any role
+					Role: "*",
+					ActionSet: &runtimev1.RuleTable_RuleRow_Action{
+						Action: rule.Action,
+					},
+					Condition:        rule.Condition,
+					Effect:           rule.Effect,
+					Scope:            p.Scope,
+					ScopePermissions: scopePermissions,
+					Version:          rpps.Meta.Version,
+					EmitOutput:       emitOutput,
+					Name:             rule.Name,
+					Principal:        principalID,
+				},
+				Params:         policyParameters,
+				EvaluationKey:  evaluationKey,
+				OriginModuleID: moduleID,
+				PolicyKind:     policy.PrincipalKind,
+			}
+
+			if p.ScopePermissions == policyv1.ScopePermissions_SCOPE_PERMISSIONS_REQUIRE_PARENTAL_CONSENT_FOR_ALLOWS &&
+				row.Effect == effectv1.Effect_EFFECT_ALLOW &&
+				row.Condition != nil {
+				row.Condition = &runtimev1.Condition{
+					Op: &runtimev1.Condition_None{
+						None: &runtimev1.Condition_ExprList{
+							Expr: []*runtimev1.Condition{row.Condition},
+						},
+					},
+				}
+				row.Effect = effectv1.Effect_EFFECT_DENY
+			}
+
+			rt.insertRule(row)
+		}
 	}
 
 	return nil
@@ -437,6 +664,7 @@ func (rt *RuleTable) addResourcePolicy(rrps *runtimev1.RunnableResourcePolicySet
 					Params:         policyParameters,
 					EvaluationKey:  evaluationKey,
 					OriginModuleID: moduleID,
+					PolicyKind:     policy.ResourceKind,
 				}
 
 				if p.ScopePermissions == policyv1.ScopePermissions_SCOPE_PERMISSIONS_REQUIRE_PARENTAL_CONSENT_FOR_ALLOWS &&
@@ -493,6 +721,7 @@ func (rt *RuleTable) addResourcePolicy(rrps *runtimev1.RunnableResourcePolicySet
 							DerivedRoleParams: derivedRoleParams,
 							EvaluationKey:     evaluationKey,
 							OriginModuleID:    moduleID,
+							PolicyKind:        policy.ResourceKind,
 						}
 
 						if p.ScopePermissions == policyv1.ScopePermissions_SCOPE_PERMISSIONS_REQUIRE_PARENTAL_CONSENT_FOR_ALLOWS &&
@@ -565,6 +794,8 @@ func (rt *RuleTable) addRolePolicy(p *runtimev1.RunnableRolePolicySet) {
 				},
 				EvaluationKey:  fmt.Sprintf("%s#%s_rule-%03d", namer.PolicyKeyFromFQN(namer.RolePolicyFQN(p.Role, p.Scope)), p.Role, idx),
 				OriginModuleID: moduleID,
+				PolicyKind:     policy.ResourceKind,
+				FromRolePolicy: true,
 			})
 		}
 	}
@@ -577,7 +808,12 @@ func (rt *RuleTable) addRolePolicy(p *runtimev1.RunnableRolePolicySet) {
 }
 
 func (rt *RuleTable) insertRule(r *Row) {
-	rt.scopeMap[r.Scope] = struct{}{}
+	switch r.PolicyKind { //nolint:exhaustive
+	case policy.PrincipalKind:
+		rt.principalScopeMap[r.Scope] = struct{}{}
+	case policy.ResourceKind:
+		rt.resourceScopeMap[r.Scope] = struct{}{}
+	}
 
 	// index as `version->scope->role_glob->action_glob`
 	{
@@ -607,23 +843,6 @@ func (rt *RuleTable) insertRule(r *Row) {
 		rows, _ := actionMap.GetWithLiteral(action)
 		rows = append(rows, r)
 		actionMap.Set(action, rows)
-	}
-
-	// separate scopedResource index
-	{
-		scopeMap, ok := rt.scopedResourceIdx[r.Version]
-		if !ok {
-			scopeMap = make(map[string]*util.GlobMap[struct{}])
-			rt.scopedResourceIdx[r.Version] = scopeMap
-		}
-
-		resourceMap, ok := scopeMap[r.Scope]
-		if !ok {
-			resourceMap = util.NewGlobMap(make(map[string]struct{}))
-			scopeMap[r.Scope] = resourceMap
-		}
-
-		resourceMap.Set(r.Resource, struct{}{})
 	}
 }
 
@@ -672,19 +891,16 @@ func (rt *RuleTable) deletePolicy(moduleID namer.ModuleID) {
 
 			if roleMap.Len() == 0 {
 				delete(scopeMap, scope)
-				delete(rt.scopeMap, scope)
+				delete(rt.principalScopeMap, scope)
+				delete(rt.resourceScopeMap, scope)
 				delete(rt.scopeScopePermissions, scope)
 				delete(rt.parentRoleAncestorsCache, scope)
 				delete(rt.parentRoles, scope)
-				if v, ok := rt.scopedResourceIdx[version]; ok {
-					delete(v, scope)
-				}
 			}
 		}
 
 		if len(scopeMap) == 0 {
 			delete(rt.primaryIdx, version)
-			delete(rt.scopedResourceIdx, version)
 		}
 	}
 
@@ -710,9 +926,9 @@ func (rt *RuleTable) purge() {
 	clear(rt.policyDerivedRoles)
 	clear(rt.primaryIdx)
 	clear(rt.schemas)
-	clear(rt.scopeMap)
+	clear(rt.principalScopeMap)
+	clear(rt.resourceScopeMap)
 	clear(rt.scopeScopePermissions)
-	clear(rt.scopedResourceIdx)
 	clear(rt.storeQueryRegister)
 }
 
@@ -720,20 +936,29 @@ func (rt *RuleTable) GetDerivedRoles(fqn string) map[string]*WrappedRunnableDeri
 	return rt.policyDerivedRoles[namer.GenModuleIDFromFQN(fqn)]
 }
 
-func (rt *RuleTable) GetAllScopes(scope, resource, version string) ([]string, string, string) {
+func (rt *RuleTable) GetAllScopes(pt policy.Kind, scope, name, version string) ([]string, string, string) {
 	var firstPolicyKey, firstFqn string
 	var scopes []string
-	if rt.ScopeExists(scope) {
-		firstFqn = namer.ResourcePolicyFQN(resource, version, scope)
+
+	var fqnFn func(string, string, string) string
+	switch pt { //nolint:exhaustive
+	case policy.PrincipalKind:
+		fqnFn = namer.PrincipalPolicyFQN
+	case policy.ResourceKind:
+		fqnFn = namer.ResourcePolicyFQN
+	}
+
+	if rt.ScopeExists(pt, scope) {
+		firstFqn = fqnFn(name, version, scope)
 		firstPolicyKey = namer.PolicyKeyFromFQN(firstFqn)
 		scopes = append(scopes, scope)
 	}
 
 	for s := range namer.ScopeParents(scope) {
-		if rt.ScopeExists(s) {
+		if rt.ScopeExists(pt, s) {
 			scopes = append(scopes, s)
 			if firstPolicyKey == "" {
-				firstFqn = namer.ResourcePolicyFQN(resource, version, s)
+				firstFqn = fqnFn(name, version, s)
 				firstPolicyKey = namer.PolicyKeyFromFQN(firstFqn)
 			}
 		}
@@ -742,12 +967,96 @@ func (rt *RuleTable) GetAllScopes(scope, resource, version string) ([]string, st
 	return scopes, firstPolicyKey, firstFqn
 }
 
+type scopeNode struct {
+	children map[string]*scopeNode
+	scope    string
+}
+
+func (rt *RuleTable) CombineScopes(principalScopes, resourceScopes []string) []string {
+	// Build a map to track all unique scopes
+	uniqueScopes := make(map[string]struct{})
+	for _, s := range principalScopes {
+		uniqueScopes[s] = struct{}{}
+	}
+	for _, s := range resourceScopes {
+		uniqueScopes[s] = struct{}{}
+	}
+
+	root := &scopeNode{scope: "", children: make(map[string]*scopeNode)}
+
+	for scope := range uniqueScopes {
+		if scope == "" {
+			continue
+		}
+
+		current := root
+		parts := strings.Split(scope, ".")
+		for i, part := range parts {
+			fullPath := strings.Join(parts[:i+1], ".")
+			if _, exists := current.children[part]; !exists {
+				current.children[part] = &scopeNode{
+					scope:    fullPath,
+					children: make(map[string]*scopeNode),
+				}
+			}
+			current = current.children[part]
+		}
+	}
+
+	// Use DFS to traverse the tree with children first, then parents
+	var result []string
+	var dfs func(n *scopeNode)
+	dfs = func(n *scopeNode) {
+		childKeys := make([]string, 0, len(n.children))
+		for k := range n.children {
+			childKeys = append(childKeys, k)
+		}
+
+		for _, key := range childKeys {
+			dfs(n.children[key])
+		}
+
+		if _, exists := uniqueScopes[n.scope]; exists {
+			result = append(result, n.scope)
+		}
+	}
+	dfs(root)
+
+	return result
+}
+
 func (rt *RuleTable) ScopedResourceExists(version, resource string, scopes []string) bool {
-	if scopeMap, ok := rt.scopedResourceIdx[version]; ok {
+	if scopeMap, ok := rt.primaryIdx[version]; ok {
 		for _, scope := range scopes {
-			if resourceMap, ok := scopeMap[scope]; ok {
-				if _, ok := resourceMap.Get(resource); ok {
-					return true
+			if roleMap, ok := scopeMap[scope]; ok && roleMap.Len() > 0 {
+				for _, actionMap := range roleMap.GetAll() {
+					for _, rules := range actionMap.GetAll() {
+						for _, rule := range rules {
+							if util.MatchesGlob(rule.Resource, resource) && rule.PolicyKind == policy.ResourceKind {
+								return true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func (rt *RuleTable) ScopedPrincipalExists(version string, scopes []string) bool {
+	if scopeMap, ok := rt.primaryIdx[version]; ok {
+		for _, scope := range scopes {
+			if roleMap, ok := scopeMap[scope]; ok && roleMap.Len() > 0 {
+				for _, actionMap := range roleMap.GetAll() {
+					for _, rules := range actionMap.GetAll() {
+						for _, rule := range rules {
+							if rule.PolicyKind == policy.PrincipalKind {
+								return true
+							}
+						}
+					}
 				}
 			}
 		}
@@ -774,12 +1083,19 @@ func (rt *RuleTable) GetRows(version, resource string, scopes, roles, actions []
 	rt.mu.RLock()
 	defer rt.mu.RUnlock()
 
+	processedActionSets := make(map[*util.GlobMap[[]*Row]]struct{})
+	processedRuleSets := make(map[*[]*Row]struct{})
 	if scopeSet, ok := rt.primaryIdx[version]; ok { //nolint:nestif
 		for _, scope := range scopes {
 			if roleSet, ok := scopeSet[scope]; ok {
 				for _, role := range roles {
 					roleFqn := namer.RolePolicyFQN(role, scope)
 					for _, actionSet := range roleSet.GetMerged(role) {
+						// wildcard roles lead to the same action set potentially being returned multiple times
+						if _, ok := processedActionSets[actionSet]; ok {
+							continue
+						}
+						processedActionSets[actionSet] = struct{}{}
 						if ars, ok := actionSet.GetWithLiteral(allowActionsIdxKey); ok {
 							actionMatchedRows := util.NewGlobMap(make(map[string][]*Row))
 							// retrieve actions mapped to all effectual rows
@@ -812,6 +1128,8 @@ func (rt *RuleTable) GetRows(version, resource string, scopes, roles, actions []
 											Scope:     scope,
 											Version:   version,
 										},
+										PolicyKind:                 policy.ResourceKind,
+										FromRolePolicy:             true,
 										NoMatchForScopePermissions: true,
 									})
 								} else {
@@ -841,6 +1159,8 @@ func (rt *RuleTable) GetRows(version, resource string, scopes, roles, actions []
 												},
 												EvaluationKey:  ar.EvaluationKey,
 												OriginModuleID: ar.OriginModuleID,
+												PolicyKind:     policy.ResourceKind,
+												FromRolePolicy: true,
 											})
 										}
 									}
@@ -850,6 +1170,10 @@ func (rt *RuleTable) GetRows(version, resource string, scopes, roles, actions []
 
 						for _, action := range actions {
 							for _, rules := range actionSet.GetMerged(action) {
+								if _, ok := processedRuleSets[&rules]; ok {
+									continue
+								}
+								processedRuleSets[&rules] = struct{}{}
 								for _, r := range rules {
 									if util.MatchesGlob(r.Resource, resource) {
 										res = append(res, r)
@@ -917,11 +1241,18 @@ func (rt *RuleTable) collectParentRoles(scope, role string, parentRoleSet, visit
 	}
 }
 
-func (rt *RuleTable) ScopeExists(scope string) bool {
+func (rt *RuleTable) ScopeExists(pt policy.Kind, scope string) bool {
 	rt.mu.RLock()
 	defer rt.mu.RUnlock()
 
-	_, ok := rt.scopeMap[scope]
+	var ok bool
+	switch pt { //nolint:exhaustive
+	case policy.PrincipalKind:
+		_, ok = rt.principalScopeMap[scope]
+	case policy.ResourceKind:
+		_, ok = rt.resourceScopeMap[scope]
+	}
+
 	return ok
 }
 

--- a/internal/namer/namer.go
+++ b/internal/namer/namer.go
@@ -333,6 +333,8 @@ func RuleFQN(rpsMeta any, scope, ruleName string) string {
 		policyFqn = PrincipalPolicyFQN(m.Principal, m.Version, scope)
 	case *runtimev1.RuleTableMetadata:
 		switch t := m.Name.(type) {
+		case *runtimev1.RuleTableMetadata_Principal:
+			policyFqn = PrincipalPolicyFQN(t.Principal, m.Version, scope)
 		case *runtimev1.RuleTableMetadata_Resource:
 			policyFqn = ResourcePolicyFQN(t.Resource, m.Version, scope)
 		case *runtimev1.RuleTableMetadata_Role:


### PR DESCRIPTION
Extend rule table implementation to handle principal policies by adding a new policy type, separate scope maps for resource and principal policies, and methods to load and evaluate principal policies alongside resource policies.

There's decent scope for further streamlining, but I don't want to make this PR more difficult to parse than it already is. Ongoing refactors can be done in future PRs. Re-introducing tracing is one of these to-dos, for example.