### PR TITLE
fix: Fix e2e blob test by guaranteeing policy existence

### DIFF
--- a/e2e/blob/blob_test.go
+++ b/e2e/blob/blob_test.go
@@ -7,9 +7,7 @@ package blob_test
 
 import (
 	"fmt"
-	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/cerbos/cerbos/internal/storage/blob"
 	"github.com/cerbos/cerbos/internal/test/e2e"
@@ -27,23 +25,5 @@ func TestBlob(t *testing.T) {
 		return env
 	}
 
-	postSetup := func(ctx e2e.Ctx) {
-		p := blob.UploadParam{
-			BucketURL:    env["E2E_BUCKET_URL"],
-			BucketPrefix: env["E2E_BUCKET_PREFIX"],
-			Username:     env["E2E_BUCKET_USERNAME"],
-			Password:     env["E2E_BUCKET_PASSWORD"],
-			Directory:    filepath.Join(ctx.SourceRoot, "internal", "test", "testdata", "store"),
-		}
-
-		cctx, cancelFn := ctx.CommandTimeoutCtx()
-		defer cancelFn()
-
-		_ = blob.CopyDirToBucket(ctx, cctx, p)
-
-		// Wait for Cerbos to pick up the changes
-		time.Sleep(5 * time.Second)
-	}
-
-	e2e.RunSuites(t, e2e.WithContextID("blob"), e2e.WithImmutableStoreSuites(), e2e.WithPostSetup(postSetup), e2e.WithComputedEnv(computedEnvFn))
+	e2e.RunSuites(t, e2e.WithContextID("blob"), e2e.WithImmutableStoreSuites(), e2e.WithComputedEnv(computedEnvFn))
 }

--- a/e2e/blob/helmfile.yaml.gotmpl
+++ b/e2e/blob/helmfile.yaml.gotmpl
@@ -1,14 +1,12 @@
 repositories:
   - name: bitnami
     url: https://charts.bitnami.com/bitnami
-
 helmDefaults:
   cleanupOnFail: true
   wait: true
   recreatePods: true
   force: true
   createNamespace: true
-
 releases:
   - name: minio
     namespace: '{{ requiredEnv "E2E_NS" }}'
@@ -39,8 +37,7 @@ releases:
           rootPassword: passw0rd
       - defaultBuckets: "cerbos"
       - persistence:
-          enabled": false
-
+          enabled: false
   - name: cerbos
     namespace: '{{ requiredEnv "E2E_NS" }}'
     needs: ["minio"]
@@ -61,6 +58,19 @@ releases:
           - '--cert={{ requiredEnv "E2E_SRC_ROOT" }}/internal/test/testdata/server/tls.crt'
           - '--key={{ requiredEnv "E2E_SRC_ROOT" }}/internal/test/testdata/server/tls.key'
           - '--namespace={{ requiredEnv "E2E_NS" }}'
+      - events: ["presync"]
+        showlogs: true
+        command: bash
+        args:
+          - -lc
+          - |
+            TMP_TAR="$(mktemp -t e2e_policies.tgz)"
+            tar -C '{{ requiredEnv "E2E_SRC_ROOT" }}/internal/test/testdata/store' -czf "$TMP_TAR" .
+            kubectl create configmap cerbos-policies-tar-{{ requiredEnv "E2E_CONTEXT_ID" }} \
+              --from-file=store.tgz="$TMP_TAR" \
+              -n '{{ requiredEnv "E2E_NS" }}' \
+              -o yaml --dry-run=client | kubectl apply -f -
+            rm -f "$TMP_TAR"
       - events: ["postuninstall"]
         showlogs: true
         command: kubectl
@@ -79,6 +89,11 @@ releases:
             emptyDir: {}
           - name: cerbos-policies
             emptyDir: {}
+          - name: e2e-policies-tar
+            configMap:
+              name: cerbos-policies-tar-{{ requiredEnv "E2E_CONTEXT_ID" }}
+          - name: e2e-policy-workdir
+            emptyDir: {}
       - volumeMounts:
           - name: cerbos-auditlog
             mountPath: /audit
@@ -89,6 +104,35 @@ releases:
             value: '{{ requiredEnv "E2E_BUCKET_USERNAME" }}'
           - name: AWS_SECRET_ACCESS_KEY
             value: '{{ requiredEnv "E2E_BUCKET_PASSWORD" }}'
+      - initContainers:
+          - name: wait-for-policies
+            image: bitnami/minio-client:latest
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: AWS_ACCESS_KEY_ID
+                value: '{{ requiredEnv "E2E_BUCKET_USERNAME" }}'
+              - name: AWS_SECRET_ACCESS_KEY
+                value: '{{ requiredEnv "E2E_BUCKET_PASSWORD" }}'
+            volumeMounts:
+              - name: e2e-policies-tar
+                mountPath: /src
+              - name: e2e-policy-workdir
+                mountPath: /work
+            command: ["/bin/sh", "-lc"]
+            args:
+              - |
+                export PATH=/opt/bitnami/minio-client/bin:$PATH
+                set -eu
+
+                # work around some permissioning issues
+                mkdir -p /work/in
+                tar -xzf /src/store.tgz -C /work/in
+
+                mc alias set minio \
+                  http://minio-{{ requiredEnv "E2E_CONTEXT_ID" }}.{{ requiredEnv "E2E_NS" }}:9000 \
+                  "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY"
+
+                mc mirror /work/in minio/cerbos/{{ requiredEnv "E2E_BUCKET_PREFIX" }}
       - cerbos:
           tlsSecretName: 'cerbos-certs-{{ requiredEnv "E2E_CONTEXT_ID" }}'
           logLevel: DEBUG


### PR DESCRIPTION
Previously, there was a race condition between policies being added to the bucket (and reflected in the rule table via event propagation) and the tests running themselves. This fixes that by ensuring the minio bucket houses the policies prior to the cerbos pod starting, so that the rule table will be initialised with the correct state.