### PR TITLE
enhancement!: Remove bundle version configuration parameter

### DIFF
--- a/deploy/charts/cerbos/values-cerbos-hub.yaml
+++ b/deploy/charts/cerbos/values-cerbos-hub.yaml
@@ -12,7 +12,6 @@ cerbos:
     storage:
       driver: "hub"
       hub:
-        bundleVersion: 2
         remote:
           deploymentID: "YOUR_DEPLOYMENT_ID" # Alternatively, add `CERBOS_HUB_DEPLOYMENT_ID=<YOUR_DEPLOYMENT_ID>` to the secret you created above
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -87,8 +87,7 @@ func TestServer(t *testing.T) {
 				dir := test.PathToDir(t, filepath.Join("bundle", fmt.Sprintf("v%d", version)))
 
 				conf := &hubstore.Conf{
-					BundleVersion: version,
-					CacheSize:     1024,
+					CacheSize: 1024,
 					Local: &hubstore.LocalSourceConf{
 						BundlePath: filepath.Join(dir, "bundle.crbp"),
 						TempDir:    t.TempDir(),

--- a/internal/storage/hub/conf.go
+++ b/internal/storage/hub/conf.go
@@ -170,6 +170,12 @@ func (rc *RemoteSourceConf) setDefaultsForUnsetFields() error {
 		return errors.New("bundleLabel, deploymentID or playgroundID must be specified")
 	}
 
+	if (rc.BundleLabel != "" && (rc.DeploymentID != "" || rc.PlaygroundID != "")) ||
+		(rc.DeploymentID != "" && (rc.BundleLabel != "" || rc.PlaygroundID != "")) ||
+		(rc.PlaygroundID != "" && (rc.BundleLabel != "" || rc.DeploymentID != "")) {
+		return errors.New("only one of the bundleLabel, deploymentID or playgroundID must be specified")
+	}
+
 	if rc.TempDir == "" {
 		dir, err := os.MkdirTemp("", "cerbos-hub-*")
 		if err != nil {

--- a/internal/storage/hub/conf_test.go
+++ b/internal/storage/hub/conf_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cerbos/cloud-api/bundle"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
@@ -170,8 +169,7 @@ func doTestConfig(driver string) func(*testing.T) {
 		}
 
 		want := &hubstore.Conf{
-			BundleVersion: bundle.Version1,
-			CacheSize:     1024,
+			CacheSize: 1024,
 			Credentials: &hub.CredentialsConf{
 				PDPID:           "pdp-id",
 				ClientID:        "client-id",

--- a/internal/storage/hub/remote_source_test.go
+++ b/internal/storage/hub/remote_source_test.go
@@ -129,7 +129,7 @@ func runRemoteTests(tctx testCtx) func(t *testing.T) {
 			})
 
 			t.Run("Playground", func(t *testing.T) {
-				rs, mockClientV1, mockClientV2 := mkRemoteSource(t, tctx, mkConf(t, tctx, withDisableAutoUpdate(), withPlayground()))
+				rs, mockClientV1, mockClientV2 := mkRemoteSource(t, tctx, mkConf(t, tctx, withDisableAutoUpdate(), withPlayground(tctx.version)))
 
 				switch tctx.version {
 				case bundleapi.Version1:
@@ -444,9 +444,9 @@ func withDisableAutoUpdate() confOption {
 	}
 }
 
-func withPlayground() confOption {
+func withPlayground(bundleVersion bundleapi.Version) confOption {
 	return func(conf *hub.Conf) {
-		switch conf.BundleVersion {
+		switch bundleVersion {
 		case bundleapi.Version1:
 			conf.Remote.BundleLabel = playgroundLabel
 		case bundleapi.Version2:
@@ -461,9 +461,8 @@ func mkConf(t *testing.T, tctx testCtx, opts ...confOption) *hub.Conf {
 	t.Helper()
 
 	conf := &hub.Conf{
-		BundleVersion: tctx.version,
-		CacheSize:     1024,
-		Remote:        &hub.RemoteSourceConf{},
+		CacheSize: 1024,
+		Remote:    &hub.RemoteSourceConf{},
 	}
 
 	switch tctx.version {


### PR DESCRIPTION
If an existing configuration parameter states `bundleVersion` field, there will be an error starting up Cerbos with this change:
```json
{
  "log.level": "error",
  "log.logger": "cerbos.server",
  "message": "Failed to start server",
  "error": "failed to create store: failed to read hub configuration: yaml: unmarshal errors:\n  line 1: field bundleVersion not found in type hub.Conf"
}
```