### PR TITLE
chore(ci): Add "v" prefix to cosign version

### DIFF
--- a/.github/workflows/aws.yaml
+++ b/.github/workflows/aws.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.0.0
         with:
-          cosign-release: 2.6.1
+          cosign-release: v2.6.1
 
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.0.0
         with:
-          cosign-release: 2.6.1
+          cosign-release: v2.6.1
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -136,7 +136,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.0.0
         with:
-          cosign-release: 2.6.1
+          cosign-release: v2.6.1
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0


### PR DESCRIPTION
I missed that the version needs to be specified with a `v` prefix.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
