### PR TITLE
chore: Exclude machineid lib from JS builds

### DIFF
--- a/internal/util/app.go
+++ b/internal/util/app.go
@@ -6,6 +6,7 @@
 package util
 
 import (
+	"github.com/keygen-sh/machineid"
 	"go.uber.org/zap"
 )
 
@@ -15,4 +16,8 @@ func DeprecationWarning(deprecated string) {
 
 func DeprecationReplacedWarning(deprecated, replacement string) {
 	zap.S().Warnf("[DEPRECATED CONFIG] %s is deprecated and will be removed in a future release. Please use %s instead.", deprecated, replacement)
+}
+
+func getMachineID() (string, error) {
+	return machineid.ID()
 }

--- a/internal/util/app_common.go
+++ b/internal/util/app_common.go
@@ -15,7 +15,6 @@ import (
 
 	pdpv1 "github.com/cerbos/cloud-api/genpb/cerbos/cloud/pdp/v1"
 	"github.com/google/uuid"
-	"github.com/keygen-sh/machineid"
 )
 
 var (
@@ -68,7 +67,7 @@ func AppShortVersion() string {
 }
 
 var getPdpID = sync.OnceValue(func() string {
-	machineID, err := machineid.ID()
+	machineID, err := getMachineID()
 	if err != nil || machineID == "" {
 		//nolint:gosec
 		uuidNodeID := md5.Sum(uuid.NodeID())

--- a/internal/util/app_stub.go
+++ b/internal/util/app_stub.go
@@ -8,3 +8,7 @@ package util
 func DeprecationWarning(deprecated string) {}
 
 func DeprecationReplacedWarning(deprecated, replacement string) {}
+
+func getMachineID() (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
This slipped through in the rebase. It'll probably be prudent to add a CI check to ensure we don't break JS builds.