### PR TITLE
fix: Fix e2e overlay test

### DIFF
--- a/e2e/blob/blob_test.go
+++ b/e2e/blob/blob_test.go
@@ -41,8 +41,8 @@ func TestBlob(t *testing.T) {
 
 		_ = blob.CopyDirToBucket(ctx, cctx, p)
 
-		// Wait for Cerbos to pickup the changes
-		time.Sleep(150 * time.Millisecond)
+		// Wait for Cerbos to pick up the changes
+		time.Sleep(5 * time.Second)
 	}
 
 	e2e.RunSuites(t, e2e.WithContextID("blob"), e2e.WithImmutableStoreSuites(), e2e.WithPostSetup(postSetup), e2e.WithComputedEnv(computedEnvFn))

--- a/e2e/overlay/overlay_test.go
+++ b/e2e/overlay/overlay_test.go
@@ -6,7 +6,10 @@
 package overlay_test
 
 import (
+	"crypto/tls"
+	"encoding/base64"
 	"fmt"
+	"net/http"
 	"strconv"
 	"testing"
 
@@ -36,13 +39,37 @@ func TestOverlay(t *testing.T) {
 	}
 
 	t.Log(">>> Testing the overlay base driver")
-	e2e.RunSuites(t, e2e.WithContextID("overlay"), e2e.WithImmutableStoreSuites(), e2e.WithComputedEnv(computedEnv))
+	e2e.RunSuites(t, e2e.WithContextID("overlay"), e2e.WithImmutableStoreSuites(), e2e.WithComputedEnv(computedEnv), e2e.WithPostSetup(reloadStore(t)))
+
 	t.Log(">>> Testing the overlay fallback driver")
 	e2e.RunSuites(t, e2e.WithContextID("overlay"), e2e.WithImmutableStoreSuites(), e2e.WithComputedEnv(computedEnv), e2e.WithPostSetup(breakDB(t)), e2e.WithOverlayMaxRetries(fallbackErrThreshold))
 }
 
 func dbURL(ctx e2e.Ctx) string {
 	return fmt.Sprintf("postgres://postgres:passw0rd@postgres-%s.%s.svc.cluster.local:5432/postgres?sslmode=disable&search_path=cerbos", ctx.ContextID, ctx.Namespace())
+}
+
+func reloadStore(t *testing.T) func(e2e.Ctx) {
+	t.Helper()
+	return func(ctx e2e.Ctx) {
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+		url := fmt.Sprintf("%s/admin/store/reload", ctx.HTTPAddr())
+
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+
+		auth := base64.StdEncoding.EncodeToString([]byte("cerbos:cerbosAdmin"))
+		req.Header.Set("Authorization", "Basic "+auth)
+
+		client := &http.Client{Transport: tr}
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
 }
 
 func breakDB(t *testing.T) func(e2e.Ctx) {


### PR DESCRIPTION
The overlay cerbos instance and cerbos admin instance for the overlay e2e tests were running in seperate pods (talking to the same postgres instance). Storage events propogate in process, so the cerbos instance used for Check requests did not see the updated policy state. This coincidentally worked before because policies were loaded lazily. In the new pre-compiled rule table world, this is not the case. Adding a refresh after the AdminSuite run ensures policy updates were reflected in the other cerbos process.

Also increased a `sleep` in the blob e2e test to give more time for events to propogate to the rule table correctly.