### PR TITLE
fix: Batch dependents and deflake CI suites

### DIFF
--- a/e2e/blob/blob_test.go
+++ b/e2e/blob/blob_test.go
@@ -42,7 +42,7 @@ func TestBlob(t *testing.T) {
 		_ = blob.CopyDirToBucket(ctx, cctx, p)
 
 		// Wait for Cerbos to pick up the changes
-		time.Sleep(5 * time.Second)
+		time.Sleep(2 * time.Second)
 	}
 
 	e2e.RunSuites(t, e2e.WithContextID("blob"), e2e.WithImmutableStoreSuites(), e2e.WithPostSetup(postSetup), e2e.WithComputedEnv(computedEnvFn))

--- a/e2e/blob/blob_test.go
+++ b/e2e/blob/blob_test.go
@@ -7,7 +7,9 @@ package blob_test
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/cerbos/cerbos/internal/storage/blob"
 	"github.com/cerbos/cerbos/internal/test/e2e"
@@ -25,5 +27,23 @@ func TestBlob(t *testing.T) {
 		return env
 	}
 
-	e2e.RunSuites(t, e2e.WithContextID("blob"), e2e.WithImmutableStoreSuites(), e2e.WithComputedEnv(computedEnvFn))
+	postSetup := func(ctx e2e.Ctx) {
+		p := blob.UploadParam{
+			BucketURL:    env["E2E_BUCKET_URL"],
+			BucketPrefix: env["E2E_BUCKET_PREFIX"],
+			Username:     env["E2E_BUCKET_USERNAME"],
+			Password:     env["E2E_BUCKET_PASSWORD"],
+			Directory:    filepath.Join(ctx.SourceRoot, "internal", "test", "testdata", "store"),
+		}
+
+		cctx, cancelFn := ctx.CommandTimeoutCtx()
+		defer cancelFn()
+
+		_ = blob.CopyDirToBucket(ctx, cctx, p)
+
+		// Wait for Cerbos to pick up the changes
+		time.Sleep(5 * time.Second)
+	}
+
+	e2e.RunSuites(t, e2e.WithContextID("blob"), e2e.WithImmutableStoreSuites(), e2e.WithPostSetup(postSetup), e2e.WithComputedEnv(computedEnvFn))
 }

--- a/e2e/blob/helmfile.yaml.gotmpl
+++ b/e2e/blob/helmfile.yaml.gotmpl
@@ -1,12 +1,14 @@
 repositories:
   - name: bitnami
     url: https://charts.bitnami.com/bitnami
+
 helmDefaults:
   cleanupOnFail: true
   wait: true
   recreatePods: true
   force: true
   createNamespace: true
+
 releases:
   - name: minio
     namespace: '{{ requiredEnv "E2E_NS" }}'
@@ -37,7 +39,8 @@ releases:
           rootPassword: passw0rd
       - defaultBuckets: "cerbos"
       - persistence:
-          enabled: false
+          enabled": false
+
   - name: cerbos
     namespace: '{{ requiredEnv "E2E_NS" }}'
     needs: ["minio"]
@@ -58,19 +61,6 @@ releases:
           - '--cert={{ requiredEnv "E2E_SRC_ROOT" }}/internal/test/testdata/server/tls.crt'
           - '--key={{ requiredEnv "E2E_SRC_ROOT" }}/internal/test/testdata/server/tls.key'
           - '--namespace={{ requiredEnv "E2E_NS" }}'
-      - events: ["presync"]
-        showlogs: true
-        command: bash
-        args:
-          - -lc
-          - |
-            TMP_TAR="$(mktemp -t e2e_policies.tgz)"
-            tar -C '{{ requiredEnv "E2E_SRC_ROOT" }}/internal/test/testdata/store' -czf "$TMP_TAR" .
-            kubectl create configmap cerbos-policies-tar-{{ requiredEnv "E2E_CONTEXT_ID" }} \
-              --from-file=store.tgz="$TMP_TAR" \
-              -n '{{ requiredEnv "E2E_NS" }}' \
-              -o yaml --dry-run=client | kubectl apply -f -
-            rm -f "$TMP_TAR"
       - events: ["postuninstall"]
         showlogs: true
         command: kubectl
@@ -89,11 +79,6 @@ releases:
             emptyDir: {}
           - name: cerbos-policies
             emptyDir: {}
-          - name: e2e-policies-tar
-            configMap:
-              name: cerbos-policies-tar-{{ requiredEnv "E2E_CONTEXT_ID" }}
-          - name: e2e-policy-workdir
-            emptyDir: {}
       - volumeMounts:
           - name: cerbos-auditlog
             mountPath: /audit
