### PR TITLE
chore: Remove superfluous compile manager subscription mechanism

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -167,7 +167,7 @@ func Start(ctx context.Context) error {
 		return fmt.Errorf("failed to create ruletable manager: %w", err)
 	}
 
-	if ss, ok := policyLoader.(storage.Subscribable); ok {
+	if ss, ok := store.(storage.Subscribable); ok {
 		ss.Subscribe(ruletableMgr)
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -326,7 +326,7 @@ func startServer(t *testing.T, conf *Conf, tpg testParamGen) {
 	ruletableMgr, err := ruletable.NewRuleTableManager(rt, tp.policyLoader, tp.store, tp.schemaMgr)
 	require.NoError(t, err)
 
-	if ss, ok := tp.policyLoader.(storage.Subscribable); ok {
+	if ss, ok := tp.store.(storage.Subscribable); ok {
 		ss.Subscribe(ruletableMgr)
 	}
 

--- a/internal/storage/blob/store.go
+++ b/internal/storage/blob/store.go
@@ -44,8 +44,9 @@ const (
 )
 
 var (
-	_ storage.SourceStore = (*Store)(nil)
-	_ storage.Reloadable  = (*Store)(nil)
+	_ storage.SourceStore  = (*Store)(nil)
+	_ storage.Reloadable   = (*Store)(nil)
+	_ storage.Subscribable = (*Store)(nil)
 )
 
 var ErrUnsupportedBucketScheme = errors.New("currently only \"s3\" and \"gs\" bucket URL schemes are supported")

--- a/internal/storage/db/mysql/mysql.go
+++ b/internal/storage/db/mysql/mysql.go
@@ -38,6 +38,7 @@ const (
 var (
 	_ storage.SourceStore  = (*Store)(nil)
 	_ storage.MutableStore = (*Store)(nil)
+	_ storage.Subscribable = (*Store)(nil)
 )
 
 func init() {

--- a/internal/storage/db/postgres/postgres.go
+++ b/internal/storage/db/postgres/postgres.go
@@ -35,6 +35,7 @@ const (
 var (
 	_ storage.SourceStore  = (*Store)(nil)
 	_ storage.MutableStore = (*Store)(nil)
+	_ storage.Subscribable = (*Store)(nil)
 )
 
 func init() {

--- a/internal/storage/db/sqlite3/sqlite3.go
+++ b/internal/storage/db/sqlite3/sqlite3.go
@@ -44,6 +44,7 @@ var migrationsFS embed.FS
 var (
 	_ storage.SourceStore  = (*Store)(nil)
 	_ storage.MutableStore = (*Store)(nil)
+	_ storage.Subscribable = (*Store)(nil)
 )
 
 const nRegexpFnArgs = 2

--- a/internal/storage/disk/disk.go
+++ b/internal/storage/disk/disk.go
@@ -28,8 +28,9 @@ import (
 const DriverName = "disk"
 
 var (
-	_ storage.SourceStore = (*Store)(nil)
-	_ storage.Reloadable  = (*Store)(nil)
+	_ storage.SourceStore  = (*Store)(nil)
+	_ storage.Reloadable   = (*Store)(nil)
+	_ storage.Subscribable = (*Store)(nil)
 )
 
 func init() {

--- a/internal/storage/git/store.go
+++ b/internal/storage/git/store.go
@@ -38,8 +38,9 @@ const DriverName = "git"
 var driverAttr = policy.SourceDriver(DriverName)
 
 var (
-	_ storage.SourceStore = (*Store)(nil)
-	_ storage.Reloadable  = (*Store)(nil)
+	_ storage.SourceStore  = (*Store)(nil)
+	_ storage.Reloadable   = (*Store)(nil)
+	_ storage.Subscribable = (*Store)(nil)
 )
 
 func init() {

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -138,7 +138,6 @@ type Store interface {
 // SourceStore is implemented by stores that have policies in their source format (uncompiled).
 type SourceStore interface {
 	Store
-	Subscribable
 	// GetFirstMatch searches for the given module IDs in order and returns the first one found.
 	GetFirstMatch(context.Context, []namer.ModuleID) (*policy.CompilationUnit, error)
 	// GetAll returns all modules that exist within the policy store


### PR DESCRIPTION
Minor housekeeping after the recent rule table work.

* Drop compile manager as event intermediary; rule table handles store events directly now.
* SourceStores are now no longer Subscribable by default (as the compile manager is no longer subscribable).