### PR TITLE
enhancement: Simplify plan with exists operation

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cerbos/cerbos/internal/audit"
 	"github.com/cerbos/cerbos/internal/audit/local"
 	"github.com/cerbos/cerbos/internal/compile"
+	"github.com/cerbos/cerbos/internal/engine/planner"
 	"github.com/cerbos/cerbos/internal/engine/ruletable"
 	"github.com/cerbos/cerbos/internal/engine/tracer"
 	"github.com/cerbos/cerbos/internal/printer"
@@ -413,7 +414,7 @@ func TestQueryPlan(t *testing.T) {
 	}
 }
 
-// Create a recursive function to normalize all expressions with commutative operators
+// Create a recursive function to normalize all expressions with commutative operators.
 func stabiliseFilter(filter *enginev1.PlanResourcesFilter) *enginev1.PlanResourcesFilter {
 	if filter == nil {
 		return nil
@@ -449,12 +450,13 @@ func stabiliseOperand(operand *enginev1.PlanResourcesFilter_Expression_Operand) 
 
 func isCommutativeOperator(op string) bool {
 	switch op {
-	case "and", "or", "eq", "ne", "add", "mult", "list", "struct":
+	case planner.And, planner.Or, planner.Equals, planner.NotEquals, planner.Add, planner.Mult:
 		return true
 	default:
 		return false
 	}
 }
+
 func stabiliseExpression(expr *enginev1.PlanResourcesFilter_Expression) *enginev1.PlanResourcesFilter_Expression {
 	if expr == nil {
 		return nil

--- a/internal/engine/planner/ast.go
+++ b/internal/engine/planner/ast.go
@@ -745,17 +745,6 @@ func normaliseFilterExprOpExpr(expr *enginev1.PlanResourcesFilter_Expression_Ope
 					}
 				}
 			}
-		case 2:
-			//TDOO: Uncomment if it's safe to make OR/AND support many arguments.
-			/* var operands1 []*enginev1.PlanResourcesFilter_Expression_Operand
-			for _, op := range operands {
-				if op.GetExpression().GetOperator() == logicalOperator {
-					operands1 = append(operands1, op.GetExpression().GetOperands()...)
-				} else {
-					operands1 = append(operands1, op)
-				}
-			}
-			operands = operands1 */
 		}
 	}
 

--- a/internal/engine/planner/ast.go
+++ b/internal/engine/planner/ast.go
@@ -746,7 +746,8 @@ func normaliseFilterExprOpExpr(expr *enginev1.PlanResourcesFilter_Expression_Ope
 				}
 			}
 		case 2:
-			var operands1 []*enginev1.PlanResourcesFilter_Expression_Operand
+			//TDOO: Uncomment if it's safe to make OR/AND support many arguments.
+			/* var operands1 []*enginev1.PlanResourcesFilter_Expression_Operand
 			for _, op := range operands {
 				if op.GetExpression().GetOperator() == logicalOperator {
 					operands1 = append(operands1, op.GetExpression().GetOperands()...)
@@ -754,7 +755,7 @@ func normaliseFilterExprOpExpr(expr *enginev1.PlanResourcesFilter_Expression_Ope
 					operands1 = append(operands1, op)
 				}
 			}
-			operands = operands1
+			operands = operands1 */
 		}
 	}
 

--- a/internal/engine/planner/ast.go
+++ b/internal/engine/planner/ast.go
@@ -745,6 +745,16 @@ func normaliseFilterExprOpExpr(expr *enginev1.PlanResourcesFilter_Expression_Ope
 					}
 				}
 			}
+		case 2:
+			var operands1 []*enginev1.PlanResourcesFilter_Expression_Operand
+			for _, op := range operands {
+				if op.GetExpression().GetOperator() == logicalOperator {
+					operands1 = append(operands1, op.GetExpression().GetOperands()...)
+				} else {
+					operands1 = append(operands1, op)
+				}
+			}
+			operands = operands1
 		}
 	}
 

--- a/internal/engine/planner/matchers/struct_matcher.go
+++ b/internal/engine/planner/matchers/struct_matcher.go
@@ -56,7 +56,7 @@ func (m *exprMatcher) run(e celast.Expr) (bool, error) {
 	return r, nil
 }
 