@@ -104,35 +89,6 @@ releases:
             value: '{{ requiredEnv "E2E_BUCKET_USERNAME" }}'
           - name: AWS_SECRET_ACCESS_KEY
             value: '{{ requiredEnv "E2E_BUCKET_PASSWORD" }}'
-      - initContainers:
-          - name: wait-for-policies
-            image: bitnami/minio-client:latest
-            imagePullPolicy: IfNotPresent
-            env:
-              - name: AWS_ACCESS_KEY_ID
-                value: '{{ requiredEnv "E2E_BUCKET_USERNAME" }}'
-              - name: AWS_SECRET_ACCESS_KEY
-                value: '{{ requiredEnv "E2E_BUCKET_PASSWORD" }}'
-            volumeMounts:
-              - name: e2e-policies-tar
-                mountPath: /src
-              - name: e2e-policy-workdir
-                mountPath: /work
-            command: ["/bin/sh", "-lc"]
-            args:
-              - |
-                export PATH=/opt/bitnami/minio-client/bin:$PATH
-                set -eu
-
-                # work around some permissioning issues
-                mkdir -p /work/in
-                tar -xzf /src/store.tgz -C /work/in
-
-                mc alias set minio \
-                  http://minio-{{ requiredEnv "E2E_CONTEXT_ID" }}.{{ requiredEnv "E2E_NS" }}:9000 \
-                  "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY"
-
-                mc mirror /work/in minio/cerbos/{{ requiredEnv "E2E_BUCKET_PREFIX" }}
       - cerbos:
           tlsSecretName: 'cerbos-certs-{{ requiredEnv "E2E_CONTEXT_ID" }}'
           logLevel: DEBUG

--- a/e2e/blob/helmfile.yaml.gotmpl
+++ b/e2e/blob/helmfile.yaml.gotmpl
@@ -39,7 +39,7 @@ releases:
           rootPassword: passw0rd
       - defaultBuckets: "cerbos"
       - persistence:
