### PR TITLE
chore(ci): Clean up .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,9 +20,6 @@ builds:
     goarch:
       - amd64
       - arm64
-    goarm:
-      - "6"
-      - "7"
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath
@@ -49,9 +46,6 @@ builds:
     goarch:
       - amd64
       - arm64
-    goarm:
-      - "6"
-      - "7"
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath
@@ -69,9 +63,6 @@ builds:
     goarch:
       - amd64
       - arm64
-    goarm:
-      - "6"
-      - "7"
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath


### PR DESCRIPTION
Remove unused "goarm" option. ARM64 doesn't support it, only ARM does.
