### PR TITLE
chore: Fix issues flagged by `gopls`

### DIFF
--- a/cmd/cerbosctl/hub/store/store.go
+++ b/cmd/cerbosctl/hub/store/store.go
@@ -24,7 +24,6 @@ import (
 const (
 	dirMode                = 0o700
 	downloadBatchSize      = 10
-	fileMode               = 0o600
 	maxFileSize            = 5 * 1024 * 1024
 	modifyFilesBatchSize   = 25
 	replaceFilesZipMaxSize = 15728640

--- a/cmd/cerbosctl/hub/store/upload_git.go
+++ b/cmd/cerbosctl/hub/store/upload_git.go
@@ -158,6 +158,7 @@ func (ugc *UploadGitCmd) batch() iter.Seq2[[]*storev1.FileOp, error] {
 				})
 			default:
 				yield(nil, fmt.Errorf("unexpected operation %s", change.operation))
+				return
 			}
 
 			batchCounter++


### PR DESCRIPTION
This PR removes an unused constant and adds a missing `return` to prevent `yield` from potentially being called after it has returned `false`.