### PR TITLE
chore: Don't set `registry-url` to avoid introducing a spurious `NODE_AUTH_TOKEN`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: .node-version
-          registry-url: https://registry.npmjs.com
 
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
https://github.com/npm/documentation/pull/1748