### PR TITLE
Add build constraint to compile manager

### DIFF
--- a/internal/compile/manager.go
+++ b/internal/compile/manager.go
@@ -1,6 +1,8 @@
 // Copyright 2021-2025 Zenauth Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !js && !wasm
+
 package compile
 
 import (


### PR DESCRIPTION
Fixes a build issue arising from compile manager requiring access to
storage packages.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
