### PR TITLE
chore(docs): Remove disableSSL and add protocol to the endpoint query param

### DIFF
--- a/docs/modules/configuration/pages/storage.adoc
+++ b/docs/modules/configuration/pages/storage.adoc
@@ -16,7 +16,7 @@ Cerbos policies can be stored in AWS S3, Google Cloud Storage, or any other S3-c
 * `bucket`: Required. A URL specifying the service (e.g. S3, GCS), the storage bucket and any other configuration parameters required by the provider.
 ** AWS S3: `s3://my-bucket?region=us-west-1`. Must specify region in the URL.
 ** Google Cloud Storage: `gs://my-bucket`
-** S3-compatible (e.g. Minio): `s3://my-bucket?endpoint=my.minio.local:8080&hostname_immutable=true&region=local`. Must specify region in the URL.
+** S3-compatible (e.g. Minio): `s3://my-bucket?endpoint=http://my.minio.local:8080&hostname_immutable=true&region=local`. Must specify region in the URL.
 * `prefix`: Optional. Look for policies only under this key prefix.
 * `workDir`: Optional. Path to the local directory to download the policies to. Defaults to the system cache directory if not specified.
 * `updatePollInterval`: Optional. How frequently the blob store should be checked to discover new or updated policies. Defaults to 0 -- which disables polling.
@@ -63,7 +63,7 @@ storage:
 storage:
   driver: "blob"
   blob:
-    bucket: "s3://my-bucket-name?endpoint=localhost:9000&hostname_immutable=true&region=local"
+    bucket: "s3://my-bucket-name?endpoint=http://localhost:9000&hostname_immutable=true&region=local"
     workDir: ${HOME}/tmp/cerbos/work
     updatePollInterval: 10s
 ----


### PR DESCRIPTION
# disableSSL
```yaml
storage:
  driver: "blob"
  blob:
    bucket: "s3://cerbos?endpoint=http://localhost:9000&hostname_immutable=true&region=local&disableSSL=true"
```
```
cerbos: error: failed to create store: failed to load AWS config: unknown query parameter "disableSSL"
```

# endpoint
## invalid configuration 1
```yaml
storage:
  driver: "blob"
  blob:
    bucket: "s3://cerbos?endpoint=localhost:9000&hostname_immutable=true&region=local"
```
```
cerbos: error: failed to create store: failed to clone blob store: failed to get next object in the bucket: blob (code=Unknown): operation error S3: ListObjectsV2, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Get "localhost:9000?list-type=2&max-keys=1000": unsupported protocol scheme "localhost"
```

## invalid configuration 2
```yaml
storage:
  driver: "blob"
  blob:
    bucket: "s3://cerbos?endpoint=127.0.0.1:9000&hostname_immutable=true&region=local"
```
```
cerbos: error: failed to create store: failed to clone blob store: failed to get next object in the bucket: blob (code=Unknown): operation error S3: ListObjectsV2, failed to parse endpoint URL: parse "127.0.0.1:9000": first path segment in URL cannot contain colon
```

## valid configuration (prepended with `http://`)
```yaml
storage:
  driver: "blob"
  blob:
    bucket: "s3://cerbos?endpoint=http://localhost:9000&hostname_immutable=true&region=local"
```