-          enabled": false
+          enabled: false
 
   - name: cerbos
     namespace: '{{ requiredEnv "E2E_NS" }}'

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -89,9 +89,8 @@ import (
 )
 
 const (
-	defaultTimeout           = 30 * time.Second
-	metricsReportingInterval = 15 * time.Second
-	minGRPCConnectTimeout    = 20 * time.Second
+	defaultTimeout        = 30 * time.Second
+	minGRPCConnectTimeout = 20 * time.Second
 
 	adminEndpoint      = "/admin"
 	apiEndpoint        = "/api"

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -129,7 +129,7 @@ func TestServer(t *testing.T) {
 
 func apiTests(tpg testParamGen) func(*testing.T) {
 	return func(t *testing.T) {
-		tr := LoadTestCases(t, "checks", "playground", "plan_resources")
+		tr := LoadTestCases(t, nil, "checks", "playground", "plan_resources")
 
 		t.Run("with_tls", func(t *testing.T) {
 			testdataDir := test.PathToDir(t, "server")
@@ -284,7 +284,7 @@ func TestAdminService(t *testing.T) {
 
 	startServer(t, conf, tpg)
 
-	tr := LoadTestCases(t, "admin", "checks")
+	tr := LoadTestCases(t, nil, "admin", "checks")
 	creds := &AuthCreds{Username: "cerbos", Password: "cerbosAdmin"}
 
 	tlsConf := &tls.Config{InsecureSkipVerify: true} //nolint:gosec

--- a/internal/server/tests.go
+++ b/internal/server/tests.go
@@ -58,7 +58,7 @@ func (AuthCreds) RequireTransportSecurity() bool {
 	return false
 }
 
-func LoadTestCases(tb testing.TB, suiteSleeps map[int]time.Duration, dirs ...string) *TestRunner {
+func LoadTestCases(tb testing.TB, suiteSleeps map[string]time.Duration, dirs ...string) *TestRunner {
 	tb.Helper()
 	var testCases []*privatev1.ServerTestCase
 
@@ -73,7 +73,7 @@ func LoadTestCases(tb testing.TB, suiteSleeps map[int]time.Duration, dirs ...str
 
 		totalTestCases += len(cases)
 		if i < len(dirs)-1 { // no point sleeping after the final suite
-			if dur, ok := suiteSleeps[i]; ok && len(cases) > 0 {
+			if dur, ok := suiteSleeps[dir]; ok && len(cases) > 0 {
 				testCaseSleeps[totalTestCases-1] = dur
 			}
 		}

--- a/internal/server/tests.go
+++ b/internal/server/tests.go
@@ -96,11 +96,11 @@ func readTestCase(tb testing.TB, name string, data []byte) *privatev1.ServerTest
 }
 
 type TestRunner struct {
+	sleeps                 map[int]time.Duration
 	Cases                  []*privatev1.ServerTestCase
 	Timeout                time.Duration
 	HealthPollInterval     time.Duration
 	CerbosClientMaxRetries uint
-	sleeps                 map[int]time.Duration
 }
 
 // WithCerbosClientRetries is relevant to Overlay storage driver calls (specifically the e2e overlay test).

--- a/internal/test/e2e/ctx.go
+++ b/internal/test/e2e/ctx.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -96,9 +97,7 @@ func (c Ctx) Environ() []string {
 	}
 
 	if c.ComputedEnv != nil {
-		for k, v := range c.ComputedEnv {
-			defaults[k] = v
-		}
+		maps.Copy(defaults, c.ComputedEnv)
 	}
 
 	var e2eVars []string //nolint:prealloc

--- a/internal/test/e2e/tests.go
+++ b/internal/test/e2e/tests.go
@@ -25,6 +25,8 @@ const (
 	ChecksSuite        = "checks"
 	PlanResourcesSuite = "plan_resources"
 	testTimeout        = 90 * time.Second // Things are slower inside Kind
+
+	adminSuiteSleepDuration = time.Millisecond * 500
 )
 
 type Opt func(*suiteOpt)
@@ -118,7 +120,14 @@ func RunSuites(t *testing.T, opts ...Opt) {
 		ctx.Logf("Finished PostSetup function")
 	}
 
-	tr := server.LoadTestCases(t, sopt.suites...)
+	sleeps := make(map[int]time.Duration)
+	for i, suite := range sopt.suites {
+		if suite == AdminSuite {
+			sleeps[i] = adminSuiteSleepDuration
+		}
+	}
+
+	tr := server.LoadTestCases(t, sleeps, sopt.suites...)
 	tr.Timeout = testTimeout
 
 	if sopt.overlayMaxRetries != 0 {

--- a/internal/test/e2e/tests.go
+++ b/internal/test/e2e/tests.go
@@ -120,14 +120,14 @@ func RunSuites(t *testing.T, opts ...Opt) {
 		ctx.Logf("Finished PostSetup function")
 	}
 
-	sleeps := make(map[int]time.Duration)
-	for i, suite := range sopt.suites {
+	suiteSleeps := make(map[string]time.Duration)
+	for _, suite := range sopt.suites {
 		if suite == AdminSuite {
-			sleeps[i] = adminSuiteSleepDuration
+			suiteSleeps[AdminSuite] = adminSuiteSleepDuration
 		}
 	}
 
-	tr := server.LoadTestCases(t, sleeps, sopt.suites...)
+	tr := server.LoadTestCases(t, suiteSleeps, sopt.suites...)
 	tr.Timeout = testTimeout
 
 	if sopt.overlayMaxRetries != 0 {

--- a/pkg/cerbos/serve_test.go
+++ b/pkg/cerbos/serve_test.go
@@ -56,7 +56,7 @@ func TestServe(t *testing.T) {
 				serveErr <- cerbos.Serve(ctx, cerbos.WithConfig(config))
 			}()
 
-			testRunner := server.LoadTestCases(t, "checks/check_resources")
+			testRunner := server.LoadTestCases(t, nil, "checks/check_resources")
 
 			t.Run("grpc", testRunner.RunGRPCTests(grpcListenAddr, grpc.WithTransportCredentials(local.NewCredentials())))
 			t.Run("http", testRunner.RunHTTPTests(fmt.Sprintf("http://%s", httpListenAddr), nil))


### PR DESCRIPTION
* Storage (blob/db): emit one deduped dependents-only event per batch;
  drop per-policy dependents (there was some duplicated effort here).
* Compile manager: stop enriching all Add/Update and Delete events with
  dependents as we now rely on the storage layers to handle this (there
  was also some duplicated effort here).
* Rule table manager: removed the index-unhealthy gate flag. It's no
  longer necessary since the compile-and-swop mechanism only mutates
  rule table state on successful compilation. Processing dependents
  atomically also relies on all to be available and valid in order for
  mutations to occur (so links are kept consistent). Without this gate,
  we bypass a large number of wasteful full reloads.
* E2E tests: I still needed to add a sleep in between the AdminSuite and
  CheckSuite in order to allow events generated in the mutable stores
  to fully propogate to the rule table before Check requests were fired
  at it. I did a hell of a lot of experimentation, and think that this
  is in part due to differing, more constrained runtime environments
  nudging us into "race" territory (I verified by checking out an old,
  previously passing commit, and saw that fail in Github's actions too).
* Other misc changes.