### PR TITLE
fix: Properly handle dependents on policy set updates

### DIFF
--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -479,7 +479,6 @@ type CelProgram struct {
 	Name string
 }
 
-// TODO(saml) this is a currently unused function that will ultimately be reworked into the instantiation for ePDP or bundle PDPs.
 func NewRuleTable(protoRT *runtimev1.RuleTable, conf *evaluator.Conf, schemaConf *schema.Conf) (*RuleTable, error) {
 	rt := &RuleTable{
 		conf: conf,

--- a/internal/ruletable/ruletable_test.go
+++ b/internal/ruletable/ruletable_test.go
@@ -1,0 +1,183 @@
+// Copyright 2021-2025 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package ruletable
+
+import (
+	"bytes"
+	"context"
+	"io/fs"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	effectv1 "github.com/cerbos/cerbos/api/genpb/cerbos/effect/v1"
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
+	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
+	"github.com/cerbos/cerbos/internal/compile"
+	"github.com/cerbos/cerbos/internal/policy"
+	"github.com/cerbos/cerbos/internal/schema"
+	"github.com/cerbos/cerbos/internal/storage"
+	"github.com/cerbos/cerbos/internal/storage/disk"
+	"github.com/cerbos/cerbos/internal/storage/index"
+)
+
+func TestRuleTableManager(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(t.Context())
+	defer cancelFunc()
+
+	memFsys := afero.NewMemMapFs()
+	fsys := afero.NewIOFS(memFsys)
+
+	idx, err := index.Build(ctx, fsys)
+	require.NoError(t, err)
+
+	store := disk.NewFromIndexWithConf(idx, &disk.Conf{})
+	store.SubscriptionManager = storage.NewSubscriptionManager(ctx)
+
+	schemaConf := schema.NewConf(schema.EnforcementNone)
+	schemaMgr := schema.NewFromConf(ctx, store, schemaConf)
+
+	compiler, err := compile.NewManager(ctx, store)
+	require.NoError(t, err)
+
+	ruletableMgr, err := NewRuleTableManager(NewProtoRuletable(), compiler, store, schemaMgr)
+	require.NoError(t, err)
+
+	store.Subscribe(ruletableMgr)
+
+	// add simple, valid policy and confirm an ALLOW request
+	resourceFile := "resource_policies/rock.yaml"
+	p := &policyv1.Policy{
+		ApiVersion: "api.cerbos.dev/v1",
+		PolicyType: &policyv1.Policy_ResourcePolicy{
+			ResourcePolicy: &policyv1.ResourcePolicy{
+				Resource: "rock",
+				Version:  "default",
+				Rules: []*policyv1.ResourceRule{
+					{
+						Actions: []string{"throw"},
+						Roles:   []string{"user"},
+						Effect:  effectv1.Effect_EFFECT_ALLOW,
+					},
+				},
+			},
+		},
+	}
+
+	addOrUpdatePolicy(t, resourceFile, p, memFsys, idx, store)
+
+	action := "throw"
+	input := &enginev1.CheckInput{
+		RequestId: "1",
+		Resource: &enginev1.Resource{
+			Kind: "rock",
+			// PolicyVersion: "default",
+			Id: "1",
+		},
+		Principal: &enginev1.Principal{
+			Id: "sam",
+			// PolicyVersion: "default",
+			Roles: []string{"user"},
+		},
+		Actions: []string{action},
+	}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		outputs, err := ruletableMgr.RuleTable.Check(ctx, []*enginev1.CheckInput{input})
+		require.NoError(t, err)
+
+		require.Len(t, outputs, 1)
+		require.Contains(t, outputs[0].Actions, action)
+		require.Equal(t, outputs[0].Actions[action].GetEffect(), effectv1.Effect_EFFECT_ALLOW)
+	}, 1*time.Second, 50*time.Millisecond)
+
+	t.Run("maintain_valid_state_on_missing_derived_role", func(t *testing.T) {
+		// Update policy so that it references a nonexistent derived role
+		p := &policyv1.Policy{
+			ApiVersion: "api.cerbos.dev/v1",
+			PolicyType: &policyv1.Policy_ResourcePolicy{
+				ResourcePolicy: &policyv1.ResourcePolicy{
+					Resource:           "rock",
+					Version:            "default",
+					ImportDerivedRoles: []string{"special_roles"},
+					Rules: []*policyv1.ResourceRule{
+						{
+							Actions:      []string{action},
+							DerivedRoles: []string{"special_user"},
+							Effect:       effectv1.Effect_EFFECT_ALLOW,
+						},
+					},
+				},
+			},
+		}
+
+		addOrUpdatePolicy(t, resourceFile, p, memFsys, idx, store)
+
+		// Check request should still return ALLOW
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			outputs, err := ruletableMgr.RuleTable.Check(ctx, []*enginev1.CheckInput{input})
+			require.NoError(t, err)
+
+			require.Len(t, outputs, 1)
+			require.Contains(t, outputs[0].Actions, action)
+			require.Equal(t, outputs[0].Actions[action].GetEffect(), effectv1.Effect_EFFECT_ALLOW)
+		}, 1*time.Second, 50*time.Millisecond)
+	})
+
+	t.Run("adding_missing_derived_role_re_enables_updates", func(t *testing.T) {
+		derivedRoleFile := "derived_roles/special_roles.yaml"
+		p := &policyv1.Policy{
+			ApiVersion: "api.cerbos.dev/v1",
+			PolicyType: &policyv1.Policy_DerivedRoles{
+				DerivedRoles: &policyv1.DerivedRoles{
+					Name: "special_roles",
+					Definitions: []*policyv1.RoleDef{
+						{
+							Name:        "special_user",
+							ParentRoles: []string{"user"},
+							Condition: &policyv1.Condition{
+								Condition: &policyv1.Condition_Match{
+									Match: &policyv1.Match{
+										Op: &policyv1.Match_Expr{
+											Expr: "true == false",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		addOrUpdatePolicy(t, derivedRoleFile, p, memFsys, idx, store)
+
+		// Check request should now return DENY
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			outputs, err := ruletableMgr.RuleTable.Check(ctx, []*enginev1.CheckInput{input})
+			require.NoError(t, err)
+
+			require.Len(t, outputs, 1)
+			require.Contains(t, outputs[0].Actions, action)
+			require.Equal(t, outputs[0].Actions[action].GetEffect(), effectv1.Effect_EFFECT_DENY)
+		}, 1*time.Second, 50*time.Millisecond)
+	})
+}
+
+func addOrUpdatePolicy(t *testing.T, f string, p *policyv1.Policy, memFsys afero.Fs, idx index.Index, store *disk.Store) {
+	t.Helper()
+
+	var s bytes.Buffer
+	require.NoError(t, policy.WritePolicy(&s, p))
+
+	require.NoError(t, afero.WriteFile(memFsys, f, s.Bytes(), fs.ModeAppend))
+
+	evt, err := idx.AddOrUpdate(index.Entry{File: f, Policy: policy.Wrap(p)})
+	require.NoError(t, err)
+
+	store.NotifySubscribers(evt)
+}

--- a/internal/storage/db/internal/db.go
+++ b/internal/storage/db/internal/db.go
@@ -234,6 +234,19 @@ func (s *dbStorage) AddOrUpdate(ctx context.Context, policies ...policy.Wrapper)
 
 	events := make([]storage.Event, len(policies))
 	err := s.db.WithTx(func(tx *goqu.TxDatabase) error {
+		modIDs := make([]namer.ModuleID, len(policies))
+		for i, p := range policies {
+			modIDs[i] = p.ID
+		}
+
+		// We only need to retrieve the state of Dependents before the update (there's no need
+		// to update a dependent policy in the rule table if it's only just been added in the
+		// same batch). Therefore, we can share the same transaction.
+		dependents, err := s.getDependents(ctx, tx, modIDs...)
+		if err != nil {
+			return err
+		}
+
 		for i, p := range policies {
 			if err := s.opts.upsertPolicy(ctx, tx, p); err != nil {
 				return fmt.Errorf("failed to upsert %s: %w", p.FQN, err)
@@ -287,7 +300,13 @@ func (s *dbStorage) AddOrUpdate(ctx context.Context, policies ...policy.Wrapper)
 				}
 			}
 
-			events[i] = storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: p.ID}
+			ev := storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: p.ID}
+
+			if deps, ok := dependents[p.ID]; ok {
+				ev.Dependents = deps
+			}
+
+			events[i] = ev
 		}
 
 		return nil
@@ -503,13 +522,28 @@ func (q getCompilationUnitsQueryBuilder) j(depth int) exp.IdentifierExpression {
 }
 
 func (s *dbStorage) GetDependents(ctx context.Context, ids ...namer.ModuleID) (map[namer.ModuleID][]namer.ModuleID, error) {
+	var dependents map[namer.ModuleID][]namer.ModuleID
+
+	err := s.db.WithTx(func(tx *goqu.TxDatabase) error {
+		var err error
+		dependents, err = s.getDependents(ctx, tx, ids...)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return dependents, nil
+}
+
+func (s *dbStorage) getDependents(ctx context.Context, tx *goqu.TxDatabase, ids ...namer.ModuleID) (map[namer.ModuleID][]namer.ModuleID, error) {
 	// Rather than writing a proper recursive query (which is pretty much impossible to do in a database-agnostic way), we're
 	// exploiting the fact that we have a maximum of two levels of dependency (resourcePolicy -> derivedRoles -> exportVariables).
 
 	// SELECT dependency_id AS policy_id, policy_id AS dependent_id
 	// FROM policy_dependency
 	// WHERE policy_dependency.dependency_id IN (?)
-	directDependentsQuery := s.db.
+	directDependentsQuery := tx.
 		Select(
 			goqu.C(PolicyDepTblDepIDCol).As("policy_id"),
 			goqu.C(PolicyDepTblPolicyIDCol).As("dependent_id"),
@@ -521,7 +555,7 @@ func (s *dbStorage) GetDependents(ctx context.Context, ids ...namer.ModuleID) (m
 	// FROM policy_dependency AS parent
 	// JOIN policy_dependency AS child ON child.policy_id = parent.dependency_id
 	// WHERE child.dependency_id IN (?)
-	transitiveDependentsQuery := s.db.
+	transitiveDependentsQuery := tx.
 		Select(
 			goqu.T("child").Col(PolicyDepTblDepIDCol).As("policy_id"),
 			goqu.T("parent").Col(PolicyDepTblPolicyIDCol).As("dependent_id"),
@@ -678,35 +712,54 @@ func (s *dbStorage) Enable(ctx context.Context, policyKey ...string) (uint32, er
 }
 
 func (s *dbStorage) Delete(ctx context.Context, ids ...namer.ModuleID) error {
-	if len(ids) == 1 {
-		_, err := s.db.Delete(PolicyTbl).Prepared(true).
-			Where(goqu.C(PolicyTblIDCol).Eq(ids[0])).
-			Executor().ExecContext(ctx)
+	return s.db.WithTx(func(tx *goqu.TxDatabase) error {
+		dependents, err := s.getDependents(ctx, tx, ids...)
 		if err != nil {
 			return err
 		}
 
-		s.NotifySubscribers(storage.NewPolicyEvent(storage.EventDeleteOrDisablePolicy, ids[0]))
+		if len(ids) == 1 {
+			_, err := tx.Delete(PolicyTbl).Prepared(true).
+				Where(goqu.C(PolicyTblIDCol).Eq(ids[0])).
+				Executor().ExecContext(ctx)
+			if err != nil {
+				return err
+			}
+
+			ev := storage.NewPolicyEvent(storage.EventDeleteOrDisablePolicy, ids[0])
+
+			if deps, ok := dependents[ids[0]]; ok {
+				ev.Dependents = deps
+			}
+
+			s.NotifySubscribers(ev)
+
+			return nil
+		}
+
+		idList := make([]any, len(ids))
+		events := make([]storage.Event, len(ids))
+
+		for i, id := range ids {
+			idList[i] = id
+			ev := storage.Event{Kind: storage.EventDeleteOrDisablePolicy, PolicyID: id}
+
+			if deps, ok := dependents[id]; ok {
+				ev.Dependents = deps
+			}
+
+			events[i] = ev
+		}
+		if _, err := tx.Delete(PolicyTbl).Prepared(true).
+			Where(goqu.C(PolicyTblIDCol).In(idList...)).
+			Executor().ExecContext(ctx); err != nil {
+			return err
+		}
+
+		s.NotifySubscribers(events...)
 
 		return nil
-	}
-
-	idList := make([]any, len(ids))
-	events := make([]storage.Event, len(ids))
-
-	for i, id := range ids {
-		idList[i] = id
-		events[i] = storage.Event{Kind: storage.EventDeleteOrDisablePolicy, PolicyID: id}
-	}
-	_, err := s.db.Delete(PolicyTbl).Prepared(true).
-		Where(goqu.C(PolicyTblIDCol).In(idList...)).
-		Executor().ExecContext(ctx)
-	if err != nil {
-		return err
-	}
-
-	s.NotifySubscribers(events...)
-	return nil
+	})
 }
 
 func (s *dbStorage) InspectPolicies(ctx context.Context, listParams storage.ListPolicyIDsParams) (map[string]*responsev1.InspectPoliciesResponse_Result, error) {

--- a/internal/storage/db/internal/db.go
+++ b/internal/storage/db/internal/db.go
@@ -302,7 +302,7 @@ func (s *dbStorage) AddOrUpdate(ctx context.Context, policies ...policy.Wrapper)
 
 			ev := storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: p.ID}
 
-			if deps, ok := dependents[p.ID]; ok {
+			if deps, ok := dependents[p.ID]; ok && len(deps) > 0 {
 				ev.Dependents = deps
 			}
 
@@ -728,7 +728,7 @@ func (s *dbStorage) Delete(ctx context.Context, ids ...namer.ModuleID) error {
 
 			ev := storage.NewPolicyEvent(storage.EventDeleteOrDisablePolicy, ids[0])
 
-			if deps, ok := dependents[ids[0]]; ok {
+			if deps, ok := dependents[ids[0]]; ok && len(deps) > 0 {
 				ev.Dependents = deps
 			}
 
@@ -744,7 +744,7 @@ func (s *dbStorage) Delete(ctx context.Context, ids ...namer.ModuleID) error {
 			idList[i] = id
 			ev := storage.Event{Kind: storage.EventDeleteOrDisablePolicy, PolicyID: id}
 
-			if deps, ok := dependents[id]; ok {
+			if deps, ok := dependents[id]; ok && len(deps) > 0 {
 				ev.Dependents = deps
 			}
 

--- a/internal/storage/index/index.go
+++ b/internal/storage/index/index.go
@@ -317,7 +317,7 @@ func (idx *index) AddOrUpdate(entry Entry) (evt storage.Event, err error) {
 		idx.addDep(modID, dep)
 	}
 
-	if deps, ok := idx.dependents[modID]; ok {
+	if deps, ok := idx.dependents[modID]; ok && len(deps) > 0 {
 		evt.Dependents = make([]namer.ModuleID, 0, len(deps))
 		for d := range deps {
 			evt.Dependents = append(evt.Dependents, d)
@@ -375,7 +375,7 @@ func (idx *index) Delete(entry Entry) (storage.Event, error) {
 	delete(idx.dependencies, modID)
 	delete(idx.executables, modID)
 
-	if deps, ok := idx.dependents[modID]; ok {
+	if deps, ok := idx.dependents[modID]; ok && len(deps) > 0 {
 		evt.Dependents = make([]namer.ModuleID, 0, len(deps))
 		for d := range deps {
 			evt.Dependents = append(evt.Dependents, d)

--- a/internal/storage/index/index.go
+++ b/internal/storage/index/index.go
@@ -317,6 +317,13 @@ func (idx *index) AddOrUpdate(entry Entry) (evt storage.Event, err error) {
 		idx.addDep(modID, dep)
 	}
 
+	if deps, ok := idx.dependents[modID]; ok {
+		evt.Dependents = make([]namer.ModuleID, 0, len(deps))
+		for d := range deps {
+			evt.Dependents = append(evt.Dependents, d)
+		}
+	}
+
 	statsCtx := context.Background()
 	metrics.Add(statsCtx, metrics.IndexEntryCount(), int64(len(idx.modIDToFile)-startCount))
 	metrics.Inc(statsCtx, metrics.IndexCRUDCount(), metrics.KindKey(crudKind))
@@ -357,6 +364,9 @@ func (idx *index) Delete(entry Entry) (storage.Event, error) {
 			if refs, ok := idx.dependents[dep]; ok {
 				delete(refs, modID)
 			}
+			if len(idx.dependents[dep]) == 0 {
+				delete(idx.dependents, dep)
+			}
 		}
 	}
 
@@ -364,6 +374,13 @@ func (idx *index) Delete(entry Entry) (storage.Event, error) {
 	delete(idx.modIDToFile, modID)
 	delete(idx.dependencies, modID)
 	delete(idx.executables, modID)
+
+	if deps, ok := idx.dependents[modID]; ok {
+		evt.Dependents = make([]namer.ModuleID, 0, len(deps))
+		for d := range deps {
+			evt.Dependents = append(evt.Dependents, d)
+		}
+	}
 
 	statsCtx := context.Background()
 	metrics.Add(statsCtx, metrics.IndexEntryCount(), int64(len(idx.modIDToFile)-startCount))

--- a/internal/storage/subscriptionmgr.go
+++ b/internal/storage/subscriptionmgr.go
@@ -7,10 +7,14 @@ package storage
 
 import (
 	"context"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/cerbos/cerbos/internal/namer"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 )
 
@@ -124,7 +128,31 @@ func TestSubscription(s Subscribable) func(*testing.T, time.Duration, ...Event) 
 		}
 
 		s.Unsubscribe(sub)
-		require.ElementsMatch(t, wantEvents, haveEvents)
+		require.Empty(
+			t,
+			cmp.Diff(
+				wantEvents,
+				haveEvents,
+				// sort top‐level Events by PolicyID.hash, then by SchemaFile for schema events
+				cmpopts.SortSlices(func(a, b Event) bool {
+					aHash := reflect.ValueOf(a.PolicyID).FieldByName("hash").Uint()
+					bHash := reflect.ValueOf(b.PolicyID).FieldByName("hash").Uint()
+					if aHash != bHash {
+						return aHash < bHash
+					}
+					// For events with same PolicyID hash (like schema events), sort by SchemaFile
+					return a.SchemaFile < b.SchemaFile
+				}),
+				// sort Dependents by hash
+				cmpopts.SortSlices(func(a, b namer.ModuleID) bool {
+					return reflect.ValueOf(a).FieldByName("hash").Uint() <
+						reflect.ValueOf(b).FieldByName("hash").Uint()
+				}),
+				// allow comparing ModuleID despite its unexported field
+				cmpopts.EquateComparable(namer.ModuleID{}),
+			),
+			"events mismatch (-want +got)",
+		)
 	}
 }
 


### PR DESCRIPTION
We now leverage the store specific `GetDependents` functionality, returned in the body of the `Event` for both `AddOrUpdate` and `Delete` events. These Dependents are then reloaded in the rule table.

Added a number of test cases to prevent further regressions.