-func getConstExprMatcher(s *structMatcher) *exprMatcher {
+func mkConstExprMatcher(s *structMatcher) *exprMatcher {
 	return &exprMatcher{
 		f: func(e celast.Expr) (bool, []celast.Expr) {
 			if e.Kind() == celast.LiteralKind {
@@ -68,7 +68,7 @@ func getConstExprMatcher(s *structMatcher) *exprMatcher {
 	}
 }
 
-func getStructIndexerExprMatcher(s *structMatcher) *exprMatcher {
+func mkStructIndexerExprMatcher(s *structMatcher) *exprMatcher {
 	return &exprMatcher{
 		f: func(e celast.Expr) (bool, []celast.Expr) {
 			ex := e
@@ -191,8 +191,8 @@ func NewExpressionProcessor() ExpressionProcessor {
 			return false, nil
 		},
 		ns: []*exprMatcher{
-			getStructIndexerExprMatcher(s1),
-			getConstExprMatcher(s1),
+			mkStructIndexerExprMatcher(s1),
+			mkConstExprMatcher(s1),
 		},
 	}
 	s2 := new(structMatcher)
@@ -206,8 +206,8 @@ func NewExpressionProcessor() ExpressionProcessor {
 			return false, nil
 		},
 		ns: []*exprMatcher{
-			getConstExprMatcher(s2),
-			getStructIndexerExprMatcher(s2),
+			mkConstExprMatcher(s2),
+			mkStructIndexerExprMatcher(s2),
 		},
 	}
 

--- a/internal/engine/planner/planner.go
+++ b/internal/engine/planner/planner.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cerbos/cerbos/internal/conditions"
 	"github.com/cerbos/cerbos/internal/engine/internal"
 	plannerutils "github.com/cerbos/cerbos/internal/engine/planner/internal"
-	"github.com/cerbos/cerbos/internal/engine/planner/matchers"
 	"github.com/cerbos/cerbos/internal/engine/ruletable"
 	"github.com/cerbos/cerbos/internal/namer"
 	"github.com/cerbos/cerbos/internal/observability/tracing"
@@ -657,7 +656,7 @@ func (p *partialEvaluator) evaluateUnknown(ctx context.Context, residual celast.
 	if err != nil {
 		return nil, err
 	}
-	m := matchers.NewExpressionProcessor()
+	m := newExpressionProcessor()
 	var r bool
 	var e celast.Expr
 	r, e, err = m.Process(residual)

--- a/internal/engine/planner/planner.go
+++ b/internal/engine/planner/planner.go
@@ -755,6 +755,7 @@ func (p *partialEvaluator) evalComprehensionBody(ctx context.Context, e celast.E
 	return evalComprehensionBodyImpl(ctx, p.env, p.vars, p.nowFn, e)
 }
 
+// TODO(dbuduev): is this (still) necessary?
 func evalComprehensionBodyImpl(ctx context.Context, env *cel.Env, pvars interpreter.PartialActivation, nowFn func() time.Time, e celast.Expr) (celast.Expr, error) {
 	if e == nil {
 		return nil, nil

--- a/internal/engine/planner/planner.go
+++ b/internal/engine/planner/planner.go
@@ -657,7 +657,7 @@ func (p *partialEvaluator) evaluateUnknown(ctx context.Context, residual celast.
 	if err != nil {
 		return nil, err
 	}
-	m := newExpressionProcessor()
+	m := newExpressionProcessor(p)
 	var r bool
 	var e celast.Expr
 	r, e, err = m.Process(ctx, residual)

--- a/internal/engine/planner/planner.go
+++ b/internal/engine/planner/planner.go
@@ -660,7 +660,7 @@ func (p *partialEvaluator) evaluateUnknown(ctx context.Context, residual celast.
 	m := newExpressionProcessor()
 	var r bool
 	var e celast.Expr
-	r, e, err = m.Process(residual, p.env)
+	r, e, err = m.Process(ctx, residual)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/planner/planner_test.go
+++ b/internal/engine/planner/planner_test.go
@@ -391,7 +391,7 @@ func TestPartialEvaluationWithGlobalVars(t *testing.T) {
 			is.NoError(err)
 			haveExpr := residualExpr(astNative, det)
 			is.NoError(err)
-			p := partialEvaluator{env: env, vars: pvars, nowFn: nowFn}
+			p := partialEvaluator{env: env, knownVars: knownVars, vars: pvars, nowFn: nowFn}
 			haveExpr, err = p.evalComprehensionBody(t.Context(), haveExpr)
 			is.NoError(err)
 			internal.RenumberIDs(haveExpr)

--- a/internal/engine/planner/planner_test.go
+++ b/internal/engine/planner/planner_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cerbos/cerbos/internal/engine/planner/internal"
 	"github.com/cerbos/cerbos/internal/test"
 	"github.com/cerbos/cerbos/internal/util"
-	"github.com/google/cel-go/interpreter"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -268,7 +267,8 @@ func TestResidualExpr(t *testing.T) {
 		`timestamp(R.attr.lastAccessed) > now()`,
 	}
 
-	env, pvars, variables := setupEnv(t)
+	env, knownVars, variables := setupEnv(t)
+	pvars, _ := cel.PartialVars(knownVars, cel.AttributePattern("R").QualString("attr"))
 	ignoreID := cmpopts.IgnoreMapEntries(func(k string, _ any) bool { return k == "id" })
 	for _, tt := range tests {
 		s := tt
@@ -300,7 +300,8 @@ func TestResidualExpr(t *testing.T) {
 			is.NoError(err)
 			got := residualExpr(nativeAST, det)
 			is.NoError(err)
-			p := newPartialEvaluator(env, pvars, nowFn)
+			p, err := newPartialEvaluator(env, knownVars, nowFn)
+			is.NoError(err)
 			got, err = p.evalComprehensionBody(t.Context(), got)
 			is.NoError(err)
 			gotExpr, err := celast.ExprToProto(got)
@@ -374,7 +375,8 @@ func TestPartialEvaluationWithGlobalVars(t *testing.T) {
 		},
 	}
 
-	env, pvars, variables := setupEnv(t)
+	env, knownVars, variables := setupEnv(t)
+	pvars, _ := cel.PartialVars(knownVars, cel.AttributePattern("R").QualString("attr"))
 	ignoreID := cmpopts.IgnoreMapEntries(func(k string, _ any) bool { return k == "id" })
 	for _, tt := range tests {
 		t.Run(tt.expr, func(t *testing.T) {
@@ -407,7 +409,7 @@ func TestPartialEvaluationWithGlobalVars(t *testing.T) {
 	}
 }
 
-func setupEnv(t *testing.T) (*cel.Env, interpreter.PartialActivation, map[string]celast.Expr) {
+func setupEnv(t *testing.T) (*cel.Env, map[string]any, map[string]celast.Expr) {
 	t.Helper()
 
 	env, err := conditions.StdEnv.Extend(cel.VariableDecls(
@@ -418,12 +420,12 @@ func setupEnv(t *testing.T) (*cel.Env, interpreter.PartialActivation, map[string
 	))
 	require.NoError(t, err)
 
-	pvars, _ := cel.PartialVars(map[string]any{
+	knownVars := map[string]any{
 		"gb":    "en_GB",
 		"gb_us": []string{"GB", "US"},
 		"ca":    "ca",
 		"T":     100,
-	}, cel.AttributePattern("R").QualString("attr"))
+	}
 
 	variables := make(map[string]celast.Expr)
 	for k, txt := range map[string]string{
@@ -437,7 +439,7 @@ func setupEnv(t *testing.T) (*cel.Env, interpreter.PartialActivation, map[string
 		require.Nil(t, iss, iss.Err())
 		variables[k] = ast.NativeRep().Expr()
 	}
-	return env, pvars, variables
+	return env, knownVars, variables
 }
 
 func TestNormaliseFilter(t *testing.T) {

--- a/internal/engine/planner/struct_matcher.go
+++ b/internal/engine/planner/struct_matcher.go
@@ -353,7 +353,6 @@ func (l *lambdaMatcher) Process(ctx context.Context, e celast.Expr) (bool, celas
 		output := mkLogicalOr(opts)
 		internal.ZeroIDs(output)
 		output.RenumberIDs(internal.NewIDGen().Remap)
-		Print(output)
 		return true, output, nil
 	default:
 		return false, nil, nil
@@ -405,19 +404,6 @@ func (l *lambdaMatcher) evaluateExpr(ctx context.Context, iterVar, iterVar2 cela
 	if err != nil {
 		return nil, err
 	}
-	Print(iterVar2)
 	output := residualExpr(ast, details)
-	Print(output)
 	return output, nil
-}
-
-func Print(expr celast.Expr) {
-
-	// Finally, unparse the expression
-	source, err := parser.Unparse(expr, nil)
-	if err != nil {
-		fmt.Println(err)
-	}
-
-	fmt.Println(source)
 }

--- a/internal/engine/planner/struct_matcher.go
+++ b/internal/engine/planner/struct_matcher.go
@@ -334,9 +334,13 @@ func (l *lambdaMatcher) Process(ctx context.Context, e celast.Expr) (bool, celas
 	l.iterVar = lambda.iterVar
 	l.iterVar2 = lambda.iterVar2
 
+	const maxItems = 25
 	switch l.iterRange.Kind() {
 	case celast.MapKind:
 		m := l.iterRange.AsMap()
+		if len(m.Entries()) > maxItems {
+			return false, nil, nil
+		}
 		opts := make([]celast.Expr, 0, len(m.Entries()))
 		for _, entry := range m.Entries() {
 			me := entry.AsMapEntry()

--- a/internal/engine/planner/struct_matcher.go
+++ b/internal/engine/planner/struct_matcher.go
@@ -347,7 +347,7 @@ func (l *lambdaMatcher) Process(ctx context.Context, e celast.Expr) (bool, celas
 		}
 		opts := make([]celast.Expr, 0, len(list.Elements()))
 		for i, el := range list.Elements() {
-			v, err := l.evaluateIterVar(ctx, l.iterVar2, el)
+			v, err := l.evaluateIterVar(ctx, el)
 			if err != nil {
 				return false, nil, err
 			}
@@ -375,11 +375,11 @@ func (l *lambdaMatcher) Process(ctx context.Context, e celast.Expr) (bool, celas
 		opts := make([]celast.Expr, 0, len(m.Entries()))
 		for _, entry := range m.Entries() {
 			me := entry.AsMapEntry()
-			k, err := l.evaluateIterVar(ctx, l.iterVar, me.Key())
+			k, err := l.evaluateIterVar(ctx, me.Key())
 			if err != nil {
 				return false, nil, err
 			}
-			v, err := l.evaluateIterVar(ctx, l.iterVar2, me.Value())
+			v, err := l.evaluateIterVar(ctx, me.Value())
 			if err != nil {
 				return false, nil, err
 			}
@@ -400,7 +400,7 @@ func (l *lambdaMatcher) Process(ctx context.Context, e celast.Expr) (bool, celas
 	}
 }
 
-func (l *lambdaMatcher) evaluateIterVar(ctx context.Context, name string, iterVar celast.Expr) (ref.Val, error) {
+func (l *lambdaMatcher) evaluateIterVar(ctx context.Context, iterVar celast.Expr) (ref.Val, error) {
 	ast := celast.NewAST(iterVar, nil)
 	p := l.partialEvaluator
 	val, _, err := conditions.ContextEval(ctx, p.env, ast, p.vars, p.nowFn)

--- a/internal/engine/planner/struct_matcher.go
+++ b/internal/engine/planner/struct_matcher.go
@@ -183,7 +183,7 @@ var supportedOps = map[string]struct{}{
 	operators.GreaterEquals: {},
 }
 
-func newExpressionProcessor() expressionProcessor {
+func newExpressionProcessor(p *partialEvaluator) expressionProcessor {
 	s1 := new(structMatcher)
 	s1.rootMatch = &exprMatcher{
 		f: func(e celast.Expr) (res bool, args []celast.Expr) {
@@ -217,7 +217,9 @@ func newExpressionProcessor() expressionProcessor {
 		},
 	}
 
-	s3 := new(lambdaMatcher)
+	s3 := &lambdaMatcher{
+		partialEvaluator: p,
+	}
 	s3.rootMatcher = &exprMatcher{
 		f: func(e celast.Expr) (bool, []celast.Expr) {
 			if e.Kind() != celast.ComprehensionKind {
@@ -236,6 +238,9 @@ func newExpressionProcessor() expressionProcessor {
 
 func mkLogicalOr(args []celast.Expr) celast.Expr {
 	const logicalOrArity = 2
+	if len(args) == 1 {
+		return args[0]
+	}
 	if len(args) == logicalOrArity {
 		return internal.MkCallExpr(operators.LogicalOr, args...)
 	}

--- a/internal/engine/planner/struct_matcher.go
+++ b/internal/engine/planner/struct_matcher.go
@@ -346,7 +346,10 @@ func (l *lambdaMatcher) Process(ctx context.Context, e celast.Expr) (bool, celas
 			}
 			opts = append(opts, ex)
 		}
-		return true, mkLogicalOr(opts), nil
+		output := mkLogicalOr(opts)
+		internal.ZeroIDs(output)
+		output.RenumberIDs(internal.NewIDGen().Remap)
+		return true, output, nil
 	}
 	return false, nil, nil
 }
@@ -386,6 +389,6 @@ func (l *lambdaMatcher) evaluateExpr(ctx context.Context, iterVar celast.Expr, i
 	if err != nil {
 		return nil, err
 	}
-
-	return residualExpr(ast, details), nil
+	output := residualExpr(ast, details)
+	return output, nil
 }

--- a/internal/engine/planner/struct_matcher.go
+++ b/internal/engine/planner/struct_matcher.go
@@ -338,7 +338,7 @@ func (l *lambdaMatcher) Process(ctx context.Context, e celast.Expr) (bool, celas
 	knownVars := make(map[string]any, len(l.partialEvaluator.knownVars)+nLambdaVars)
 	maps.Copy(knownVars, l.partialEvaluator.knownVars)
 
-	const maxItems = 25
+	const maxItems = 10
 	switch l.iterRange.Kind() {
 	case celast.ListKind:
 		list := l.iterRange.AsList()

--- a/internal/engine/planner/struct_matcher_test.go
+++ b/internal/engine/planner/struct_matcher_test.go
@@ -57,6 +57,18 @@ func TestStructMatcher(t *testing.T) {
 			expr: `{1: {"colors": ["red"]}}.exists(k, v, R.attr.color in v["colors"])`,
 			want: `R.attr.color in ["red"]`,
 		},
+		{
+			expr: `{1: {"colors": ["red"]}}.exists(v, R.attr.color == v)`,
+			want: `R.attr.color == 1`,
+		},
+		{
+			expr: `[1, 2].exists(v, R.attr.color == v)`,
+			want: `R.attr.color == 1 || R.attr.color == 2`,
+		},
+		{
+			expr: `[1, 2].exists(i, v, R.attr.color == v && R.attr.size == i)`,
+			want: `R.attr.color == 1 && R.attr.size == 0 || R.attr.color == 2 && R.attr.size == 1`,
+		},
 	}
 	env := conditions.StdEnv
 	knownVars := make(map[string]any)

--- a/internal/engine/planner/struct_matcher_test.go
+++ b/internal/engine/planner/struct_matcher_test.go
@@ -6,7 +6,9 @@ package planner
 import (
 	"testing"
 
+	celast "github.com/google/cel-go/common/ast"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/cerbos/cerbos/internal/conditions"
 )
@@ -53,7 +55,10 @@ func TestStructMatcher(t *testing.T) {
 			s := newExpressionProcessor()
 			e := ast.NativeRep().Expr()
 			// t.Log(protojson.Format(ast.Expr()))
-			res, _, err := s.Process(e, env)
+			res, e1, err := s.Process(t.Context(), e)
+			require.NoError(t, err)
+			ep, err := celast.ExprToProto(e1)
+			t.Log(protojson.Format(ep))
 			require.NoError(t, err)
 			require.Equal(t, test.res, res)
 		})

--- a/internal/engine/planner/struct_matcher_test.go
+++ b/internal/engine/planner/struct_matcher_test.go
@@ -54,11 +54,7 @@ func TestStructMatcher(t *testing.T) {
 	}
 	env := conditions.StdEnv
 	knownVars := make(map[string]any)
-	// env, knownVars, variables := setupEnv(t)
-	nowFn := func() time.Time {
-		return time.Now()
-	}
-	p, err := newPartialEvaluator(env, knownVars, nowFn)
+	p, err := newPartialEvaluator(env, knownVars, time.Now)
 	require.NoError(t, err)
 	s := newExpressionProcessor(p)
 	for _, tc := range tests {
@@ -72,18 +68,19 @@ func TestStructMatcher(t *testing.T) {
 				require.False(t, matched)
 			} else {
 				require.True(t, matched)
-				unparsed, err := unparseExpr(t, e1)
-				require.NoError(t, err)
+				unparsed := unparseExpr(t, e1)
 				require.Empty(t, cmp.Diff(stripWs(tc.want), stripWs(unparsed)))
 			}
 		})
 	}
 }
+
 func stripWs(s string) string {
-	r := regexp.MustCompile("\\s+")
+	r := regexp.MustCompile(`\s+`)
 	return string(r.ReplaceAll([]byte(s), []byte(" ")))
 }
-func unparseExpr(t *testing.T, expr celast.Expr) (string, error) {
+
+func unparseExpr(t *testing.T, expr celast.Expr) string {
 	t.Helper()
 	protoExpr, err := celast.ExprToProto(expr)
 	require.NoError(t, err)
@@ -100,5 +97,5 @@ func unparseExpr(t *testing.T, expr celast.Expr) (string, error) {
 
 	source, err := parser.Unparse(astExpr, srcInfo)
 	require.NoError(t, err)
-	return source, nil
+	return source
 }

--- a/internal/engine/planner/struct_matcher_test.go
+++ b/internal/engine/planner/struct_matcher_test.go
@@ -48,12 +48,13 @@ func TestStructMatcher(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.expr, func(t *testing.T) {
-			ast, issues := conditions.StdEnv.Compile(test.expr)
+			env := conditions.StdEnv
+			ast, issues := env.Compile(test.expr)
 			require.Nil(t, issues.Err())
 			s := newExpressionProcessor()
 			e := ast.NativeRep().Expr()
 			t.Log(protojson.Format(ast.Expr()))
-			res, _, err := s.Process(e)
+			res, _, err := s.Process(e, env)
 			require.NoError(t, err)
 			require.Equal(t, test.res, res)
 		})

--- a/internal/engine/planner/struct_matcher_test.go
+++ b/internal/engine/planner/struct_matcher_test.go
@@ -53,6 +53,10 @@ func TestStructMatcher(t *testing.T) {
 			expr: "{1: 1}.exists(k, v, k == v)",
 			want: "true",
 		},
+		{
+			expr: `{1: {"colors": ["red"]}}.exists(k, v, R.attr.color in v["colors"])`,
+			want: `R.attr.color in ["red"]`,
+		},
 	}
 	env := conditions.StdEnv
 	knownVars := make(map[string]any)

--- a/internal/engine/planner/struct_matcher_test.go
+++ b/internal/engine/planner/struct_matcher_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/cerbos/cerbos/internal/conditions"
 )
@@ -42,7 +41,7 @@ func TestStructMatcher(t *testing.T) {
 			expr: "3 in P.attr.anyMap[R.attr.Id]",
 		},
 		{
-			expr: "{1: 1}.exists(k, v, k == v)",
+			expr: "{1: [1, 2]}.exists(k, v, k in v)",
 			res:  true,
 		},
 	}
@@ -53,7 +52,7 @@ func TestStructMatcher(t *testing.T) {
 			require.Nil(t, issues.Err())
 			s := newExpressionProcessor()
 			e := ast.NativeRep().Expr()
-			t.Log(protojson.Format(ast.Expr()))
+			// t.Log(protojson.Format(ast.Expr()))
 			res, _, err := s.Process(e, env)
 			require.NoError(t, err)
 			require.Equal(t, test.res, res)

--- a/internal/engine/planner/struct_matcher_test.go
+++ b/internal/engine/planner/struct_matcher_test.go
@@ -51,6 +51,10 @@ func TestStructMatcher(t *testing.T) {
 			want: `R.attr.color == "red" && R.attr.shape == "square" || R.attr.color == "blue" && R.attr.shape == "triangle" ||
         R.attr.color == "black" && R.attr.shape == "circle"`,
 		},
+		{
+			expr: "{1: 1}.exists(k, v, k == v)",
+			want: "true",
+		},
 	}
 	env := conditions.StdEnv
 	knownVars := make(map[string]any)

--- a/internal/engine/planner/struct_matcher_test.go
+++ b/internal/engine/planner/struct_matcher_test.go
@@ -1,12 +1,13 @@
 // Copyright 2021-2025 Zenauth Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-package matchers
+package planner
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/cerbos/cerbos/internal/conditions"
 )
@@ -40,13 +41,19 @@ func TestStructMatcher(t *testing.T) {
 		{
 			expr: "3 in P.attr.anyMap[R.attr.Id]",
 		},
+		{
+			expr: "{1: 1}.exists(k, v, k == v)",
+			res:  true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.expr, func(t *testing.T) {
 			ast, issues := conditions.StdEnv.Compile(test.expr)
 			require.Nil(t, issues.Err())
-			s := NewExpressionProcessor()
-			res, _, err := s.Process(ast.NativeRep().Expr())
+			s := newExpressionProcessor()
+			e := ast.NativeRep().Expr()
+			t.Log(protojson.Format(ast.Expr()))
+			res, _, err := s.Process(e)
 			require.NoError(t, err)
 			require.Equal(t, test.res, res)
 		})

--- a/internal/engine/planner/struct_matcher_test.go
+++ b/internal/engine/planner/struct_matcher_test.go
@@ -4,12 +4,15 @@
 package planner
 
 import (
+	"regexp"
 	"testing"
 	"time"
 
 	celast "github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/parser"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/encoding/protojson"
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 
 	"github.com/cerbos/cerbos/internal/conditions"
 )
@@ -18,10 +21,12 @@ func TestStructMatcher(t *testing.T) {
 	tests := []struct {
 		expr string
 		res  bool
+		want string
 	}{
 		{
 			expr: "{\"a\": 3}[R.attr.Id] == 4",
 			res:  true,
+			want: `R.attr.Id == "a" && 4 == 3`,
 		},
 		{
 			expr: "4 == {\"a\": 3}[R.attr.Id]", // can't swap args
@@ -32,6 +37,7 @@ func TestStructMatcher(t *testing.T) {
 		{
 			expr: `{"a1": {"role": "OWNER"}}[R.id].role == "OWNER"`,
 			res:  true,
+			want: `R.id == "a1" && "OWNER" == {"role": "OWNER"}.role`,
 		},
 		{
 			expr: "P.attr.anyMap[R.attr.Id][R.attr.value]",
@@ -39,13 +45,16 @@ func TestStructMatcher(t *testing.T) {
 		{
 			expr: "3 in {\"a\": [3, 4]}[R.attr.Id]",
 			res:  true,
+			want: `R.attr.Id == "a" && 3 in [3, 4]`,
 		},
 		{
 			expr: "3 in P.attr.anyMap[R.attr.Id]",
 		},
 		{
-			expr: `{1: "red"}.exists(k, v, R.attr.team == v)`,
-			res:  true,
+			expr: `{1: ["red", "square"], 2: ["blue", "triangle"], 3: ["black", "circle"]}.exists(k, v, R.attr.color == v[0] && R.attr.shape == v[1])`,
+			want: `R.attr.color == "red" && R.attr.shape == "square" || R.attr.color == "blue" && R.attr.shape == "triangle" ||
+        R.attr.color == "black" && R.attr.shape == "circle"`,
+			res: true,
 		},
 	}
 	env := conditions.StdEnv
@@ -57,17 +66,42 @@ func TestStructMatcher(t *testing.T) {
 	p, err := newPartialEvaluator(env, knownVars, nowFn)
 	require.NoError(t, err)
 	s := newExpressionProcessor(p)
-	for _, test := range tests {
-		t.Run(test.expr, func(t *testing.T) {
-			ast, issues := env.Compile(test.expr)
+	for _, tc := range tests {
+		t.Run(tc.expr, func(t *testing.T) {
+			ast, issues := env.Compile(tc.expr)
 			require.Nil(t, issues.Err())
 			e := ast.NativeRep().Expr()
 			res, e1, err := s.Process(t.Context(), e)
 			require.NoError(t, err)
-			ep, err := celast.ExprToProto(e1)
-			require.NoError(t, err)
-			t.Log("result= ", protojson.Format(ep))
-			require.Equal(t, test.res, res)
+			require.Equal(t, tc.res, res)
+			if tc.res {
+				unparsed, err := unparseExpr(t, e1)
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(stripWs(tc.want), stripWs(unparsed)))
+			}
 		})
 	}
+}
+func stripWs(s string) string {
+	r := regexp.MustCompile("\\s+")
+	return string(r.ReplaceAll([]byte(s), []byte(" ")))
+}
+func unparseExpr(t *testing.T, expr celast.Expr) (string, error) {
+	t.Helper()
+	protoExpr, err := celast.ExprToProto(expr)
+	require.NoError(t, err)
+
+	astExpr, err := celast.ProtoToExpr(protoExpr)
+	require.NoError(t, err)
+
+	checkedExpr := &exprpb.CheckedExpr{
+		Expr:       protoExpr,
+		SourceInfo: &exprpb.SourceInfo{},
+	}
+	srcInfo, err := celast.ProtoToSourceInfo(checkedExpr.SourceInfo)
+	require.NoError(t, err)
+
+	source, err := parser.Unparse(astExpr, srcInfo)
+	require.NoError(t, err)
+	return source, nil
 }

--- a/internal/test/testdata/query_planner/policies/resource_policies/report_with_map.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policies/report_with_map.yaml
@@ -95,3 +95,11 @@ resourcePolicy:
       effect: EFFECT_ALLOW
       derivedRoles:
         - workspace_admin
+    - actions:
+        - match_by
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: P.attr.figures.exists(k, v, R.attr.color in v["colors"] && R.attr.shape in v["shapes"] && R.attr.size in v["sizes"])

--- a/internal/test/testdata/query_planner/suite/harry.yaml
+++ b/internal/test/testdata/query_planner/suite/harry.yaml
@@ -101,18 +101,18 @@ tests:
       kind: KIND_CONDITIONAL
       condition:
         expression:
-          operator: exists
+          operator: or
           operands:
-            - value: ["team1", "team2"]
             - expression:
-                operator: lambda
+                operator: eq
                 operands:
-                  - expression:
-                      operator: eq
-                      operands:
-                        - variable: t
-                        - variable: request.resource.attr.teamId
-                  - variable: t
+                  - value: team1
+                  - variable: request.resource.attr.teamId
+            - expression:
+                operator: eq
+                operands:
+                  - value: team2
+                  - variable: request.resource.attr.teamId
   - action: map-all
     resource:
       kind: leave_request

--- a/internal/test/testdata/query_planner/suite/macro_user.yaml
+++ b/internal/test/testdata/query_planner/suite/macro_user.yaml
@@ -155,18 +155,18 @@ tests:
       kind: KIND_CONDITIONAL
       condition:
         expression:
-          operator: exists
+          operator: or
           operands:
-            - value: ["employee", "user"]
             - expression:
-                operator: lambda
+                operator: in
                 operands:
-                  - expression:
-                      operator: in
-                      operands:
-                        - variable: x
-                        - variable: request.resource.attr.roles
-                  - variable: x
+                  - value: "employee"
+                  - variable: request.resource.attr.roles
+            - expression:
+                operator: in
+                operands:
+                  - value: "user"
+                  - variable: request.resource.attr.roles
   - action: exists_one
     resource:
       kind: macro

--- a/internal/test/testdata/query_planner/suite/report_with_map.yaml
+++ b/internal/test/testdata/query_planner/suite/report_with_map.yaml
@@ -182,20 +182,20 @@ tests:
                 operator: and
                 operands:
                   - expression:
-                      operator: in
+                      operator: eq
                       operands:
                         - variable: request.resource.attr.color
-                        - value: ["red"]
+                        - value: "red"
                   - expression:
                       operator: in
                       operands:
                         - variable: request.resource.attr.shape
                         - value: ["square", "circle"]
                   - expression:
-                      operator: in
+                      operator: eq
                       operands:
                         - variable: request.resource.attr.size
-                        - value: ["small"]
+                        - value: "small"
             - expression:
                 operator: and
                 operands:
@@ -205,10 +205,10 @@ tests:
                         - variable: request.resource.attr.color
                         - value: ["blue", "black"]
                   - expression:
-                      operator: in
+                      operator: eq
                       operands:
                         - variable: request.resource.attr.shape
-                        - value: ["rectangle"]
+                        - value: "rectangle"
                   - expression:
                       operator: in
                       operands:

--- a/internal/test/testdata/query_planner/suite/report_with_map.yaml
+++ b/internal/test/testdata/query_planner/suite/report_with_map.yaml
@@ -182,15 +182,18 @@ tests:
                 operator: and
                 operands:
                   - expression:
-                      operator: eq
+                      operator: and
                       operands:
-                        - variable: request.resource.attr.color
-                        - value: "red"
-                  - expression:
-                      operator: in
-                      operands:
-                        - variable: request.resource.attr.shape
-                        - value: ["square", "circle"]
+                        - expression:
+                            operator: eq
+                            operands:
+                              - variable: request.resource.attr.color
+                              - value: "red"
+                        - expression:
+                            operator: in
+                            operands:
+                              - variable: request.resource.attr.shape
+                              - value: ["square", "circle"]
                   - expression:
                       operator: eq
                       operands:
@@ -200,15 +203,18 @@ tests:
                 operator: and
                 operands:
                   - expression:
-                      operator: in
-                      operands:
-                        - variable: request.resource.attr.color
-                        - value: ["blue", "black"]
-                  - expression:
-                      operator: eq
-                      operands:
-                        - variable: request.resource.attr.shape
-                        - value: "rectangle"
+                      operator: and
+                      # operands:
+                        - expression:
+                            operator: in
+                            operands:
+                              - variable: request.resource.attr.color
+                              - value: ["blue", "black"]
+                        - expression:
+                            operator: eq
+                            operands:
+                              - variable: request.resource.attr.shape
+                              - value: "rectangle"
                   - expression:
                       operator: in
                       operands:

--- a/internal/test/testdata/query_planner/suite/report_with_map.yaml
+++ b/internal/test/testdata/query_planner/suite/report_with_map.yaml
@@ -204,7 +204,7 @@ tests:
                 operands:
                   - expression:
                       operator: and
-                      # operands:
+                      operands:
                         - expression:
                             operator: in
                             operands:

--- a/internal/test/testdata/query_planner/suite/report_with_map.yaml
+++ b/internal/test/testdata/query_planner/suite/report_with_map.yaml
@@ -28,7 +28,19 @@ principal: {
         "name": "workspaceB",
         "role": "MEMBER"
       }
-    ]
+    ],
+    "figures": {
+      "set-1": {
+        "colors": ["red"],
+        "shapes": ["square", "circle"],
+        "sizes": ["small"]
+      },
+      "set-2": {
+        "colors": ["blue", "black"],
+        "shapes": ["rectangle"],
+        "sizes": ["small", "large"]
+      },
+    }
   }
 }
 tests:
@@ -156,3 +168,49 @@ tests:
           operands:
             - variable: request.resource.attr.location_id
             - value: "1"
+  - action: match_by
+    resource:
+      kind: report_with_map
+      policyVersion: default
+    want:
+      kind: KIND_CONDITIONAL
+      condition:
+        expression:
+          operator: or
+          operands:
+            - expression:
+                operator: and
+                operands:
+                  - expression:
+                      operator: in
+                      operands:
+                        - variable: request.resource.attr.color
+                        - value: ["red"]
+                  - expression:
+                      operator: in
+                      operands:
+                        - variable: request.resource.attr.shape
+                        - value: ["square", "circle"]
+                  - expression:
+                      operator: in
+                      operands:
+                        - variable: request.resource.attr.size
+                        - value: ["small"]
+            - expression:
+                operator: and
+                operands:
+                  - expression:
+                      operator: in
+                      operands:
+                        - variable: request.resource.attr.color
+                        - value: ["blue", "black"]
+                  - expression:
+                      operator: in
+                      operands:
+                        - variable: request.resource.attr.shape
+                        - value: ["rectangle"]
+                  - expression:
+                      operator: in
+                      operands:
+                        - variable: request.resource.attr.size
+                        - value: ["small", "large"]


### PR DESCRIPTION
In case a collection is a known value, then `collection.exists(t, <bodyExpr>) can be simplified as a logical OR of the body expr evaluated for each value of `t` in the collection. The collection can be either a map or a list. Both single- and two-var operations are supported.