### PR TITLE
chore(ci): Clear disk space quicker

### DIFF
--- a/.github/actions/free-disk-space/action.yaml
+++ b/.github/actions/free-disk-space/action.yaml
@@ -1,0 +1,12 @@
+name: Free disk space
+description: Remove unused files to free-up disk space
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |-
+        df -h
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        sudo docker image prune --all --force
+        sudo docker builder prune -a
+        df -h

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -44,15 +44,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
+        uses: ./.github/actions/free-disk-space
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -109,16 +101,8 @@ jobs:
     outputs:
       job-total: ${{ strategy.job-total }}
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false # this might remove tools that are actually needed, if set to "true" but frees about 6 GB
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -322,15 +306,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
+        uses: ./.github/actions/free-disk-space
 
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
The action to clear disk space takes about 10 minutes to run. Hopefully
this will be faster and clear enough disk space for the workflow to run.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
