### PR TITLE
chore(ci): Fix cosign version to 2.6.1

### DIFF
--- a/.github/workflows/aws.yaml
+++ b/.github/workflows/aws.yaml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.0.0
+        with:
+          cosign-release: 2.6.1
 
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.0.0
+        with:
+          cosign-release: 2.6.1
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -135,6 +135,8 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.0.0
+        with:
+          cosign-release: 2.6.1
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0


### PR DESCRIPTION
This is temporary because signing with cosign 3.x is broken at the
moment. I can't run cosign 3.x on my machine to debug either.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
