### PR TITLE
Use `extractions/setup-crate` directly

### DIFF
--- a/.github/actions/setup-just/action.yaml
+++ b/.github/actions/setup-just/action.yaml
@@ -1,0 +1,12 @@
+name: Set up just
+
+description: Install the just command runner
+
+runs:
+  using: composite
+
+  steps:
+    - name: Set up just
+      uses: extractions/setup-crate@4993624604c307fbca528d28a3c8b60fa5ecc859 # v1
+      with:
+        repo: casey/just

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -47,7 +47,7 @@ jobs:
           write_build_cache: true
 
       - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: ./.github/actions/setup-just
 
       - name: Warm cache
         if: ${{ steps.setup.outputs.cache_hit != 'true' }}

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: ./.github/actions/setup-just
 
       - name: Generate
         run: just generate
@@ -113,7 +113,7 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: ./.github/actions/setup-just
 
       - name: Download previous test times
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
@@ -179,7 +179,7 @@ jobs:
           check-latest: true
 
       - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: ./.github/actions/setup-just
 
       - name: Download JUnit reports
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
@@ -235,7 +235,7 @@ jobs:
           cache: false
 
       - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: ./.github/actions/setup-just
 
       - name: modernize
         run: just lint-modernize

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -237,7 +237,7 @@ jobs:
           path: dist/
 
       - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: ./.github/actions/setup-just
 
       - name: Prepare, package and publish Lambda function to AWS SARs
         run: |-

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -29,7 +29,7 @@ jobs:
           write_build_cache: true
 
       - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: ./.github/actions/setup-just
 
       - name: Generate
         run: just generate

--- a/.github/workflows/test-lambda-publish.yaml
+++ b/.github/workflows/test-lambda-publish.yaml
@@ -92,7 +92,7 @@ jobs:
           use-installer: true
 
       - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: ./.github/actions/setup-just
 
       - name: Test Lambda function publishing
         run: |


### PR DESCRIPTION
`extractions/setup-just` depends on an unpinned version of it.

https://github.com/extractions/setup-just/issues/23