### PR TITLE
fix: Sanitize `redisMap.getAllKeys` to return the category key alone

### DIFF
--- a/internal/ruletable/index/redis.go
+++ b/internal/ruletable/index/redis.go
@@ -397,7 +397,7 @@ func (rm *redisMap) getAllKeys(ctx context.Context) (map[string]struct{}, error)
 
 	res := make(map[string]struct{}, len(catsKeys))
 	for _, catKey := range catsKeys {
-		res[catKey] = struct{}{}
+		res[rm.catFromSumsKey(catKey)] = struct{}{}
 	}
 
 	return res, nil


### PR DESCRIPTION
This should have been the case prior, I missed it when I copied the `getAll` implementation.