### PR TITLE
enhancement: Static rule table evaluator

### DIFF
--- a/api/genpb/cerbos/runtime/v1/hashpb_helpers.pb.go
+++ b/api/genpb/cerbos/runtime/v1/hashpb_helpers.pb.go
@@ -418,6 +418,17 @@ func cerbos_runtime_v1_RuleTableMetadata_hashpb_sum(m *RuleTableMetadata, hasher
 	}
 }
 
+func cerbos_runtime_v1_RuleTable_JSONSchema_hashpb_sum(m *RuleTable_JSONSchema, hasher hash.Hash, ignore map[string]struct{}) {
+	if _, ok := ignore["cerbos.runtime.v1.RuleTable.JSONSchema.id"]; !ok {
+		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(m.GetId()))))
+		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetId()), len(m.GetId())))
+	}
+	if _, ok := ignore["cerbos.runtime.v1.RuleTable.JSONSchema.content"]; !ok {
+		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(m.GetContent()))))
+		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetContent()), len(m.GetContent())))
+	}
+}
+
 func cerbos_runtime_v1_RuleTable_PolicyDerivedRoles_hashpb_sum(m *RuleTable_PolicyDerivedRoles, hasher hash.Hash, ignore map[string]struct{}) {
 	if _, ok := ignore["cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.derived_roles"]; !ok {
 		if len(m.DerivedRoles) > 0 {
@@ -630,6 +641,17 @@ func cerbos_runtime_v1_RuleTable_hashpb_sum(m *RuleTable, hasher hash.Hash, igno
 				_, _ = hasher.Write(protowire.AppendVarint(nil, k))
 				if m.PolicyDerivedRoles[k] != nil {
 					cerbos_runtime_v1_RuleTable_PolicyDerivedRoles_hashpb_sum(m.PolicyDerivedRoles[k], hasher, ignore)
+				}
+			}
+		}
+	}
+	if _, ok := ignore["cerbos.runtime.v1.RuleTable.json_schemas"]; !ok {
+		if len(m.JsonSchemas) > 0 {
+			for _, k := range slices.Sorted(maps.Keys(m.JsonSchemas)) {
+				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(k))))
+				_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(k), len(k)))
+				if m.JsonSchemas[k] != nil {
+					cerbos_runtime_v1_RuleTable_JSONSchema_hashpb_sum(m.JsonSchemas[k], hasher, ignore)
 				}
 			}
 		}

--- a/api/genpb/cerbos/runtime/v1/hashpb_helpers.pb.go
+++ b/api/genpb/cerbos/runtime/v1/hashpb_helpers.pb.go
@@ -419,13 +419,9 @@ func cerbos_runtime_v1_RuleTableMetadata_hashpb_sum(m *RuleTableMetadata, hasher
 }
 
 func cerbos_runtime_v1_RuleTable_JSONSchema_hashpb_sum(m *RuleTable_JSONSchema, hasher hash.Hash, ignore map[string]struct{}) {
-	if _, ok := ignore["cerbos.runtime.v1.RuleTable.JSONSchema.id"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(m.GetId()))))
-		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetId()), len(m.GetId())))
-	}
 	if _, ok := ignore["cerbos.runtime.v1.RuleTable.JSONSchema.content"]; !ok {
 		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(m.GetContent()))))
-		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetContent()), len(m.GetContent())))
+		_, _ = hasher.Write(m.GetContent())
 	}
 }
 

--- a/api/genpb/cerbos/runtime/v1/runtime.pb.go
+++ b/api/genpb/cerbos/runtime/v1/runtime.pb.go
@@ -1619,8 +1619,7 @@ func (x *RuleTable_PolicyDerivedRoles) GetDerivedRoles() map[string]*RunnableDer
 
 type RuleTable_JSONSchema struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Content       string                 `protobuf:"bytes,2,opt,name=content,proto3" json:"content,omitempty"`
+	Content       []byte                 `protobuf:"bytes,1,opt,name=content,proto3" json:"content,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1655,18 +1654,11 @@ func (*RuleTable_JSONSchema) Descriptor() ([]byte, []int) {
 	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{1, 3}
 }
 
-func (x *RuleTable_JSONSchema) GetId() string {
-	if x != nil {
-		return x.Id
-	}
-	return ""
-}
-
-func (x *RuleTable_JSONSchema) GetContent() string {
+func (x *RuleTable_JSONSchema) GetContent() []byte {
 	if x != nil {
 		return x.Content
 	}
-	return ""
+	return nil
 }
 
 type RuleTable_RuleRow_AllowActions struct {
@@ -3214,7 +3206,7 @@ const file_cerbos_runtime_v1_runtime_proto_rawDesc = "" +
 	"rolePolicy\x12)\n" +
 	"\x10compiler_version\x18\x06 \x01(\rR\x0fcompilerVersionB\f\n" +
 	"\n" +
-	"policy_set\"\xe2\x17\n" +
+	"policy_set\"\xd2\x17\n" +
 	"\tRuleTable\x12:\n" +
 	"\x05rules\x18\x01 \x03(\v2$.cerbos.runtime.v1.RuleTable.RuleRowR\x05rules\x12C\n" +
 	"\aschemas\x18\x02 \x03(\v2).cerbos.runtime.v1.RuleTable.SchemasEntryR\aschemas\x12:\n" +
@@ -3271,11 +3263,10 @@ const file_cerbos_runtime_v1_runtime_proto_rawDesc = "" +
 	"\rderived_roles\x18\x01 \x03(\v2A.cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntryR\fderivedRoles\x1ag\n" +
 	"\x11DerivedRolesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12<\n" +
-	"\x05value\x18\x02 \x01(\v2&.cerbos.runtime.v1.RunnableDerivedRoleR\x05value:\x028\x01\x1a6\n" +
+	"\x05value\x18\x02 \x01(\v2&.cerbos.runtime.v1.RunnableDerivedRoleR\x05value:\x028\x01\x1a&\n" +
 	"\n" +
-	"JSONSchema\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
-	"\acontent\x18\x02 \x01(\tR\acontent\x1aU\n" +
+	"JSONSchema\x12\x18\n" +
+	"\acontent\x18\x01 \x01(\fR\acontent\x1aU\n" +
 	"\fSchemasEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\x04R\x03key\x12/\n" +
 	"\x05value\x18\x02 \x01(\v2\x19.cerbos.policy.v1.SchemasR\x05value:\x028\x01\x1a]\n" +

--- a/api/genpb/cerbos/runtime/v1/runtime.pb.go
+++ b/api/genpb/cerbos/runtime/v1/runtime.pb.go
@@ -187,6 +187,7 @@ type RuleTable struct {
 	Meta               map[uint64]*RuleTableMetadata            `protobuf:"bytes,3,rep,name=meta,proto3" json:"meta,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	ScopeParentRoles   map[string]*RuleTable_RoleParentRoles    `protobuf:"bytes,4,rep,name=scope_parent_roles,json=scopeParentRoles,proto3" json:"scope_parent_roles,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	PolicyDerivedRoles map[uint64]*RuleTable_PolicyDerivedRoles `protobuf:"bytes,5,rep,name=policy_derived_roles,json=policyDerivedRoles,proto3" json:"policy_derived_roles,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	JsonSchemas        map[string]*RuleTable_JSONSchema         `protobuf:"bytes,6,rep,name=json_schemas,json=jsonSchemas,proto3" json:"json_schemas,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -252,6 +253,13 @@ func (x *RuleTable) GetScopeParentRoles() map[string]*RuleTable_RoleParentRoles 
 func (x *RuleTable) GetPolicyDerivedRoles() map[uint64]*RuleTable_PolicyDerivedRoles {
 	if x != nil {
 		return x.PolicyDerivedRoles
+	}
+	return nil
+}
+
+func (x *RuleTable) GetJsonSchemas() map[string]*RuleTable_JSONSchema {
+	if x != nil {
+		return x.JsonSchemas
 	}
 	return nil
 }
@@ -1609,6 +1617,58 @@ func (x *RuleTable_PolicyDerivedRoles) GetDerivedRoles() map[string]*RunnableDer
 	return nil
 }
 
+type RuleTable_JSONSchema struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Content       string                 `protobuf:"bytes,2,opt,name=content,proto3" json:"content,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RuleTable_JSONSchema) Reset() {
+	*x = RuleTable_JSONSchema{}
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RuleTable_JSONSchema) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RuleTable_JSONSchema) ProtoMessage() {}
+
+func (x *RuleTable_JSONSchema) ProtoReflect() protoreflect.Message {
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RuleTable_JSONSchema.ProtoReflect.Descriptor instead.
+func (*RuleTable_JSONSchema) Descriptor() ([]byte, []int) {
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{1, 3}
+}
+
+func (x *RuleTable_JSONSchema) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *RuleTable_JSONSchema) GetContent() string {
+	if x != nil {
+		return x.Content
+	}
+	return ""
+}
+
 type RuleTable_RuleRow_AllowActions struct {
 	state         protoimpl.MessageState    `protogen:"open.v1"`
 	Actions       map[string]*emptypb.Empty `protobuf:"bytes,1,rep,name=actions,proto3" json:"actions,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
