### PR TITLE
fix: Handle multi-role planner precedence correctly

### DIFF
--- a/internal/test/testdata/query_planner/policies/resource_policies/leave_request.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policies/leave_request.yaml
@@ -216,3 +216,39 @@ resourcePolicy:
       condition:
         match:
           expr: P.attr.account_id in (R.attr.accounts_people.map(ap, ap.account_id))
+    - actions: ["multi-role-test"]
+      roles: ["employee"]
+      effect: EFFECT_DENY
+    - actions: ["multi-role-test"]
+      roles: ["user"]
+      effect: EFFECT_ALLOW
+    - actions: ["multi-role-test-conditional-allow"]
+      roles: ["employee"]
+      effect: EFFECT_DENY
+    - actions: ["multi-role-test-conditional-allow"]
+      roles: ["user"]
+      effect: EFFECT_ALLOW
+      condition:
+        match:
+          expr: V.is_owner
+    - actions: ["multi-role-test-conditional-deny"]
+      roles: ["employee"]
+      effect: EFFECT_DENY
+      condition:
+        match:
+          expr: V.is_owner
+    - actions: ["multi-role-test-conditional-deny"]
+      roles: ["user"]
+      effect: EFFECT_ALLOW
+    - actions: ["multi-role-test-conditional-allow-deny"]
+      roles: ["employee"]
+      effect: EFFECT_DENY
+      condition:
+        match:
+          expr: V.is_owner
+    - actions: ["multi-role-test-conditional-allow-deny"]
+      roles: ["user"]
+      effect: EFFECT_ALLOW
+      condition:
+        match:
+          expr: V.is_owner

--- a/internal/test/testdata/query_planner/suite/harry.yaml
+++ b/internal/test/testdata/query_planner/suite/harry.yaml
@@ -153,3 +153,50 @@ tests:
                       operands:
                         - variable: ap.account_id
                         - variable: ap
+  - action: multi-role-test
+    resource:
+      kind: leave_request
+      policyVersion: default
+    want:
+      kind: KIND_ALWAYS_ALLOWED
+  - action: multi-role-test-conditional-allow
+    resource:
+      kind: leave_request
+      policyVersion: default
+    want:
+      kind: KIND_CONDITIONAL
+      condition:
+        expression:
+          operator: eq
+          operands:
+            - variable: request.resource.attr.owner
+            - value: harry
+  - action: multi-role-test-conditional-deny
+    resource:
+      kind: leave_request
+      policyVersion: default
+    want:
+      kind: KIND_ALWAYS_ALLOWED
+  - action: multi-role-test-conditional-allow-deny
+    resource:
+      kind: leave_request
+      policyVersion: default
+    want:
+      kind: KIND_CONDITIONAL
+      condition:
+        expression:
+          operator: and
+          operands:
+            - expression:
+                operator: eq
+                operands:
+                  - variable: request.resource.attr.owner
+                  - value: harry
+            - expression:
+                operator: not
+                operands:
+                  - expression:
+                      operator: eq
+                      operands:
+                        - variable: request.resource.attr.owner
+                        - value: harry


### PR DESCRIPTION
Previously, unconditional DENY rules were incorrectly overriding ALLOW rules from other roles if the ALLOW was conditional.

Fixes https://github.com/cerbos/cerbos/issues/2591