### PR TITLE
Options to control instrumentation of in-process service

### DIFF
--- a/cmd/awslambda/extension/main.go
+++ b/cmd/awslambda/extension/main.go
@@ -31,7 +31,7 @@ func main() {
 		logLevel = "info"
 	}
 
-	logging.InitLogging(ctx, logLevel)
+	logging.InitLogging(ctx, logLevel, nil)
 	defer zap.L().Sync() //nolint:errcheck
 
 	runtimeAPI := os.Getenv("AWS_LAMBDA_RUNTIME_API")

--- a/cmd/awslambda/function/main.go
+++ b/cmd/awslambda/function/main.go
@@ -22,7 +22,7 @@ func main() {
 		logLevel = "info"
 	}
 
-	logging.InitLogging(ctx, logLevel)
+	logging.InitLogging(ctx, logLevel, nil)
 	defer zap.L().Sync() //nolint:errcheck
 
 	handler, err := awslambda.NewFunctionHandler(ctx)

--- a/cmd/cerbos/run/run.go
+++ b/cmd/cerbos/run/run.go
@@ -84,7 +84,7 @@ func (c *Cmd) Run(k *kong.Kong) error {
 	notifyCtx, stopFunc := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stopFunc()
 
-	logging.InitLogging(notifyCtx, c.LogLevel)
+	logging.InitLogging(notifyCtx, c.LogLevel, nil)
 	defer zap.L().Sync() //nolint:errcheck
 
 	log := zap.S().Named("run")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -55,7 +55,7 @@ type testParam struct {
 type testParamGen func(*testing.T) testParam
 
 func TestServer(t *testing.T) {
-	logging.InitLogging(t.Context(), "ERROR")
+	logging.InitLogging(t.Context(), "ERROR", nil)
 
 	t.Run("store=disk", func(t *testing.T) {
 		tpg := func(t *testing.T) testParam {

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -33,7 +33,7 @@ import (
 
 func init() {
 	if logLevel := os.Getenv("CERBOS_TEST_LOG_LEVEL"); logLevel != "" {
-		logging.InitLogging(context.Background(), logLevel)
+		logging.InitLogging(context.Background(), logLevel, nil)
 	}
 }
 


### PR DESCRIPTION
Adds ability to switch off Otel instrumentation and inject a different
Zap core to redirect logging.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
