### PR TITLE
fix: Increase blob e2e sleep period

### DIFF
--- a/e2e/blob/blob_test.go
+++ b/e2e/blob/blob_test.go
@@ -42,7 +42,7 @@ func TestBlob(t *testing.T) {
 		_ = blob.CopyDirToBucket(ctx, cctx, p)
 
 		// Wait for Cerbos to pick up the changes
-		time.Sleep(2 * time.Second)
+		time.Sleep(5 * time.Second)
 	}
 
 	e2e.RunSuites(t, e2e.WithContextID("blob"), e2e.WithImmutableStoreSuites(), e2e.WithPostSetup(postSetup), e2e.WithComputedEnv(computedEnvFn))


### PR DESCRIPTION
I optimistically reduced it to 2 seconds (for which it sometimes successfully passes tests). However, we're still seeing flakes, so I'm tuning it back up to 5 seconds.