### PR TITLE
enhancement: Stream test suite results

### DIFF
--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -65,8 +65,7 @@ func Verify(ctx context.Context, fsys fs.FS, eng Checker, conf Config) (*policyv
 
 // VerifyStream runs test suites and streams results as each suite completes.
 // It returns the number of test suites, a channel of results, and any setup error.
-// Callers must either consume all results from the channel or cancel the context
-// to avoid goroutine leaks.
+// Callers may cancel the context to stop workers early and avoid unnecessary work.
 func VerifyStream(ctx context.Context, fsys fs.FS, eng Checker, conf Config) (int, <-chan SuiteResult, error) {
 	suiteDefs, fixtureDefs, err := discoverTestFiles(ctx, fsys)
 	if err != nil {


### PR DESCRIPTION
Add verify.VerifyStream function that streams test suite results via channel as each suite completes.
By default, it runs tests concurrently.

```txt
goos: linux
goarch: arm64
pkg: github.com/cerbos/cerbos/internal/verify
         │ ../cerbos-main/before.txt │              after.txt              │
         │          sec/op           │   sec/op     vs base                │
Verify-5                 173.9m ± 5%   108.4m ± 3%  -37.65% (p=0.000 n=10)

         │ ../cerbos-main/before.txt │              after.txt              │
         │           B/op            │     B/op      vs base               │
Verify-5                153.5Mi ± 0%   153.0Mi ± 0%  -0.31% (p=0.001 n=10)

         │ ../cerbos-main/before.txt │             after.txt              │
         │         allocs/op         │  allocs/op   vs base               │
Verify-5                 2.342M ± 0%   2.340M ± 0%  -0.07% (p=0.001 n=10)
```