### PR TITLE
chore(ci): Use legacy Bitnami registry

### DIFF
--- a/e2e/blob/helmfile.yaml.gotmpl
+++ b/e2e/blob/helmfile.yaml.gotmpl
@@ -34,6 +34,8 @@ releases:
           - '{{ requiredEnv "E2E_NS" }}'
     values:
       - nameOverride: '{{ requiredEnv "E2E_CONTEXT_ID" }}'
+      - image:
+          repository: bitnamilegacy/minio
       - auth:
           rootUser: admin
           rootPassword: passw0rd
@@ -121,6 +123,6 @@ releases:
                 bucket: '{{ requiredEnv "E2E_BUCKET_URL" }}'
                 prefix: '{{ requiredEnv "E2E_BUCKET_PREFIX" }}'
                 workDir: /data
-                updatePollInterval: 0.5s
+                updatePollInterval: 250ms
             telemetry:
               disabled: true

--- a/e2e/git/helmfile.yaml.gotmpl
+++ b/e2e/git/helmfile.yaml.gotmpl
@@ -1,7 +1,3 @@
-repositories:
-  - name: bitnami
-    url: https://charts.bitnami.com/bitnami
-
 helmDefaults:
   cleanupOnFail: true
   wait: true

--- a/e2e/lenientscopes/helmfile.yaml.gotmpl
+++ b/e2e/lenientscopes/helmfile.yaml.gotmpl
@@ -1,7 +1,3 @@
-repositories:
-  - name: bitnami
-    url: https://charts.bitnami.com/bitnami
-
 helmDefaults:
   cleanupOnFail: true
   wait: true

--- a/e2e/mysql/helmfile.yaml.gotmpl
+++ b/e2e/mysql/helmfile.yaml.gotmpl
@@ -51,15 +51,14 @@ releases:
           - '{{ requiredEnv "E2E_NS" }}'
     values:
       - nameOverride: '{{ requiredEnv "E2E_CONTEXT_ID" }}'
+      - image:
+          repository: bitnamilegacy/mysql
       - auth:
           rootPassword: passw0rd
       - primary:
           persistence:
             enabled: false
       - initdbScriptsConfigMap: mysql-init
-      - image:
-          repository: mysql
-          tag: "9"
 
   - name: cerbos
     namespace: '{{ requiredEnv "E2E_NS" }}'

--- a/e2e/overlay/helmfile.yaml.gotmpl
+++ b/e2e/overlay/helmfile.yaml.gotmpl
@@ -1,6 +1,6 @@
 repositories:
   - name: bitnami
-    url: https://charts.bitnami.com/bitnami
+    url:  https://charts.bitnami.com/bitnami
 
 helmDefaults:
   cleanupOnFail: true
@@ -51,6 +51,8 @@ releases:
           - '{{ requiredEnv "E2E_NS" }}'
     values:
       - nameOverride: '{{ requiredEnv "E2E_CONTEXT_ID" }}'
+      - image:
+          repository: bitnamilegacy/postgresql
       - auth:
           postgresPassword: passw0rd
       - primary:

--- a/e2e/postgres/helmfile.yaml.gotmpl
+++ b/e2e/postgres/helmfile.yaml.gotmpl
@@ -51,6 +51,8 @@ releases:
           - '{{ requiredEnv "E2E_NS" }}'
     values:
       - nameOverride: '{{ requiredEnv "E2E_CONTEXT_ID" }}'
+      - image:
+          repository: bitnamilegacy/postgresql
       - auth:
           postgresPassword: passw0rd
       - primary:


### PR DESCRIPTION
They have moved all images to `bitnamilegacy` repository. This is a
temporary fix until we can address #2648.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>


