### PR TITLE
fix: Handle const false DENY nodes in role-level query planning

### DIFF
--- a/internal/engine/planner/planner.go
+++ b/internal/engine/planner/planner.go
@@ -295,6 +295,10 @@ func EvaluateRuleTableQueryPlan(ctx context.Context, ruleTable *ruletable.RuleTa
 								scopeAllowNode = mkOrNode([]*qpN{scopeAllowNode, node})
 							}
 						case effectv1.Effect_EFFECT_DENY:
+							// ignore constant false DENY nodes
+							if b, ok := isNodeConstBool(node); ok && !b {
+								continue
+							}
 							if scopeDenyNode == nil {
 								scopeDenyNode = node
 							} else {
@@ -409,7 +413,7 @@ func EvaluateRuleTableQueryPlan(ctx context.Context, ruleTable *ruletable.RuleTa
 			}
 		}
 
-		if nf.allowIsEmpty() && !nf.denyIsEmpty() { // reset an conditional DENY to an unconditional one
+		if nf.allowIsEmpty() && !nf.denyIsEmpty() { // reset a conditional DENY to an unconditional one
 			nf.resetToUnconditionalDeny()
 		}
 		f, err := toFilter(nf.toAST())

--- a/internal/test/testdata/query_planner/policies/derived_roles/globex_roles.yaml
+++ b/internal/test/testdata/query_planner/policies/derived_roles/globex_roles.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../../../schema/jsonschema/cerbos/policy/v1/Policy.schema.json
+---
+apiVersion: api.cerbos.dev/v1
+derivedRoles:
+  name: globex_roles
+  definitions:
+    - name: FINANCE
+      parentRoles: ["USER"]
+      condition:
+        match:
+          expr: request.principal.attr.department == "FINANCE"

--- a/internal/test/testdata/query_planner/policies/resource_policies/stapler.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policies/stapler.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=../../../../../../schema/jsonschema/cerbos/policy/v1/Policy.schema.json
+---
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: "default"
+  importDerivedRoles:
+    - globex_roles
+  resource: "stapler"
+
+  rules:
+    - actions: ["*"]
+      effect: EFFECT_ALLOW
+      roles:
+        - ADMIN
+
+    # If the `principal` is not part of the organization, then they are denied
+    - actions: ["*"]
+      effect: EFFECT_DENY
+      roles:
+        - "*"
+      condition:
+        match:
+          expr: >
+            !(R.scope in P.attr.organizations)
+
+    # A `principal` that belongs to any of these groups "OWNER", "FINANCE" or
+    # "REGION_MANAGER" is allowed to perform action "view".
+    - actions: ["view"]
+      effect: EFFECT_ALLOW
+      derivedRoles:
+        - FINANCE

--- a/internal/test/testdata/query_planner/policies/role_policies/globex_superapprover.yaml
+++ b/internal/test/testdata/query_planner/policies/role_policies/globex_superapprover.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../../../../../../schema/jsonschema/cerbos/policy/v1/Policy.schema.json
+---
+apiVersion: "api.cerbos.dev/v1"
+rolePolicy:
+  role: "SUPERAPPROVER"
+  scope: "GLOBEX"
+  parentRoles:
+    - "ADMIN"
+  rules:
+    - resource: "stapler"
+      allowActions:
+        - "approve"
+      condition:
+        match:
+          expr: "R.attr.amount <= 100000"

--- a/internal/test/testdata/query_planner/suite/globex.yaml
+++ b/internal/test/testdata/query_planner/suite/globex.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../../.jsonschema/QueryPlannerTestSuite.schema.json
+---
+description: Guard against denied scoped role overriding non-matching DENY rule in base scope for other role
+principal:
+    id: frank
+    policyVersion: default
+    roles:
+        - USER
+        - SUPERAPPROVER
+    attr:
+      department: "FINANCE"
+      organizations: ["GLOBEX"]
+      region: "EMEA"
+tests:
+    - action: view
+      resource:
+        kind: stapler
+        scope: GLOBEX
+        policyVersion: default
+      want:
+        kind: KIND_ALWAYS_ALLOWED


### PR DESCRIPTION
The query planner was incorrectly handling cases where a role's DENY node was a union of constant boolean values (e.g. `OR(const true, const false)`). The existing logic only recognized singular constant true DENY nodes using `isNodeConstBool(roleDenyNode); ok && b`, but failed to identify that `OR(true, false)` is logically equivalent to `true`.

This caused inconsistent role merging/resolution as role nodes weren't being correctly normalised (`roleAllowNode = mkFalseNode`, `roleDenyNode = nil`) which then meant we had unwanted residual nodes at the point of merging those from independent roles.