### PR TITLE
fix(plan): Remove unnecessary check

### DIFF
--- a/internal/ruletable/planner/ast.go
+++ b/internal/ruletable/planner/ast.go
@@ -553,11 +553,6 @@ func buildLambdaExprOp(expr, cur *exprpb.Expr) (*exprOp, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, ok := lambda.Node.(*exprOpExpr); !ok {
-		if _, ok = lambda.Node.(*exprOpVar); !ok {
-			return nil, fmt.Errorf("expected expression or variable, got %T", lambda.Node)
-		}
-	}
 	return lambda, nil
 }
 


### PR DESCRIPTION
Lambda node can be a value. `[1,2].all(x, false)` is a valid CEL expression. 
In the context of the query planner, `R.attr.teams.all(t, false)` can be safely rendered. We can simplify this expression later.
Fixes https://github.com/cerbos/cerbos/issues/2820