### PR TITLE
Revert breaking change to EPDP interface

### DIFF
--- a/internal/ruletable/evaluator.go
+++ b/internal/ruletable/evaluator.go
@@ -7,12 +7,11 @@ import (
 	"context"
 	"fmt"
 
+	auditv1 "github.com/cerbos/cerbos/api/genpb/cerbos/audit/v1"
 	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	"github.com/cerbos/cerbos/internal/evaluator"
 	"github.com/cerbos/cerbos/internal/schema"
 )
-
-var _ evaluator.Evaluator = (*Evaluator)(nil)
 
 func NewEvaluator(evalConf *evaluator.Conf, schemaConf *schema.Conf, ruleTable *RuleTable) (*Evaluator, error) {
 	schemaMgr, err := schema.NewStaticFromConf(schemaConf, ruleTable.Schemas, ruleTable.JsonSchemas)
@@ -33,12 +32,24 @@ type Evaluator struct {
 	ruleTable *RuleTable
 }
 
-func (e *Evaluator) Check(ctx context.Context, inputs []*enginev1.CheckInput, opts ...evaluator.CheckOpt) ([]*enginev1.CheckOutput, error) {
-	outputs, _, err := e.ruleTable.Check(ctx, e.evalConf, e.schemaMgr, inputs, opts...)
+func (e *Evaluator) Check(ctx context.Context, inputs []*enginev1.CheckInput, opts ...evaluator.CheckOpt) ([]*enginev1.CheckOutput, *auditv1.AuditTrail, error) {
+	return e.ruleTable.Check(ctx, e.evalConf, e.schemaMgr, inputs, opts...)
+}
+
+func (e *Evaluator) Plan(ctx context.Context, input *enginev1.PlanResourcesInput, opts ...evaluator.CheckOpt) (*enginev1.PlanResourcesOutput, *auditv1.AuditTrail, error) {
+	return e.ruleTable.Plan(ctx, e.evalConf, e.schemaMgr, input, opts...)
+}
+
+type withoutAuditTrail Evaluator
+
+var _ evaluator.Evaluator = (*withoutAuditTrail)(nil)
+
+func (w *withoutAuditTrail) Check(ctx context.Context, inputs []*enginev1.CheckInput, opts ...evaluator.CheckOpt) ([]*enginev1.CheckOutput, error) {
+	outputs, _, err := (*Evaluator)(w).Check(ctx, inputs, opts...)
 	return outputs, err
 }
 
-func (e *Evaluator) Plan(ctx context.Context, input *enginev1.PlanResourcesInput, opts ...evaluator.CheckOpt) (*enginev1.PlanResourcesOutput, error) {
-	output, _, err := e.ruleTable.Plan(ctx, e.evalConf, e.schemaMgr, input, opts...)
+func (w *withoutAuditTrail) Plan(ctx context.Context, input *enginev1.PlanResourcesInput, opts ...evaluator.CheckOpt) (*enginev1.PlanResourcesOutput, error) {
+	output, _, err := (*Evaluator)(w).Plan(ctx, input, opts...)
 	return output, err
 }

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -1853,7 +1853,8 @@ func addNode(curr, next *planner.QpN, combine func([]*planner.QpN) *planner.QpN)
 }
 
 func (rt *RuleTable) Evaluator(evalConf *evaluator.Conf, schemaConf *schema.Conf) (evaluator.Evaluator, error) {
-	return NewEvaluator(evalConf, schemaConf, rt)
+	evaluator, err := NewEvaluator(evalConf, schemaConf, rt)
+	return (*withoutAuditTrail)(evaluator), err
 }
 
 // ListRuleTableRowActions returns unique list of actions in a rule table row.

--- a/private/ruletable/ruletable.go
+++ b/private/ruletable/ruletable.go
@@ -4,11 +4,14 @@
 package ruletable
 
 import (
+	"context"
 	"fmt"
 
 	epdpv2 "github.com/cerbos/cloud-api/genpb/cerbos/cloud/epdp/v2"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	auditv1 "github.com/cerbos/cerbos/api/genpb/cerbos/audit/v1"
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
 	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
 	"github.com/cerbos/cerbos/internal/evaluator"
 	"github.com/cerbos/cerbos/internal/namer"
@@ -17,9 +20,12 @@ import (
 	"github.com/cerbos/cerbos/internal/schema"
 )
 
-type RuleTable = internalruletable.RuleTable
+type Evaluator interface {
+	Check(context.Context, []*enginev1.CheckInput, ...evaluator.CheckOpt) ([]*enginev1.CheckOutput, *auditv1.AuditTrail, error)
+	Plan(context.Context, *enginev1.PlanResourcesInput, ...evaluator.CheckOpt) (*enginev1.PlanResourcesOutput, *auditv1.AuditTrail, error)
+}
 
-func NewRuleTableFromProto(protoRT *runtimev1.RuleTable, conf *epdpv2.Config) (evaluator.Evaluator, error) {
+func NewRuleTableFromProto(protoRT *runtimev1.RuleTable, conf *epdpv2.Config) (Evaluator, error) {
 	rt, err := internalruletable.NewRuleTable(index.NewMem(), protoRT)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create rule table: %w", err)


### PR DESCRIPTION
https://github.com/cerbos/cerbos/pull/2836 is a breaking change for the EPDP because it removes the audit trail from the returned values.

This PR reverts to the previous interface and makes it explicit to help prevent future regressions.