### PR TITLE
chore(ci): Don't bother caching dependencies for `upload-test-times` job

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -180,22 +180,15 @@ jobs:
       - name: Check test results
         run: test "${{ needs.test.result }}" = "success"
 
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false # this might remove tools that are actually needed, if set to "true" but frees about 6 GB
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
-
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Go and restore cached dependencies
-        uses: ./.github/actions/setup-go
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.x
+          cache: false
+          check-latest: true
 
       - name: Install just
         uses: extractions/setup-just@v2


### PR DESCRIPTION
`free-disk-space` takes up the majority of the `upload-test-times` job's 5 minute timeout. We only need it because our Go cache can get very big. Overall, the time to free disk space and restore the cache ~probably~ definitely exceeds the time it would take to run `just test-times` without caching, so this PR removes the cache usage from the job (reducing the time it takes from at least 4 minutes to about 40 seconds).