@@ -1618,7 +1678,7 @@ type RuleTable_RuleRow_AllowActions struct {
 
 func (x *RuleTable_RuleRow_AllowActions) Reset() {
 	*x = RuleTable_RuleRow_AllowActions{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[23]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1630,7 +1690,7 @@ func (x *RuleTable_RuleRow_AllowActions) String() string {
 func (*RuleTable_RuleRow_AllowActions) ProtoMessage() {}
 
 func (x *RuleTable_RuleRow_AllowActions) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[23]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1663,7 +1723,7 @@ type RuleTable_RuleRow_Params struct {
 
 func (x *RuleTable_RuleRow_Params) Reset() {
 	*x = RuleTable_RuleRow_Params{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[24]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1675,7 +1735,7 @@ func (x *RuleTable_RuleRow_Params) String() string {
 func (*RuleTable_RuleRow_Params) ProtoMessage() {}
 
 func (x *RuleTable_RuleRow_Params) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[24]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1714,7 +1774,7 @@ type RuleTable_RoleParentRoles_ParentRoles struct {
 
 func (x *RuleTable_RoleParentRoles_ParentRoles) Reset() {
 	*x = RuleTable_RoleParentRoles_ParentRoles{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[27]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1726,7 +1786,7 @@ func (x *RuleTable_RoleParentRoles_ParentRoles) String() string {
 func (*RuleTable_RoleParentRoles_ParentRoles) ProtoMessage() {}
 
 func (x *RuleTable_RoleParentRoles_ParentRoles) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[27]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1760,7 +1820,7 @@ type RunnableRolePolicySet_Metadata struct {
 
 func (x *RunnableRolePolicySet_Metadata) Reset() {
 	*x = RunnableRolePolicySet_Metadata{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[32]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1772,7 +1832,7 @@ func (x *RunnableRolePolicySet_Metadata) String() string {
 func (*RunnableRolePolicySet_Metadata) ProtoMessage() {}
 
 func (x *RunnableRolePolicySet_Metadata) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[32]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1820,7 +1880,7 @@ type RunnableRolePolicySet_Rule struct {
 
 func (x *RunnableRolePolicySet_Rule) Reset() {
 	*x = RunnableRolePolicySet_Rule{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[33]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1832,7 +1892,7 @@ func (x *RunnableRolePolicySet_Rule) String() string {
 func (*RunnableRolePolicySet_Rule) ProtoMessage() {}
 
 func (x *RunnableRolePolicySet_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[33]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1878,7 +1938,7 @@ type RunnableRolePolicySet_RuleList struct {
 
 func (x *RunnableRolePolicySet_RuleList) Reset() {
 	*x = RunnableRolePolicySet_RuleList{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[34]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1890,7 +1950,7 @@ func (x *RunnableRolePolicySet_RuleList) String() string {
 func (*RunnableRolePolicySet_RuleList) ProtoMessage() {}
 
 func (x *RunnableRolePolicySet_RuleList) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[34]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1926,7 +1986,7 @@ type RunnableResourcePolicySet_Metadata struct {
 
 func (x *RunnableResourcePolicySet_Metadata) Reset() {
 	*x = RunnableResourcePolicySet_Metadata{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[39]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1938,7 +1998,7 @@ func (x *RunnableResourcePolicySet_Metadata) String() string {
 func (*RunnableResourcePolicySet_Metadata) ProtoMessage() {}
 
 func (x *RunnableResourcePolicySet_Metadata) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[39]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2006,7 +2066,7 @@ type RunnableResourcePolicySet_Policy struct {
 
 func (x *RunnableResourcePolicySet_Policy) Reset() {
 	*x = RunnableResourcePolicySet_Policy{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[40]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2018,7 +2078,7 @@ func (x *RunnableResourcePolicySet_Policy) String() string {
 func (*RunnableResourcePolicySet_Policy) ProtoMessage() {}
 
 func (x *RunnableResourcePolicySet_Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[40]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2108,7 +2168,7 @@ type RunnableResourcePolicySet_Policy_Rule struct {
 
 func (x *RunnableResourcePolicySet_Policy_Rule) Reset() {
 	*x = RunnableResourcePolicySet_Policy_Rule{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[43]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2120,7 +2180,7 @@ func (x *RunnableResourcePolicySet_Policy_Rule) String() string {
 func (*RunnableResourcePolicySet_Policy_Rule) ProtoMessage() {}
 
 func (x *RunnableResourcePolicySet_Policy_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[43]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2203,7 +2263,7 @@ type RunnableDerivedRolesSet_Metadata struct {
 
 func (x *RunnableDerivedRolesSet_Metadata) Reset() {
 	*x = RunnableDerivedRolesSet_Metadata{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[53]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2215,7 +2275,7 @@ func (x *RunnableDerivedRolesSet_Metadata) String() string {
 func (*RunnableDerivedRolesSet_Metadata) ProtoMessage() {}
 
 func (x *RunnableDerivedRolesSet_Metadata) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[53]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2255,7 +2315,7 @@ type RunnableVariablesSet_Metadata struct {
 
 func (x *RunnableVariablesSet_Metadata) Reset() {
 	*x = RunnableVariablesSet_Metadata{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[56]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2267,7 +2327,7 @@ func (x *RunnableVariablesSet_Metadata) String() string {
 func (*RunnableVariablesSet_Metadata) ProtoMessage() {}
 
 func (x *RunnableVariablesSet_Metadata) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[56]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2310,7 +2370,7 @@ type RunnablePrincipalPolicySet_Metadata struct {
 
 func (x *RunnablePrincipalPolicySet_Metadata) Reset() {
 	*x = RunnablePrincipalPolicySet_Metadata{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[59]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2322,7 +2382,7 @@ func (x *RunnablePrincipalPolicySet_Metadata) String() string {
 func (*RunnablePrincipalPolicySet_Metadata) ProtoMessage() {}
 
 func (x *RunnablePrincipalPolicySet_Metadata) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[59]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2388,7 +2448,7 @@ type RunnablePrincipalPolicySet_Policy struct {
 
 func (x *RunnablePrincipalPolicySet_Policy) Reset() {
 	*x = RunnablePrincipalPolicySet_Policy{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[60]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2400,7 +2460,7 @@ func (x *RunnablePrincipalPolicySet_Policy) String() string {
 func (*RunnablePrincipalPolicySet_Policy) ProtoMessage() {}
 
 func (x *RunnablePrincipalPolicySet_Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[60]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2474,7 +2534,7 @@ type RunnablePrincipalPolicySet_Policy_ActionRule struct {
 
 func (x *RunnablePrincipalPolicySet_Policy_ActionRule) Reset() {
 	*x = RunnablePrincipalPolicySet_Policy_ActionRule{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[63]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2486,7 +2546,7 @@ func (x *RunnablePrincipalPolicySet_Policy_ActionRule) String() string {
 func (*RunnablePrincipalPolicySet_Policy_ActionRule) ProtoMessage() {}
 
 func (x *RunnablePrincipalPolicySet_Policy_ActionRule) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[63]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2554,7 +2614,7 @@ type RunnablePrincipalPolicySet_Policy_ResourceRules struct {
 
 func (x *RunnablePrincipalPolicySet_Policy_ResourceRules) Reset() {
 	*x = RunnablePrincipalPolicySet_Policy_ResourceRules{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[64]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2566,7 +2626,7 @@ func (x *RunnablePrincipalPolicySet_Policy_ResourceRules) String() string {
 func (*RunnablePrincipalPolicySet_Policy_ResourceRules) ProtoMessage() {}
 
 func (x *RunnablePrincipalPolicySet_Policy_ResourceRules) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[64]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2599,7 +2659,7 @@ type Output_When struct {
 
 func (x *Output_When) Reset() {
 	*x = Output_When{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[68]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2611,7 +2671,7 @@ func (x *Output_When) String() string {
 func (*Output_When) ProtoMessage() {}
 
 func (x *Output_When) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[68]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2650,7 +2710,7 @@ type Condition_ExprList struct {
 
 func (x *Condition_ExprList) Reset() {
 	*x = Condition_ExprList{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[69]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2662,7 +2722,7 @@ func (x *Condition_ExprList) String() string {
 func (*Condition_ExprList) ProtoMessage() {}
 
 func (x *Condition_ExprList) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[69]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2698,7 +2758,7 @@ type CompileErrors_Err struct {
 
 func (x *CompileErrors_Err) Reset() {
 	*x = CompileErrors_Err{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[70]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2710,7 +2770,7 @@ func (x *CompileErrors_Err) String() string {
 func (*CompileErrors_Err) ProtoMessage() {}
 
 func (x *CompileErrors_Err) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[70]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2773,7 +2833,7 @@ type IndexBuildErrors_DuplicateDef struct {
 
 func (x *IndexBuildErrors_DuplicateDef) Reset() {
 	*x = IndexBuildErrors_DuplicateDef{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[71]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2785,7 +2845,7 @@ func (x *IndexBuildErrors_DuplicateDef) String() string {
 func (*IndexBuildErrors_DuplicateDef) ProtoMessage() {}
 
 func (x *IndexBuildErrors_DuplicateDef) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[71]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2844,7 +2904,7 @@ type IndexBuildErrors_MissingImport struct {
 
 func (x *IndexBuildErrors_MissingImport) Reset() {
 	*x = IndexBuildErrors_MissingImport{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[72]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2856,7 +2916,7 @@ func (x *IndexBuildErrors_MissingImport) String() string {
 func (*IndexBuildErrors_MissingImport) ProtoMessage() {}
 
 func (x *IndexBuildErrors_MissingImport) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[72]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2931,7 +2991,7 @@ type IndexBuildErrors_MissingScope struct {
 
 func (x *IndexBuildErrors_MissingScope) Reset() {
 	*x = IndexBuildErrors_MissingScope{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[73]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2943,7 +3003,7 @@ func (x *IndexBuildErrors_MissingScope) String() string {
 func (*IndexBuildErrors_MissingScope) ProtoMessage() {}
 
 func (x *IndexBuildErrors_MissingScope) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[73]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2982,7 +3042,7 @@ type IndexBuildErrors_ScopePermissionsConflicts struct {
 
 func (x *IndexBuildErrors_ScopePermissionsConflicts) Reset() {
 	*x = IndexBuildErrors_ScopePermissionsConflicts{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[74]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2994,7 +3054,7 @@ func (x *IndexBuildErrors_ScopePermissionsConflicts) String() string {
 func (*IndexBuildErrors_ScopePermissionsConflicts) ProtoMessage() {}
 
 func (x *IndexBuildErrors_ScopePermissionsConflicts) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[74]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3029,7 +3089,7 @@ type IndexBuildErrors_LoadFailure struct {
 
 func (x *IndexBuildErrors_LoadFailure) Reset() {
 	*x = IndexBuildErrors_LoadFailure{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[75]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3041,7 +3101,7 @@ func (x *IndexBuildErrors_LoadFailure) String() string {
 func (*IndexBuildErrors_LoadFailure) ProtoMessage() {}
 
 func (x *IndexBuildErrors_LoadFailure) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[75]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3090,7 +3150,7 @@ type IndexBuildErrors_Disabled struct {
 
 func (x *IndexBuildErrors_Disabled) Reset() {
 	*x = IndexBuildErrors_Disabled{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[76]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3102,7 +3162,7 @@ func (x *IndexBuildErrors_Disabled) String() string {
 func (*IndexBuildErrors_Disabled) ProtoMessage() {}
 
 func (x *IndexBuildErrors_Disabled) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[76]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3154,13 +3214,14 @@ const file_cerbos_runtime_v1_runtime_proto_rawDesc = "" +
 	"rolePolicy\x12)\n" +
 	"\x10compiler_version\x18\x06 \x01(\rR\x0fcompilerVersionB\f\n" +
 	"\n" +
-	"policy_set\"\xef\x15\n" +
+	"policy_set\"\xe2\x17\n" +
 	"\tRuleTable\x12:\n" +
 	"\x05rules\x18\x01 \x03(\v2$.cerbos.runtime.v1.RuleTable.RuleRowR\x05rules\x12C\n" +
 	"\aschemas\x18\x02 \x03(\v2).cerbos.runtime.v1.RuleTable.SchemasEntryR\aschemas\x12:\n" +
 	"\x04meta\x18\x03 \x03(\v2&.cerbos.runtime.v1.RuleTable.MetaEntryR\x04meta\x12`\n" +
 	"\x12scope_parent_roles\x18\x04 \x03(\v22.cerbos.runtime.v1.RuleTable.ScopeParentRolesEntryR\x10scopeParentRoles\x12f\n" +
-	"\x14policy_derived_roles\x18\x05 \x03(\v24.cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntryR\x12policyDerivedRoles\x1a\xab\v\n" +
+	"\x14policy_derived_roles\x18\x05 \x03(\v24.cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntryR\x12policyDerivedRoles\x12P\n" +
+	"\fjson_schemas\x18\x06 \x03(\v2-.cerbos.runtime.v1.RuleTable.JsonSchemasEntryR\vjsonSchemas\x1a\xab\v\n" +
 	"\aRuleRow\x12\x1d\n" +
 	"\n" +
 	"origin_fqn\x18\x01 \x01(\tR\toriginFqn\x12\x1a\n" +
@@ -3210,7 +3271,11 @@ const file_cerbos_runtime_v1_runtime_proto_rawDesc = "" +
 	"\rderived_roles\x18\x01 \x03(\v2A.cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntryR\fderivedRoles\x1ag\n" +
 	"\x11DerivedRolesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12<\n" +
-	"\x05value\x18\x02 \x01(\v2&.cerbos.runtime.v1.RunnableDerivedRoleR\x05value:\x028\x01\x1aU\n" +
+	"\x05value\x18\x02 \x01(\v2&.cerbos.runtime.v1.RunnableDerivedRoleR\x05value:\x028\x01\x1a6\n" +
+	"\n" +
+	"JSONSchema\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
+	"\acontent\x18\x02 \x01(\tR\acontent\x1aU\n" +
 	"\fSchemasEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\x04R\x03key\x12/\n" +
 	"\x05value\x18\x02 \x01(\v2\x19.cerbos.policy.v1.SchemasR\x05value:\x028\x01\x1a]\n" +
@@ -3222,7 +3287,10 @@ const file_cerbos_runtime_v1_runtime_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v2,.cerbos.runtime.v1.RuleTable.RoleParentRolesR\x05value:\x028\x01\x1av\n" +
 	"\x17PolicyDerivedRolesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\x04R\x03key\x12E\n" +
-	"\x05value\x18\x02 \x01(\v2/.cerbos.runtime.v1.RuleTable.PolicyDerivedRolesR\x05value:\x028\x01\"\x86\x04\n" +
+	"\x05value\x18\x02 \x01(\v2/.cerbos.runtime.v1.RuleTable.PolicyDerivedRolesR\x05value:\x028\x01\x1ag\n" +
+	"\x10JsonSchemasEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12=\n" +
+	"\x05value\x18\x02 \x01(\v2'.cerbos.runtime.v1.RuleTable.JSONSchemaR\x05value:\x028\x01\"\x86\x04\n" +
 	"\x11RuleTableMetadata\x12\x10\n" +
 	"\x03fqn\x18\x01 \x01(\tR\x03fqn\x12\x1c\n" +
 	"\bresource\x18\x02 \x01(\tH\x00R\bresource\x12\x14\n" +
@@ -3487,7 +3555,7 @@ func file_cerbos_runtime_v1_runtime_proto_rawDescGZIP() []byte {
 	return file_cerbos_runtime_v1_runtime_proto_rawDescData
 }
 
-var file_cerbos_runtime_v1_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 77)
+var file_cerbos_runtime_v1_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 79)
 var file_cerbos_runtime_v1_runtime_proto_goTypes = []any{
 	(*RunnablePolicySet)(nil),              // 0: cerbos.runtime.v1.RunnablePolicySet
 	(*RuleTable)(nil),                      // 1: cerbos.runtime.v1.RuleTable
@@ -3508,74 +3576,76 @@ var file_cerbos_runtime_v1_runtime_proto_goTypes = []any{
 	(*RuleTable_RuleRow)(nil),              // 16: cerbos.runtime.v1.RuleTable.RuleRow
 	(*RuleTable_RoleParentRoles)(nil),      // 17: cerbos.runtime.v1.RuleTable.RoleParentRoles
 	(*RuleTable_PolicyDerivedRoles)(nil),   // 18: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles
-	nil,                                    // 19: cerbos.runtime.v1.RuleTable.SchemasEntry
-	nil,                                    // 20: cerbos.runtime.v1.RuleTable.MetaEntry
-	nil,                                    // 21: cerbos.runtime.v1.RuleTable.ScopeParentRolesEntry
-	nil,                                    // 22: cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntry
-	(*RuleTable_RuleRow_AllowActions)(nil), // 23: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions
-	(*RuleTable_RuleRow_Params)(nil),       // 24: cerbos.runtime.v1.RuleTable.RuleRow.Params
-	nil,                                    // 25: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry
-	nil,                                    // 26: cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry
-	(*RuleTable_RoleParentRoles_ParentRoles)(nil), // 27: cerbos.runtime.v1.RuleTable.RoleParentRoles.ParentRoles
-	nil,                                    // 28: cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry
-	nil,                                    // 29: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry
-	nil,                                    // 30: cerbos.runtime.v1.RuleTableMetadata.SourceAttributesEntry
-	nil,                                    // 31: cerbos.runtime.v1.RuleTableMetadata.AnnotationsEntry
-	(*RunnableRolePolicySet_Metadata)(nil), // 32: cerbos.runtime.v1.RunnableRolePolicySet.Metadata
-	(*RunnableRolePolicySet_Rule)(nil),     // 33: cerbos.runtime.v1.RunnableRolePolicySet.Rule
-	(*RunnableRolePolicySet_RuleList)(nil), // 34: cerbos.runtime.v1.RunnableRolePolicySet.RuleList
-	nil,                                    // 35: cerbos.runtime.v1.RunnableRolePolicySet.ResourcesEntry
-	nil,                                    // 36: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry
-	nil,                                    // 37: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.AnnotationsEntry
-	nil,                                    // 38: cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry
-	(*RunnableResourcePolicySet_Metadata)(nil), // 39: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata
-	(*RunnableResourcePolicySet_Policy)(nil),   // 40: cerbos.runtime.v1.RunnableResourcePolicySet.Policy
-	nil,                                        // 41: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry
-	nil,                                        // 42: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.AnnotationsEntry
-	(*RunnableResourcePolicySet_Policy_Rule)(nil), // 43: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule
-	nil,                                      // 44: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry
-	nil,                                      // 45: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry
-	nil,                                      // 46: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry
-	nil,                                      // 47: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry
-	nil,                                      // 48: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry
-	nil,                                      // 49: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry
-	nil,                                      // 50: cerbos.runtime.v1.RunnableDerivedRole.ParentRolesEntry
-	nil,                                      // 51: cerbos.runtime.v1.RunnableDerivedRole.VariablesEntry
-	nil,                                      // 52: cerbos.runtime.v1.RunnableDerivedRole.ConstantsEntry
-	(*RunnableDerivedRolesSet_Metadata)(nil), // 53: cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata
-	nil,                                      // 54: cerbos.runtime.v1.RunnableDerivedRolesSet.DerivedRolesEntry
-	nil,                                      // 55: cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.AnnotationsEntry
-	(*RunnableVariablesSet_Metadata)(nil),    // 56: cerbos.runtime.v1.RunnableVariablesSet.Metadata
-	nil,                                      // 57: cerbos.runtime.v1.RunnableVariablesSet.VariablesEntry
-	nil,                                      // 58: cerbos.runtime.v1.RunnableVariablesSet.Metadata.AnnotationsEntry
-	(*RunnablePrincipalPolicySet_Metadata)(nil), // 59: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata
-	(*RunnablePrincipalPolicySet_Policy)(nil),   // 60: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy
-	nil, // 61: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry
-	nil, // 62: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.AnnotationsEntry
-	(*RunnablePrincipalPolicySet_Policy_ActionRule)(nil),    // 63: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule
-	(*RunnablePrincipalPolicySet_Policy_ResourceRules)(nil), // 64: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules
-	nil,                                    // 65: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry
-	nil,                                    // 66: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry
-	nil,                                    // 67: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry
-	(*Output_When)(nil),                    // 68: cerbos.runtime.v1.Output.When
-	(*Condition_ExprList)(nil),             // 69: cerbos.runtime.v1.Condition.ExprList
-	(*CompileErrors_Err)(nil),              // 70: cerbos.runtime.v1.CompileErrors.Err
-	(*IndexBuildErrors_DuplicateDef)(nil),  // 71: cerbos.runtime.v1.IndexBuildErrors.DuplicateDef
-	(*IndexBuildErrors_MissingImport)(nil), // 72: cerbos.runtime.v1.IndexBuildErrors.MissingImport
-	(*IndexBuildErrors_MissingScope)(nil),  // 73: cerbos.runtime.v1.IndexBuildErrors.MissingScope
-	(*IndexBuildErrors_ScopePermissionsConflicts)(nil), // 74: cerbos.runtime.v1.IndexBuildErrors.ScopePermissionsConflicts
-	(*IndexBuildErrors_LoadFailure)(nil),               // 75: cerbos.runtime.v1.IndexBuildErrors.LoadFailure
-	(*IndexBuildErrors_Disabled)(nil),                  // 76: cerbos.runtime.v1.IndexBuildErrors.Disabled
-	(v1.ScopePermissions)(0),                           // 77: cerbos.policy.v1.ScopePermissions
-	(*v1.Schemas)(nil),                                 // 78: cerbos.policy.v1.Schemas
-	(*v1alpha1.CheckedExpr)(nil),                       // 79: google.api.expr.v1alpha1.CheckedExpr
-	(v11.Effect)(0),                                    // 80: cerbos.effect.v1.Effect
-	(v1.Kind)(0),                                       // 81: cerbos.policy.v1.Kind
-	(*emptypb.Empty)(nil),                              // 82: google.protobuf.Empty
-	(*structpb.Value)(nil),                             // 83: google.protobuf.Value
-	(*v1.SourceAttributes)(nil),                        // 84: cerbos.policy.v1.SourceAttributes
-	(*v12.Position)(nil),                               // 85: cerbos.source.v1.Position
-	(*v12.Error)(nil),                                  // 86: cerbos.source.v1.Error
+	(*RuleTable_JSONSchema)(nil),           // 19: cerbos.runtime.v1.RuleTable.JSONSchema
+	nil,                                    // 20: cerbos.runtime.v1.RuleTable.SchemasEntry
+	nil,                                    // 21: cerbos.runtime.v1.RuleTable.MetaEntry
+	nil,                                    // 22: cerbos.runtime.v1.RuleTable.ScopeParentRolesEntry
+	nil,                                    // 23: cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntry
+	nil,                                    // 24: cerbos.runtime.v1.RuleTable.JsonSchemasEntry
+	(*RuleTable_RuleRow_AllowActions)(nil), // 25: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions
+	(*RuleTable_RuleRow_Params)(nil),       // 26: cerbos.runtime.v1.RuleTable.RuleRow.Params
+	nil,                                    // 27: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry
+	nil,                                    // 28: cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry
+	(*RuleTable_RoleParentRoles_ParentRoles)(nil), // 29: cerbos.runtime.v1.RuleTable.RoleParentRoles.ParentRoles
+	nil,                                    // 30: cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry
+	nil,                                    // 31: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry
+	nil,                                    // 32: cerbos.runtime.v1.RuleTableMetadata.SourceAttributesEntry
+	nil,                                    // 33: cerbos.runtime.v1.RuleTableMetadata.AnnotationsEntry
+	(*RunnableRolePolicySet_Metadata)(nil), // 34: cerbos.runtime.v1.RunnableRolePolicySet.Metadata
+	(*RunnableRolePolicySet_Rule)(nil),     // 35: cerbos.runtime.v1.RunnableRolePolicySet.Rule
+	(*RunnableRolePolicySet_RuleList)(nil), // 36: cerbos.runtime.v1.RunnableRolePolicySet.RuleList
+	nil,                                    // 37: cerbos.runtime.v1.RunnableRolePolicySet.ResourcesEntry
+	nil,                                    // 38: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry
+	nil,                                    // 39: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.AnnotationsEntry
+	nil,                                    // 40: cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry
+	(*RunnableResourcePolicySet_Metadata)(nil), // 41: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata
+	(*RunnableResourcePolicySet_Policy)(nil),   // 42: cerbos.runtime.v1.RunnableResourcePolicySet.Policy
+	nil,                                        // 43: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry
+	nil,                                        // 44: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.AnnotationsEntry
+	(*RunnableResourcePolicySet_Policy_Rule)(nil), // 45: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule
+	nil,                                      // 46: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry
+	nil,                                      // 47: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry
+	nil,                                      // 48: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry
+	nil,                                      // 49: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry
+	nil,                                      // 50: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry
+	nil,                                      // 51: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry
+	nil,                                      // 52: cerbos.runtime.v1.RunnableDerivedRole.ParentRolesEntry
+	nil,                                      // 53: cerbos.runtime.v1.RunnableDerivedRole.VariablesEntry
+	nil,                                      // 54: cerbos.runtime.v1.RunnableDerivedRole.ConstantsEntry
+	(*RunnableDerivedRolesSet_Metadata)(nil), // 55: cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata
+	nil,                                      // 56: cerbos.runtime.v1.RunnableDerivedRolesSet.DerivedRolesEntry
+	nil,                                      // 57: cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.AnnotationsEntry
+	(*RunnableVariablesSet_Metadata)(nil),    // 58: cerbos.runtime.v1.RunnableVariablesSet.Metadata
+	nil,                                      // 59: cerbos.runtime.v1.RunnableVariablesSet.VariablesEntry
+	nil,                                      // 60: cerbos.runtime.v1.RunnableVariablesSet.Metadata.AnnotationsEntry
+	(*RunnablePrincipalPolicySet_Metadata)(nil), // 61: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata
+	(*RunnablePrincipalPolicySet_Policy)(nil),   // 62: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy
+	nil, // 63: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry
+	nil, // 64: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.AnnotationsEntry
+	(*RunnablePrincipalPolicySet_Policy_ActionRule)(nil),    // 65: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule
+	(*RunnablePrincipalPolicySet_Policy_ResourceRules)(nil), // 66: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules
+	nil,                                    // 67: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry
+	nil,                                    // 68: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry
+	nil,                                    // 69: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry
+	(*Output_When)(nil),                    // 70: cerbos.runtime.v1.Output.When
+	(*Condition_ExprList)(nil),             // 71: cerbos.runtime.v1.Condition.ExprList
+	(*CompileErrors_Err)(nil),              // 72: cerbos.runtime.v1.CompileErrors.Err
+	(*IndexBuildErrors_DuplicateDef)(nil),  // 73: cerbos.runtime.v1.IndexBuildErrors.DuplicateDef
+	(*IndexBuildErrors_MissingImport)(nil), // 74: cerbos.runtime.v1.IndexBuildErrors.MissingImport
+	(*IndexBuildErrors_MissingScope)(nil),  // 75: cerbos.runtime.v1.IndexBuildErrors.MissingScope
+	(*IndexBuildErrors_ScopePermissionsConflicts)(nil), // 76: cerbos.runtime.v1.IndexBuildErrors.ScopePermissionsConflicts
+	(*IndexBuildErrors_LoadFailure)(nil),               // 77: cerbos.runtime.v1.IndexBuildErrors.LoadFailure
+	(*IndexBuildErrors_Disabled)(nil),                  // 78: cerbos.runtime.v1.IndexBuildErrors.Disabled
+	(v1.ScopePermissions)(0),                           // 79: cerbos.policy.v1.ScopePermissions
+	(*v1.Schemas)(nil),                                 // 80: cerbos.policy.v1.Schemas
+	(*v1alpha1.CheckedExpr)(nil),                       // 81: google.api.expr.v1alpha1.CheckedExpr
+	(v11.Effect)(0),                                    // 82: cerbos.effect.v1.Effect
+	(v1.Kind)(0),                                       // 83: cerbos.policy.v1.Kind
+	(*emptypb.Empty)(nil),                              // 84: google.protobuf.Empty
+	(*structpb.Value)(nil),                             // 85: google.protobuf.Value
+	(*v1.SourceAttributes)(nil),                        // 86: cerbos.policy.v1.SourceAttributes
+	(*v12.Position)(nil),                               // 87: cerbos.source.v1.Position
+	(*v12.Error)(nil),                                  // 88: cerbos.source.v1.Error
 }
 var file_cerbos_runtime_v1_runtime_proto_depIdxs = []int32{
 	4,   // 0: cerbos.runtime.v1.RunnablePolicySet.resource_policy:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet
@@ -3584,135 +3654,137 @@ var file_cerbos_runtime_v1_runtime_proto_depIdxs = []int32{
 	7,   // 3: cerbos.runtime.v1.RunnablePolicySet.variables:type_name -> cerbos.runtime.v1.RunnableVariablesSet
 	3,   // 4: cerbos.runtime.v1.RunnablePolicySet.role_policy:type_name -> cerbos.runtime.v1.RunnableRolePolicySet
 	16,  // 5: cerbos.runtime.v1.RuleTable.rules:type_name -> cerbos.runtime.v1.RuleTable.RuleRow
-	19,  // 6: cerbos.runtime.v1.RuleTable.schemas:type_name -> cerbos.runtime.v1.RuleTable.SchemasEntry
-	20,  // 7: cerbos.runtime.v1.RuleTable.meta:type_name -> cerbos.runtime.v1.RuleTable.MetaEntry
-	21,  // 8: cerbos.runtime.v1.RuleTable.scope_parent_roles:type_name -> cerbos.runtime.v1.RuleTable.ScopeParentRolesEntry
-	22,  // 9: cerbos.runtime.v1.RuleTable.policy_derived_roles:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntry
-	30,  // 10: cerbos.runtime.v1.RuleTableMetadata.source_attributes:type_name -> cerbos.runtime.v1.RuleTableMetadata.SourceAttributesEntry
-	31,  // 11: cerbos.runtime.v1.RuleTableMetadata.annotations:type_name -> cerbos.runtime.v1.RuleTableMetadata.AnnotationsEntry
-	32,  // 12: cerbos.runtime.v1.RunnableRolePolicySet.meta:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata
-	77,  // 13: cerbos.runtime.v1.RunnableRolePolicySet.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
-	35,  // 14: cerbos.runtime.v1.RunnableRolePolicySet.resources:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.ResourcesEntry
-	39,  // 15: cerbos.runtime.v1.RunnableResourcePolicySet.meta:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata
-	40,  // 16: cerbos.runtime.v1.RunnableResourcePolicySet.policies:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy
-	78,  // 17: cerbos.runtime.v1.RunnableResourcePolicySet.schemas:type_name -> cerbos.policy.v1.Schemas
-	50,  // 18: cerbos.runtime.v1.RunnableDerivedRole.parent_roles:type_name -> cerbos.runtime.v1.RunnableDerivedRole.ParentRolesEntry
-	51,  // 19: cerbos.runtime.v1.RunnableDerivedRole.variables:type_name -> cerbos.runtime.v1.RunnableDerivedRole.VariablesEntry
-	12,  // 20: cerbos.runtime.v1.RunnableDerivedRole.condition:type_name -> cerbos.runtime.v1.Condition
-	11,  // 21: cerbos.runtime.v1.RunnableDerivedRole.ordered_variables:type_name -> cerbos.runtime.v1.Variable
-	52,  // 22: cerbos.runtime.v1.RunnableDerivedRole.constants:type_name -> cerbos.runtime.v1.RunnableDerivedRole.ConstantsEntry
-	53,  // 23: cerbos.runtime.v1.RunnableDerivedRolesSet.meta:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata
-	54,  // 24: cerbos.runtime.v1.RunnableDerivedRolesSet.derived_roles:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet.DerivedRolesEntry
-	56,  // 25: cerbos.runtime.v1.RunnableVariablesSet.meta:type_name -> cerbos.runtime.v1.RunnableVariablesSet.Metadata
-	57,  // 26: cerbos.runtime.v1.RunnableVariablesSet.variables:type_name -> cerbos.runtime.v1.RunnableVariablesSet.VariablesEntry
-	59,  // 27: cerbos.runtime.v1.RunnablePrincipalPolicySet.meta:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata
-	60,  // 28: cerbos.runtime.v1.RunnablePrincipalPolicySet.policies:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy
-	79,  // 29: cerbos.runtime.v1.Expr.checked:type_name -> google.api.expr.v1alpha1.CheckedExpr
-	68,  // 30: cerbos.runtime.v1.Output.when:type_name -> cerbos.runtime.v1.Output.When
-	9,   // 31: cerbos.runtime.v1.Variable.expr:type_name -> cerbos.runtime.v1.Expr
-	69,  // 32: cerbos.runtime.v1.Condition.all:type_name -> cerbos.runtime.v1.Condition.ExprList
-	69,  // 33: cerbos.runtime.v1.Condition.any:type_name -> cerbos.runtime.v1.Condition.ExprList
-	69,  // 34: cerbos.runtime.v1.Condition.none:type_name -> cerbos.runtime.v1.Condition.ExprList
-	9,   // 35: cerbos.runtime.v1.Condition.expr:type_name -> cerbos.runtime.v1.Expr
-	70,  // 36: cerbos.runtime.v1.CompileErrors.errors:type_name -> cerbos.runtime.v1.CompileErrors.Err
-	71,  // 37: cerbos.runtime.v1.IndexBuildErrors.duplicate_defs:type_name -> cerbos.runtime.v1.IndexBuildErrors.DuplicateDef
-	75,  // 38: cerbos.runtime.v1.IndexBuildErrors.load_failures:type_name -> cerbos.runtime.v1.IndexBuildErrors.LoadFailure
-	72,  // 39: cerbos.runtime.v1.IndexBuildErrors.missing_imports:type_name -> cerbos.runtime.v1.IndexBuildErrors.MissingImport
-	76,  // 40: cerbos.runtime.v1.IndexBuildErrors.disabled_defs:type_name -> cerbos.runtime.v1.IndexBuildErrors.Disabled
-	73,  // 41: cerbos.runtime.v1.IndexBuildErrors.missing_scope_details:type_name -> cerbos.runtime.v1.IndexBuildErrors.MissingScope
-	74,  // 42: cerbos.runtime.v1.IndexBuildErrors.scope_permissions_conflicts:type_name -> cerbos.runtime.v1.IndexBuildErrors.ScopePermissionsConflicts
-	14,  // 43: cerbos.runtime.v1.Errors.index_build_errors:type_name -> cerbos.runtime.v1.IndexBuildErrors
-	13,  // 44: cerbos.runtime.v1.Errors.compile_errors:type_name -> cerbos.runtime.v1.CompileErrors
-	23,  // 45: cerbos.runtime.v1.RuleTable.RuleRow.allow_actions:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.AllowActions
-	12,  // 46: cerbos.runtime.v1.RuleTable.RuleRow.condition:type_name -> cerbos.runtime.v1.Condition
-	12,  // 47: cerbos.runtime.v1.RuleTable.RuleRow.derived_role_condition:type_name -> cerbos.runtime.v1.Condition
-	80,  // 48: cerbos.runtime.v1.RuleTable.RuleRow.effect:type_name -> cerbos.effect.v1.Effect
-	77,  // 49: cerbos.runtime.v1.RuleTable.RuleRow.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
-	10,  // 50: cerbos.runtime.v1.RuleTable.RuleRow.emit_output:type_name -> cerbos.runtime.v1.Output
-	24,  // 51: cerbos.runtime.v1.RuleTable.RuleRow.params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
-	24,  // 52: cerbos.runtime.v1.RuleTable.RuleRow.derived_role_params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
-	81,  // 53: cerbos.runtime.v1.RuleTable.RuleRow.policy_kind:type_name -> cerbos.policy.v1.Kind
-	28,  // 54: cerbos.runtime.v1.RuleTable.RoleParentRoles.role_parent_roles:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry
-	29,  // 55: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.derived_roles:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry
-	78,  // 56: cerbos.runtime.v1.RuleTable.SchemasEntry.value:type_name -> cerbos.policy.v1.Schemas
-	2,   // 57: cerbos.runtime.v1.RuleTable.MetaEntry.value:type_name -> cerbos.runtime.v1.RuleTableMetadata
-	17,  // 58: cerbos.runtime.v1.RuleTable.ScopeParentRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles
-	18,  // 59: cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRoles
-	25,  // 60: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.actions:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry
-	11,  // 61: cerbos.runtime.v1.RuleTable.RuleRow.Params.ordered_variables:type_name -> cerbos.runtime.v1.Variable
-	26,  // 62: cerbos.runtime.v1.RuleTable.RuleRow.Params.constants:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry
-	82,  // 63: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry.value:type_name -> google.protobuf.Empty
-	83,  // 64: cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry.value:type_name -> google.protobuf.Value
-	27,  // 65: cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles.ParentRoles
-	5,   // 66: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
-	84,  // 67: cerbos.runtime.v1.RuleTableMetadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
-	36,  // 68: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry
-	37,  // 69: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata.AnnotationsEntry
-	38,  // 70: cerbos.runtime.v1.RunnableRolePolicySet.Rule.allow_actions:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry
-	12,  // 71: cerbos.runtime.v1.RunnableRolePolicySet.Rule.condition:type_name -> cerbos.runtime.v1.Condition
-	33,  // 72: cerbos.runtime.v1.RunnableRolePolicySet.RuleList.rules:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Rule
-	34,  // 73: cerbos.runtime.v1.RunnableRolePolicySet.ResourcesEntry.value:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.RuleList
-	84,  // 74: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
-	82,  // 75: cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry.value:type_name -> google.protobuf.Empty
-	41,  // 76: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry
-	42,  // 77: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.AnnotationsEntry
-	44,  // 78: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.derived_roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry
-	45,  // 79: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.variables:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry
-	43,  // 80: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.rules:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule
-	78,  // 81: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.schemas:type_name -> cerbos.policy.v1.Schemas
-	11,  // 82: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ordered_variables:type_name -> cerbos.runtime.v1.Variable
-	77,  // 83: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
-	46,  // 84: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.constants:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry
-	84,  // 85: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
-	47,  // 86: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.actions:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry
-	48,  // 87: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.derived_roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry
-	49,  // 88: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry
-	12,  // 89: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.condition:type_name -> cerbos.runtime.v1.Condition
-	80,  // 90: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.effect:type_name -> cerbos.effect.v1.Effect
-	9,   // 91: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.output:type_name -> cerbos.runtime.v1.Expr
-	10,  // 92: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.emit_output:type_name -> cerbos.runtime.v1.Output
-	5,   // 93: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
-	9,   // 94: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
-	83,  // 95: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry.value:type_name -> google.protobuf.Value
-	82,  // 96: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry.value:type_name -> google.protobuf.Empty
-	82,  // 97: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry.value:type_name -> google.protobuf.Empty
-	82,  // 98: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry.value:type_name -> google.protobuf.Empty
-	82,  // 99: cerbos.runtime.v1.RunnableDerivedRole.ParentRolesEntry.value:type_name -> google.protobuf.Empty
-	9,   // 100: cerbos.runtime.v1.RunnableDerivedRole.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
-	83,  // 101: cerbos.runtime.v1.RunnableDerivedRole.ConstantsEntry.value:type_name -> google.protobuf.Value
-	55,  // 102: cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.AnnotationsEntry
-	5,   // 103: cerbos.runtime.v1.RunnableDerivedRolesSet.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
-	58,  // 104: cerbos.runtime.v1.RunnableVariablesSet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableVariablesSet.Metadata.AnnotationsEntry
-	9,   // 105: cerbos.runtime.v1.RunnableVariablesSet.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
-	61,  // 106: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry
-	62,  // 107: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.AnnotationsEntry
-	65,  // 108: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.variables:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry
-	66,  // 109: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.resource_rules:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry
-	11,  // 110: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ordered_variables:type_name -> cerbos.runtime.v1.Variable
-	77,  // 111: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
-	67,  // 112: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.constants:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry
-	84,  // 113: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
-	12,  // 114: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.condition:type_name -> cerbos.runtime.v1.Condition
-	80,  // 115: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.effect:type_name -> cerbos.effect.v1.Effect
-	9,   // 116: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.output:type_name -> cerbos.runtime.v1.Expr
-	10,  // 117: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.emit_output:type_name -> cerbos.runtime.v1.Output
-	63,  // 118: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules.action_rules:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule
-	9,   // 119: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
-	64,  // 120: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry.value:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules
-	83,  // 121: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry.value:type_name -> google.protobuf.Value
-	9,   // 122: cerbos.runtime.v1.Output.When.rule_activated:type_name -> cerbos.runtime.v1.Expr
-	9,   // 123: cerbos.runtime.v1.Output.When.condition_not_met:type_name -> cerbos.runtime.v1.Expr
-	12,  // 124: cerbos.runtime.v1.Condition.ExprList.expr:type_name -> cerbos.runtime.v1.Condition
-	85,  // 125: cerbos.runtime.v1.CompileErrors.Err.position:type_name -> cerbos.source.v1.Position
-	85,  // 126: cerbos.runtime.v1.IndexBuildErrors.DuplicateDef.position:type_name -> cerbos.source.v1.Position
-	85,  // 127: cerbos.runtime.v1.IndexBuildErrors.MissingImport.position:type_name -> cerbos.source.v1.Position
-	86,  // 128: cerbos.runtime.v1.IndexBuildErrors.LoadFailure.error_details:type_name -> cerbos.source.v1.Error
-	85,  // 129: cerbos.runtime.v1.IndexBuildErrors.Disabled.position:type_name -> cerbos.source.v1.Position
-	130, // [130:130] is the sub-list for method output_type
-	130, // [130:130] is the sub-list for method input_type
-	130, // [130:130] is the sub-list for extension type_name
-	130, // [130:130] is the sub-list for extension extendee
-	0,   // [0:130] is the sub-list for field type_name
+	20,  // 6: cerbos.runtime.v1.RuleTable.schemas:type_name -> cerbos.runtime.v1.RuleTable.SchemasEntry
+	21,  // 7: cerbos.runtime.v1.RuleTable.meta:type_name -> cerbos.runtime.v1.RuleTable.MetaEntry
+	22,  // 8: cerbos.runtime.v1.RuleTable.scope_parent_roles:type_name -> cerbos.runtime.v1.RuleTable.ScopeParentRolesEntry
+	23,  // 9: cerbos.runtime.v1.RuleTable.policy_derived_roles:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntry
+	24,  // 10: cerbos.runtime.v1.RuleTable.json_schemas:type_name -> cerbos.runtime.v1.RuleTable.JsonSchemasEntry
+	32,  // 11: cerbos.runtime.v1.RuleTableMetadata.source_attributes:type_name -> cerbos.runtime.v1.RuleTableMetadata.SourceAttributesEntry
+	33,  // 12: cerbos.runtime.v1.RuleTableMetadata.annotations:type_name -> cerbos.runtime.v1.RuleTableMetadata.AnnotationsEntry
+	34,  // 13: cerbos.runtime.v1.RunnableRolePolicySet.meta:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata
+	79,  // 14: cerbos.runtime.v1.RunnableRolePolicySet.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
+	37,  // 15: cerbos.runtime.v1.RunnableRolePolicySet.resources:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.ResourcesEntry
+	41,  // 16: cerbos.runtime.v1.RunnableResourcePolicySet.meta:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata
+	42,  // 17: cerbos.runtime.v1.RunnableResourcePolicySet.policies:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy
+	80,  // 18: cerbos.runtime.v1.RunnableResourcePolicySet.schemas:type_name -> cerbos.policy.v1.Schemas
+	52,  // 19: cerbos.runtime.v1.RunnableDerivedRole.parent_roles:type_name -> cerbos.runtime.v1.RunnableDerivedRole.ParentRolesEntry
+	53,  // 20: cerbos.runtime.v1.RunnableDerivedRole.variables:type_name -> cerbos.runtime.v1.RunnableDerivedRole.VariablesEntry
+	12,  // 21: cerbos.runtime.v1.RunnableDerivedRole.condition:type_name -> cerbos.runtime.v1.Condition
+	11,  // 22: cerbos.runtime.v1.RunnableDerivedRole.ordered_variables:type_name -> cerbos.runtime.v1.Variable
+	54,  // 23: cerbos.runtime.v1.RunnableDerivedRole.constants:type_name -> cerbos.runtime.v1.RunnableDerivedRole.ConstantsEntry
+	55,  // 24: cerbos.runtime.v1.RunnableDerivedRolesSet.meta:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata
+	56,  // 25: cerbos.runtime.v1.RunnableDerivedRolesSet.derived_roles:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet.DerivedRolesEntry
+	58,  // 26: cerbos.runtime.v1.RunnableVariablesSet.meta:type_name -> cerbos.runtime.v1.RunnableVariablesSet.Metadata
+	59,  // 27: cerbos.runtime.v1.RunnableVariablesSet.variables:type_name -> cerbos.runtime.v1.RunnableVariablesSet.VariablesEntry
+	61,  // 28: cerbos.runtime.v1.RunnablePrincipalPolicySet.meta:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata
+	62,  // 29: cerbos.runtime.v1.RunnablePrincipalPolicySet.policies:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy
+	81,  // 30: cerbos.runtime.v1.Expr.checked:type_name -> google.api.expr.v1alpha1.CheckedExpr
+	70,  // 31: cerbos.runtime.v1.Output.when:type_name -> cerbos.runtime.v1.Output.When
+	9,   // 32: cerbos.runtime.v1.Variable.expr:type_name -> cerbos.runtime.v1.Expr
+	71,  // 33: cerbos.runtime.v1.Condition.all:type_name -> cerbos.runtime.v1.Condition.ExprList
+	71,  // 34: cerbos.runtime.v1.Condition.any:type_name -> cerbos.runtime.v1.Condition.ExprList
+	71,  // 35: cerbos.runtime.v1.Condition.none:type_name -> cerbos.runtime.v1.Condition.ExprList
+	9,   // 36: cerbos.runtime.v1.Condition.expr:type_name -> cerbos.runtime.v1.Expr
+	72,  // 37: cerbos.runtime.v1.CompileErrors.errors:type_name -> cerbos.runtime.v1.CompileErrors.Err
+	73,  // 38: cerbos.runtime.v1.IndexBuildErrors.duplicate_defs:type_name -> cerbos.runtime.v1.IndexBuildErrors.DuplicateDef
+	77,  // 39: cerbos.runtime.v1.IndexBuildErrors.load_failures:type_name -> cerbos.runtime.v1.IndexBuildErrors.LoadFailure
+	74,  // 40: cerbos.runtime.v1.IndexBuildErrors.missing_imports:type_name -> cerbos.runtime.v1.IndexBuildErrors.MissingImport
+	78,  // 41: cerbos.runtime.v1.IndexBuildErrors.disabled_defs:type_name -> cerbos.runtime.v1.IndexBuildErrors.Disabled
+	75,  // 42: cerbos.runtime.v1.IndexBuildErrors.missing_scope_details:type_name -> cerbos.runtime.v1.IndexBuildErrors.MissingScope
+	76,  // 43: cerbos.runtime.v1.IndexBuildErrors.scope_permissions_conflicts:type_name -> cerbos.runtime.v1.IndexBuildErrors.ScopePermissionsConflicts
+	14,  // 44: cerbos.runtime.v1.Errors.index_build_errors:type_name -> cerbos.runtime.v1.IndexBuildErrors
+	13,  // 45: cerbos.runtime.v1.Errors.compile_errors:type_name -> cerbos.runtime.v1.CompileErrors
+	25,  // 46: cerbos.runtime.v1.RuleTable.RuleRow.allow_actions:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.AllowActions
+	12,  // 47: cerbos.runtime.v1.RuleTable.RuleRow.condition:type_name -> cerbos.runtime.v1.Condition
+	12,  // 48: cerbos.runtime.v1.RuleTable.RuleRow.derived_role_condition:type_name -> cerbos.runtime.v1.Condition
+	82,  // 49: cerbos.runtime.v1.RuleTable.RuleRow.effect:type_name -> cerbos.effect.v1.Effect
+	79,  // 50: cerbos.runtime.v1.RuleTable.RuleRow.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
+	10,  // 51: cerbos.runtime.v1.RuleTable.RuleRow.emit_output:type_name -> cerbos.runtime.v1.Output
+	26,  // 52: cerbos.runtime.v1.RuleTable.RuleRow.params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
+	26,  // 53: cerbos.runtime.v1.RuleTable.RuleRow.derived_role_params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
+	83,  // 54: cerbos.runtime.v1.RuleTable.RuleRow.policy_kind:type_name -> cerbos.policy.v1.Kind
+	30,  // 55: cerbos.runtime.v1.RuleTable.RoleParentRoles.role_parent_roles:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry
+	31,  // 56: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.derived_roles:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry
+	80,  // 57: cerbos.runtime.v1.RuleTable.SchemasEntry.value:type_name -> cerbos.policy.v1.Schemas
+	2,   // 58: cerbos.runtime.v1.RuleTable.MetaEntry.value:type_name -> cerbos.runtime.v1.RuleTableMetadata
+	17,  // 59: cerbos.runtime.v1.RuleTable.ScopeParentRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles
+	18,  // 60: cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRoles
+	19,  // 61: cerbos.runtime.v1.RuleTable.JsonSchemasEntry.value:type_name -> cerbos.runtime.v1.RuleTable.JSONSchema
+	27,  // 62: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.actions:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry
+	11,  // 63: cerbos.runtime.v1.RuleTable.RuleRow.Params.ordered_variables:type_name -> cerbos.runtime.v1.Variable
+	28,  // 64: cerbos.runtime.v1.RuleTable.RuleRow.Params.constants:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry
+	84,  // 65: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry.value:type_name -> google.protobuf.Empty
+	85,  // 66: cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry.value:type_name -> google.protobuf.Value
+	29,  // 67: cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles.ParentRoles
+	5,   // 68: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
+	86,  // 69: cerbos.runtime.v1.RuleTableMetadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
+	38,  // 70: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry
+	39,  // 71: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata.AnnotationsEntry
+	40,  // 72: cerbos.runtime.v1.RunnableRolePolicySet.Rule.allow_actions:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry
+	12,  // 73: cerbos.runtime.v1.RunnableRolePolicySet.Rule.condition:type_name -> cerbos.runtime.v1.Condition
+	35,  // 74: cerbos.runtime.v1.RunnableRolePolicySet.RuleList.rules:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Rule
+	36,  // 75: cerbos.runtime.v1.RunnableRolePolicySet.ResourcesEntry.value:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.RuleList
+	86,  // 76: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
+	84,  // 77: cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry.value:type_name -> google.protobuf.Empty
+	43,  // 78: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry
+	44,  // 79: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.AnnotationsEntry
+	46,  // 80: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.derived_roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry
+	47,  // 81: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.variables:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry
+	45,  // 82: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.rules:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule
+	80,  // 83: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.schemas:type_name -> cerbos.policy.v1.Schemas
+	11,  // 84: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ordered_variables:type_name -> cerbos.runtime.v1.Variable
+	79,  // 85: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
+	48,  // 86: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.constants:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry
+	86,  // 87: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
+	49,  // 88: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.actions:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry
+	50,  // 89: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.derived_roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry
+	51,  // 90: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry
+	12,  // 91: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.condition:type_name -> cerbos.runtime.v1.Condition
+	82,  // 92: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.effect:type_name -> cerbos.effect.v1.Effect
+	9,   // 93: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.output:type_name -> cerbos.runtime.v1.Expr
+	10,  // 94: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.emit_output:type_name -> cerbos.runtime.v1.Output
+	5,   // 95: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
+	9,   // 96: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
+	85,  // 97: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry.value:type_name -> google.protobuf.Value
+	84,  // 98: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry.value:type_name -> google.protobuf.Empty
+	84,  // 99: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry.value:type_name -> google.protobuf.Empty
+	84,  // 100: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry.value:type_name -> google.protobuf.Empty
+	84,  // 101: cerbos.runtime.v1.RunnableDerivedRole.ParentRolesEntry.value:type_name -> google.protobuf.Empty
+	9,   // 102: cerbos.runtime.v1.RunnableDerivedRole.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
+	85,  // 103: cerbos.runtime.v1.RunnableDerivedRole.ConstantsEntry.value:type_name -> google.protobuf.Value
+	57,  // 104: cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.AnnotationsEntry
+	5,   // 105: cerbos.runtime.v1.RunnableDerivedRolesSet.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
+	60,  // 106: cerbos.runtime.v1.RunnableVariablesSet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableVariablesSet.Metadata.AnnotationsEntry
+	9,   // 107: cerbos.runtime.v1.RunnableVariablesSet.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
+	63,  // 108: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry
+	64,  // 109: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.AnnotationsEntry
+	67,  // 110: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.variables:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry
+	68,  // 111: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.resource_rules:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry
+	11,  // 112: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ordered_variables:type_name -> cerbos.runtime.v1.Variable
+	79,  // 113: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
+	69,  // 114: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.constants:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry
+	86,  // 115: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
+	12,  // 116: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.condition:type_name -> cerbos.runtime.v1.Condition
+	82,  // 117: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.effect:type_name -> cerbos.effect.v1.Effect
+	9,   // 118: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.output:type_name -> cerbos.runtime.v1.Expr
+	10,  // 119: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.emit_output:type_name -> cerbos.runtime.v1.Output
+	65,  // 120: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules.action_rules:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule
+	9,   // 121: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
+	66,  // 122: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry.value:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules
+	85,  // 123: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry.value:type_name -> google.protobuf.Value
+	9,   // 124: cerbos.runtime.v1.Output.When.rule_activated:type_name -> cerbos.runtime.v1.Expr
+	9,   // 125: cerbos.runtime.v1.Output.When.condition_not_met:type_name -> cerbos.runtime.v1.Expr
+	12,  // 126: cerbos.runtime.v1.Condition.ExprList.expr:type_name -> cerbos.runtime.v1.Condition
+	87,  // 127: cerbos.runtime.v1.CompileErrors.Err.position:type_name -> cerbos.source.v1.Position
+	87,  // 128: cerbos.runtime.v1.IndexBuildErrors.DuplicateDef.position:type_name -> cerbos.source.v1.Position
+	87,  // 129: cerbos.runtime.v1.IndexBuildErrors.MissingImport.position:type_name -> cerbos.source.v1.Position
+	88,  // 130: cerbos.runtime.v1.IndexBuildErrors.LoadFailure.error_details:type_name -> cerbos.source.v1.Error
+	87,  // 131: cerbos.runtime.v1.IndexBuildErrors.Disabled.position:type_name -> cerbos.source.v1.Position
+	132, // [132:132] is the sub-list for method output_type
+	132, // [132:132] is the sub-list for method input_type
+	132, // [132:132] is the sub-list for extension type_name
+	132, // [132:132] is the sub-list for extension extendee
+	0,   // [0:132] is the sub-list for field type_name
 }
 
 func init() { file_cerbos_runtime_v1_runtime_proto_init() }
@@ -3752,7 +3824,7 @@ func file_cerbos_runtime_v1_runtime_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerbos_runtime_v1_runtime_proto_rawDesc), len(file_cerbos_runtime_v1_runtime_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   77,
+			NumMessages:   79,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/genpb/cerbos/runtime/v1/runtime_hashpb.pb.go
+++ b/api/genpb/cerbos/runtime/v1/runtime_hashpb.pb.go
@@ -74,6 +74,14 @@ func (m *RuleTable_PolicyDerivedRoles) HashPB(hasher hash.Hash, ignore map[strin
 
 // HashPB computes a hash of the message using the given hash function
 // The ignore set must contain fully-qualified field names (pkg.msg.field) that should be ignored from the hash
+func (m *RuleTable_JSONSchema) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
+	if m != nil {
+		cerbos_runtime_v1_RuleTable_JSONSchema_hashpb_sum(m, hasher, ignore)
+	}
+}
+
+// HashPB computes a hash of the message using the given hash function
+// The ignore set must contain fully-qualified field names (pkg.msg.field) that should be ignored from the hash
 func (m *RuleTableMetadata) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
 	if m != nil {
 		cerbos_runtime_v1_RuleTableMetadata_hashpb_sum(m, hasher, ignore)

--- a/api/genpb/cerbos/runtime/v1/runtime_vtproto.pb.go
+++ b/api/genpb/cerbos/runtime/v1/runtime_vtproto.pb.go
@@ -732,13 +732,6 @@ func (m *RuleTable_JSONSchema) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 		copy(dAtA[i:], m.Content)
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Content)))
 		i--
-		dAtA[i] = 0x12
-	}
-	if len(m.Id) > 0 {
-		i -= len(m.Id)
-		copy(dAtA[i:], m.Id)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Id)))
-		i--
 		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
@@ -4077,10 +4070,6 @@ func (m *RuleTable_JSONSchema) SizeVT() (n int) {
 	}
 	var l int
 	_ = l
-	l = len(m.Id)
-	if l > 0 {
-		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
-	}
 	l = len(m.Content)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
@@ -7276,41 +7265,9 @@ func (m *RuleTable_JSONSchema) UnmarshalVT(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Id = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 2:
-			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Content", wireType)
 			}
-			var stringLen uint64
+			var byteLen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -7320,23 +7277,25 @@ func (m *RuleTable_JSONSchema) UnmarshalVT(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
+				byteLen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
+			if byteLen < 0 {
 				return protohelpers.ErrInvalidLength
 			}
-			postIndex := iNdEx + intStringLen
+			postIndex := iNdEx + byteLen
 			if postIndex < 0 {
 				return protohelpers.ErrInvalidLength
 			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Content = string(dAtA[iNdEx:postIndex])
+			m.Content = append(m.Content[:0], dAtA[iNdEx:postIndex]...)
+			if m.Content == nil {
+				m.Content = []byte{}
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/api/genpb/cerbos/runtime/v1/runtime_vtproto.pb.go
+++ b/api/genpb/cerbos/runtime/v1/runtime_vtproto.pb.go
@@ -697,6 +697,53 @@ func (m *RuleTable_PolicyDerivedRoles) MarshalToSizedBufferVT(dAtA []byte) (int,
 	return len(dAtA) - i, nil
 }
 
+func (m *RuleTable_JSONSchema) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RuleTable_JSONSchema) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *RuleTable_JSONSchema) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Content) > 0 {
+		i -= len(m.Content)
+		copy(dAtA[i:], m.Content)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Content)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Id) > 0 {
+		i -= len(m.Id)
+		copy(dAtA[i:], m.Id)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Id)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *RuleTable) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -726,6 +773,28 @@ func (m *RuleTable) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.JsonSchemas) > 0 {
+		for k := range m.JsonSchemas {
+			v := m.JsonSchemas[k]
+			baseI := i
+			size, err := v.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x32
+		}
 	}
 	if len(m.PolicyDerivedRoles) > 0 {
 		for k := range m.PolicyDerivedRoles {
@@ -4002,6 +4071,24 @@ func (m *RuleTable_PolicyDerivedRoles) SizeVT() (n int) {
 	return n
 }
 
+func (m *RuleTable_JSONSchema) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Id)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Content)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *RuleTable) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -4069,6 +4156,19 @@ func (m *RuleTable) SizeVT() (n int) {
 			}
 			l += 1 + protohelpers.SizeOfVarint(uint64(l))
 			mapEntrySize := 1 + protohelpers.SizeOfVarint(uint64(k)) + l
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	if len(m.JsonSchemas) > 0 {
+		for k, v := range m.JsonSchemas {
+			_ = k
+			_ = v
+			l = 0
+			if v != nil {
+				l = v.SizeVT()
+			}
+			l += 1 + protohelpers.SizeOfVarint(uint64(l))
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + l
 			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
 		}
 	}
@@ -7145,6 +7245,121 @@ func (m *RuleTable_PolicyDerivedRoles) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *RuleTable_JSONSchema) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RuleTable_JSONSchema: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RuleTable_JSONSchema: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Id = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Content", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Content = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *RuleTable) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -7689,6 +7904,135 @@ func (m *RuleTable) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.PolicyDerivedRoles[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field JsonSchemas", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.JsonSchemas == nil {
+				m.JsonSchemas = make(map[string]*RuleTable_JSONSchema)
+			}
+			var mapkey string
+			var mapvalue *RuleTable_JSONSchema
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var mapmsglen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapmsglen |= int(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if mapmsglen < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postmsgIndex := iNdEx + mapmsglen
+					if postmsgIndex < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postmsgIndex > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = &RuleTable_JSONSchema{}
+					if err := mapvalue.UnmarshalVT(dAtA[iNdEx:postmsgIndex]); err != nil {
+						return err
+					}
+					iNdEx = postmsgIndex
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.JsonSchemas[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/api/private/cerbos/runtime/v1/runtime.proto
+++ b/api/private/cerbos/runtime/v1/runtime.proto
@@ -74,8 +74,7 @@ message RuleTable {
   }
 
   message JSONSchema {
-    string id = 1;
-    string content = 2;
+    bytes content = 1;
   }
 
   repeated RuleRow rules = 1;

--- a/api/private/cerbos/runtime/v1/runtime.proto
+++ b/api/private/cerbos/runtime/v1/runtime.proto
@@ -73,11 +73,17 @@ message RuleTable {
     map<string, RunnableDerivedRole> derived_roles = 1;
   }
 
+  message JSONSchema {
+    string id = 1;
+    string content = 2;
+  }
+
   repeated RuleRow rules = 1;
   map<uint64, cerbos.policy.v1.Schemas> schemas = 2;
   map<uint64, RuleTableMetadata> meta = 3;
   map<string, RoleParentRoles> scope_parent_roles = 4;
   map<uint64, PolicyDerivedRoles> policy_derived_roles = 5;
+  map<string, JSONSchema> json_schemas = 6;
 }
 
 message RuleTableMetadata {

--- a/cmd/cerbos/compile/compile.go
+++ b/cmd/cerbos/compile/compile.go
@@ -133,7 +133,7 @@ func (c *Cmd) Run(k *kong.Kong) error {
 			Trace:                   c.Verbose,
 		}
 
-		rt := ruletable.NewRuletable()
+		rt := ruletable.NewProtoRuletable()
 
 		compileMgr, err := compile.NewManager(ctx, store, schemaMgr)
 		if err != nil {

--- a/cmd/cerbos/compile/compile.go
+++ b/cmd/cerbos/compile/compile.go
@@ -144,7 +144,7 @@ func (c *Cmd) Run(k *kong.Kong) error {
 			return err
 		}
 
-		rtMgr, err := ruletable.NewRuleTableManager(rt, compileMgr, schemaMgr)
+		rtMgr, err := ruletable.NewRuleTableManager(rt, compileMgr, store, schemaMgr)
 		if err != nil {
 			return fmt.Errorf("failed to create ruletable manager: %w", err)
 		}

--- a/cmd/cerbos/compile/compile.go
+++ b/cmd/cerbos/compile/compile.go
@@ -135,7 +135,7 @@ func (c *Cmd) Run(k *kong.Kong) error {
 
 		rt := ruletable.NewProtoRuletable()
 
-		compileMgr, err := compile.NewManager(ctx, store, schemaMgr)
+		compileMgr, err := compile.NewManager(ctx, store)
 		if err != nil {
 			return err
 		}

--- a/cmd/cerbos/compile/compile.go
+++ b/cmd/cerbos/compile/compile.go
@@ -140,7 +140,7 @@ func (c *Cmd) Run(k *kong.Kong) error {
 			return err
 		}
 
-		if err := ruletable.Load(ctx, rt, compileMgr, store); err != nil {
+		if err := ruletable.LoadPolicies(ctx, rt, compileMgr); err != nil {
 			return err
 		}
 

--- a/cmd/cerbos/compile/compile.go
+++ b/cmd/cerbos/compile/compile.go
@@ -140,7 +140,7 @@ func (c *Cmd) Run(k *kong.Kong) error {
 			return err
 		}
 
-		if err := ruletable.LoadFromPolicyLoader(ctx, rt, compileMgr); err != nil {
+		if err := ruletable.Load(ctx, rt, compileMgr, store); err != nil {
 			return err
 		}
 

--- a/docs/modules/configuration/partials/fullconfiguration.adoc
+++ b/docs/modules/configuration/partials/fullconfiguration.adoc
@@ -83,6 +83,7 @@ engine:
   defaultPolicyVersion: "default" # DefaultPolicyVersion defines what version to assume if the request does not specify one.
   globals: {"environment": "staging"} # Globals are environment-specific variables to be made available to policy conditions.
   lenientScopeSearch: false # LenientScopeSearch configures the engine to ignore missing scopes and search upwards through the scope tree until it finds a usable policy.
+  policyLoaderTimeout: 2s # PolicyLoaderTimeout is the timeout for loading policies from the policy store.
 hub:
   credentials: # Credentials holds Cerbos Hub client credentials.
     clientID: 92B0K05B6HOF # ClientID of the Cerbos Hub credential. Defaults to the value of the CERBOS_HUB_CLIENT_ID environment variable.

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -347,13 +347,13 @@ func checkReferencedSchemas(modCtx *moduleCtx, rp *policyv1.ResourcePolicy, sche
 	}
 
 	if ps := rp.Schemas.PrincipalSchema; ps != nil && ps.Ref != "" {
-		if err := schemaMgr.CheckSchema(context.TODO(), ps.Ref); err != nil {
+		if _, err := schemaMgr.LoadSchema(context.TODO(), ps.Ref); err != nil {
 			modCtx.addErrForProtoPath(policy.ResourcePolicyPrincipalSchemaProtoPath(), errInvalidSchema, "Failed to load principal schema %q: %v", ps.Ref, err)
 		}
 	}
 
 	if rs := rp.Schemas.ResourceSchema; rs != nil && rs.Ref != "" {
-		if err := schemaMgr.CheckSchema(context.TODO(), rs.Ref); err != nil {
+		if _, err := schemaMgr.LoadSchema(context.TODO(), rs.Ref); err != nil {
 			modCtx.addErrForProtoPath(policy.ResourcePolicyResourceSchemaProtoPath(), errInvalidSchema, "Failed to load resource schema %q: %v", rs.Ref, err)
 		}
 	}

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -44,6 +44,9 @@ func BatchCompile(queue <-chan *policy.CompilationUnit, schemaMgr schema.Manager
 	return errs.ErrOrNil()
 }
 
+// Compile compiles a single policy compilation unit into a runnable policy set.
+// The schemaMgr parameter is optional - pass nil to skip schema validation,
+// or provide a SchemaManager instance to enable validation against schema files.
 func Compile(unit *policy.CompilationUnit, schemaMgr schema.Manager) (rps *runtimev1.RunnablePolicySet, err error) {
 	uc := newUnitCtx(unit)
 	mc := uc.moduleCtx(unit.ModID)
@@ -183,8 +186,10 @@ func compileResourcePolicy(modCtx *moduleCtx, schemaMgr schema.Manager) (*runtim
 		return nil, nil
 	}
 
-	if err := checkReferencedSchemas(modCtx, rp, schemaMgr); err != nil {
-		return nil, nil
+	if schemaMgr != nil {
+		if err := checkReferencedSchemas(modCtx, rp, schemaMgr); err != nil {
+			return nil, nil
+		}
 	}
 
 	compilePolicyConstants(modCtx, rp.Constants)

--- a/internal/compile/manager_test.go
+++ b/internal/compile/manager_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cerbos/cerbos/internal/compile"
 	"github.com/cerbos/cerbos/internal/namer"
 	"github.com/cerbos/cerbos/internal/policy"
-	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage"
 	"github.com/cerbos/cerbos/internal/test"
 )
@@ -194,7 +193,7 @@ func mkManager(t *testing.T) (*compile.Manager, *MockStore, context.CancelFunc) 
 	mockStore := &MockStore{}
 	mockStore.On("Subscribe", mock.Anything)
 
-	mgr, err := compile.NewManager(ctx, mockStore, schema.NewNopManager())
+	mgr, err := compile.NewManager(ctx, mockStore)
 	require.NoError(t, err)
 
 	return mgr, mockStore, cancelFunc

--- a/internal/compile/manager_test.go
+++ b/internal/compile/manager_test.go
@@ -247,6 +247,14 @@ func (ms *MockStore) GetAll(ctx context.Context) ([]*policy.CompilationUnit, err
 	return args.Get(0).([]*policy.CompilationUnit), args.Error(1)
 }
 
+func (ms *MockStore) GetAllMatching(ctx context.Context, modIDs []namer.ModuleID) ([]*policy.CompilationUnit, error) {
+	args := ms.MethodCalled("GetAllMatching", ctx, modIDs)
+	if res := args.Get(0); res == nil {
+		return nil, args.Error(0)
+	}
+	return args.Get(0).([]*policy.CompilationUnit), args.Error(1)
+}
+
 func (ms *MockStore) GetCompilationUnits(ctx context.Context, ids ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error) {
 	args := ms.MethodCalled("GetCompilationUnits", ctx, ids)
 	res := args.Get(0)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -255,11 +255,6 @@ func (engine *Engine) doPlanResources(ctx context.Context, input *enginev1.PlanR
 		return nil, nil, err
 	}
 
-	// TODO(saml) remove with patching
-	if err := engine.ruleTableManager.Reload(ctx); err != nil {
-		return nil, nil, err
-	}
-
 	ppVersion := engine.policyVersion(input.Principal.PolicyVersion, opts.evalParams)
 	rpVersion := engine.policyVersion(input.Resource.PolicyVersion, opts.evalParams)
 
@@ -443,11 +438,6 @@ func (engine *Engine) evaluate(ctx context.Context, input *enginev1.CheckInput, 
 	}
 
 	tctx := tracer.Start(checkOpts.tracerSink)
-
-	// TODO(saml) remove with patching
-	if err := engine.ruleTableManager.Reload(ctx); err != nil {
-		return nil, nil, err
-	}
 
 	// evaluate the policies
 	result, err := engine.ruleTableManager.Check(ctx, tctx, checkOpts.evalParams, input)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -303,6 +303,7 @@ func (engine *Engine) logPlanDecision(ctx context.Context, input *enginev1.PlanR
 	return output, planErr
 }
 
+// TODO(saml) make `Engine` and `RuleTable` both satisfy a new `Evaluator` interface with `Check` and `Plan`
 func (engine *Engine) Check(ctx context.Context, inputs []*enginev1.CheckInput, opts ...CheckOpt) ([]*enginev1.CheckOutput, error) {
 	outputs, trail, err := metrics.RecordDuration3(metrics.EngineCheckLatency(), func() (outputs []*enginev1.CheckOutput, trail *auditv1.AuditTrail, err error) {
 		ctx, span := tracing.StartSpan(ctx, "engine.Check")

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cerbos/cerbos/internal/audit/local"
 	"github.com/cerbos/cerbos/internal/compile"
 	"github.com/cerbos/cerbos/internal/engine/tracer"
+	"github.com/cerbos/cerbos/internal/evaluator"
 	"github.com/cerbos/cerbos/internal/printer"
 	"github.com/cerbos/cerbos/internal/ruletable"
 	"github.com/cerbos/cerbos/internal/ruletable/planner"
@@ -57,7 +58,7 @@ func TestCheck(t *testing.T) {
 			mockAuditLog.clear()
 
 			traceCollector := tracer.NewCollector()
-			haveOutputs, err := eng.Check(t.Context(), tc.Inputs, WithTraceSink(traceCollector))
+			haveOutputs, err := eng.Check(t.Context(), tc.Inputs, evaluator.WithTraceSink(traceCollector))
 
 			if tc.WantError {
 				require.Error(t, err)
@@ -153,7 +154,7 @@ func TestCheckWithLenientScopeSearch(t *testing.T) {
 			mockAuditLog.clear()
 
 			traceCollector := tracer.NewCollector()
-			haveOutputs, err := eng.Check(t.Context(), tc.Inputs, WithTraceSink(traceCollector))
+			haveOutputs, err := eng.Check(t.Context(), tc.Inputs, evaluator.WithTraceSink(traceCollector))
 
 			if tc.WantError {
 				require.Error(t, err)
@@ -210,7 +211,7 @@ func TestSchemaValidation(t *testing.T) {
 				t.Run(tcase.Name, func(t *testing.T) {
 					tc := readTestCase(t, tcase.Input)
 
-					haveOutputs, err := eng.Check(t.Context(), tc.Inputs, WithTraceSink(newTestTraceSink(t)))
+					haveOutputs, err := eng.Check(t.Context(), tc.Inputs, evaluator.WithTraceSink(newTestTraceSink(t)))
 
 					if tc.WantError {
 						require.Error(t, err)
@@ -266,7 +267,7 @@ func BenchmarkCheck(b *testing.B) {
 	}
 }
 
-func runBenchmarks(b *testing.B, eng *Engine, testCases []test.Case) {
+func runBenchmarks(b *testing.B, eng evaluator.Evaluator, testCases []test.Case) {
 	b.Helper()
 
 	for _, tcase := range testCases {
@@ -403,7 +404,7 @@ func TestQueryPlan(t *testing.T) {
 					} else {
 						request.Actions = []string{tt.Action} //nolint:staticcheck
 					}
-					response, err := eng.PlanResources(t.Context(), request, WithNowFunc(func() time.Time { return timestamp }))
+					response, err := eng.Plan(t.Context(), request, evaluator.WithNowFunc(func() time.Time { return timestamp }))
 					if tt.WantErr {
 						is.Error(err)
 					} else {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -45,6 +45,7 @@ var dummy int
 
 func TestCheck(t *testing.T) {
 	mockAuditLog := &mockAuditLog{}
+	// TODO(saml) when both `Engine` and `RuleTable` satisfy the new `Evaluator` interface, we can test for both circumstances here
 	eng, cancelFunc := mkEngine(t, param{auditLog: mockAuditLog, schemaEnforcement: schema.EnforcementNone})
 	defer cancelFunc()
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -352,7 +352,7 @@ func mkEngine(tb testing.TB, p param) (evaluator.Evaluator, context.CancelFunc) 
 	rt := ruletable.NewProtoRuletable()
 	require.NoError(tb, ruletable.Load(ctx, rt, compiler, store))
 
-	ruletableMgr, err := ruletable.NewRuleTableManager(rt, compiler, schemaMgr)
+	ruletableMgr, err := ruletable.NewRuleTableManager(rt, compiler, store, schemaMgr)
 	require.NoError(tb, err)
 
 	evalConf := &evaluator.Conf{}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -326,10 +326,7 @@ func mkEngine(tb testing.TB, p param) (evaluator.Evaluator, context.CancelFunc) 
 	store, err := disk.NewStore(ctx, &disk.Conf{Directory: dir})
 	require.NoError(tb, err)
 
-	schemaConf := schema.NewConf(p.schemaEnforcement)
-	schemaMgr := schema.NewFromConf(ctx, store, schemaConf)
-
-	compiler, err := compile.NewManager(ctx, store, schemaMgr)
+	compiler, err := compile.NewManager(ctx, store)
 	require.NoError(tb, err)
 
 	var auditLog audit.Log
@@ -351,6 +348,9 @@ func mkEngine(tb testing.TB, p param) (evaluator.Evaluator, context.CancelFunc) 
 
 	rt := ruletable.NewProtoRuletable()
 	require.NoError(tb, ruletable.Load(ctx, rt, compiler, store))
+
+	schemaConf := schema.NewConf(p.schemaEnforcement)
+	schemaMgr := schema.NewFromConf(ctx, store, schemaConf)
 
 	ruletableMgr, err := ruletable.NewRuleTableManager(rt, compiler, store, schemaMgr)
 	require.NoError(tb, err)
@@ -386,10 +386,7 @@ func mkRuleTable(tb testing.TB, p param) (evaluator.Evaluator, context.CancelFun
 
 	protoRT := ruletable.NewProtoRuletable()
 
-	schemaConf := schema.NewConf(p.schemaEnforcement)
-	schemaMgr := schema.NewFromConf(ctx, store, schemaConf)
-
-	compiler, err := compile.NewManager(ctx, store, schemaMgr)
+	compiler, err := compile.NewManager(ctx, store)
 	require.NoError(tb, err)
 
 	err = ruletable.Load(ctx, protoRT, compiler, store)
@@ -400,7 +397,7 @@ func mkRuleTable(tb testing.TB, p param) (evaluator.Evaluator, context.CancelFun
 	evalConf.Globals = map[string]any{"environment": "test"}
 	evalConf.LenientScopeSearch = p.lenientScopeSearch
 
-	rt, err := ruletable.NewRuleTable(protoRT, evalConf, schemaConf)
+	rt, err := ruletable.NewRuleTable(protoRT, evalConf, schema.NewConf(p.schemaEnforcement))
 	require.NoError(tb, err)
 
 	return rt, cancelFunc

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -333,7 +333,7 @@ func mkEngine(tb testing.TB, p param) (*Engine, context.CancelFunc) {
 		auditLog = audit.NewNopLog()
 	}
 
-	rt := ruletable.NewRuletable()
+	rt := ruletable.NewProtoRuletable()
 	require.NoError(tb, ruletable.LoadFromPolicyLoader(ctx, rt, compiler))
 
 	ruletableMgr, err := ruletable.NewRuleTableManager(rt, compiler, schemaMgr)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -347,7 +347,7 @@ func mkEngine(tb testing.TB, p param) (evaluator.Evaluator, context.CancelFunc) 
 	}
 
 	rt := ruletable.NewProtoRuletable()
-	require.NoError(tb, ruletable.Load(ctx, rt, compiler, store))
+	require.NoError(tb, ruletable.LoadPolicies(ctx, rt, compiler))
 
 	schemaConf := schema.NewConf(p.schemaEnforcement)
 	schemaMgr := schema.NewFromConf(ctx, store, schemaConf)
@@ -389,7 +389,10 @@ func mkRuleTable(tb testing.TB, p param) (evaluator.Evaluator, context.CancelFun
 	compiler, err := compile.NewManager(ctx, store)
 	require.NoError(tb, err)
 
-	err = ruletable.Load(ctx, protoRT, compiler, store)
+	err = ruletable.LoadPolicies(ctx, protoRT, compiler)
+	require.NoError(tb, err)
+
+	err = ruletable.LoadSchemas(ctx, protoRT, store)
 	require.NoError(tb, err)
 
 	evalConf := &evaluator.Conf{}

--- a/internal/engine/evaluator_test.go
+++ b/internal/engine/evaluator_test.go
@@ -15,19 +15,21 @@ import (
 	privatev1 "github.com/cerbos/cerbos/api/genpb/cerbos/private/v1"
 	"github.com/cerbos/cerbos/internal/compile"
 	"github.com/cerbos/cerbos/internal/engine/tracer"
+	"github.com/cerbos/cerbos/internal/evaluator"
 	"github.com/cerbos/cerbos/internal/ruletable"
 	"github.com/cerbos/cerbos/internal/test"
 	"github.com/cerbos/cerbos/internal/util"
 	"github.com/stretchr/testify/require"
 )
 
+// TODO(saml) migrate this to the new `internal/evaluator` package?
 func TestSatisfiesCondition(t *testing.T) {
 	testCases := test.LoadTestCases(t, "cel_eval")
 
 	timeNow, err := time.Parse(time.RFC3339, "2021-04-22T10:05:20.021-05:00")
 	require.NoError(t, err, "Failed to parse timestamp")
 
-	eparams := ruletable.EvalParams{NowFunc: func() time.Time { return timeNow }}
+	eparams := evaluator.EvalParams{NowFunc: func() time.Time { return timeNow }}
 
 	for _, tcase := range testCases {
 		t.Run(tcase.Name, func(t *testing.T) {

--- a/internal/engine/evaluator_test.go
+++ b/internal/engine/evaluator_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TODO(saml) migrate this to the new `internal/evaluator` package?
 func TestSatisfiesCondition(t *testing.T) {
 	testCases := test.LoadTestCases(t, "cel_eval")
 

--- a/internal/engine/policyloader/policy_loader.go
+++ b/internal/engine/policyloader/policy_loader.go
@@ -13,4 +13,5 @@ import (
 type PolicyLoader interface {
 	GetFirstMatch(context.Context, []namer.ModuleID) (*runtimev1.RunnablePolicySet, error)
 	GetAll(context.Context) ([]*runtimev1.RunnablePolicySet, error)
+	GetAllMatching(context.Context, []namer.ModuleID) ([]*runtimev1.RunnablePolicySet, error)
 }

--- a/internal/evaluator/conf.go
+++ b/internal/evaluator/conf.go
@@ -1,7 +1,7 @@
 // Copyright 2021-2025 Zenauth Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-package engine
+package evaluator
 
 import (
 	"errors"

--- a/internal/evaluator/conf.go
+++ b/internal/evaluator/conf.go
@@ -7,12 +7,17 @@ import (
 	"errors"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/cerbos/cerbos/internal/config"
 	"github.com/cerbos/cerbos/internal/namer"
 )
 
-const confKey = "engine"
+const (
+	confKey = "engine"
+
+	defaultPolicyLoaderTimeout = 2 * time.Second
+)
 
 var errEmptyDefaultVersion = errors.New("engine.defaultVersion must not be an empty string")
 
@@ -24,7 +29,9 @@ type Conf struct {
 	DefaultPolicyVersion string `yaml:"defaultPolicyVersion" conf:",example=\"default\""`
 	// LenientScopeSearch configures the engine to ignore missing scopes and search upwards through the scope tree until it finds a usable policy.
 	LenientScopeSearch bool `yaml:"lenientScopeSearch" conf:",example=false"`
-	NumWorkers         uint `yaml:"numWorkers" conf:",ignore"`
+	// PolicyLoaderTimeout is the timeout for loading policies from the policy store.
+	PolicyLoaderTimeout time.Duration `yaml:"policyLoaderTimeout" conf:",example=2s"`
+	NumWorkers          uint          `yaml:"numWorkers" conf:",ignore"`
 }
 
 func (c *Conf) Key() string {
@@ -33,6 +40,7 @@ func (c *Conf) Key() string {
 
 func (c *Conf) SetDefaults() {
 	c.DefaultPolicyVersion = namer.DefaultVersion
+	c.PolicyLoaderTimeout = defaultPolicyLoaderTimeout
 	c.NumWorkers = uint(runtime.NumCPU() + 4) //nolint:mnd
 }
 

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -99,16 +99,6 @@ func PolicyVersion(version string, params EvalParams) string {
 	return version
 }
 
-// TODO(saml) migrate the engine config to here somehow? This is just copied from `engine/conf.go` for now
-type Conf struct {
-	// Globals are environment-specific variables to be made available to policy conditions.
-	Globals map[string]any `yaml:"globals" conf:",example={\"environment\": \"staging\"}"`
-	// DefaultPolicyVersion defines what version to assume if the request does not specify one.
-	DefaultPolicyVersion string `yaml:"defaultPolicyVersion" conf:",example=\"default\""`
-	// LenientScopeSearch configures the engine to ignore missing scopes and search upwards through the scope tree until it finds a usable policy.
-	LenientScopeSearch bool `yaml:"lenientScopeSearch" conf:",example=false"`
-}
-
 func NewCheckOptions(ctx context.Context, conf *Conf, opts ...CheckOpt) *CheckOptions {
 	var tracerSink tracer.Sink
 	if debugEnabled, ok := os.LookupEnv("CERBOS_DEBUG_ENGINE"); ok && debugEnabled != "false" {

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -1,0 +1,132 @@
+// Copyright 2021-2025 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package evaluator
+
+import (
+	"context"
+	"os"
+	"time"
+
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
+	"github.com/cerbos/cerbos/internal/conditions"
+	"github.com/cerbos/cerbos/internal/engine/tracer"
+	"github.com/cerbos/cerbos/internal/observability/logging"
+	"go.uber.org/zap"
+)
+
+type Evaluator interface {
+	Check(context.Context, []*enginev1.CheckInput, ...CheckOpt) ([]*enginev1.CheckOutput, error)
+	Plan(context.Context, *enginev1.PlanResourcesInput, ...CheckOpt) (*enginev1.PlanResourcesOutput, error)
+}
+
+// CheckOpt defines options for engine Check calls.
+type CheckOpt func(*CheckOptions)
+
+func WithTraceSink(tracerSink tracer.Sink) CheckOpt {
+	return func(co *CheckOptions) {
+		co.TracerSink = tracerSink
+	}
+}
+
+// WithZapTraceSink sets an engine tracer with Zap set as the sink.
+func WithZapTraceSink(log *zap.Logger) CheckOpt {
+	return WithTraceSink(tracer.NewZapSink(log))
+}
+
+// WithNowFunc sets the function for determining `now` during condition evaluation.
+// The function should return the same timestamp every time it is invoked.
+func WithNowFunc(nowFunc func() time.Time) CheckOpt {
+	return func(co *CheckOptions) {
+		co.EvalParams.NowFunc = nowFunc
+	}
+}
+
+// WithLenientScopeSearch enables lenient scope search.
+func WithLenientScopeSearch() CheckOpt {
+	return func(co *CheckOptions) {
+		co.EvalParams.LenientScopeSearch = true
+	}
+}
+
+// WithGlobals sets the global variables for the engine.
+func WithGlobals(globals map[string]any) CheckOpt {
+	return func(co *CheckOptions) {
+		co.EvalParams.Globals = globals
+	}
+}
+
+// WithDefaultPolicyVersion sets the default policy version for the engine.
+func WithDefaultPolicyVersion(defaultPolicyVersion string) CheckOpt {
+	return func(co *CheckOptions) {
+		co.EvalParams.DefaultPolicyVersion = defaultPolicyVersion
+	}
+}
+
+type CheckOptions struct {
+	TracerSink tracer.Sink
+	EvalParams EvalParams
+}
+
+func (co *CheckOptions) NowFunc() func() time.Time {
+	return co.EvalParams.NowFunc
+}
+
+func (co *CheckOptions) DefaultPolicyVersion() string {
+	return co.EvalParams.DefaultPolicyVersion
+}
+
+func (co *CheckOptions) LenientScopeSearch() bool {
+	return co.EvalParams.LenientScopeSearch
+}
+
+func (co *CheckOptions) Globals() map[string]any {
+	return co.EvalParams.Globals
+}
+
+type EvalParams struct {
+	Globals              map[string]any
+	NowFunc              conditions.NowFunc
+	DefaultPolicyVersion string
+	LenientScopeSearch   bool
+}
+
+func PolicyVersion(version string, params EvalParams) string {
+	if version == "" {
+		version = params.DefaultPolicyVersion
+	}
+
+	return version
+}
+
+// TODO(saml) migrate the engine config to here somehow? This is just copied from `engine/conf.go` for now
+type Conf struct {
+	// Globals are environment-specific variables to be made available to policy conditions.
+	Globals map[string]any `yaml:"globals" conf:",example={\"environment\": \"staging\"}"`
+	// DefaultPolicyVersion defines what version to assume if the request does not specify one.
+	DefaultPolicyVersion string `yaml:"defaultPolicyVersion" conf:",example=\"default\""`
+	// LenientScopeSearch configures the engine to ignore missing scopes and search upwards through the scope tree until it finds a usable policy.
+	LenientScopeSearch bool `yaml:"lenientScopeSearch" conf:",example=false"`
+}
+
+func NewCheckOptions(ctx context.Context, conf *Conf, opts ...CheckOpt) *CheckOptions {
+	var tracerSink tracer.Sink
+	if debugEnabled, ok := os.LookupEnv("CERBOS_DEBUG_ENGINE"); ok && debugEnabled != "false" {
+		tracerSink = tracer.NewZapSink(logging.FromContext(ctx).Named("tracer"))
+	}
+
+	co := &CheckOptions{TracerSink: tracerSink, EvalParams: EvalParams{
+		Globals:              conf.Globals,
+		DefaultPolicyVersion: conf.DefaultPolicyVersion,
+		LenientScopeSearch:   conf.LenientScopeSearch,
+	}}
+	for _, opt := range opts {
+		opt(co)
+	}
+
+	if co.EvalParams.NowFunc == nil {
+		co.EvalParams.NowFunc = conditions.Now()
+	}
+
+	return co
+}

--- a/internal/ruletable/manager.go
+++ b/internal/ruletable/manager.go
@@ -25,6 +25,7 @@ import (
 type Manager struct {
 	*RuleTable
 	policyLoader               policyloader.PolicyLoader
+	schemaLoader               schema.Loader
 	log                        *zap.SugaredLogger
 	ruleTable                  *runtimev1.RuleTable
 	mu                         sync.RWMutex
@@ -105,7 +106,7 @@ func (mgr *Manager) reload(ctx context.Context) error {
 
 	// If compilation fails, maintain the last valid rule table state.
 	// Set isStale to false to prevent repeated recompilation attempts until new events arrive.
-	if err := LoadFromPolicyLoader(ctx, rt, mgr.policyLoader); err != nil {
+	if err := Load(ctx, rt, mgr.policyLoader, mgr.schemaLoader); err != nil {
 		mgr.log.Errorf("Rule table compilation failed, using previous valid state: %v", err)
 		mgr.isStale.Store(false)
 		mgr.awaitingHealthyPolicyStore.Store(true)

--- a/internal/ruletable/manager.go
+++ b/internal/ruletable/manager.go
@@ -207,7 +207,7 @@ func (mgr *Manager) doDeletePolicy(moduleID namer.ModuleID) {
 
 	for version, scopeMap := range mgr.primaryIdx {
 		for scope, roleMap := range scopeMap {
-			scopedParentRoleAncestors := mgr.parentRoleAncestorsCache[scope]
+			scopedParentRoleAncestors := mgr.parentRoleAncestors[scope]
 
 			for role, actionMap := range roleMap.GetAll() {
 				for action, rules := range actionMap.GetAll() {
@@ -238,7 +238,7 @@ func (mgr *Manager) doDeletePolicy(moduleID namer.ModuleID) {
 				delete(mgr.principalScopeMap, scope)
 				delete(mgr.resourceScopeMap, scope)
 				delete(mgr.scopeScopePermissions, scope)
-				delete(mgr.parentRoleAncestorsCache, scope)
+				delete(mgr.parentRoleAncestors, scope)
 			}
 		}
 

--- a/internal/ruletable/manager.go
+++ b/internal/ruletable/manager.go
@@ -79,12 +79,6 @@ func (mgr *Manager) OnStorageEvent(events ...storage.Event) {
 			if err := mgr.processPolicyEvent(event); err != nil {
 				mgr.log.Warnw("Error processing storage event, maintaining last valid state", "event", event, "error", err)
 			}
-		case storage.EventAddOrUpdateSchema, storage.EventDeleteSchema:
-			// TODO(saml) granular handling of schema updates.
-			// If we can retrieve all policies that reference a given schema, we can update each of those individually
-			// if mgr.awaitingHealthyPolicyStore.Load() {
-			mgr.reload()
-			// }
 		default:
 			mgr.log.Debugw("Ignoring storage event", "event", event)
 		}
@@ -175,6 +169,10 @@ func (mgr *Manager) processPolicyEvent(evt storage.Event) (err error) {
 }
 
 func (mgr *Manager) addPolicy(rps *runtimev1.RunnablePolicySet) error {
+	if rps == nil {
+		return nil
+	}
+
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 

--- a/internal/ruletable/manager.go
+++ b/internal/ruletable/manager.go
@@ -179,9 +179,7 @@ func (mgr *Manager) addPolicy(rps *runtimev1.RunnablePolicySet) error {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 
-	AddPolicy(mgr.RuleTable.RuleTable, rps)
-
-	if err := mgr.indexAndPurgeRules(); err != nil {
+	if err := mgr.indexRules(AddPolicy(mgr.RuleTable.RuleTable, rps)); err != nil {
 		return fmt.Errorf("failed to index and purge rules: %w", err)
 	}
 

--- a/internal/ruletable/manager.go
+++ b/internal/ruletable/manager.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	auditv1 "github.com/cerbos/cerbos/api/genpb/cerbos/audit/v1"
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
@@ -16,29 +17,29 @@ import (
 	"github.com/cerbos/cerbos/internal/engine/policyloader"
 	"github.com/cerbos/cerbos/internal/engine/tracer"
 	"github.com/cerbos/cerbos/internal/evaluator"
-	"github.com/cerbos/cerbos/internal/observability/logging"
+	"github.com/cerbos/cerbos/internal/namer"
 	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage"
 	"go.uber.org/zap"
 )
+
+const loaderFetchTimeout = 2 * time.Second
 
 type Manager struct {
 	*RuleTable
 	policyLoader               policyloader.PolicyLoader
 	schemaLoader               schema.Loader
 	log                        *zap.SugaredLogger
-	ruleTable                  *runtimev1.RuleTable
 	mu                         sync.RWMutex
-	isStale                    atomic.Bool
 	awaitingHealthyPolicyStore atomic.Bool
 }
 
-func NewRuleTableManager(protoRT *runtimev1.RuleTable, policyLoader policyloader.PolicyLoader, schemaMgr schema.Manager) (*Manager, error) {
+func NewRuleTableManager(protoRT *runtimev1.RuleTable, policyLoader policyloader.PolicyLoader, schemaLoader schema.Loader, schemaMgr schema.Manager) (*Manager, error) {
 	rt := &RuleTable{
 		schemaMgr: schemaMgr,
 	}
 
-	if err := rt.load(protoRT); err != nil {
+	if err := rt.init(protoRT); err != nil {
 		return nil, err
 	}
 
@@ -46,16 +47,11 @@ func NewRuleTableManager(protoRT *runtimev1.RuleTable, policyLoader policyloader
 		log:          zap.S().Named("ruletable"),
 		RuleTable:    rt,
 		policyLoader: policyLoader,
-		ruleTable:    protoRT,
+		schemaLoader: schemaLoader,
 	}, nil
 }
 
 func (mgr *Manager) Check(ctx context.Context, tctx tracer.Context, evalParams evaluator.EvalParams, input *enginev1.CheckInput) (*enginev1.CheckOutput, *auditv1.AuditTrail, error) {
-	if err := mgr.reload(ctx); err != nil {
-		logging.FromContext(ctx).Error("Failed to evaluate policies", zap.Error(err))
-		return nil, nil, fmt.Errorf("failed to evaluate policies: %w", err)
-	}
-
 	mgr.mu.RLock()
 	defer mgr.mu.RUnlock()
 
@@ -63,10 +59,6 @@ func (mgr *Manager) Check(ctx context.Context, tctx tracer.Context, evalParams e
 }
 
 func (mgr *Manager) Plan(ctx context.Context, input *enginev1.PlanResourcesInput, principalVersion, resourceVersion string, nowFunc conditions.NowFunc, globals map[string]any) (*enginev1.PlanResourcesOutput, *auditv1.AuditTrail, error) {
-	if err := mgr.reload(ctx); err != nil {
-		return nil, nil, err
-	}
-
 	mgr.mu.RLock()
 	defer mgr.mu.RUnlock()
 
@@ -79,27 +71,32 @@ func (mgr *Manager) SubscriberID() string {
 
 func (mgr *Manager) OnStorageEvent(events ...storage.Event) {
 	for _, event := range events {
-		switch event.Kind { //nolint:exhaustive
+		switch event.Kind {
 		case storage.EventReload:
-			mgr.isStale.Store(true)
+			mgr.reload()
 		case storage.EventAddOrUpdatePolicy, storage.EventDeleteOrDisablePolicy:
-			mgr.isStale.Store(true)
+			mgr.log.Debugw("Processing storage event", "event", event)
+			if err := mgr.processPolicyEvent(event); err != nil {
+				mgr.log.Warnw("Error processing storage event, maintaining last valid state", "event", event, "error", err)
+			}
+		case storage.EventAddOrUpdateSchema, storage.EventDeleteSchema:
+			// TODO(saml) granular handling of schema updates.
+			// If we can retrieve all policies that reference a given schema, we can update each of those individually
+			// if mgr.awaitingHealthyPolicyStore.Load() {
+			mgr.reload()
+			// }
+		default:
+			mgr.log.Debugw("Ignoring storage event", "event", event)
 		}
 	}
 }
 
-// TODO(saml) update this post patching.
-func (mgr *Manager) reload(ctx context.Context) error {
+func (mgr *Manager) reload() error {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 
-	if !mgr.isStale.Load() {
-		// TODO(saml) this atomic bool is only used for logging purposes. Remove with patching
-		if mgr.awaitingHealthyPolicyStore.Load() {
-			mgr.log.Debug("Policy store invalid, using previous valid state")
-		}
-		return nil
-	}
+	ctx, cancelFunc := context.WithTimeout(context.Background(), loaderFetchTimeout)
+	defer cancelFunc()
 
 	mgr.log.Info("Reloading rule table")
 	rt := NewProtoRuletable()
@@ -108,17 +105,147 @@ func (mgr *Manager) reload(ctx context.Context) error {
 	// Set isStale to false to prevent repeated recompilation attempts until new events arrive.
 	if err := Load(ctx, rt, mgr.policyLoader, mgr.schemaLoader); err != nil {
 		mgr.log.Errorf("Rule table compilation failed, using previous valid state: %v", err)
-		mgr.isStale.Store(false)
 		mgr.awaitingHealthyPolicyStore.Store(true)
 		return nil
 	}
 
-	if err := mgr.load(rt); err != nil {
+	if err := mgr.init(rt); err != nil {
 		return err
 	}
 
-	mgr.isStale.Store(false)
 	mgr.awaitingHealthyPolicyStore.Store(false)
 
 	return nil
+}
+
+func (mgr *Manager) processPolicyEvent(evt storage.Event) (err error) {
+	if mgr.awaitingHealthyPolicyStore.Load() {
+		return mgr.reload()
+	}
+
+	defer func() {
+		if err != nil {
+			mgr.awaitingHealthyPolicyStore.Store(true)
+		}
+	}()
+
+	mgr.deletePolicy(evt.PolicyID)
+
+	if evt.OldPolicyID != nil {
+		mgr.deletePolicy(*evt.OldPolicyID)
+	}
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), loaderFetchTimeout)
+	defer cancelFunc()
+
+	if evt.Kind == storage.EventAddOrUpdatePolicy {
+		var rps *runtimev1.RunnablePolicySet
+		rps, err = mgr.policyLoader.GetFirstMatch(ctx, []namer.ModuleID{evt.PolicyID})
+		if err != nil {
+			return fmt.Errorf("failed to load policy: %w", err)
+		}
+
+		if rps != nil {
+			if err = mgr.addPolicy(rps); err != nil {
+				return err
+			}
+		}
+	}
+
+	if len(evt.Dependents) > 0 {
+		// handle dependents reloading atomically
+		toReload, err := mgr.policyLoader.GetAllMatching(ctx, evt.Dependents)
+		if err != nil {
+			return fmt.Errorf("failed to load dependent policies: %w", err)
+		}
+
+		// we leave ruletable state static until we're sure all dependents are valid, and then update
+		for _, modID := range evt.Dependents {
+			mgr.deletePolicy(modID)
+		}
+
+		for _, rps := range toReload {
+			if err = mgr.addPolicy(rps); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (mgr *Manager) addPolicy(rps *runtimev1.RunnablePolicySet) error {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+
+	AddPolicy(mgr.RuleTable.RuleTable, rps)
+
+	if err := mgr.RuleTable.indexAndPurgeRules(); err != nil {
+		return fmt.Errorf("failed to index and purge rules: %w", err)
+	}
+
+	return nil
+}
+
+func (mgr *Manager) deletePolicy(moduleID namer.ModuleID) {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+
+	mgr.doDeletePolicy(moduleID)
+}
+
+// doDeletePolicy implements the delete logic. The caller must obtain a lock first.
+func (mgr *Manager) doDeletePolicy(moduleID namer.ModuleID) {
+	meta := mgr.Meta[moduleID.RawValue()]
+	if meta == nil {
+		return
+	}
+
+	mgr.log.Debugf("Deleting policy %s", meta.GetFqn())
+
+	for version, scopeMap := range mgr.primaryIdx {
+		for scope, roleMap := range scopeMap {
+			scopedParentRoleAncestors := mgr.parentRoleAncestorsCache[scope]
+
+			for role, actionMap := range roleMap.GetAll() {
+				for action, rules := range actionMap.GetAll() {
+					newRules := make([]*Row, 0, len(rules))
+					for _, r := range rules {
+						if r.OriginFqn != meta.GetFqn() {
+							newRules = append(newRules, r)
+						} else {
+							mgr.log.Debugf("Dropping rule %s", r.GetOriginFqn())
+						}
+					}
+
+					if len(newRules) > 0 {
+						actionMap.Set(action, newRules)
+					} else {
+						actionMap.DeleteLiteral(action)
+					}
+				}
+
+				if actionMap.Len() == 0 {
+					roleMap.DeleteLiteral(role)
+					delete(scopedParentRoleAncestors, role)
+				}
+			}
+
+			if roleMap.Len() == 0 {
+				delete(scopeMap, scope)
+				delete(mgr.principalScopeMap, scope)
+				delete(mgr.resourceScopeMap, scope)
+				delete(mgr.scopeScopePermissions, scope)
+				delete(mgr.parentRoleAncestorsCache, scope)
+			}
+		}
+
+		if len(scopeMap) == 0 {
+			delete(mgr.primaryIdx, version)
+		}
+	}
+
+	delete(mgr.Schemas, moduleID.RawValue())
+	delete(mgr.Meta, moduleID.RawValue())
+	delete(mgr.policyDerivedRoles, moduleID)
 }

--- a/internal/ruletable/manager.go
+++ b/internal/ruletable/manager.go
@@ -62,7 +62,7 @@ func (mgr *Manager) Plan(ctx context.Context, input *enginev1.PlanResourcesInput
 	mgr.mu.RLock()
 	defer mgr.mu.RUnlock()
 
-	return mgr.PlanWithAuditTrail(ctx, input, principalVersion, resourceVersion, nowFunc, globals)
+	return mgr.planWithAuditTrail(ctx, input, principalVersion, resourceVersion, nowFunc, globals)
 }
 
 func (mgr *Manager) SubscriberID() string {

--- a/internal/ruletable/manager.go
+++ b/internal/ruletable/manager.go
@@ -1,0 +1,117 @@
+// Copyright 2021-2025 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package ruletable
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	auditv1 "github.com/cerbos/cerbos/api/genpb/cerbos/audit/v1"
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
+	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
+	"github.com/cerbos/cerbos/internal/conditions"
+	"github.com/cerbos/cerbos/internal/engine/policyloader"
+	"github.com/cerbos/cerbos/internal/engine/tracer"
+	"github.com/cerbos/cerbos/internal/schema"
+	"github.com/cerbos/cerbos/internal/storage"
+	"go.uber.org/zap"
+)
+
+type Manager struct {
+	*RuleTable
+	log          *zap.SugaredLogger
+	mu           sync.RWMutex
+	policyLoader policyloader.PolicyLoader
+	// schemaMgr                  schema.Manager
+	ruleTable                  *runtimev1.RuleTable
+	isStale                    atomic.Bool
+	awaitingHealthyPolicyStore atomic.Bool
+}
+
+func NewRuleTableManager(rt *runtimev1.RuleTable, policyLoader policyloader.PolicyLoader, schemaMgr schema.Manager) (*Manager, error) {
+	manager, err := NewRuleTable(rt, schemaMgr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Manager{
+		log:          zap.S().Named("ruletable"),
+		RuleTable:    manager,
+		policyLoader: policyLoader,
+		ruleTable:    rt,
+	}, nil
+}
+
+func (mgr *Manager) Check(ctx context.Context, tctx tracer.Context, evalParams EvalParams, input *enginev1.CheckInput) (*PolicyEvalResult, error) {
+	if err := mgr.reload(ctx); err != nil {
+		return nil, err
+	}
+
+	mgr.mu.RLock()
+	defer mgr.mu.RUnlock()
+
+	return mgr.RuleTable.Check(ctx, tctx, evalParams, input)
+}
+
+func (mgr *Manager) Plan(ctx context.Context, input *enginev1.PlanResourcesInput, principalVersion, resourceVersion string, nowFunc conditions.NowFunc, globals map[string]any) (*enginev1.PlanResourcesOutput, *auditv1.AuditTrail, error) {
+	if err := mgr.reload(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	mgr.mu.RLock()
+	defer mgr.mu.RUnlock()
+
+	return mgr.RuleTable.Plan(ctx, input, principalVersion, resourceVersion, nowFunc, globals)
+}
+
+func (mgr *Manager) SubscriberID() string {
+	return "engine.RuleTable"
+}
+
+func (mgr *Manager) OnStorageEvent(events ...storage.Event) {
+	for _, event := range events {
+		switch event.Kind {
+		case storage.EventReload:
+			mgr.isStale.Store(true)
+		case storage.EventAddOrUpdatePolicy, storage.EventDeleteOrDisablePolicy:
+			mgr.isStale.Store(true)
+		}
+	}
+}
+
+// TODO(saml) remove this post patching
+func (mgr *Manager) reload(ctx context.Context) error {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+
+	if !mgr.isStale.Load() {
+		// TODO(saml) this atomic bool is only used for logging purposes. Remove with patching
+		if mgr.awaitingHealthyPolicyStore.Load() {
+			mgr.log.Debug("Policy store invalid, using previous valid state")
+		}
+		return nil
+	}
+
+	mgr.log.Info("Reloading rule table")
+	rt := NewProtoRuletable()
+
+	// If compilation fails, maintain the last valid rule table state.
+	// Set isStale to false to prevent repeated recompilation attempts until new events arrive.
+	if err := LoadFromPolicyLoader(ctx, rt, mgr.policyLoader); err != nil {
+		mgr.log.Errorf("Rule table compilation failed, using previous valid state: %v", err)
+		mgr.isStale.Store(false)
+		mgr.awaitingHealthyPolicyStore.Store(true)
+		return nil
+	}
+
+	if err := mgr.load(rt); err != nil {
+		return err
+	}
+
+	mgr.isStale.Store(false)
+	mgr.awaitingHealthyPolicyStore.Store(false)
+
+	return nil
+}

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -60,7 +60,7 @@ func NewProtoRuletable() *runtimev1.RuleTable {
 	}
 }
 
-func Load(ctx context.Context, rt *runtimev1.RuleTable, pl policyloader.PolicyLoader, sl schema.Loader) error {
+func LoadPolicies(ctx context.Context, rt *runtimev1.RuleTable, pl policyloader.PolicyLoader) error {
 	rps, err := pl.GetAll(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get all policies: %w", err)
@@ -70,6 +70,10 @@ func Load(ctx context.Context, rt *runtimev1.RuleTable, pl policyloader.PolicyLo
 		AddPolicy(rt, p)
 	}
 
+	return nil
+}
+
+func LoadSchemas(ctx context.Context, rt *runtimev1.RuleTable, sl schema.Loader) error {
 	if err := buildRawSchemas(ctx, rt, schema.DefaultResolver(sl)); err != nil {
 		return err
 	}

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -527,7 +527,6 @@ func (rt *RuleTable) indexAndPurgeRules() error {
 		}
 
 		rt.indexRule(row)
-
 	}
 
 	// rules are now indexed, we can clear up any unnecessary transport state

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -1703,11 +1703,11 @@ func (rt *RuleTable) Plan(ctx context.Context, input *enginev1.PlanResourcesInpu
 	principalVersion := evaluator.PolicyVersion(input.Principal.PolicyVersion, checkOpts.EvalParams)
 	resourceVersion := evaluator.PolicyVersion(input.Resource.PolicyVersion, checkOpts.EvalParams)
 
-	out, _, err := rt.PlanWithAuditTrail(ctx, input, principalVersion, resourceVersion, checkOpts.NowFunc(), checkOpts.Globals())
+	out, _, err := rt.planWithAuditTrail(ctx, input, principalVersion, resourceVersion, checkOpts.NowFunc(), checkOpts.Globals())
 	return out, err
 }
 
-func (rt *RuleTable) PlanWithAuditTrail(ctx context.Context, input *enginev1.PlanResourcesInput, principalVersion, resourceVersion string, nowFunc conditions.NowFunc, globals map[string]any) (*enginev1.PlanResourcesOutput, *auditv1.AuditTrail, error) {
+func (rt *RuleTable) planWithAuditTrail(ctx context.Context, input *enginev1.PlanResourcesInput, principalVersion, resourceVersion string, nowFunc conditions.NowFunc, globals map[string]any) (*enginev1.PlanResourcesOutput, *auditv1.AuditTrail, error) {
 	fqn := namer.ResourcePolicyFQN(input.Resource.Kind, resourceVersion, input.Resource.Scope)
 
 	_, span := tracing.StartSpan(ctx, "engine.Plan")

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -99,7 +99,7 @@ func addPrincipalPolicy(rt *runtimev1.RuleTable, rpps *runtimev1.RunnablePrincip
 
 	policies := rpps.GetPolicies()
 	if len(policies) == 0 {
-		return
+		return res
 	}
 
 	// We only process the first of principal policy sets as it's assumed parent scopes are handled in separate calls
@@ -174,7 +174,7 @@ func addPrincipalPolicy(rt *runtimev1.RuleTable, rpps *runtimev1.RunnablePrincip
 		}
 	}
 
-	return
+	return res
 }
 
 func addResourcePolicy(rt *runtimev1.RuleTable, rrps *runtimev1.RunnableResourcePolicySet) (res []*runtimev1.RuleTable_RuleRow) {
@@ -182,7 +182,7 @@ func addResourcePolicy(rt *runtimev1.RuleTable, rrps *runtimev1.RunnableResource
 
 	policies := rrps.GetPolicies()
 	if len(policies) == 0 {
-		return
+		return res
 	}
 
 	// we only process the first of resource policy sets as it's assumed parent scopes are handled in separate calls
@@ -312,7 +312,7 @@ func addResourcePolicy(rt *runtimev1.RuleTable, rrps *runtimev1.RunnableResource
 		}
 	}
 
-	return
+	return res
 }
 
 func addRolePolicy(rt *runtimev1.RuleTable, p *runtimev1.RunnableRolePolicySet) (res []*runtimev1.RuleTable_RuleRow) {
@@ -356,7 +356,7 @@ func addRolePolicy(rt *runtimev1.RuleTable, p *runtimev1.RunnableRolePolicySet) 
 		Roles: p.ParentRoles,
 	}
 
-	return
+	return res
 }
 
 func buildRawSchemas(ctx context.Context, rt *runtimev1.RuleTable, resolver schema.Resolver) error {

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -23,6 +23,7 @@ import (
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
 	privatev1 "github.com/cerbos/cerbos/api/genpb/cerbos/private/v1"
+	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
 	"github.com/cerbos/cerbos/internal/cache"
 	"github.com/cerbos/cerbos/internal/observability/logging"
 	"github.com/cerbos/cerbos/internal/observability/tracing"
@@ -48,9 +49,13 @@ func (vr *ValidationResult) add(errs ...ValidationError) {
 }
 
 type Manager interface {
+	managerLoader
 	ValidateCheckInput(context.Context, *policyv1.Schemas, *enginev1.CheckInput) (*ValidationResult, error)
 	ValidatePlanResourcesInput(context.Context, *policyv1.Schemas, *enginev1.PlanResourcesInput) (*ValidationResult, error)
-	CheckSchema(context.Context, string) error
+}
+
+type managerLoader interface {
+	LoadSchema(context.Context, string) (*jsonschema.Schema, error)
 }
 
 type Loader interface {
@@ -73,93 +78,96 @@ func (NopManager) ValidatePlanResourcesInput(_ context.Context, _ *policyv1.Sche
 	return alwaysValidResult, nil
 }
 
-func (NopManager) CheckSchema(_ context.Context, _ string) error {
-	return nil
+func (NopManager) LoadSchema(_ context.Context, _ string) (*jsonschema.Schema, error) {
+	return nil, nil
 }
 
-type manager struct {
-	conf     *Conf
-	log      *zap.Logger
-	cache    *cache.Cache[string, *cacheEntry]
-	resolver Resolver
-}
-
-func New(ctx context.Context, loader Loader) (Manager, error) {
+func NewStatic(schemas map[uint64]*policyv1.Schemas, rawSchemas map[string]*runtimev1.RuleTable_JSONSchema) (*StaticManager, error) {
 	conf, err := GetConf()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config section %q: %w", confKey, err)
 	}
 
-	return NewFromConf(ctx, loader, conf), nil
-}
-
-func NewFromConf(_ context.Context, loader Loader, conf *Conf) Manager {
 	if conf.Enforcement == EnforcementNone {
-		return NopManager{}
+		return &StaticManager{}, nil
 	}
 
-	mgr := &manager{
-		conf:     conf,
-		log:      zap.L().Named("schema"),
-		cache:    cache.New[string, *cacheEntry]("schema", conf.CacheSize),
-		resolver: defaultResolver(loader),
+	sm := &StaticManager{
+		conf: conf,
+		log:  zap.L().Named("schema"),
+	}
+	sm.loader = sm
+
+	comp, err := PreCompileSchemas(schemas, rawSchemas)
+	if err != nil {
+		return nil, err
 	}
 
-	if s, ok := loader.(storage.Subscribable); ok {
-		s.Subscribe(mgr)
-	}
+	sm.CompiledSchemas = comp
 
-	return mgr
+	return sm, nil
 }
 
-func NewEphemeral(resolver Resolver) Manager {
-	mgr := &manager{
-		conf:     NewConf(EnforcementReject),
-		log:      zap.L().Named("schema"),
-		cache:    cache.New[string, *cacheEntry]("schema", defaultCacheSize),
-		resolver: resolver,
-	}
-
-	return mgr
+type StaticManager struct {
+	conf            *Conf
+	log             *zap.Logger
+	CompiledSchemas map[string]*jsonschema.Schema
+	loader          managerLoader
 }
 
-func defaultResolver(loader Loader) Resolver {
-	return func(ctx context.Context, path string) (io.ReadCloser, error) {
-		u, err := url.Parse(path)
-		if err != nil {
-			return nil, err
+func PreCompileSchemas(schemas map[uint64]*policyv1.Schemas, rawSchemas map[string]*runtimev1.RuleTable_JSONSchema) (map[string]*jsonschema.Schema, error) {
+	res := make(map[string]*jsonschema.Schema)
+
+	compiler := jsonschema.NewCompiler()
+	compiler.AssertFormat = true
+	compiler.AssertContent = true
+
+	for ref, raw := range rawSchemas {
+		if err := compiler.AddResource(ref, strings.NewReader(raw.GetContent())); err != nil {
+			return nil, fmt.Errorf("failed to add schema %s: %w", ref, err)
 		}
-
-		if u.Scheme == "" || u.Scheme == URLScheme {
-			relativePath := strings.TrimPrefix(u.Path, "/")
-			return loader.LoadSchema(ctx, relativePath)
-		}
-
-		schemaLoader, ok := jsonschema.Loaders[u.Scheme]
-		if !ok {
-			return nil, jsonschema.LoaderNotFoundError(path)
-		}
-		return schemaLoader(path)
 	}
+
+	for _, schema := range schemas {
+		for _, r := range []string{schema.GetPrincipalSchema().GetRef(), schema.GetResourceSchema().GetRef()} {
+			if r == "" {
+				continue
+			}
+
+			if _, ok := res[r]; !ok {
+				comp, err := compiler.Compile(r)
+				if err != nil {
+					return nil, fmt.Errorf("failed to compile schema %s: %w", r, err)
+				}
+
+				res[r] = comp
+			}
+		}
+	}
+
+	return res, nil
 }
 
-func (m *manager) CheckSchema(ctx context.Context, url string) error {
-	_, err := m.loadSchema(ctx, url)
-	return err
+func (m *StaticManager) LoadSchema(ctx context.Context, url string) (*jsonschema.Schema, error) {
+	schema, ok := m.CompiledSchemas[url]
+	if !ok {
+		return nil, fmt.Errorf("schema %q not found", url)
+	}
+	return schema, nil
 }
 
-func (m *manager) ValidateCheckInput(ctx context.Context, schemas *policyv1.Schemas, input *enginev1.CheckInput) (*ValidationResult, error) {
+func (m *StaticManager) ValidateCheckInput(ctx context.Context, schemas *policyv1.Schemas, input *enginev1.CheckInput) (*ValidationResult, error) {
 	return m.validate(ctx, schemas, input.Principal.Attr, input.Resource.Attr, input.Actions, nil)
 }
 
-func (m *manager) ValidatePlanResourcesInput(ctx context.Context, schemas *policyv1.Schemas, input *enginev1.PlanResourcesInput) (*ValidationResult, error) {
+func (m *StaticManager) ValidatePlanResourcesInput(ctx context.Context, schemas *policyv1.Schemas, input *enginev1.PlanResourcesInput) (*ValidationResult, error) {
 	return m.validate(ctx, schemas, input.Principal.Attr, input.Resource.Attr, input.Actions, func(err *jsonschema.ValidationError) bool {
 		// resource attributes are optional for query planning, so ignore errors from required properties
 		return !strings.HasSuffix(err.KeywordLocation, "/required")
 	})
 }
 
-func (m *manager) validate(ctx context.Context, schemas *policyv1.Schemas, principalAttr, resourceAttr map[string]*structpb.Value, actions []string, resourceErrorFilter validationErrorFilter) (*ValidationResult, error) {
+func (m *StaticManager) validate(ctx context.Context, schemas *policyv1.Schemas, principalAttr, resourceAttr map[string]*structpb.Value, actions []string, resourceErrorFilter validationErrorFilter) (*ValidationResult, error) {
 	result := &ValidationResult{Reject: m.conf.Enforcement == EnforcementReject}
 	if schemas == nil {
 		return result, nil
@@ -191,7 +199,7 @@ func (m *manager) validate(ctx context.Context, schemas *policyv1.Schemas, princ
 	return result, nil
 }
 
-func (m *manager) validateAttr(ctx context.Context, src ErrSource, schemaRef *policyv1.Schemas_Schema, attr map[string]*structpb.Value, actions []string, errorFilter validationErrorFilter) error {
+func (m *StaticManager) validateAttr(ctx context.Context, src ErrSource, schemaRef *policyv1.Schemas_Schema, attr map[string]*structpb.Value, actions []string, errorFilter validationErrorFilter) error {
 	if schemaRef == nil || schemaRef.Ref == "" {
 		return nil
 	}
@@ -210,7 +218,7 @@ func (m *manager) validateAttr(ctx context.Context, src ErrSource, schemaRef *po
 		}
 	}
 
-	schema, err := m.loadSchema(ctx, schemaRef.Ref)
+	schema, err := m.loader.LoadSchema(ctx, schemaRef.Ref)
 	if err != nil {
 		m.log.Warn("Failed to load schema", zap.String("schema", schemaRef.Ref), zap.Error(err))
 		return newSchemaLoadErr(src, schemaRef.Ref)
@@ -246,7 +254,78 @@ func attrToJSONObject(src ErrSource, attr map[string]*structpb.Value) (any, erro
 	return gjson.GetBytes(jsonBytes, attrPath).Value(), nil
 }
 
-func (m *manager) loadSchema(ctx context.Context, url string) (*jsonschema.Schema, error) {
+type manager struct {
+	StaticManager
+	cache    *cache.Cache[string, *cacheEntry]
+	resolver Resolver
+}
+
+func New(ctx context.Context, loader Loader) (Manager, error) {
+	conf, err := GetConf()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get config section %q: %w", confKey, err)
+	}
+
+	return NewFromConf(ctx, loader, conf), nil
+}
+
+func NewFromConf(_ context.Context, loader Loader, conf *Conf) Manager {
+	if conf.Enforcement == EnforcementNone {
+		return NopManager{}
+	}
+
+	mgr := &manager{
+		StaticManager: StaticManager{
+			conf: conf,
+			log:  zap.L().Named("schema"),
+		},
+		cache:    cache.New[string, *cacheEntry]("schema", conf.CacheSize),
+		resolver: defaultResolver(loader),
+	}
+	mgr.loader = mgr
+
+	if s, ok := loader.(storage.Subscribable); ok {
+		s.Subscribe(mgr)
+	}
+
+	return mgr
+}
+
+func NewEphemeral(resolver Resolver) Manager {
+	mgr := &manager{
+		StaticManager: StaticManager{
+			conf: NewConf(EnforcementReject),
+			log:  zap.L().Named("schema"),
+		},
+		cache:    cache.New[string, *cacheEntry]("schema", defaultCacheSize),
+		resolver: resolver,
+	}
+	mgr.loader = mgr
+
+	return mgr
+}
+
+func defaultResolver(loader Loader) Resolver {
+	return func(ctx context.Context, path string) (io.ReadCloser, error) {
+		u, err := url.Parse(path)
+		if err != nil {
+			return nil, err
+		}
+
+		if u.Scheme == "" || u.Scheme == URLScheme {
+			relativePath := strings.TrimPrefix(u.Path, "/")
+			return loader.LoadSchema(ctx, relativePath)
+		}
+
+		schemaLoader, ok := jsonschema.Loaders[u.Scheme]
+		if !ok {
+			return nil, jsonschema.LoaderNotFoundError(path)
+		}
+		return schemaLoader(path)
+	}
+}
+
+func (m *manager) LoadSchema(ctx context.Context, url string) (*jsonschema.Schema, error) {
 	entry, ok := m.cache.Get(url)
 	if ok {
 		return entry.schema, entry.err

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -89,10 +89,6 @@ func NewStatic(schemas map[uint64]*policyv1.Schemas, rawSchemas map[string]*runt
 		return nil, fmt.Errorf("failed to get config section %q: %w", confKey, err)
 	}
 
-	if conf.Enforcement == EnforcementNone {
-		return &StaticManager{}, nil
-	}
-
 	return NewStaticFromConf(conf, schemas, rawSchemas)
 }
 

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -73,7 +73,7 @@ func TestLoad(t *testing.T) {
 		t.Run(storeName, func(t *testing.T) {
 			for _, tc := range testCases {
 				t.Run(tc.name, func(t *testing.T) {
-					err := mgr.CheckSchema(t.Context(), tc.url)
+					_, err := mgr.LoadSchema(t.Context(), tc.url)
 					if tc.wantErr {
 						require.Error(t, err)
 						return
@@ -173,17 +173,20 @@ func TestCache(t *testing.T) {
 		schemaURL := fmt.Sprintf("%s:///complex_object.json", schema.URLScheme)
 
 		// control test (everything is as it should be)
-		require.NoError(t, mgr.CheckSchema(t.Context(), schemaURL))
+		_, err := mgr.LoadSchema(t.Context(), schemaURL)
+		require.NoError(t, err)
 
 		// write rubbish to file
 		require.NoError(t, afero.WriteFile(fsys, schemaFile, []byte("blah"), 0o644))
 		s.OnStorageEvent(storage.Event{Kind: storage.EventAddOrUpdateSchema, SchemaFile: "complex_object.json"})
-		require.Error(t, mgr.CheckSchema(t.Context(), schemaURL))
+		_, err = mgr.LoadSchema(t.Context(), schemaURL)
+		require.Error(t, err)
 
 		// reset
 		require.NoError(t, afero.WriteFile(fsys, schemaFile, schemaBytes, 0o644))
 		s.OnStorageEvent(storage.Event{Kind: storage.EventAddOrUpdateSchema, SchemaFile: "complex_object.json"})
-		require.NoError(t, mgr.CheckSchema(t.Context(), schemaURL))
+		_, err = mgr.LoadSchema(t.Context(), schemaURL)
+		require.NoError(t, err)
 	})
 
 	t.Run("add_and_delete", func(t *testing.T) {
@@ -191,17 +194,20 @@ func TestCache(t *testing.T) {
 		schemaURL := fmt.Sprintf("%s:///wibble.json", schema.URLScheme)
 
 		// control test
-		require.Error(t, mgr.CheckSchema(t.Context(), schemaURL))
+		_, err = mgr.LoadSchema(t.Context(), schemaURL)
+		require.Error(t, err)
 
 		// add file
 		require.NoError(t, afero.WriteFile(fsys, schemaFile, schemaBytes, 0o644))
 		s.OnStorageEvent(storage.Event{Kind: storage.EventAddOrUpdateSchema, SchemaFile: "wibble.json"})
-		require.NoError(t, mgr.CheckSchema(t.Context(), schemaURL))
+		_, err = mgr.LoadSchema(t.Context(), schemaURL)
+		require.NoError(t, err)
 
 		// delete file
 		require.NoError(t, fsys.Remove(schemaFile))
 		s.OnStorageEvent(storage.Event{Kind: storage.EventDeleteSchema, SchemaFile: "wibble.json"})
-		require.Error(t, mgr.CheckSchema(t.Context(), schemaURL))
+		_, err = mgr.LoadSchema(t.Context(), schemaURL)
+		require.Error(t, err)
 	})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -163,7 +163,7 @@ func Start(ctx context.Context) error {
 		return err
 	}
 
-	ruletableMgr, err := ruletable.NewRuleTableManager(rt, policyLoader, schemaMgr)
+	ruletableMgr, err := ruletable.NewRuleTableManager(rt, policyLoader, store, schemaMgr)
 	if err != nil {
 		return fmt.Errorf("failed to create ruletable manager: %w", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -157,7 +157,7 @@ func Start(ctx context.Context) error {
 		return ErrInvalidStore
 	}
 
-	rt := ruletable.NewRuletable()
+	rt := ruletable.NewProtoRuletable()
 
 	if err := ruletable.LoadFromPolicyLoader(ctx, rt, policyLoader); err != nil {
 		return err

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -159,7 +159,7 @@ func Start(ctx context.Context) error {
 
 	rt := ruletable.NewProtoRuletable()
 
-	if err := ruletable.LoadFromPolicyLoader(ctx, rt, policyLoader); err != nil {
+	if err := ruletable.Load(ctx, rt, policyLoader, store); err != nil {
 		return err
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -153,7 +153,7 @@ func Start(ctx context.Context) error {
 
 	rt := ruletable.NewProtoRuletable()
 
-	if err := ruletable.Load(ctx, rt, policyLoader, store); err != nil {
+	if err := ruletable.LoadPolicies(ctx, rt, policyLoader); err != nil {
 		return err
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -127,19 +127,13 @@ func Start(ctx context.Context) error {
 		return fmt.Errorf("failed to create store: %w", err)
 	}
 
-	// create schema manager
-	schemaMgr, err := internalSchema.New(ctx, store)
-	if err != nil {
-		return fmt.Errorf("failed to create schema manager: %w", err)
-	}
-
 	var policyLoader policyloader.PolicyLoader
 	switch st := store.(type) {
 	// Overlay needs to take precedence over BinaryStore in this type switch,
 	// as our overlay store implements BinaryStore also
 	case overlay.Overlay:
 		// create wrapped policy loader
-		pl, err := st.GetOverlayPolicyLoader(ctx, schemaMgr)
+		pl, err := st.GetOverlayPolicyLoader(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to create overlay policy loader: %w", err)
 		}
@@ -149,7 +143,7 @@ func Start(ctx context.Context) error {
 
 	case storage.SourceStore:
 		// create compile manager
-		policyLoader, err = compile.NewManager(ctx, st, schemaMgr)
+		policyLoader, err = compile.NewManager(ctx, st)
 		if err != nil {
 			return fmt.Errorf("failed to create compile manager: %w", err)
 		}
@@ -161,6 +155,12 @@ func Start(ctx context.Context) error {
 
 	if err := ruletable.Load(ctx, rt, policyLoader, store); err != nil {
 		return err
+	}
+
+	// create schema manager
+	schemaMgr, err := internalSchema.New(ctx, store)
+	if err != nil {
+		return fmt.Errorf("failed to create schema manager: %w", err)
 	}
 
 	ruletableMgr, err := ruletable.NewRuleTableManager(rt, policyLoader, store, schemaMgr)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -324,7 +324,7 @@ func startServer(t *testing.T, conf *Conf, tpg testParamGen) {
 		},
 	}})
 
-	rt := ruletable.NewRuletable()
+	rt := ruletable.NewProtoRuletable()
 
 	require.NoError(t, ruletable.LoadFromPolicyLoader(ctx, rt, tp.policyLoader))
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -63,14 +63,13 @@ func TestServer(t *testing.T) {
 			store, err := disk.NewStore(ctx, &disk.Conf{Directory: dir})
 			require.NoError(t, err)
 
-			schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
-			policyLoader, err := compile.NewManager(ctx, store, schemaMgr)
+			policyLoader, err := compile.NewManager(ctx, store)
 			require.NoError(t, err)
 
 			tp := testParam{
 				store:        store,
 				policyLoader: policyLoader,
-				schemaMgr:    schemaMgr,
+				schemaMgr:    schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject)),
 			}
 			return tp
 		}
@@ -257,14 +256,13 @@ func TestAdminService(t *testing.T) {
 		store, err := sqlite3.NewStore(ctx, &sqlite3.Conf{DSN: fmt.Sprintf("%s?_fk=true", filepath.Join(t.TempDir(), "cerbos.db"))})
 		require.NoError(t, err)
 
-		schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
-		policyLoader, err := compile.NewManager(ctx, store, schemaMgr)
+		policyLoader, err := compile.NewManager(ctx, store)
 		require.NoError(t, err)
 
 		return testParam{
 			store:        store,
 			policyLoader: policyLoader,
-			schemaMgr:    schemaMgr,
+			schemaMgr:    schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject)),
 		}
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -328,7 +328,7 @@ func startServer(t *testing.T, conf *Conf, tpg testParamGen) {
 
 	require.NoError(t, ruletable.Load(ctx, rt, tp.policyLoader, tp.store))
 
-	ruletableMgr, err := ruletable.NewRuleTableManager(rt, tp.policyLoader, tp.schemaMgr)
+	ruletableMgr, err := ruletable.NewRuleTableManager(rt, tp.policyLoader, tp.store, tp.schemaMgr)
 	require.NoError(t, err)
 
 	if ss, ok := tp.policyLoader.(storage.Subscribable); ok {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -324,7 +324,7 @@ func startServer(t *testing.T, conf *Conf, tpg testParamGen) {
 
 	rt := ruletable.NewProtoRuletable()
 
-	require.NoError(t, ruletable.Load(ctx, rt, tp.policyLoader, tp.store))
+	require.NoError(t, ruletable.LoadPolicies(ctx, rt, tp.policyLoader))
 
 	ruletableMgr, err := ruletable.NewRuleTableManager(rt, tp.policyLoader, tp.store, tp.schemaMgr)
 	require.NoError(t, err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -326,7 +326,7 @@ func startServer(t *testing.T, conf *Conf, tpg testParamGen) {
 
 	rt := ruletable.NewProtoRuletable()
 
-	require.NoError(t, ruletable.LoadFromPolicyLoader(ctx, rt, tp.policyLoader))
+	require.NoError(t, ruletable.Load(ctx, rt, tp.policyLoader, tp.store))
 
 	ruletableMgr, err := ruletable.NewRuleTableManager(rt, tp.policyLoader, tp.schemaMgr)
 	require.NoError(t, err)

--- a/internal/storage/blob/store.go
+++ b/internal/storage/blob/store.go
@@ -457,6 +457,10 @@ func (s *Store) GetAll(ctx context.Context) ([]*policy.CompilationUnit, error) {
 	return s.idx.GetAll(ctx)
 }
 
+func (s *Store) GetAllMatching(_ context.Context, modIDs []namer.ModuleID) ([]*policy.CompilationUnit, error) {
+	return s.idx.GetAllMatching(modIDs)
+}
+
 func (s *Store) GetCompilationUnits(_ context.Context, ids ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error) {
 	return s.idx.GetCompilationUnits(ids...)
 }

--- a/internal/storage/db/internal/db.go
+++ b/internal/storage/db/internal/db.go
@@ -48,6 +48,7 @@ type DBStorage interface {
 	AddOrUpdate(ctx context.Context, policies ...policy.Wrapper) error
 	GetFirstMatch(ctx context.Context, candidates []namer.ModuleID) (*policy.CompilationUnit, error)
 	GetAll(ctx context.Context) ([]*policy.CompilationUnit, error)
+	GetAllMatching(ctx context.Context, modIDs []namer.ModuleID) ([]*policy.CompilationUnit, error)
 	GetCompilationUnits(ctx context.Context, ids ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error)
 	GetDependents(ctx context.Context, ids ...namer.ModuleID) (map[namer.ModuleID][]namer.ModuleID, error)
 	HasDescendants(ctx context.Context, ids ...namer.ModuleID) (map[namer.ModuleID]bool, error)
@@ -325,6 +326,22 @@ func (s *dbStorage) GetAll(ctx context.Context) ([]*policy.CompilationUnit, erro
 		modIDs[i] = namer.GenModuleIDFromFQN(namer.FQNFromPolicyKey(k))
 	}
 
+	cus, err := s.GetCompilationUnits(ctx, modIDs...)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]*policy.CompilationUnit, len(cus))
+	var i int
+	for _, cu := range cus {
+		res[i] = cu
+		i++
+	}
+
+	return res, nil
+}
+
+func (s *dbStorage) GetAllMatching(ctx context.Context, modIDs []namer.ModuleID) ([]*policy.CompilationUnit, error) {
 	cus, err := s.GetCompilationUnits(ctx, modIDs...)
 	if err != nil {
 		return nil, err

--- a/internal/storage/disk/disk.go
+++ b/internal/storage/disk/disk.go
@@ -105,6 +105,10 @@ func (s *Store) GetAll(ctx context.Context) ([]*policy.CompilationUnit, error) {
 	return s.idx.GetAll(ctx)
 }
 
+func (s *Store) GetAllMatching(_ context.Context, modIDs []namer.ModuleID) ([]*policy.CompilationUnit, error) {
+	return s.idx.GetAllMatching(modIDs)
+}
+
 func (s *Store) GetCompilationUnits(_ context.Context, ids ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error) {
 	return s.idx.GetCompilationUnits(ids...)
 }

--- a/internal/storage/git/store.go
+++ b/internal/storage/git/store.go
@@ -146,6 +146,10 @@ func (s *Store) GetAll(ctx context.Context) ([]*policy.CompilationUnit, error) {
 	return s.idx.GetAll(ctx)
 }
 
+func (s *Store) GetAllMatching(_ context.Context, modIDs []namer.ModuleID) ([]*policy.CompilationUnit, error) {
+	return s.idx.GetAllMatching(modIDs)
+}
+
 func (s *Store) GetCompilationUnits(_ context.Context, ids ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error) {
 	return s.idx.GetCompilationUnits(ids...)
 }

--- a/internal/storage/hub/bundle.go
+++ b/internal/storage/hub/bundle.go
@@ -323,6 +323,24 @@ func (b *Bundle) GetAll(_ context.Context) ([]*runtimev1.RunnablePolicySet, erro
 	return res, nil
 }
 
+// GetAllMatching attempts to retrieve all policies from the passed modIDs, unlike `GetFirstMatch` which returns the first
+// of the passed candidates, this function returns list of all available modules from the provided IDs.
+func (b *Bundle) GetAllMatching(_ context.Context, modIDs []namer.ModuleID) ([]*runtimev1.RunnablePolicySet, error) {
+	res := []*runtimev1.RunnablePolicySet{}
+	for _, id := range modIDs {
+		policySet, err := b.getMatch(id)
+		if err != nil {
+			return nil, err
+		}
+
+		if policySet != nil {
+			res = append(res, policySet)
+		}
+	}
+
+	return res, nil
+}
+
 func (b *Bundle) getMatch(id namer.ModuleID) (*runtimev1.RunnablePolicySet, error) {
 	idHex := id.HexStr()
 	fileName := policyDir + idHex

--- a/internal/storage/hub/local_source.go
+++ b/internal/storage/hub/local_source.go
@@ -217,6 +217,13 @@ func (ls *LocalSource) GetAll(ctx context.Context) (pss []*runtimev1.RunnablePol
 	return pss, err
 }
 
+func (ls *LocalSource) GetAllMatching(ctx context.Context, modIDs []namer.ModuleID) (pss []*runtimev1.RunnablePolicySet, err error) {
+	ls.mu.RLock()
+	pss, err = ls.bundle.GetAllMatching(ctx, modIDs)
+	ls.mu.RUnlock()
+	return pss, err
+}
+
 func (ls *LocalSource) Reload(_ context.Context) error {
 	return ls.loadBundle()
 }

--- a/internal/storage/hub/remote_source.go
+++ b/internal/storage/hub/remote_source.go
@@ -591,6 +591,17 @@ func (s *RemoteSource) GetAll(ctx context.Context) ([]*runtimev1.RunnablePolicyS
 	return s.bundle.GetAll(ctx)
 }
 
+func (s *RemoteSource) GetAllMatching(ctx context.Context, modIDs []namer.ModuleID) ([]*runtimev1.RunnablePolicySet, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.bundle == nil {
+		return nil, ErrBundleNotLoaded
+	}
+
+	return s.bundle.GetAllMatching(ctx, modIDs)
+}
+
 func (s *RemoteSource) InspectPolicies(ctx context.Context, params storage.ListPolicyIDsParams) (map[string]*responsev1.InspectPoliciesResponse_Result, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/storage/hub/source_wrappers.go
+++ b/internal/storage/hub/source_wrappers.go
@@ -70,6 +70,12 @@ func (is instrumentedSource) GetAll(ctx context.Context) ([]*runtimev1.RunnableP
 	})
 }
 
+func (is instrumentedSource) GetAllMatching(ctx context.Context, modIDs []namer.ModuleID) ([]*runtimev1.RunnablePolicySet, error) {
+	return measureBinaryOp(ctx, is.name, "GetAllMatching", func(ctx context.Context) ([]*runtimev1.RunnablePolicySet, error) {
+		return is.source.GetAllMatching(ctx, modIDs)
+	})
+}
+
 func (is instrumentedSource) Reload(ctx context.Context) error {
 	if r, ok := is.source.(storage.Reloadable); ok {
 		return r.Reload(ctx)

--- a/internal/storage/hub/store.go
+++ b/internal/storage/hub/store.go
@@ -142,6 +142,10 @@ func (hs *HybridStore) GetAll(ctx context.Context) ([]*runtimev1.RunnablePolicyS
 	return hs.withActiveSource().GetAll(ctx)
 }
 
+func (hs *HybridStore) GetAllMatching(ctx context.Context, candidates []namer.ModuleID) ([]*runtimev1.RunnablePolicySet, error) {
+	return hs.withActiveSource().GetAllMatching(ctx, candidates)
+}
+
 func (hs *HybridStore) Subscribe(s storage.Subscriber) {
 	hs.local.Subscribe(s)
 	hs.remote.Subscribe(s)

--- a/internal/storage/index/index.go
+++ b/internal/storage/index/index.go
@@ -48,6 +48,7 @@ type Index interface {
 	storage.Instrumented
 	GetFirstMatch([]namer.ModuleID) (*policy.CompilationUnit, error)
 	GetAll(context.Context) ([]*policy.CompilationUnit, error)
+	GetAllMatching([]namer.ModuleID) ([]*policy.CompilationUnit, error)
 	GetCompilationUnits(...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error)
 	GetDependents(...namer.ModuleID) (map[namer.ModuleID][]namer.ModuleID, error)
 	AddOrUpdate(Entry) (storage.Event, error)
@@ -114,6 +115,22 @@ func (idx *index) GetAll(ctx context.Context) ([]*policy.CompilationUnit, error)
 
 	for cu := range idx.GetAllCompilationUnits(ctx) {
 		res = append(res, cu)
+	}
+
+	return res, nil
+}
+
+func (idx *index) GetAllMatching(modIDs []namer.ModuleID) ([]*policy.CompilationUnit, error) {
+	cus, err := idx.GetCompilationUnits(modIDs...)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]*policy.CompilationUnit, len(cus))
+	var i int
+	for _, cu := range cus {
+		res[i] = cu
+		i++
 	}
 
 	return res, nil

--- a/internal/storage/overlay/overlay.go
+++ b/internal/storage/overlay/overlay.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/cerbos/cerbos/internal/engine/policyloader"
-	"github.com/cerbos/cerbos/internal/schema"
 )
 
 // The interface is defined here because placing in storage causes a circular dependency,
@@ -15,5 +14,5 @@ import (
 // `schema` in order to build the compile managers in the GetOverlayPolicyLoader method.
 type Overlay interface {
 	// GetOverlayPolicyLoader returns a PolicyLoader implementation that wraps two SourceStores
-	GetOverlayPolicyLoader(ctx context.Context, schemaMgr schema.Manager) (policyloader.PolicyLoader, error)
+	GetOverlayPolicyLoader(ctx context.Context) (policyloader.PolicyLoader, error)
 }

--- a/internal/storage/overlay/store.go
+++ b/internal/storage/overlay/store.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cerbos/cerbos/internal/config"
 	"github.com/cerbos/cerbos/internal/engine/policyloader"
 	"github.com/cerbos/cerbos/internal/namer"
-	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage"
 )
 
@@ -117,11 +116,11 @@ func newCircuitBreaker(conf *Conf) *gobreaker.CircuitBreaker[any] {
 }
 
 // GetOverlayPolicyLoader instantiates both the base and fallback policy loaders and then returns itself.
-func (s *Store) GetOverlayPolicyLoader(ctx context.Context, schemaMgr schema.Manager) (policyloader.PolicyLoader, error) {
+func (s *Store) GetOverlayPolicyLoader(ctx context.Context) (policyloader.PolicyLoader, error) {
 	getPolicyLoader := func(storeInterface storage.Store) (policyloader.PolicyLoader, error) {
 		switch st := storeInterface.(type) {
 		case storage.SourceStore:
-			pl, err := compile.NewManager(ctx, st, schemaMgr)
+			pl, err := compile.NewManager(ctx, st)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create compile manager: %w", err)
 			}

--- a/internal/storage/overlay/store.go
+++ b/internal/storage/overlay/store.go
@@ -173,6 +173,16 @@ func (s *Store) GetFirstMatch(ctx context.Context, candidates []namer.ModuleID) 
 	)
 }
 
+func (s *Store) GetAllMatching(ctx context.Context, modIDs []namer.ModuleID) ([]*runtimev1.RunnablePolicySet, error) {
+	return withCircuitBreaker(
+		s,
+		func() ([]*runtimev1.RunnablePolicySet, error) { return s.basePolicyLoader.GetAllMatching(ctx, modIDs) },
+		func() ([]*runtimev1.RunnablePolicySet, error) {
+			return s.fallbackPolicyLoader.GetAllMatching(ctx, modIDs)
+		},
+	)
+}
+
 //
 // Store interface methods
 //

--- a/internal/storage/overlay/store_test.go
+++ b/internal/storage/overlay/store_test.go
@@ -17,7 +17,6 @@ import (
 	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
 	"github.com/cerbos/cerbos/internal/config"
 	"github.com/cerbos/cerbos/internal/namer"
-	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage"
 	"github.com/cerbos/cerbos/internal/storage/blob"
 	"github.com/cerbos/cerbos/internal/storage/disk"
@@ -65,13 +64,10 @@ func TestDriverInstantiation(t *testing.T) {
 		require.NoError(t, err, "error creating store")
 		require.Equal(t, DriverName, store.Driver())
 
-		schemaMgr, err := schema.New(ctx, store)
-		require.NoError(t, err, "error creating schema manager")
-
 		overlayStore, ok := store.(Overlay)
 		require.True(t, ok, "store does not implement Overlay interface")
 
-		_, err = overlayStore.GetOverlayPolicyLoader(ctx, schemaMgr)
+		_, err = overlayStore.GetOverlayPolicyLoader(ctx)
 		require.NoError(t, err, "error creating overlay policy loader")
 
 		wrappedStore, ok := store.(*Store)

--- a/internal/storage/overlay/store_test.go
+++ b/internal/storage/overlay/store_test.go
@@ -249,6 +249,11 @@ func (m *MockPolicyLoader) GetAll(ctx context.Context) ([]*runtimev1.RunnablePol
 	return args.Get(0).([]*runtimev1.RunnablePolicySet), args.Error(1)
 }
 
+func (m *MockPolicyLoader) GetAllMatching(ctx context.Context, modIDs []namer.ModuleID) ([]*runtimev1.RunnablePolicySet, error) {
+	args := m.Called(ctx, modIDs)
+	return args.Get(0).([]*runtimev1.RunnablePolicySet), args.Error(1)
+}
+
 type MockStore struct {
 	mock.Mock
 }
@@ -302,6 +307,11 @@ func (m *MockBinaryStore) GetFirstMatch(ctx context.Context, candidates []namer.
 
 func (m *MockBinaryStore) GetAll(ctx context.Context) ([]*runtimev1.RunnablePolicySet, error) {
 	args := m.Called(ctx)
+	return args.Get(0).([]*runtimev1.RunnablePolicySet), args.Error(1)
+}
+
+func (m *MockBinaryStore) GetAllMatching(ctx context.Context, modIDs []namer.ModuleID) ([]*runtimev1.RunnablePolicySet, error) {
+	args := m.Called(ctx, modIDs)
 	return args.Get(0).([]*runtimev1.RunnablePolicySet), args.Error(1)
 }
 

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -138,6 +138,8 @@ type SourceStore interface {
 	GetFirstMatch(context.Context, []namer.ModuleID) (*policy.CompilationUnit, error)
 	// GetAll returns all modules that exist within the policy store
 	GetAll(context.Context) ([]*policy.CompilationUnit, error)
+	// GetAllMatching returns all modules that exist for the provided module IDs
+	GetAllMatching(context.Context, []namer.ModuleID) ([]*policy.CompilationUnit, error)
 	// GetCompilationUnits gets the compilation units for the given module IDs.
 	GetCompilationUnits(context.Context, ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error)
 	// GetDependents returns the dependents of the given modules.
@@ -154,6 +156,8 @@ type BinaryStore interface {
 	GetFirstMatch(context.Context, []namer.ModuleID) (*runtimev1.RunnablePolicySet, error)
 	// GetAll returns all modules that exist within the policy store
 	GetAll(context.Context) ([]*runtimev1.RunnablePolicySet, error)
+	// GetAllMatching returns all modules that exist for the provided module IDs
+	GetAllMatching(context.Context, []namer.ModuleID) ([]*runtimev1.RunnablePolicySet, error)
 }
 
 // MutableStore is a store that allows mutations.
@@ -214,6 +218,7 @@ type Event struct {
 	SchemaFile  string
 	Kind        EventKind
 	PolicyID    namer.ModuleID
+	Dependents  []namer.ModuleID
 }
 
 func (evt Event) String() string {

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -216,9 +216,9 @@ const (
 type Event struct {
 	OldPolicyID *namer.ModuleID
 	SchemaFile  string
+	Dependents  []namer.ModuleID
 	Kind        EventKind
 	PolicyID    namer.ModuleID
-	Dependents  []namer.ModuleID
 }
 
 func (evt Event) String() string {

--- a/internal/svc/cerbos_svc.go
+++ b/internal/svc/cerbos_svc.go
@@ -72,7 +72,7 @@ func (cs *CerbosService) PlanResources(ctx context.Context, request *requestv1.P
 		AuxData:     auxData,
 		IncludeMeta: request.IncludeMeta,
 	}
-	output, err := cs.eng.PlanResources(logging.ToContext(ctx, log), input)
+	output, err := cs.eng.Plan(logging.ToContext(ctx, log), input)
 	if err != nil {
 		log.Error("Resources query plan request failed", zap.Error(err))
 		if errors.Is(err, compile.PolicyCompilationErr{}) {

--- a/internal/svc/playground_svc.go
+++ b/internal/svc/playground_svc.go
@@ -450,7 +450,7 @@ type components struct {
 }
 
 func (c *components) mkEngine(ctx context.Context) (*engine.Engine, error) {
-	cm, err := compile.NewManager(ctx, c.store, c.schemaMgr)
+	cm, err := compile.NewManager(ctx, c.store)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/svc/playground_svc.go
+++ b/internal/svc/playground_svc.go
@@ -455,7 +455,7 @@ func (c *components) mkEngine(ctx context.Context) (*engine.Engine, error) {
 		return nil, err
 	}
 
-	rt := ruletable.NewRuletable()
+	rt := ruletable.NewProtoRuletable()
 
 	if err := ruletable.LoadFromPolicyLoader(ctx, rt, cm); err != nil {
 		return nil, err

--- a/internal/svc/playground_svc.go
+++ b/internal/svc/playground_svc.go
@@ -461,7 +461,7 @@ func (c *components) mkEngine(ctx context.Context) (*engine.Engine, error) {
 		return nil, err
 	}
 
-	ruletableMgr, err := ruletable.NewRuleTableManager(rt, cm, c.schemaMgr)
+	ruletableMgr, err := ruletable.NewRuleTableManager(rt, cm, c.store, c.schemaMgr)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/svc/playground_svc.go
+++ b/internal/svc/playground_svc.go
@@ -457,7 +457,7 @@ func (c *components) mkEngine(ctx context.Context) (*engine.Engine, error) {
 
 	rt := ruletable.NewProtoRuletable()
 
-	if err := ruletable.Load(ctx, rt, cm, c.store); err != nil {
+	if err := ruletable.LoadPolicies(ctx, rt, cm); err != nil {
 		return nil, err
 	}
 

--- a/internal/svc/playground_svc.go
+++ b/internal/svc/playground_svc.go
@@ -457,7 +457,7 @@ func (c *components) mkEngine(ctx context.Context) (*engine.Engine, error) {
 
 	rt := ruletable.NewProtoRuletable()
 
-	if err := ruletable.LoadFromPolicyLoader(ctx, rt, cm); err != nil {
+	if err := ruletable.Load(ctx, rt, cm, c.store); err != nil {
 		return nil, err
 	}
 

--- a/internal/test/mocks/Index.go
+++ b/internal/test/mocks/Index.go
@@ -368,6 +368,68 @@ func (_c *Index_GetAllCompilationUnits_Call) RunAndReturn(run func(context1 cont
 	return _c
 }
 
+// GetAllMatching provides a mock function for the type Index
+func (_mock *Index) GetAllMatching(moduleIDs []namer.ModuleID) ([]*policy.CompilationUnit, error) {
+	ret := _mock.Called(moduleIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllMatching")
+	}
+
+	var r0 []*policy.CompilationUnit
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]namer.ModuleID) ([]*policy.CompilationUnit, error)); ok {
+		return returnFunc(moduleIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]namer.ModuleID) []*policy.CompilationUnit); ok {
+		r0 = returnFunc(moduleIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*policy.CompilationUnit)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func([]namer.ModuleID) error); ok {
+		r1 = returnFunc(moduleIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Index_GetAllMatching_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllMatching'
+type Index_GetAllMatching_Call struct {
+	*mock.Call
+}
+
+// GetAllMatching is a helper method to define mock.On call
+//   - moduleIDs []namer.ModuleID
+func (_e *Index_Expecter) GetAllMatching(moduleIDs interface{}) *Index_GetAllMatching_Call {
+	return &Index_GetAllMatching_Call{Call: _e.mock.On("GetAllMatching", moduleIDs)}
+}
+
+func (_c *Index_GetAllMatching_Call) Run(run func(moduleIDs []namer.ModuleID)) *Index_GetAllMatching_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []namer.ModuleID
+		if args[0] != nil {
+			arg0 = args[0].([]namer.ModuleID)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Index_GetAllMatching_Call) Return(compilationUnits []*policy.CompilationUnit, err error) *Index_GetAllMatching_Call {
+	_c.Call.Return(compilationUnits, err)
+	return _c
+}
+
+func (_c *Index_GetAllMatching_Call) RunAndReturn(run func(moduleIDs []namer.ModuleID) ([]*policy.CompilationUnit, error)) *Index_GetAllMatching_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetCompilationUnits provides a mock function for the type Index
 func (_mock *Index) GetCompilationUnits(moduleIDs ...namer.ModuleID) (map[namer.ModuleID]*policy.CompilationUnit, error) {
 	var tmpRet mock.Arguments

--- a/internal/verify/junit/junit_test.go
+++ b/internal/verify/junit/junit_test.go
@@ -144,7 +144,7 @@ func mkEngine(t *testing.T) *engine.Engine {
 	require.NoError(t, err)
 
 	rt := ruletable.NewProtoRuletable()
-	require.NoError(t, ruletable.LoadFromPolicyLoader(ctx, rt, mgr))
+	require.NoError(t, ruletable.Load(ctx, rt, mgr, store))
 
 	ruletableMgr, err := ruletable.NewRuleTableManager(rt, mgr, schemaMgr)
 	require.NoError(t, err)

--- a/internal/verify/junit/junit_test.go
+++ b/internal/verify/junit/junit_test.go
@@ -143,7 +143,7 @@ func mkEngine(t *testing.T) *engine.Engine {
 	mgr, err := compile.NewManager(ctx, store, schemaMgr)
 	require.NoError(t, err)
 
-	rt := ruletable.NewRuletable()
+	rt := ruletable.NewProtoRuletable()
 	require.NoError(t, ruletable.LoadFromPolicyLoader(ctx, rt, mgr))
 
 	ruletableMgr, err := ruletable.NewRuleTableManager(rt, mgr, schemaMgr)

--- a/internal/verify/junit/junit_test.go
+++ b/internal/verify/junit/junit_test.go
@@ -137,14 +137,14 @@ func mkEngine(t *testing.T) *engine.Engine {
 	store, err := disk.NewStore(ctx, &disk.Conf{Directory: dir})
 	require.NoError(t, err)
 
-	schemaMgr, err := schema.New(ctx, store)
-	require.NoError(t, err)
-
-	mgr, err := compile.NewManager(ctx, store, schemaMgr)
+	mgr, err := compile.NewManager(ctx, store)
 	require.NoError(t, err)
 
 	rt := ruletable.NewProtoRuletable()
 	require.NoError(t, ruletable.Load(ctx, rt, mgr, store))
+
+	schemaMgr, err := schema.New(ctx, store)
+	require.NoError(t, err)
 
 	ruletableMgr, err := ruletable.NewRuleTableManager(rt, mgr, store, schemaMgr)
 	require.NoError(t, err)

--- a/internal/verify/junit/junit_test.go
+++ b/internal/verify/junit/junit_test.go
@@ -146,7 +146,7 @@ func mkEngine(t *testing.T) *engine.Engine {
 	rt := ruletable.NewProtoRuletable()
 	require.NoError(t, ruletable.Load(ctx, rt, mgr, store))
 
-	ruletableMgr, err := ruletable.NewRuleTableManager(rt, mgr, schemaMgr)
+	ruletableMgr, err := ruletable.NewRuleTableManager(rt, mgr, store, schemaMgr)
 	require.NoError(t, err)
 
 	eng, err := engine.New(ctx, engine.Components{

--- a/internal/verify/junit/junit_test.go
+++ b/internal/verify/junit/junit_test.go
@@ -141,7 +141,7 @@ func mkEngine(t *testing.T) *engine.Engine {
 	require.NoError(t, err)
 
 	rt := ruletable.NewProtoRuletable()
-	require.NoError(t, ruletable.Load(ctx, rt, mgr, store))
+	require.NoError(t, ruletable.LoadPolicies(ctx, rt, mgr))
 
 	schemaMgr, err := schema.New(ctx, store)
 	require.NoError(t, err)

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -12,7 +12,7 @@ import (
 
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
-	"github.com/cerbos/cerbos/internal/engine"
+	"github.com/cerbos/cerbos/internal/evaluator"
 	internaljsonschema "github.com/cerbos/cerbos/internal/jsonschema"
 	"github.com/cerbos/cerbos/internal/util"
 	"github.com/cerbos/cerbos/internal/validator"
@@ -26,7 +26,7 @@ type Config struct {
 }
 
 type Checker interface {
-	Check(ctx context.Context, inputs []*enginev1.CheckInput, opts ...engine.CheckOpt) ([]*enginev1.CheckOutput, error)
+	Check(ctx context.Context, inputs []*enginev1.CheckInput, opts ...evaluator.CheckOpt) ([]*enginev1.CheckOutput, error)
 }
 
 // Verify runs the test suites from the provided directory.

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -380,14 +380,14 @@ func mkEngine(t *testing.T) *engine.Engine {
 	store, err := disk.NewStore(ctx, &disk.Conf{Directory: dir})
 	require.NoError(t, err)
 
-	schemaMgr, err := schema.New(ctx, store)
-	require.NoError(t, err)
-
-	mgr, err := compile.NewManager(ctx, store, schemaMgr)
+	mgr, err := compile.NewManager(ctx, store)
 	require.NoError(t, err)
 
 	rt := ruletable.NewProtoRuletable()
 	require.NoError(t, ruletable.Load(ctx, rt, mgr, store))
+
+	schemaMgr, err := schema.New(ctx, store)
+	require.NoError(t, err)
 
 	ruletableMgr, err := ruletable.NewRuleTableManager(rt, mgr, store, schemaMgr)
 	require.NoError(t, err)

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -386,7 +386,7 @@ func mkEngine(t *testing.T) *engine.Engine {
 	mgr, err := compile.NewManager(ctx, store, schemaMgr)
 	require.NoError(t, err)
 
-	rt := ruletable.NewRuletable()
+	rt := ruletable.NewProtoRuletable()
 	require.NoError(t, ruletable.LoadFromPolicyLoader(ctx, rt, mgr))
 
 	ruletableMgr, err := ruletable.NewRuleTableManager(rt, mgr, schemaMgr)

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -389,7 +389,7 @@ func mkEngine(t *testing.T) *engine.Engine {
 	rt := ruletable.NewProtoRuletable()
 	require.NoError(t, ruletable.Load(ctx, rt, mgr, store))
 
-	ruletableMgr, err := ruletable.NewRuleTableManager(rt, mgr, schemaMgr)
+	ruletableMgr, err := ruletable.NewRuleTableManager(rt, mgr, store, schemaMgr)
 	require.NoError(t, err)
 
 	eng, err := engine.New(ctx, engine.Components{

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -387,7 +387,7 @@ func mkEngine(t *testing.T) *engine.Engine {
 	require.NoError(t, err)
 
 	rt := ruletable.NewProtoRuletable()
-	require.NoError(t, ruletable.LoadFromPolicyLoader(ctx, rt, mgr))
+	require.NoError(t, ruletable.Load(ctx, rt, mgr, store))
 
 	ruletableMgr, err := ruletable.NewRuleTableManager(rt, mgr, schemaMgr)
 	require.NoError(t, err)

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -384,7 +384,7 @@ func mkEngine(t *testing.T) *engine.Engine {
 	require.NoError(t, err)
 
 	rt := ruletable.NewProtoRuletable()
-	require.NoError(t, ruletable.Load(ctx, rt, mgr, store))
+	require.NoError(t, ruletable.LoadPolicies(ctx, rt, mgr))
 
 	schemaMgr, err := schema.New(ctx, store)
 	require.NoError(t, err)

--- a/private/check/check.go
+++ b/private/check/check.go
@@ -84,8 +84,7 @@ func (g *TestFixtureGetter) GetAllTestFixtures() []*TestFixtureCtx {
 
 func Check(ctx context.Context, conf *evaluator.Conf, idx compile.Index, inputs []*enginev1.CheckInput) ([]*enginev1.CheckOutput, error) {
 	store := disk.NewFromIndexWithConf(idx, &disk.Conf{})
-	schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
-	compiler, err := internalcompile.NewManager(ctx, store, schemaMgr)
+	compiler, err := internalcompile.NewManager(ctx, store)
 	if err != nil {
 		return nil, err
 	}
@@ -95,6 +94,8 @@ func Check(ctx context.Context, conf *evaluator.Conf, idx compile.Index, inputs 
 	if err := ruletable.Load(ctx, rt, compiler, store); err != nil {
 		return nil, err
 	}
+
+	schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
 
 	ruletableMgr, err := ruletable.NewRuleTableManager(rt, compiler, store, schemaMgr)
 	if err != nil {

--- a/private/check/check.go
+++ b/private/check/check.go
@@ -90,7 +90,7 @@ func Check(ctx context.Context, conf *engine.Conf, idx compile.Index, inputs []*
 		return nil, err
 	}
 
-	rt := ruletable.NewRuletable()
+	rt := ruletable.NewProtoRuletable()
 
 	if err := ruletable.LoadFromPolicyLoader(ctx, rt, compiler); err != nil {
 		return nil, err

--- a/private/check/check.go
+++ b/private/check/check.go
@@ -96,7 +96,7 @@ func Check(ctx context.Context, conf *evaluator.Conf, idx compile.Index, inputs 
 		return nil, err
 	}
 
-	ruletableMgr, err := ruletable.NewRuleTableManager(rt, compiler, schemaMgr)
+	ruletableMgr, err := ruletable.NewRuleTableManager(rt, compiler, store, schemaMgr)
 	if err != nil {
 		return nil, err
 	}

--- a/private/check/check.go
+++ b/private/check/check.go
@@ -91,7 +91,7 @@ func Check(ctx context.Context, conf *evaluator.Conf, idx compile.Index, inputs 
 
 	rt := ruletable.NewProtoRuletable()
 
-	if err := ruletable.Load(ctx, rt, compiler, store); err != nil {
+	if err := ruletable.LoadPolicies(ctx, rt, compiler); err != nil {
 		return nil, err
 	}
 

--- a/private/check/check.go
+++ b/private/check/check.go
@@ -10,13 +10,13 @@ import (
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	internalcompile "github.com/cerbos/cerbos/internal/compile"
 	internalengine "github.com/cerbos/cerbos/internal/engine"
+	"github.com/cerbos/cerbos/internal/evaluator"
 	"github.com/cerbos/cerbos/internal/ruletable"
 	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage/disk"
 	"github.com/cerbos/cerbos/internal/util"
 	"github.com/cerbos/cerbos/internal/verify"
 	"github.com/cerbos/cerbos/private/compile"
-	"github.com/cerbos/cerbos/private/engine"
 )
 
 type TestFixtureGetter struct {
@@ -82,7 +82,7 @@ func (g *TestFixtureGetter) GetAllTestFixtures() []*TestFixtureCtx {
 	return fixtures
 }
 
-func Check(ctx context.Context, conf *engine.Conf, idx compile.Index, inputs []*enginev1.CheckInput) ([]*enginev1.CheckOutput, error) {
+func Check(ctx context.Context, conf *evaluator.Conf, idx compile.Index, inputs []*enginev1.CheckInput) ([]*enginev1.CheckOutput, error) {
 	store := disk.NewFromIndexWithConf(idx, &disk.Conf{})
 	schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
 	compiler, err := internalcompile.NewManager(ctx, store, schemaMgr)
@@ -92,7 +92,7 @@ func Check(ctx context.Context, conf *engine.Conf, idx compile.Index, inputs []*
 
 	rt := ruletable.NewProtoRuletable()
 
-	if err := ruletable.LoadFromPolicyLoader(ctx, rt, compiler); err != nil {
+	if err := ruletable.Load(ctx, rt, compiler, store); err != nil {
 		return nil, err
 	}
 

--- a/private/engine/engine.go
+++ b/private/engine/engine.go
@@ -33,7 +33,7 @@ func FromBundle(ctx context.Context, params BundleParams) (*Engine, error) {
 
 	schemaMgr := schema.NewFromConf(ctx, bundleSrc, schema.NewConf(schema.EnforcementReject))
 
-	rt := ruletable.NewRuletable()
+	rt := ruletable.NewProtoRuletable()
 
 	if err := ruletable.LoadFromPolicyLoader(ctx, rt, bundleSrc); err != nil {
 		return nil, err

--- a/private/engine/engine.go
+++ b/private/engine/engine.go
@@ -36,7 +36,7 @@ func FromBundle(ctx context.Context, params BundleParams) (*Engine, error) {
 
 	rt := ruletable.NewProtoRuletable()
 
-	if err := ruletable.Load(ctx, rt, bundleSrc, bundleSrc); err != nil {
+	if err := ruletable.LoadPolicies(ctx, rt, bundleSrc); err != nil {
 		return nil, err
 	}
 

--- a/private/engine/engine.go
+++ b/private/engine/engine.go
@@ -40,7 +40,7 @@ func FromBundle(ctx context.Context, params BundleParams) (*Engine, error) {
 		return nil, err
 	}
 
-	ruletableMgr, err := ruletable.NewRuleTableManager(rt, bundleSrc, schemaMgr)
+	ruletableMgr, err := ruletable.NewRuleTableManager(rt, bundleSrc, bundleSrc, schemaMgr)
 	if err != nil {
 		return nil, err
 	}

--- a/private/engine/engine.go
+++ b/private/engine/engine.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/cerbos/cerbos/internal/engine"
+	"github.com/cerbos/cerbos/internal/evaluator"
 	"github.com/cerbos/cerbos/internal/ruletable"
 	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage/hub"
@@ -15,7 +16,7 @@ import (
 )
 
 type (
-	Conf         = engine.Conf
+	Conf         = evaluator.Conf
 	BundleParams = hub.LocalParams
 	Engine       = engine.Engine
 )
@@ -35,7 +36,7 @@ func FromBundle(ctx context.Context, params BundleParams) (*Engine, error) {
 
 	rt := ruletable.NewProtoRuletable()
 
-	if err := ruletable.LoadFromPolicyLoader(ctx, rt, bundleSrc); err != nil {
+	if err := ruletable.Load(ctx, rt, bundleSrc, bundleSrc); err != nil {
 		return nil, err
 	}
 

--- a/private/plan/plan.go
+++ b/private/plan/plan.go
@@ -24,7 +24,7 @@ func Resources(ctx context.Context, conf *engine.Conf, idx compile.Index, input 
 		return nil, err
 	}
 
-	rt := ruletable.NewRuletable()
+	rt := ruletable.NewProtoRuletable()
 
 	if err := ruletable.LoadFromPolicyLoader(ctx, rt, compiler); err != nil {
 		return nil, err

--- a/private/plan/plan.go
+++ b/private/plan/plan.go
@@ -9,14 +9,14 @@ import (
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	internalcompile "github.com/cerbos/cerbos/internal/compile"
 	internalengine "github.com/cerbos/cerbos/internal/engine"
+	"github.com/cerbos/cerbos/internal/evaluator"
 	"github.com/cerbos/cerbos/internal/ruletable"
 	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage/disk"
 	"github.com/cerbos/cerbos/private/compile"
-	"github.com/cerbos/cerbos/private/engine"
 )
 
-func Resources(ctx context.Context, conf *engine.Conf, idx compile.Index, input *enginev1.PlanResourcesInput) (*enginev1.PlanResourcesOutput, error) {
+func Resources(ctx context.Context, conf *evaluator.Conf, idx compile.Index, input *enginev1.PlanResourcesInput) (*enginev1.PlanResourcesOutput, error) {
 	store := disk.NewFromIndexWithConf(idx, &disk.Conf{})
 	schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
 	compiler, err := internalcompile.NewManager(ctx, store, schemaMgr)
@@ -26,7 +26,7 @@ func Resources(ctx context.Context, conf *engine.Conf, idx compile.Index, input 
 
 	rt := ruletable.NewProtoRuletable()
 
-	if err := ruletable.LoadFromPolicyLoader(ctx, rt, compiler); err != nil {
+	if err := ruletable.Load(ctx, rt, compiler, store); err != nil {
 		return nil, err
 	}
 

--- a/private/plan/plan.go
+++ b/private/plan/plan.go
@@ -25,7 +25,7 @@ func Resources(ctx context.Context, conf *evaluator.Conf, idx compile.Index, inp
 
 	rt := ruletable.NewProtoRuletable()
 
-	if err := ruletable.Load(ctx, rt, compiler, store); err != nil {
+	if err := ruletable.LoadPolicies(ctx, rt, compiler); err != nil {
 		return nil, err
 	}
 

--- a/private/plan/plan.go
+++ b/private/plan/plan.go
@@ -18,8 +18,7 @@ import (
 
 func Resources(ctx context.Context, conf *evaluator.Conf, idx compile.Index, input *enginev1.PlanResourcesInput) (*enginev1.PlanResourcesOutput, error) {
 	store := disk.NewFromIndexWithConf(idx, &disk.Conf{})
-	schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
-	compiler, err := internalcompile.NewManager(ctx, store, schemaMgr)
+	compiler, err := internalcompile.NewManager(ctx, store)
 	if err != nil {
 		return nil, err
 	}
@@ -29,6 +28,8 @@ func Resources(ctx context.Context, conf *evaluator.Conf, idx compile.Index, inp
 	if err := ruletable.Load(ctx, rt, compiler, store); err != nil {
 		return nil, err
 	}
+
+	schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
 
 	ruletableMgr, err := ruletable.NewRuleTableManager(rt, compiler, store, schemaMgr)
 	if err != nil {

--- a/private/plan/plan.go
+++ b/private/plan/plan.go
@@ -30,7 +30,7 @@ func Resources(ctx context.Context, conf *evaluator.Conf, idx compile.Index, inp
 		return nil, err
 	}
 
-	ruletableMgr, err := ruletable.NewRuleTableManager(rt, compiler, schemaMgr)
+	ruletableMgr, err := ruletable.NewRuleTableManager(rt, compiler, store, schemaMgr)
 	if err != nil {
 		return nil, err
 	}

--- a/private/plan/plan.go
+++ b/private/plan/plan.go
@@ -36,5 +36,5 @@ func Resources(ctx context.Context, conf *engine.Conf, idx compile.Index, input 
 	}
 
 	eng := internalengine.NewEphemeral(conf, ruletableMgr, schemaMgr)
-	return eng.PlanResources(ctx, input)
+	return eng.Plan(ctx, input)
 }

--- a/private/verify/verify.go
+++ b/private/verify/verify.go
@@ -60,7 +60,7 @@ func Files(ctx context.Context, fsys fs.FS, idx compile.Index) (*policyv1.TestRe
 		return nil, err
 	}
 
-	ruletableMgr, err := ruletable.NewRuleTableManager(rt, compiler, schemaMgr)
+	ruletableMgr, err := ruletable.NewRuleTableManager(rt, compiler, store, schemaMgr)
 	if err != nil {
 		return nil, err
 	}

--- a/private/verify/verify.go
+++ b/private/verify/verify.go
@@ -55,7 +55,7 @@ func Files(ctx context.Context, fsys fs.FS, idx compile.Index) (*policyv1.TestRe
 
 	rt := ruletable.NewProtoRuletable()
 
-	if err := ruletable.Load(ctx, rt, compiler, store); err != nil {
+	if err := ruletable.LoadPolicies(ctx, rt, compiler); err != nil {
 		return nil, err
 	}
 

--- a/private/verify/verify.go
+++ b/private/verify/verify.go
@@ -18,6 +18,7 @@ import (
 	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
 	internalcompile "github.com/cerbos/cerbos/internal/compile"
 	internalengine "github.com/cerbos/cerbos/internal/engine"
+	"github.com/cerbos/cerbos/internal/evaluator"
 	"github.com/cerbos/cerbos/internal/ruletable"
 	"github.com/cerbos/cerbos/internal/schema"
 	"github.com/cerbos/cerbos/internal/storage/disk"
@@ -141,6 +142,6 @@ func WithCustomChecker(ctx context.Context, fsys fs.FS, eng Checker, opts ...Opt
 
 type checkFunc func(context.Context, []*enginev1.CheckInput, CheckOptions) ([]*enginev1.CheckOutput, error)
 
-func (f checkFunc) Check(ctx context.Context, inputs []*enginev1.CheckInput, opts ...internalengine.CheckOpt) ([]*enginev1.CheckOutput, error) {
+func (f checkFunc) Check(ctx context.Context, inputs []*enginev1.CheckInput, opts ...evaluator.CheckOpt) ([]*enginev1.CheckOutput, error) {
 	return f(ctx, inputs, internalengine.ApplyCheckOptions(opts...))
 }

--- a/private/verify/verify.go
+++ b/private/verify/verify.go
@@ -48,8 +48,7 @@ func Files(ctx context.Context, fsys fs.FS, idx compile.Index) (*policyv1.TestRe
 	}
 
 	store := disk.NewFromIndexWithConf(idx, &disk.Conf{})
-	schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
-	compiler, err := internalcompile.NewManager(ctx, store, schemaMgr)
+	compiler, err := internalcompile.NewManager(ctx, store)
 	if err != nil {
 		return nil, err
 	}
@@ -59,6 +58,8 @@ func Files(ctx context.Context, fsys fs.FS, idx compile.Index) (*policyv1.TestRe
 	if err := ruletable.Load(ctx, rt, compiler, store); err != nil {
 		return nil, err
 	}
+
+	schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementReject))
 
 	ruletableMgr, err := ruletable.NewRuleTableManager(rt, compiler, store, schemaMgr)
 	if err != nil {

--- a/private/verify/verify.go
+++ b/private/verify/verify.go
@@ -53,7 +53,7 @@ func Files(ctx context.Context, fsys fs.FS, idx compile.Index) (*policyv1.TestRe
 		return nil, err
 	}
 
-	rt := ruletable.NewRuletable()
+	rt := ruletable.NewProtoRuletable()
 
 	if err := ruletable.LoadFromPolicyLoader(ctx, rt, compiler); err != nil {
 		return nil, err

--- a/private/verify/verify.go
+++ b/private/verify/verify.go
@@ -56,7 +56,7 @@ func Files(ctx context.Context, fsys fs.FS, idx compile.Index) (*policyv1.TestRe
 
 	rt := ruletable.NewProtoRuletable()
 
-	if err := ruletable.LoadFromPolicyLoader(ctx, rt, compiler); err != nil {
+	if err := ruletable.Load(ctx, rt, compiler, store); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
* Introduces a new `evaluator.Evaluator` interface, with `Check` and `Plan` methods. The engine and (wrapped) static rule table both implement this interface (thus we can test both in the engine test suite).
* Creates a new static schema manager by storing the schema files as raw bytes in the proto type, and compiling into a static manager at start time.
* RuleTableManager now handles store events and updates the rule table accordingly.