### PR TITLE
Use namer.ScopeValue when fitting

### DIFF
--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -5,12 +5,12 @@ package evaluator
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	"github.com/cerbos/cerbos/internal/conditions"
 	"github.com/cerbos/cerbos/internal/engine/tracer"
+	"github.com/cerbos/cerbos/internal/namer"
 )
 
 type Evaluator interface {
@@ -109,5 +109,5 @@ func Scope(scope string, params EvalParams) string {
 		scope = params.DefaultScope
 	}
 
-	return strings.TrimPrefix(scope, ".")
+	return namer.ScopeValue(scope)
 }

--- a/internal/verify/test_filter.go
+++ b/internal/verify/test_filter.go
@@ -6,7 +6,6 @@ package verify
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
@@ -113,7 +112,7 @@ func policyVersion(fixture interface{ GetPolicyVersion() string }, options *poli
 }
 
 func scope(fixture interface{ GetScope() string }, options *policyv1.TestOptions) string {
-	if scope := strings.TrimPrefix(fixture.GetScope(), "."); scope != "" {
+	if scope := namer.ScopeValue(fixture.GetScope()); scope != "" {
 		return scope
 	}
 


### PR DESCRIPTION
I forgot to update some parts to use `namer.ScopeValue`.