### PR TITLE
fix: Use CollectT in EventuallyWithT

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/spf13/afero v1.14.0
 	github.com/spiffe/go-spiffe/v2 v2.6.0
 	github.com/stoewer/go-strcase v1.3.1
-	github.com/stretchr/testify v1.10.0
+	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/pretty v1.2.1
 	github.com/tidwall/sjson v1.2.5

--- a/go.sum
+++ b/go.sum
@@ -646,8 +646,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/internal/ruletable/ruletable_test.go
+++ b/internal/ruletable/ruletable_test.go
@@ -98,10 +98,10 @@ func TestRuleTableManager(t *testing.T) {
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		output, _, err := ruletableMgr.Check(ctx, tctx, evalParams, input)
-		require.NoError(t, err)
+		require.NoError(c, err)
 
-		require.Contains(t, output.Actions, action)
-		require.Equal(t, output.Actions[action].GetEffect(), effectv1.Effect_EFFECT_ALLOW)
+		require.Contains(c, output.Actions, action)
+		require.Equal(c, output.Actions[action].GetEffect(), effectv1.Effect_EFFECT_ALLOW)
 	}, 1*time.Second, 50*time.Millisecond)
 
 	t.Run("maintain_valid_state_on_missing_derived_role", func(t *testing.T) {
@@ -129,10 +129,10 @@ func TestRuleTableManager(t *testing.T) {
 		// Check request should still return ALLOW
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			output, _, err := ruletableMgr.Check(ctx, tctx, evalParams, input)
-			require.NoError(t, err)
+			require.NoError(c, err)
 
-			require.Contains(t, output.Actions, action)
-			require.Equal(t, output.Actions[action].GetEffect(), effectv1.Effect_EFFECT_ALLOW)
+			require.Contains(c, output.Actions, action)
+			require.Equal(c, output.Actions[action].GetEffect(), effectv1.Effect_EFFECT_ALLOW)
 		}, 1*time.Second, 50*time.Millisecond)
 	})
 
@@ -167,10 +167,10 @@ func TestRuleTableManager(t *testing.T) {
 		// Check request should now return DENY
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			output, _, err := ruletableMgr.Check(ctx, tctx, evalParams, input)
-			require.NoError(t, err)
+			require.NoError(c, err)
 
-			require.Contains(t, output.Actions, action)
-			require.Equal(t, output.Actions[action].GetEffect(), effectv1.Effect_EFFECT_DENY)
+			require.Contains(c, output.Actions, action)
+			require.Equal(c, output.Actions[action].GetEffect(), effectv1.Effect_EFFECT_DENY)
 		}, 1*time.Second, 50*time.Millisecond)
 	})
 
@@ -204,10 +204,10 @@ func TestRuleTableManager(t *testing.T) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			output, _, err := ruletableMgr.Check(ctx, tctx, evalParams, input)
-			require.NoError(t, err)
+			require.NoError(c, err)
 
-			require.Contains(t, output.Actions, action)
-			require.Equal(t, output.Actions[action].GetEffect(), effectv1.Effect_EFFECT_ALLOW)
+			require.Contains(c, output.Actions, action)
+			require.Equal(c, output.Actions[action].GetEffect(), effectv1.Effect_EFFECT_ALLOW)
 		}, 1*time.Second, 50*time.Millisecond)
 	})
 
@@ -261,10 +261,10 @@ func TestRuleTableManager(t *testing.T) {
 		// The check should be allowed
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			output, _, err := ruletableMgr.Check(ctx, tctx, evalParams, input)
-			require.NoError(t, err)
+			require.NoError(c, err)
 
-			require.Contains(t, output.Actions, action)
-			require.Equal(t, output.Actions[action].GetEffect(), effectv1.Effect_EFFECT_ALLOW)
+			require.Contains(c, output.Actions, action)
+			require.Equal(c, output.Actions[action].GetEffect(), effectv1.Effect_EFFECT_ALLOW)
 		}, 1*time.Second, 50*time.Millisecond)
 
 		// Now update the export constant rule
@@ -284,10 +284,10 @@ func TestRuleTableManager(t *testing.T) {
 		// The rule table should be updated, and the check request should now be denied
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			output, _, err := ruletableMgr.Check(ctx, tctx, evalParams, input)
-			require.NoError(t, err)
+			require.NoError(c, err)
 
-			require.Contains(t, output.Actions, action)
-			require.Equal(t, output.Actions[action].GetEffect(), effectv1.Effect_EFFECT_DENY)
+			require.Contains(c, output.Actions, action)
+			require.Equal(c, output.Actions[action].GetEffect(), effectv1.Effect_EFFECT_DENY)
 		}, 1*time.Second, 50*time.Millisecond)
 	})
 }


### PR DESCRIPTION
Replace assertions inside require.EventuallyWithT closures to use CollectT (c) instead of *testing.T (t) so failures are correctly collected across retries and avoid flakiness and unpredictable race conditions.
