### PR TITLE
Use shared Renovate config preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,20 +1,9 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "configMigration": true,
-    "commitMessageLowerCase": "never",
-    "minimumReleaseAge": "5 days",
-    "internalChecksFilter": "strict",
     "extends": [
+        "github>cerbos/renovate",
         "group:allNonMajor",
-        "helpers:pinGitHubActionDigests",
-        "schedule:weekly",
-        ":automergeDisabled",
-        ":combinePatchMinorReleases",
-        ":dependencyDashboard",
-        ":gitSignOff",
-        ":renovatePrefix",
-        ":semanticCommitTypeAll(chore)",
-        ":separateMultipleMajorReleases"
+        ":combinePatchMinorReleases"
     ],
     "ignoreDeps": [
         "github.com/cerbos/go-yaml"
@@ -49,11 +38,7 @@
                 "gomod"
             ],
             "groupName": "Go deps",
-            "groupSlug": "go-deps",
-            "postUpdateOptions": [
-                "gomodTidy",
-                "gomodUpdateImportPaths"
-            ]
+            "groupSlug": "go-deps"
         },
         {
             "matchManagers": [


### PR DESCRIPTION
This PR updates the Renovate config to use [our shared preset](https://github.com/cerbos/renovate/blob/main/default.json).