### PR TITLE
chore: Ruletable optimization clean-up

### DIFF
--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -265,7 +265,6 @@ func intersect3(a, b, c *rowSet) *rowSet {
 		}
 	}
 
-	// sets is a fixed-size [3] array, so indexing is always safe
 	small, mid, large := sets[0], sets[1], sets[2] //nolint:gosec // G602: false positive
 	// Pre-allocate with capacity of smallest set
 	res := newRowSetCap(len(small.m))


### PR DESCRIPTION
Mostly clean-up, but also a few optimisations (a marginal improvement):
- unionAll special case,
- hasIntersectionWith,
- GetAllRows result pre-allocation (not covered by the BenchmarkEvaluator).