### PR TITLE
fix: Correctly intersect role policy DENYs for multi-role principals

### DIFF
--- a/internal/test/testdata/query_planner/policies/role_policies/role_comb_a.yaml
+++ b/internal/test/testdata/query_planner/policies/role_policies/role_comb_a.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../../../../../../schema/jsonschema/cerbos/policy/v1/Policy.schema.json
+---
+apiVersion: api.cerbos.dev/v1
+rolePolicy:
+  role: comb_a
+  scope: acme
+  parentRoles:
+    - USER
+  rules:
+    - resource: x
+      allowActions:
+        - debug
+      condition:
+        match:
+          expr: R.attr.is_buggy == true

--- a/internal/test/testdata/query_planner/policies/role_policies/role_comb_b.yaml
+++ b/internal/test/testdata/query_planner/policies/role_policies/role_comb_b.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../../../../../../schema/jsonschema/cerbos/policy/v1/Policy.schema.json
+---
+apiVersion: api.cerbos.dev/v1
+rolePolicy:
+  role: comb_b
+  scope: acme
+  parentRoles:
+    - USER
+  rules:
+    - resource: x
+      allowActions:
+        - debug
+      condition:
+        match:
+          expr: R.attr.is_enabled == true

--- a/internal/test/testdata/query_planner/suite/combined_role_policies.yaml
+++ b/internal/test/testdata/query_planner/suite/combined_role_policies.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=../../.jsonschema/QueryPlannerTestSuite.schema.json
+---
+description: Separate role policy allowed rules are correctly negatively combined 
+principal:
+    id: user123
+    policyVersion: default
+    roles:
+        - comb_a
+        - comb_b
+tests:
+    - action: debug
+      resource:
+        kind: x
+        scope: acme
+        policyVersion: default
+      want:
+        kind: KIND_CONDITIONAL
+        condition:
+          expression:
+            operator: not
+            operands:
+              - expression:
+                  operator: and
+                  operands:
+                    - expression:
+                        operator: not
+                        operands:
+                        - expression:
+                            operator: eq
+                            operands:
+                              - variable: request.resource.attr.is_buggy
+                              - value: true
+                    - expression:
+                        operator: not
+                        operands:
+                        - expression:
+                            operator: eq
+                            operands:
+                              - variable: request.resource.attr.is_enabled
+                              - value: true


### PR DESCRIPTION
Previously, DENYs from role policies were aggregated using a union (OR) strategy, causing a single role's DENY to block access globally even if other roles did not deny it (via `(not (or (not (FOO) (not (BAR)))))`). This change implements intersection (AND) logic for role policies, ensuring a request is only denied if *all* of the principal's active roles explicitly deny the action via their respective role policies (`(not (and (not (FOO) (not (BAR)))))`).