### PR TITLE
enhancement: Stickier PDP IDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/jwalton/gchalk v1.3.0
 	github.com/jwalton/go-supportscolor v1.2.0
 	github.com/kavu/go_reuseport v1.5.0
+	github.com/keygen-sh/machineid v1.1.1
 	github.com/lestrrat-go/httprc/v3 v3.0.0
 	github.com/lestrrat-go/jwx/v3 v3.0.8
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -477,6 +477,8 @@ github.com/kavu/go_reuseport v1.5.0 h1:UNuiY2OblcqAtVDE8Gsg1kZz8zbBWg907sP1ceBV+
 github.com/kavu/go_reuseport v1.5.0/go.mod h1:CG8Ee7ceMFSMnx/xr25Vm0qXaj2Z4i5PWoUx+JZ5/CU=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
+github.com/keygen-sh/machineid v1.1.1 h1:L6G3+l5/0ZgvDST1EE6L8Yfqcss7EC8xs0Q8gEQyIo0=
+github.com/keygen-sh/machineid v1.1.1/go.mod h1:xBhEE0H4t3N05kn+vBNlOnhTf5NMz36YmrmpdrjpgsI=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/internal/util/app.go
+++ b/internal/util/app.go
@@ -4,7 +4,9 @@
 package util
 
 import (
+	"crypto/hmac"
 	"crypto/md5" //nolint:gosec
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"runtime/debug"
@@ -13,6 +15,7 @@ import (
 
 	pdpv1 "github.com/cerbos/cloud-api/genpb/cerbos/cloud/pdp/v1"
 	"github.com/google/uuid"
+	"github.com/keygen-sh/machineid"
 	"go.uber.org/zap"
 )
 
@@ -21,7 +24,11 @@ var (
 	BuildDate = "unknown"
 	Commit    = "unknown"
 	Version   = "unknown"
+
+	appID = []byte(AppName)
 )
+
+const nodeIDLen = 16
 
 func AppVersion() string {
 	var sb strings.Builder
@@ -62,9 +69,21 @@ func AppShortVersion() string {
 }
 
 var getPdpID = sync.OnceValue(func() string {
-	//nolint:gosec
-	nodeID := md5.Sum(uuid.NodeID())
-	return fmt.Sprintf("%X-%d", nodeID, os.Getpid())
+	machineID, err := machineid.ID()
+	if err != nil || machineID == "" {
+		//nolint:gosec
+		uuidNodeID := md5.Sum(uuid.NodeID())
+		return fmt.Sprintf("%X-%d", uuidNodeID, os.Getpid())
+	}
+
+	mac := hmac.New(sha256.New, []byte(machineID))
+	mac.Write(appID)
+	safeID := mac.Sum(nil)
+	if len(safeID) > nodeIDLen {
+		safeID = safeID[:nodeIDLen]
+	}
+
+	return fmt.Sprintf("%X-%d", safeID, os.Getpid())
 })
 
 func PDPIdentifier(pdpID string) *pdpv1.Identifier {


### PR DESCRIPTION
This can help reduce the noise in audit logs because the ID is "sticky".
Otherwise, the same PDP could get different IDs on each restart even
though it's still running on the same hardware. These IDs are still
perfectly opaque and don't reveal anything other than the fact that the
PDP is running on the same anonymous machine every time it's restarted.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
