### PR TITLE
chore(ci): Move all Minio images to bitnamilegacy 

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -62,17 +62,17 @@ jobs:
           wait: 180s
 
       - name: Run E2E Tests
-        run: e2e/run.sh
+        run: e2e/run.sh ./blob/...
         env:
           E2E_SKIP_CLUSTER: "true"
           E2E_NO_CLEANUP: "true"
 
-      - name: Notify Slack
-        if: failure()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v2
-        with:
-          channel_id: C02TMGNNL4V
-          status: FAILED
-          color: danger
+      #- name: Notify Slack
+      #  if: failure()
+      #  env:
+      #    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      #  uses: voxmedia/github-action-slack-notify-build@v2
+      #  with:
+      #    channel_id: C02TMGNNL4V
+      #    status: FAILED
+      #    color: danger

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -62,17 +62,17 @@ jobs:
           wait: 180s
 
       - name: Run E2E Tests
-        run: e2e/run.sh ./blob/...
+        run: e2e/run.sh
         env:
           E2E_SKIP_CLUSTER: "true"
           E2E_NO_CLEANUP: "true"
 
-      #- name: Notify Slack
-      #  if: failure()
-      #  env:
-      #    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      #  uses: voxmedia/github-action-slack-notify-build@v2
-      #  with:
-      #    channel_id: C02TMGNNL4V
-      #    status: FAILED
-      #    color: danger
+      - name: Notify Slack
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v2
+        with:
+          channel_id: C02TMGNNL4V
+          status: FAILED
+          color: danger

--- a/e2e/blob/blob_test.go
+++ b/e2e/blob/blob_test.go
@@ -88,7 +88,7 @@ func TestBlob(t *testing.T) {
 		// Give it another 5 seconds to allow events to propagate from the store to the ruletable.
 		// 5 seconds might seem excessive, but the Github CI runners are driving me up the wall so
 		// I want to give this test as much chance as possible at passing.
-		time.Sleep(time.Second * 5)
+		time.Sleep(time.Second * 30)
 	}
 
 	e2e.RunSuites(t, e2e.WithContextID("blob"), e2e.WithImmutableStoreSuites(), e2e.WithPostSetup(postSetup), e2e.WithComputedEnv(computedEnvFn))

--- a/e2e/blob/helmfile.yaml.gotmpl
+++ b/e2e/blob/helmfile.yaml.gotmpl
@@ -36,6 +36,14 @@ releases:
       - nameOverride: '{{ requiredEnv "E2E_CONTEXT_ID" }}'
       - image:
           repository: bitnamilegacy/minio
+      - clientImage:
+          repository: bitnamilegacy/minio-client
+      - consoleImage:
+          repository: bitnamilegacy/minio-object-browser
+      - defaultInitContainers:
+          volumePermissions:
+            image:
+              repository: bitnamilegacy/os-shell
       - auth:
           rootUser: admin
           rootPassword: passw0rd

--- a/e2e/blob/helmfile.yaml.gotmpl
+++ b/e2e/blob/helmfile.yaml.gotmpl
@@ -38,8 +38,9 @@ releases:
           repository: bitnamilegacy/minio
       - clientImage:
           repository: bitnamilegacy/minio-client
-      - consoleImage:
-          repository: bitnamilegacy/minio-object-browser
+      - console:
+          image:
+            repository: bitnamilegacy/minio-object-browser
       - defaultInitContainers:
           volumePermissions:
             image:


### PR DESCRIPTION
The minio chart uses several images that don't exist in the bitnami repo anymore.

Also increases the blob store sleep to 30 seconds.