### PR TITLE
Pin golangci-lint version in CI

### DIFF
--- a/.github/actions/golangci-lint/action.yaml
+++ b/.github/actions/golangci-lint/action.yaml
@@ -1,0 +1,27 @@
+name: golangci-lint
+
+description: Lint Go code
+
+inputs:
+  working-directory:
+    description: golangci-lint working directory. The default is the project root.
+    required: false
+
+runs:
+  using: composite
+
+  steps:
+    - name: Get golangci-lint version
+      id: version
+      shell: bash
+      run: |
+        version=$(go list -m -f "{{.Version}}" github.com/golangci/golangci-lint/v2)
+        printf "version=%s\n" "${version}" >> "${GITHUB_OUTPUT}"
+      working-directory: tools
+
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 # v9
+      with:
+        args: --config="${{ github.workspace }}/.golangci.yaml" --verbose
+        version: ${{ steps.version.outputs.version }}
+        working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -241,10 +241,7 @@ jobs:
         run: just lint-modernize
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-        with:
-          version: latest
-          args: "--config=.golangci.yaml -v"
+        uses: ./.github/actions/golangci-lint
 
   buf:
     needs: changes


### PR DESCRIPTION
This PR makes sure that we use the same linter version locally and in CI.