### PR TITLE
Remove `cerbos.runtime.v1.Expr.checked_v2` field

### DIFF
--- a/api/genpb/cerbos/runtime/v1/hashpb_helpers.pb.go
+++ b/api/genpb/cerbos/runtime/v1/hashpb_helpers.pb.go
@@ -169,11 +169,6 @@ func cerbos_runtime_v1_Expr_hashpb_sum(m *Expr, hasher hash.Hash, ignore map[str
 			google_api_expr_v1alpha1_CheckedExpr_hashpb_sum(m.GetChecked(), hasher, ignore)
 		}
 	}
-	if _, ok := ignore["cerbos.runtime.v1.Expr.checked_v2"]; !ok {
-		if m.GetCheckedV2() != nil {
-			google_api_expr_v1alpha1_CheckedExpr_hashpb_sum(m.GetCheckedV2(), hasher, ignore)
-		}
-	}
 }
 
 func cerbos_runtime_v1_IndexBuildErrors_Disabled_hashpb_sum(m *IndexBuildErrors_Disabled, hasher hash.Hash, ignore map[string]struct{}) {

--- a/api/genpb/cerbos/runtime/v1/runtime.pb.go
+++ b/api/genpb/cerbos/runtime/v1/runtime.pb.go
@@ -828,11 +828,9 @@ func (x *RunnablePrincipalPolicySet) GetPolicies() []*RunnablePrincipalPolicySet
 }
 
 type Expr struct {
-	state    protoimpl.MessageState `protogen:"open.v1"`
-	Original string                 `protobuf:"bytes,1,opt,name=original,proto3" json:"original,omitempty"`
-	// Deprecated: Marked as deprecated in cerbos/runtime/v1/runtime.proto.
-	Checked       *v1alpha1.CheckedExpr `protobuf:"bytes,2,opt,name=checked,proto3" json:"checked,omitempty"`
-	CheckedV2     *v1alpha1.CheckedExpr `protobuf:"bytes,3,opt,name=checked_v2,json=checkedV2,proto3" json:"checked_v2,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Original      string                 `protobuf:"bytes,1,opt,name=original,proto3" json:"original,omitempty"`
+	Checked       *v1alpha1.CheckedExpr  `protobuf:"bytes,2,opt,name=checked,proto3" json:"checked,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -874,17 +872,9 @@ func (x *Expr) GetOriginal() string {
 	return ""
 }
 
-// Deprecated: Marked as deprecated in cerbos/runtime/v1/runtime.proto.
 func (x *Expr) GetChecked() *v1alpha1.CheckedExpr {
 	if x != nil {
 		return x.Checked
-	}
-	return nil
-}
-
-func (x *Expr) GetCheckedV2() *v1alpha1.CheckedExpr {
-	if x != nil {
-		return x.CheckedV2
 	}
 	return nil
 }
@@ -3537,12 +3527,10 @@ const file_cerbos_runtime_v1_runtime_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v2B.cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesR\x05value:\x028\x01\x1aT\n" +
 	"\x0eConstantsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
-	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"\xad\x01\n" +
+	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"c\n" +
 	"\x04Expr\x12\x1a\n" +
-	"\boriginal\x18\x01 \x01(\tR\boriginal\x12C\n" +
-	"\achecked\x18\x02 \x01(\v2%.google.api.expr.v1alpha1.CheckedExprB\x02\x18\x01R\achecked\x12D\n" +
-	"\n" +
-	"checked_v2\x18\x03 \x01(\v2%.google.api.expr.v1alpha1.CheckedExprR\tcheckedV2\"\xca\x01\n" +
+	"\boriginal\x18\x01 \x01(\tR\boriginal\x12?\n" +
+	"\achecked\x18\x02 \x01(\v2%.google.api.expr.v1alpha1.CheckedExprR\achecked\"\xca\x01\n" +
 	"\x06Output\x122\n" +
 	"\x04when\x18\x01 \x01(\v2\x1e.cerbos.runtime.v1.Output.WhenR\x04when\x1a\x8b\x01\n" +
 	"\x04When\x12>\n" +
@@ -3748,113 +3736,112 @@ var file_cerbos_runtime_v1_runtime_proto_depIdxs = []int32{
 	62,  // 29: cerbos.runtime.v1.RunnablePrincipalPolicySet.meta:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata
 	63,  // 30: cerbos.runtime.v1.RunnablePrincipalPolicySet.policies:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy
 	82,  // 31: cerbos.runtime.v1.Expr.checked:type_name -> google.api.expr.v1alpha1.CheckedExpr
-	82,  // 32: cerbos.runtime.v1.Expr.checked_v2:type_name -> google.api.expr.v1alpha1.CheckedExpr
-	71,  // 33: cerbos.runtime.v1.Output.when:type_name -> cerbos.runtime.v1.Output.When
-	9,   // 34: cerbos.runtime.v1.Variable.expr:type_name -> cerbos.runtime.v1.Expr
-	72,  // 35: cerbos.runtime.v1.Condition.all:type_name -> cerbos.runtime.v1.Condition.ExprList
-	72,  // 36: cerbos.runtime.v1.Condition.any:type_name -> cerbos.runtime.v1.Condition.ExprList
-	72,  // 37: cerbos.runtime.v1.Condition.none:type_name -> cerbos.runtime.v1.Condition.ExprList
-	9,   // 38: cerbos.runtime.v1.Condition.expr:type_name -> cerbos.runtime.v1.Expr
-	73,  // 39: cerbos.runtime.v1.CompileErrors.errors:type_name -> cerbos.runtime.v1.CompileErrors.Err
-	74,  // 40: cerbos.runtime.v1.IndexBuildErrors.duplicate_defs:type_name -> cerbos.runtime.v1.IndexBuildErrors.DuplicateDef
-	78,  // 41: cerbos.runtime.v1.IndexBuildErrors.load_failures:type_name -> cerbos.runtime.v1.IndexBuildErrors.LoadFailure
-	75,  // 42: cerbos.runtime.v1.IndexBuildErrors.missing_imports:type_name -> cerbos.runtime.v1.IndexBuildErrors.MissingImport
-	79,  // 43: cerbos.runtime.v1.IndexBuildErrors.disabled_defs:type_name -> cerbos.runtime.v1.IndexBuildErrors.Disabled
-	76,  // 44: cerbos.runtime.v1.IndexBuildErrors.missing_scope_details:type_name -> cerbos.runtime.v1.IndexBuildErrors.MissingScope
-	77,  // 45: cerbos.runtime.v1.IndexBuildErrors.scope_permissions_conflicts:type_name -> cerbos.runtime.v1.IndexBuildErrors.ScopePermissionsConflicts
-	14,  // 46: cerbos.runtime.v1.Errors.index_build_errors:type_name -> cerbos.runtime.v1.IndexBuildErrors
-	13,  // 47: cerbos.runtime.v1.Errors.compile_errors:type_name -> cerbos.runtime.v1.CompileErrors
-	26,  // 48: cerbos.runtime.v1.RuleTable.RuleRow.allow_actions:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.AllowActions
-	12,  // 49: cerbos.runtime.v1.RuleTable.RuleRow.condition:type_name -> cerbos.runtime.v1.Condition
-	12,  // 50: cerbos.runtime.v1.RuleTable.RuleRow.derived_role_condition:type_name -> cerbos.runtime.v1.Condition
-	83,  // 51: cerbos.runtime.v1.RuleTable.RuleRow.effect:type_name -> cerbos.effect.v1.Effect
-	80,  // 52: cerbos.runtime.v1.RuleTable.RuleRow.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
-	10,  // 53: cerbos.runtime.v1.RuleTable.RuleRow.emit_output:type_name -> cerbos.runtime.v1.Output
-	27,  // 54: cerbos.runtime.v1.RuleTable.RuleRow.params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
-	27,  // 55: cerbos.runtime.v1.RuleTable.RuleRow.derived_role_params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
-	84,  // 56: cerbos.runtime.v1.RuleTable.RuleRow.policy_kind:type_name -> cerbos.policy.v1.Kind
-	31,  // 57: cerbos.runtime.v1.RuleTable.RoleParentRoles.role_parent_roles:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry
-	32,  // 58: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.derived_roles:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry
-	81,  // 59: cerbos.runtime.v1.RuleTable.SchemasEntry.value:type_name -> cerbos.policy.v1.Schemas
-	2,   // 60: cerbos.runtime.v1.RuleTable.MetaEntry.value:type_name -> cerbos.runtime.v1.RuleTableMetadata
-	17,  // 61: cerbos.runtime.v1.RuleTable.ScopeParentRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles
-	18,  // 62: cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRoles
-	19,  // 63: cerbos.runtime.v1.RuleTable.JsonSchemasEntry.value:type_name -> cerbos.runtime.v1.RuleTable.JSONSchema
-	28,  // 64: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.actions:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry
-	11,  // 65: cerbos.runtime.v1.RuleTable.RuleRow.Params.ordered_variables:type_name -> cerbos.runtime.v1.Variable
-	29,  // 66: cerbos.runtime.v1.RuleTable.RuleRow.Params.constants:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry
-	85,  // 67: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry.value:type_name -> google.protobuf.Empty
-	86,  // 68: cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry.value:type_name -> google.protobuf.Value
-	30,  // 69: cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles.ParentRoles
-	5,   // 70: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
-	87,  // 71: cerbos.runtime.v1.RuleTableMetadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
-	39,  // 72: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry
-	40,  // 73: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata.AnnotationsEntry
-	41,  // 74: cerbos.runtime.v1.RunnableRolePolicySet.Rule.allow_actions:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry
-	12,  // 75: cerbos.runtime.v1.RunnableRolePolicySet.Rule.condition:type_name -> cerbos.runtime.v1.Condition
-	36,  // 76: cerbos.runtime.v1.RunnableRolePolicySet.RuleList.rules:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Rule
-	37,  // 77: cerbos.runtime.v1.RunnableRolePolicySet.ResourcesEntry.value:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.RuleList
-	87,  // 78: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
-	85,  // 79: cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry.value:type_name -> google.protobuf.Empty
-	44,  // 80: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry
-	45,  // 81: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.AnnotationsEntry
-	47,  // 82: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.derived_roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry
-	48,  // 83: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.variables:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry
-	46,  // 84: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.rules:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule
-	81,  // 85: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.schemas:type_name -> cerbos.policy.v1.Schemas
-	11,  // 86: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ordered_variables:type_name -> cerbos.runtime.v1.Variable
-	80,  // 87: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
-	49,  // 88: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.constants:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry
-	87,  // 89: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
-	50,  // 90: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.actions:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry
-	51,  // 91: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.derived_roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry
-	52,  // 92: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry
-	12,  // 93: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.condition:type_name -> cerbos.runtime.v1.Condition
-	83,  // 94: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.effect:type_name -> cerbos.effect.v1.Effect
-	9,   // 95: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.output:type_name -> cerbos.runtime.v1.Expr
-	10,  // 96: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.emit_output:type_name -> cerbos.runtime.v1.Output
-	5,   // 97: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
-	9,   // 98: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
-	86,  // 99: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry.value:type_name -> google.protobuf.Value
-	85,  // 100: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry.value:type_name -> google.protobuf.Empty
-	85,  // 101: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry.value:type_name -> google.protobuf.Empty
-	85,  // 102: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry.value:type_name -> google.protobuf.Empty
-	85,  // 103: cerbos.runtime.v1.RunnableDerivedRole.ParentRolesEntry.value:type_name -> google.protobuf.Empty
-	9,   // 104: cerbos.runtime.v1.RunnableDerivedRole.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
-	86,  // 105: cerbos.runtime.v1.RunnableDerivedRole.ConstantsEntry.value:type_name -> google.protobuf.Value
-	58,  // 106: cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.AnnotationsEntry
-	5,   // 107: cerbos.runtime.v1.RunnableDerivedRolesSet.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
-	61,  // 108: cerbos.runtime.v1.RunnableVariablesSet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableVariablesSet.Metadata.AnnotationsEntry
-	9,   // 109: cerbos.runtime.v1.RunnableVariablesSet.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
-	64,  // 110: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry
-	65,  // 111: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.AnnotationsEntry
-	68,  // 112: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.variables:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry
-	69,  // 113: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.resource_rules:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry
-	11,  // 114: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ordered_variables:type_name -> cerbos.runtime.v1.Variable
-	80,  // 115: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
-	70,  // 116: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.constants:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry
-	87,  // 117: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
-	12,  // 118: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.condition:type_name -> cerbos.runtime.v1.Condition
-	83,  // 119: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.effect:type_name -> cerbos.effect.v1.Effect
-	9,   // 120: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.output:type_name -> cerbos.runtime.v1.Expr
-	10,  // 121: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.emit_output:type_name -> cerbos.runtime.v1.Output
-	66,  // 122: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules.action_rules:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule
-	9,   // 123: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
-	67,  // 124: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry.value:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules
-	86,  // 125: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry.value:type_name -> google.protobuf.Value
-	9,   // 126: cerbos.runtime.v1.Output.When.rule_activated:type_name -> cerbos.runtime.v1.Expr
-	9,   // 127: cerbos.runtime.v1.Output.When.condition_not_met:type_name -> cerbos.runtime.v1.Expr
-	12,  // 128: cerbos.runtime.v1.Condition.ExprList.expr:type_name -> cerbos.runtime.v1.Condition
-	88,  // 129: cerbos.runtime.v1.CompileErrors.Err.position:type_name -> cerbos.source.v1.Position
-	88,  // 130: cerbos.runtime.v1.IndexBuildErrors.DuplicateDef.position:type_name -> cerbos.source.v1.Position
-	88,  // 131: cerbos.runtime.v1.IndexBuildErrors.MissingImport.position:type_name -> cerbos.source.v1.Position
-	89,  // 132: cerbos.runtime.v1.IndexBuildErrors.LoadFailure.error_details:type_name -> cerbos.source.v1.Error
-	88,  // 133: cerbos.runtime.v1.IndexBuildErrors.Disabled.position:type_name -> cerbos.source.v1.Position
-	134, // [134:134] is the sub-list for method output_type
-	134, // [134:134] is the sub-list for method input_type
-	134, // [134:134] is the sub-list for extension type_name
-	134, // [134:134] is the sub-list for extension extendee
-	0,   // [0:134] is the sub-list for field type_name
+	71,  // 32: cerbos.runtime.v1.Output.when:type_name -> cerbos.runtime.v1.Output.When
+	9,   // 33: cerbos.runtime.v1.Variable.expr:type_name -> cerbos.runtime.v1.Expr
+	72,  // 34: cerbos.runtime.v1.Condition.all:type_name -> cerbos.runtime.v1.Condition.ExprList
+	72,  // 35: cerbos.runtime.v1.Condition.any:type_name -> cerbos.runtime.v1.Condition.ExprList
+	72,  // 36: cerbos.runtime.v1.Condition.none:type_name -> cerbos.runtime.v1.Condition.ExprList
+	9,   // 37: cerbos.runtime.v1.Condition.expr:type_name -> cerbos.runtime.v1.Expr
+	73,  // 38: cerbos.runtime.v1.CompileErrors.errors:type_name -> cerbos.runtime.v1.CompileErrors.Err
+	74,  // 39: cerbos.runtime.v1.IndexBuildErrors.duplicate_defs:type_name -> cerbos.runtime.v1.IndexBuildErrors.DuplicateDef
+	78,  // 40: cerbos.runtime.v1.IndexBuildErrors.load_failures:type_name -> cerbos.runtime.v1.IndexBuildErrors.LoadFailure
+	75,  // 41: cerbos.runtime.v1.IndexBuildErrors.missing_imports:type_name -> cerbos.runtime.v1.IndexBuildErrors.MissingImport
+	79,  // 42: cerbos.runtime.v1.IndexBuildErrors.disabled_defs:type_name -> cerbos.runtime.v1.IndexBuildErrors.Disabled
+	76,  // 43: cerbos.runtime.v1.IndexBuildErrors.missing_scope_details:type_name -> cerbos.runtime.v1.IndexBuildErrors.MissingScope
+	77,  // 44: cerbos.runtime.v1.IndexBuildErrors.scope_permissions_conflicts:type_name -> cerbos.runtime.v1.IndexBuildErrors.ScopePermissionsConflicts
+	14,  // 45: cerbos.runtime.v1.Errors.index_build_errors:type_name -> cerbos.runtime.v1.IndexBuildErrors
+	13,  // 46: cerbos.runtime.v1.Errors.compile_errors:type_name -> cerbos.runtime.v1.CompileErrors
+	26,  // 47: cerbos.runtime.v1.RuleTable.RuleRow.allow_actions:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.AllowActions
+	12,  // 48: cerbos.runtime.v1.RuleTable.RuleRow.condition:type_name -> cerbos.runtime.v1.Condition
+	12,  // 49: cerbos.runtime.v1.RuleTable.RuleRow.derived_role_condition:type_name -> cerbos.runtime.v1.Condition
+	83,  // 50: cerbos.runtime.v1.RuleTable.RuleRow.effect:type_name -> cerbos.effect.v1.Effect
+	80,  // 51: cerbos.runtime.v1.RuleTable.RuleRow.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
+	10,  // 52: cerbos.runtime.v1.RuleTable.RuleRow.emit_output:type_name -> cerbos.runtime.v1.Output
+	27,  // 53: cerbos.runtime.v1.RuleTable.RuleRow.params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
+	27,  // 54: cerbos.runtime.v1.RuleTable.RuleRow.derived_role_params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
+	84,  // 55: cerbos.runtime.v1.RuleTable.RuleRow.policy_kind:type_name -> cerbos.policy.v1.Kind
+	31,  // 56: cerbos.runtime.v1.RuleTable.RoleParentRoles.role_parent_roles:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry
+	32,  // 57: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.derived_roles:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry
+	81,  // 58: cerbos.runtime.v1.RuleTable.SchemasEntry.value:type_name -> cerbos.policy.v1.Schemas
+	2,   // 59: cerbos.runtime.v1.RuleTable.MetaEntry.value:type_name -> cerbos.runtime.v1.RuleTableMetadata
+	17,  // 60: cerbos.runtime.v1.RuleTable.ScopeParentRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles
+	18,  // 61: cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRoles
+	19,  // 62: cerbos.runtime.v1.RuleTable.JsonSchemasEntry.value:type_name -> cerbos.runtime.v1.RuleTable.JSONSchema
+	28,  // 63: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.actions:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry
+	11,  // 64: cerbos.runtime.v1.RuleTable.RuleRow.Params.ordered_variables:type_name -> cerbos.runtime.v1.Variable
+	29,  // 65: cerbos.runtime.v1.RuleTable.RuleRow.Params.constants:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry
+	85,  // 66: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry.value:type_name -> google.protobuf.Empty
+	86,  // 67: cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry.value:type_name -> google.protobuf.Value
+	30,  // 68: cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles.ParentRoles
+	5,   // 69: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
+	87,  // 70: cerbos.runtime.v1.RuleTableMetadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
+	39,  // 71: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry
+	40,  // 72: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata.AnnotationsEntry
+	41,  // 73: cerbos.runtime.v1.RunnableRolePolicySet.Rule.allow_actions:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry
+	12,  // 74: cerbos.runtime.v1.RunnableRolePolicySet.Rule.condition:type_name -> cerbos.runtime.v1.Condition
+	36,  // 75: cerbos.runtime.v1.RunnableRolePolicySet.RuleList.rules:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Rule
+	37,  // 76: cerbos.runtime.v1.RunnableRolePolicySet.ResourcesEntry.value:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.RuleList
+	87,  // 77: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
+	85,  // 78: cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry.value:type_name -> google.protobuf.Empty
+	44,  // 79: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry
+	45,  // 80: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.AnnotationsEntry
+	47,  // 81: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.derived_roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry
+	48,  // 82: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.variables:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry
+	46,  // 83: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.rules:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule
+	81,  // 84: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.schemas:type_name -> cerbos.policy.v1.Schemas
+	11,  // 85: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ordered_variables:type_name -> cerbos.runtime.v1.Variable
+	80,  // 86: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
+	49,  // 87: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.constants:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry
+	87,  // 88: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
+	50,  // 89: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.actions:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry
+	51,  // 90: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.derived_roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry
+	52,  // 91: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry
+	12,  // 92: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.condition:type_name -> cerbos.runtime.v1.Condition
+	83,  // 93: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.effect:type_name -> cerbos.effect.v1.Effect
+	9,   // 94: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.output:type_name -> cerbos.runtime.v1.Expr
+	10,  // 95: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.emit_output:type_name -> cerbos.runtime.v1.Output
+	5,   // 96: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
+	9,   // 97: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
+	86,  // 98: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry.value:type_name -> google.protobuf.Value
+	85,  // 99: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry.value:type_name -> google.protobuf.Empty
+	85,  // 100: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry.value:type_name -> google.protobuf.Empty
+	85,  // 101: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry.value:type_name -> google.protobuf.Empty
+	85,  // 102: cerbos.runtime.v1.RunnableDerivedRole.ParentRolesEntry.value:type_name -> google.protobuf.Empty
+	9,   // 103: cerbos.runtime.v1.RunnableDerivedRole.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
+	86,  // 104: cerbos.runtime.v1.RunnableDerivedRole.ConstantsEntry.value:type_name -> google.protobuf.Value
+	58,  // 105: cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.AnnotationsEntry
+	5,   // 106: cerbos.runtime.v1.RunnableDerivedRolesSet.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
+	61,  // 107: cerbos.runtime.v1.RunnableVariablesSet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableVariablesSet.Metadata.AnnotationsEntry
+	9,   // 108: cerbos.runtime.v1.RunnableVariablesSet.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
+	64,  // 109: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry
+	65,  // 110: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.AnnotationsEntry
+	68,  // 111: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.variables:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry
+	69,  // 112: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.resource_rules:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry
+	11,  // 113: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ordered_variables:type_name -> cerbos.runtime.v1.Variable
+	80,  // 114: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
+	70,  // 115: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.constants:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry
+	87,  // 116: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
+	12,  // 117: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.condition:type_name -> cerbos.runtime.v1.Condition
+	83,  // 118: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.effect:type_name -> cerbos.effect.v1.Effect
+	9,   // 119: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.output:type_name -> cerbos.runtime.v1.Expr
+	10,  // 120: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.emit_output:type_name -> cerbos.runtime.v1.Output
+	66,  // 121: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules.action_rules:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule
+	9,   // 122: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
+	67,  // 123: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry.value:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules
+	86,  // 124: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry.value:type_name -> google.protobuf.Value
+	9,   // 125: cerbos.runtime.v1.Output.When.rule_activated:type_name -> cerbos.runtime.v1.Expr
+	9,   // 126: cerbos.runtime.v1.Output.When.condition_not_met:type_name -> cerbos.runtime.v1.Expr
+	12,  // 127: cerbos.runtime.v1.Condition.ExprList.expr:type_name -> cerbos.runtime.v1.Condition
+	88,  // 128: cerbos.runtime.v1.CompileErrors.Err.position:type_name -> cerbos.source.v1.Position
+	88,  // 129: cerbos.runtime.v1.IndexBuildErrors.DuplicateDef.position:type_name -> cerbos.source.v1.Position
+	88,  // 130: cerbos.runtime.v1.IndexBuildErrors.MissingImport.position:type_name -> cerbos.source.v1.Position
+	89,  // 131: cerbos.runtime.v1.IndexBuildErrors.LoadFailure.error_details:type_name -> cerbos.source.v1.Error
+	88,  // 132: cerbos.runtime.v1.IndexBuildErrors.Disabled.position:type_name -> cerbos.source.v1.Position
+	133, // [133:133] is the sub-list for method output_type
+	133, // [133:133] is the sub-list for method input_type
+	133, // [133:133] is the sub-list for extension type_name
+	133, // [133:133] is the sub-list for extension extendee
+	0,   // [0:133] is the sub-list for field type_name
 }
 
 func init() { file_cerbos_runtime_v1_runtime_proto_init() }

--- a/api/genpb/cerbos/runtime/v1/runtime_vtproto.pb.go
+++ b/api/genpb/cerbos/runtime/v1/runtime_vtproto.pb.go
@@ -2714,28 +2714,6 @@ func (m *Expr) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if m.CheckedV2 != nil {
-		if vtmsg, ok := interface{}(m.CheckedV2).(interface {
-			MarshalToSizedBufferVT([]byte) (int, error)
-		}); ok {
-			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
-			if err != nil {
-				return 0, err
-			}
-			i -= size
-			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
-		} else {
-			encoded, err := proto.Marshal(m.CheckedV2)
-			if err != nil {
-				return 0, err
-			}
-			i -= len(encoded)
-			copy(dAtA[i:], encoded)
-			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
-		}
-		i--
-		dAtA[i] = 0x1a
-	}
 	if m.Checked != nil {
 		if vtmsg, ok := interface{}(m.Checked).(interface {
 			MarshalToSizedBufferVT([]byte) (int, error)
@@ -5060,16 +5038,6 @@ func (m *Expr) SizeVT() (n int) {
 			l = size.SizeVT()
 		} else {
 			l = proto.Size(m.Checked)
-		}
-		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
-	}
-	if m.CheckedV2 != nil {
-		if size, ok := interface{}(m.CheckedV2).(interface {
-			SizeVT() int
-		}); ok {
-			l = size.SizeVT()
-		} else {
-			l = proto.Size(m.CheckedV2)
 		}
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -14428,50 +14396,6 @@ func (m *Expr) UnmarshalVT(dAtA []byte) error {
 				}
 			} else {
 				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Checked); err != nil {
-					return err
-				}
-			}
-			iNdEx = postIndex
-		case 3:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field CheckedV2", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.CheckedV2 == nil {
-				m.CheckedV2 = &v1alpha1.CheckedExpr{}
-			}
-			if unmarshal, ok := interface{}(m.CheckedV2).(interface {
-				UnmarshalVT([]byte) error
-			}); ok {
-				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
-					return err
-				}
-			} else {
-				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.CheckedV2); err != nil {
 					return err
 				}
 			}

--- a/api/private/cerbos/runtime/v1/runtime.proto
+++ b/api/private/cerbos/runtime/v1/runtime.proto
@@ -253,8 +253,7 @@ message RunnablePrincipalPolicySet {
 
 message Expr {
   string original = 1;
-  google.api.expr.v1alpha1.CheckedExpr checked = 2 [deprecated = true];
-  google.api.expr.v1alpha1.CheckedExpr checked_v2 = 3;
+  google.api.expr.v1alpha1.CheckedExpr checked = 2;
 }
 
 message Output {

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -625,6 +625,6 @@ func migrateFromCompilerVersion0To1(policies *runtimev1.RunnablePolicySet) error
 }
 
 func migrateFromCompilerVersion1To2(policies *runtimev1.RunnablePolicySet) error {
-	conditions.WalkExprs(policies, conditions.MigrateExprToCheckedV2)
+	conditions.WalkExprs(policies, conditions.MigrateVariablesType)
 	return nil
 }

--- a/internal/compile/conditions.go
+++ b/internal/compile/conditions.go
@@ -81,8 +81,8 @@ func compileCELExpr(modCtx *moduleCtx, path, expr string, markReferencedConstant
 	}
 
 	return &runtimev1.Expr{
-		Original:  expr,
-		CheckedV2: checkedExpr,
+		Original: expr,
+		Checked:  checkedExpr,
 	}
 }
 

--- a/internal/compile/variables.go
+++ b/internal/compile/variables.go
@@ -185,7 +185,7 @@ func variableDefinitionPlaces(contexts []*variableCtx) []string {
 func (vd *variableDefinitions) resolveReferences() {
 	for referrerName, referrerID := range vd.ids {
 		referrer := vd.graph.Node(referrerID).(*variableNode) //nolint:forcetypeassert
-		constants, variables := vd.references(fmt.Sprintf("variable '%s'", referrerName), referrer.Expr.CheckedV2)
+		constants, variables := vd.references(fmt.Sprintf("variable '%s'", referrerName), referrer.Expr.Checked)
 
 		for referencedConstName := range constants {
 			if !vd.modCtx.constants.IsDefined(referencedConstName) {
@@ -267,7 +267,7 @@ func (vd *variableDefinitions) use(id int64, name string) {
 	vd.used[name] = struct{}{}
 
 	node := vd.graph.Node(id).(*variableNode) //nolint:forcetypeassert
-	vd.modCtx.constants.Use(node.varCtx.path, node.Expr.CheckedV2)
+	vd.modCtx.constants.Use(node.varCtx.path, node.Expr.Checked)
 
 	references := vd.graph.To(id)
 	for references.Next() {

--- a/internal/conditions/cel.go
+++ b/internal/conditions/cel.go
@@ -53,8 +53,7 @@ var (
 		decls.NewVariable(CELGlobalsAbbrev, types.VariablesType),
 	}
 
-	mapStringDynType *exprpb.Type
-	variablesType    *exprpb.Type
+	variablesType *exprpb.Type
 )
 
 func init() {
@@ -86,11 +85,6 @@ func init() {
 	TrueExpr, err = compileConstant("true")
 	if err != nil {
 		panic(fmt.Errorf("failed to compile constant 'true': %w", err))
-	}
-
-	mapStringDynType, err = cel.TypeToExprType(cel.MapType(cel.StringType, cel.DynType))
-	if err != nil {
-		panic(fmt.Errorf("failed to convert map<string, dyn> type to proto: %w", err))
 	}
 
 	variablesType, err = cel.TypeToExprType(types.VariablesType)

--- a/internal/inspect/visit.go
+++ b/internal/inspect/visit.go
@@ -261,7 +261,7 @@ func visitCompiledExpr(expr *runtimev1.Expr, visitor ast.Visitor) error {
 		return nil
 	}
 
-	exprAST, err := ast.ToAST(expr.CheckedV2)
+	exprAST, err := ast.ToAST(expr.Checked)
 	if err != nil {
 		return fmt.Errorf("failed to convert checked expression %q to AST: %w", expr.Original, err)
 	}

--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -1153,7 +1153,7 @@ func getCelProgramsFromExpressions(vars []*runtimev1.Variable) ([]*CelProgram, e
 
 	for i, v := range vars {
 		p, err := conditions.StdEnv.Program(
-			cel.CheckedExprToAst(v.Expr.CheckedV2),
+			cel.CheckedExprToAst(v.Expr.Checked),
 			cel.CustomDecorator(conditions.CacheFriendlyTimeDecorator()),
 		)
 		if err != nil {

--- a/internal/ruletable/planner/planner.go
+++ b/internal/ruletable/planner/planner.go
@@ -390,7 +390,7 @@ func (evalCtx *EvalContext) EvaluateCondition(ctx context.Context, condition *ru
 			res.Node = &qpNLO{LogicalOperation: MkAndLogicalOperation(nodes)}
 		}
 	case *runtimev1.Condition_Expr:
-		expr := t.Expr.GetCheckedV2().GetExpr()
+		expr := t.Expr.GetChecked().GetExpr()
 		ex, err := celast.ProtoToExpr(expr)
 		if err != nil {
 			return nil, fmt.Errorf("celast.ProtoToExpr: %w", err)
@@ -713,7 +713,7 @@ func VariableExprs(variables []*runtimev1.Variable) (map[string]celast.Expr, err
 
 	exprs := make(map[string]celast.Expr, len(variables))
 	for _, variable := range variables {
-		e, err := celast.ProtoToExpr(variable.Expr.GetCheckedV2().GetExpr())
+		e, err := celast.ProtoToExpr(variable.Expr.GetChecked().GetExpr())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/ruletable/planner/planner_test.go
+++ b/internal/ruletable/planner/planner_test.go
@@ -57,8 +57,8 @@ func Test_evaluateCondition(t *testing.T) {
 		checkedExpr, err := cel.AstToCheckedExpr(ast)
 		require.NoError(t, err)
 		c := &runtimev1.Condition{Op: &runtimev1.Condition_Expr{Expr: &runtimev1.Expr{
-			Original:  expr,
-			CheckedV2: checkedExpr,
+			Original: expr,
+			Checked:  checkedExpr,
 		}}}
 		return args{
 			expr:      expr,

--- a/internal/test/testdata/compile/multiple_imports.yaml.golden
+++ b/internal/test/testdata/compile/multiple_imports.yaml.golden
@@ -34,7 +34,7 @@
                   {
                     "expr": {
                       "original": "request.resource.attr.geography == request.principal.attr.geography",
-                      "checkedV2": {
+                      "checked": {
                         "referenceMap": {
                           "1": {
                             "name": "request"
@@ -170,7 +170,7 @@
                   {
                     "expr": {
                       "original": "request.resource.attr.geography == request.principal.attr.managed_geographies",
-                      "checkedV2": {
+                      "checked": {
                         "referenceMap": {
                           "1": {
                             "name": "request"
@@ -316,7 +316,7 @@
             "condition": {
               "expr": {
                 "original": "R.attr.owner == P.id",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "R"
@@ -468,7 +468,7 @@
             "condition": {
               "expr": {
                 "original": "request.resource.attr.status == \"PENDING_APPROVAL\"",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "request"

--- a/internal/test/testdata/compile/principal_policy.yaml.golden
+++ b/internal/test/testdata/compile/principal_policy.yaml.golden
@@ -24,7 +24,7 @@
                 "condition": {
                   "expr": {
                     "original": "request.resource.attr.dev_record == true",
-                    "checkedV2": {
+                    "checked": {
                       "referenceMap": {
                         "1": {
                           "name": "request"
@@ -122,7 +122,7 @@
                   "when": {
                     "ruleActivated": {
                       "original": "\"donald_duck_dev_record_override:%s\".format([request.resource.attr.dev_record == true])",
-                      "checkedV2": {
+                      "checked": {
                         "referenceMap": {
                           "2": {
                             "overloadId": [

--- a/internal/test/testdata/compile/scoped_principal_policy_set.yaml.golden
+++ b/internal/test/testdata/compile/scoped_principal_policy_set.yaml.golden
@@ -70,7 +70,7 @@
                 "condition": {
                   "expr": {
                     "original": "request.resource.attr.dev_record == true",
-                    "checkedV2": {
+                    "checked": {
                       "referenceMap": {
                         "1": {
                           "name": "request"

--- a/internal/test/testdata/compile/scoped_resource_policy_set.yaml.golden
+++ b/internal/test/testdata/compile/scoped_resource_policy_set.yaml.golden
@@ -43,7 +43,7 @@
                   {
                     "expr": {
                       "original": "request.resource.attr.geography == request.principal.attr.geography",
-                      "checkedV2": {
+                      "checked": {
                         "referenceMap": {
                           "1": {
                             "name": "request"
@@ -179,7 +179,7 @@
                   {
                     "expr": {
                       "original": "request.resource.attr.geography == request.principal.attr.managed_geographies",
-                      "checkedV2": {
+                      "checked": {
                         "referenceMap": {
                           "1": {
                             "name": "request"
@@ -333,7 +333,7 @@
             "condition": {
               "expr": {
                 "original": "request.resource.attr.status == \"PENDING_APPROVAL\"",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "request"
@@ -469,7 +469,7 @@
                   {
                     "expr": {
                       "original": "request.resource.attr.geography == request.principal.attr.geography",
-                      "checkedV2": {
+                      "checked": {
                         "referenceMap": {
                           "1": {
                             "name": "request"
@@ -605,7 +605,7 @@
                   {
                     "expr": {
                       "original": "request.resource.attr.geography == request.principal.attr.managed_geographies",
-                      "checkedV2": {
+                      "checked": {
                         "referenceMap": {
                           "1": {
                             "name": "request"
@@ -751,7 +751,7 @@
             "condition": {
               "expr": {
                 "original": "R.attr.owner == P.id",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "R"
@@ -893,7 +893,7 @@
             "condition": {
               "expr": {
                 "original": "request.resource.attr.status == \"PENDING_APPROVAL\"",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "request"

--- a/internal/test/testdata/compile/simple_valid_policy_set.yaml.golden
+++ b/internal/test/testdata/compile/simple_valid_policy_set.yaml.golden
@@ -34,7 +34,7 @@
                   {
                     "expr": {
                       "original": "request.resource.attr.geography == request.principal.attr.geography",
-                      "checkedV2": {
+                      "checked": {
                         "referenceMap": {
                           "1": {
                             "name": "request"
@@ -170,7 +170,7 @@
                   {
                     "expr": {
                       "original": "request.resource.attr.geography == request.principal.attr.managed_geographies",
-                      "checkedV2": {
+                      "checked": {
                         "referenceMap": {
                           "1": {
                             "name": "request"
@@ -316,7 +316,7 @@
             "condition": {
               "expr": {
                 "original": "R.attr.owner == P.id",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "R"
@@ -429,7 +429,7 @@
               "when": {
                 "ruleActivated": {
                   "original": "\"wildcard:%s\".format([request.principal.id])",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "2": {
                         "overloadId": [
@@ -521,7 +521,7 @@
                 },
                 "conditionNotMet": {
                   "original": "\"condition_not_met:wildcard:%s\".format([request.principal.id])",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "2": {
                         "overloadId": [
@@ -627,7 +627,7 @@
               "when": {
                 "ruleActivated": {
                   "original": "\"create:%s\".format([request.principal.id])",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "2": {
                         "overloadId": [
@@ -734,7 +734,7 @@
               "when": {
                 "conditionNotMet": {
                   "original": "\"something_arbitrary\"",
-                  "checkedV2": {
+                  "checked": {
                     "typeMap": {
                       "1": {
                         "primitive": "STRING"
@@ -781,7 +781,7 @@
             "condition": {
               "expr": {
                 "original": "// Comment\nrequest.resource.attr.status == \"PENDING_APPROVAL\"",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "request"
@@ -880,7 +880,7 @@
               "when": {
                 "ruleActivated": {
                   "original": "\"pending_approval:%s\".format([request.resource.attr.status == \"PENDING_APPROVAL\"])",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "2": {
                         "overloadId": [

--- a/internal/test/testdata/compile/variables_principal_policy.yaml.golden
+++ b/internal/test/testdata/compile/variables_principal_policy.yaml.golden
@@ -24,7 +24,7 @@
         "variables": {
           "a": {
             "original": "constants.a",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "constants"
@@ -64,7 +64,7 @@
           },
           "ab": {
             "original": "V.a + V.b",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "V"
@@ -152,7 +152,7 @@
           },
           "b": {
             "original": "C.b",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "C"
@@ -192,7 +192,7 @@
           },
           "j": {
             "original": "constants.j",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "constants"
@@ -240,7 +240,7 @@
                 "condition": {
                   "expr": {
                     "original": "V.ab < V.j && V.ab > C.z",
-                    "checkedV2": {
+                    "checked": {
                       "referenceMap": {
                         "1": {
                           "name": "V"
@@ -435,7 +435,7 @@
             "name": "a",
             "expr": {
               "original": "constants.a",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "constants"
@@ -478,7 +478,7 @@
             "name": "b",
             "expr": {
               "original": "C.b",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "C"
@@ -521,7 +521,7 @@
             "name": "ab",
             "expr": {
               "original": "V.a + V.b",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "V"
@@ -612,7 +612,7 @@
             "name": "j",
             "expr": {
               "original": "constants.j",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "constants"
@@ -664,7 +664,7 @@
         "variables": {
           "a": {
             "original": "constants.a",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "constants"
@@ -704,7 +704,7 @@
           },
           "ab": {
             "original": "V.a + V.b",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "V"
@@ -792,7 +792,7 @@
           },
           "abc": {
             "original": "variables.ab + variables.c",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "variables"
@@ -880,7 +880,7 @@
           },
           "abce": {
             "original": "variables.abc + variables.e",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "variables"
@@ -968,7 +968,7 @@
           },
           "b": {
             "original": "C.b",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "C"
@@ -1008,7 +1008,7 @@
           },
           "c": {
             "original": "constants.c",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "constants"
@@ -1048,7 +1048,7 @@
           },
           "e": {
             "original": "constants.e",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "constants"
@@ -1088,7 +1088,7 @@
           },
           "f": {
             "original": "C.f",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "C"
@@ -1128,7 +1128,7 @@
           },
           "h": {
             "original": "C.h",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "C"
@@ -1176,7 +1176,7 @@
                 "condition": {
                   "expr": {
                     "original": "V.abce > C.z",
-                    "checkedV2": {
+                    "checked": {
                       "referenceMap": {
                         "1": {
                           "name": "V"
@@ -1273,7 +1273,7 @@
                   "when": {
                     "ruleActivated": {
                       "original": "variables.f",
-                      "checkedV2": {
+                      "checked": {
                         "referenceMap": {
                           "1": {
                             "name": "variables"
@@ -1324,7 +1324,7 @@
                 "condition": {
                   "expr": {
                     "original": "variables.h > constants.z",
-                    "checkedV2": {
+                    "checked": {
                       "referenceMap": {
                         "1": {
                           "name": "variables"
@@ -1426,7 +1426,7 @@
             "name": "a",
             "expr": {
               "original": "constants.a",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "constants"
@@ -1469,7 +1469,7 @@
             "name": "b",
             "expr": {
               "original": "C.b",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "C"
@@ -1512,7 +1512,7 @@
             "name": "ab",
             "expr": {
               "original": "V.a + V.b",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "V"
@@ -1603,7 +1603,7 @@
             "name": "c",
             "expr": {
               "original": "constants.c",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "constants"
@@ -1646,7 +1646,7 @@
             "name": "abc",
             "expr": {
               "original": "variables.ab + variables.c",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "variables"
@@ -1737,7 +1737,7 @@
             "name": "e",
             "expr": {
               "original": "constants.e",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "constants"
@@ -1780,7 +1780,7 @@
             "name": "abce",
             "expr": {
               "original": "variables.abc + variables.e",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "variables"
@@ -1871,7 +1871,7 @@
             "name": "f",
             "expr": {
               "original": "C.f",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "C"
@@ -1914,7 +1914,7 @@
             "name": "h",
             "expr": {
               "original": "C.h",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "C"

--- a/internal/test/testdata/compile/variables_resource_policy.yaml.golden
+++ b/internal/test/testdata/compile/variables_resource_policy.yaml.golden
@@ -30,7 +30,7 @@
             "variables": {
               "b": {
                 "original": "C.b",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "C"
@@ -70,7 +70,7 @@
               },
               "c": {
                 "original": "constants.c",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "constants"
@@ -110,7 +110,7 @@
               },
               "f": {
                 "original": "C.f",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "C"
@@ -150,7 +150,7 @@
               },
               "h": {
                 "original": "constants.h",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "constants"
@@ -190,7 +190,7 @@
               },
               "hi": {
                 "original": "V.h + V.i",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "V"
@@ -278,7 +278,7 @@
               },
               "i": {
                 "original": "C.i",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "C"
@@ -323,7 +323,7 @@
                   {
                     "expr": {
                       "original": "V.b > V.c",
-                      "checkedV2": {
+                      "checked": {
                         "referenceMap": {
                           "1": {
                             "name": "V"
@@ -418,7 +418,7 @@
                   {
                     "expr": {
                       "original": "variables.f > variables.hi",
-                      "checkedV2": {
+                      "checked": {
                         "referenceMap": {
                           "1": {
                             "name": "variables"
@@ -518,7 +518,7 @@
                 "name": "b",
                 "expr": {
                   "original": "C.b",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "C"
@@ -561,7 +561,7 @@
                 "name": "c",
                 "expr": {
                   "original": "constants.c",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "constants"
@@ -604,7 +604,7 @@
                 "name": "f",
                 "expr": {
                   "original": "C.f",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "C"
@@ -647,7 +647,7 @@
                 "name": "h",
                 "expr": {
                   "original": "constants.h",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "constants"
@@ -690,7 +690,7 @@
                 "name": "i",
                 "expr": {
                   "original": "C.i",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "C"
@@ -733,7 +733,7 @@
                 "name": "hi",
                 "expr": {
                   "original": "V.h + V.i",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "V"
@@ -834,7 +834,7 @@
         "variables": {
           "a": {
             "original": "constants.a",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "constants"
@@ -874,7 +874,7 @@
           },
           "ab": {
             "original": "V.a + V.b",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "V"
@@ -962,7 +962,7 @@
           },
           "b": {
             "original": "C.b",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "C"
@@ -1002,7 +1002,7 @@
           },
           "n": {
             "original": "constants.n",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "constants"
@@ -1053,7 +1053,7 @@
             "condition": {
               "expr": {
                 "original": "variables.n > variables.ab",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "variables"
@@ -1153,7 +1153,7 @@
             "name": "a",
             "expr": {
               "original": "constants.a",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "constants"
@@ -1196,7 +1196,7 @@
             "name": "b",
             "expr": {
               "original": "C.b",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "C"
@@ -1239,7 +1239,7 @@
             "name": "ab",
             "expr": {
               "original": "V.a + V.b",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "V"
@@ -1330,7 +1330,7 @@
             "name": "n",
             "expr": {
               "original": "constants.n",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "constants"
@@ -1387,7 +1387,7 @@
             "variables": {
               "a": {
                 "original": "constants.a",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "constants"
@@ -1427,7 +1427,7 @@
               },
               "ab": {
                 "original": "V.a + V.b",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "V"
@@ -1515,7 +1515,7 @@
               },
               "abg": {
                 "original": "variables.ab + variables.g",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "variables"
@@ -1603,7 +1603,7 @@
               },
               "b": {
                 "original": "C.b",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "C"
@@ -1643,7 +1643,7 @@
               },
               "c": {
                 "original": "constants.c",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "constants"
@@ -1683,7 +1683,7 @@
               },
               "e": {
                 "original": "constants.e",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "constants"
@@ -1723,7 +1723,7 @@
               },
               "g": {
                 "original": "C.g",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "C"
@@ -1763,7 +1763,7 @@
               },
               "h": {
                 "original": "constants.h",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "constants"
@@ -1808,7 +1808,7 @@
                   {
                     "expr": {
                       "original": "V.abg > 0",
-                      "checkedV2": {
+                      "checked": {
                         "referenceMap": {
                           "1": {
                             "name": "V"
@@ -1882,7 +1882,7 @@
                         {
                           "expr": {
                             "original": "variables.c < variables.h",
-                            "checkedV2": {
+                            "checked": {
                               "referenceMap": {
                                 "1": {
                                   "name": "variables"
@@ -1977,7 +1977,7 @@
                         {
                           "expr": {
                             "original": "V.e > C.z",
-                            "checkedV2": {
+                            "checked": {
                               "referenceMap": {
                                 "1": {
                                   "name": "V"
@@ -2080,7 +2080,7 @@
                 "name": "a",
                 "expr": {
                   "original": "constants.a",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "constants"
@@ -2123,7 +2123,7 @@
                 "name": "b",
                 "expr": {
                   "original": "C.b",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "C"
@@ -2166,7 +2166,7 @@
                 "name": "ab",
                 "expr": {
                   "original": "V.a + V.b",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "V"
@@ -2257,7 +2257,7 @@
                 "name": "c",
                 "expr": {
                   "original": "constants.c",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "constants"
@@ -2300,7 +2300,7 @@
                 "name": "e",
                 "expr": {
                   "original": "constants.e",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "constants"
@@ -2343,7 +2343,7 @@
                 "name": "g",
                 "expr": {
                   "original": "C.g",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "C"
@@ -2386,7 +2386,7 @@
                 "name": "abg",
                 "expr": {
                   "original": "variables.ab + variables.g",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "variables"
@@ -2477,7 +2477,7 @@
                 "name": "h",
                 "expr": {
                   "original": "constants.h",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "constants"
@@ -2536,7 +2536,7 @@
             "variables": {
               "b": {
                 "original": "C.b",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "C"
@@ -2576,7 +2576,7 @@
               },
               "c": {
                 "original": "constants.c",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "constants"
@@ -2616,7 +2616,7 @@
               },
               "f": {
                 "original": "C.f",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "C"
@@ -2656,7 +2656,7 @@
               },
               "h": {
                 "original": "constants.h",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "constants"
@@ -2696,7 +2696,7 @@
               },
               "hi": {
                 "original": "V.h + V.i",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "V"
@@ -2784,7 +2784,7 @@
               },
               "i": {
                 "original": "C.i",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "C"
@@ -2829,7 +2829,7 @@
                   {
                     "expr": {
                       "original": "V.b > V.c",
-                      "checkedV2": {
+                      "checked": {
                         "referenceMap": {
                           "1": {
                             "name": "V"
@@ -2924,7 +2924,7 @@
                   {
                     "expr": {
                       "original": "variables.f > variables.hi",
-                      "checkedV2": {
+                      "checked": {
                         "referenceMap": {
                           "1": {
                             "name": "variables"
@@ -3024,7 +3024,7 @@
                 "name": "b",
                 "expr": {
                   "original": "C.b",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "C"
@@ -3067,7 +3067,7 @@
                 "name": "c",
                 "expr": {
                   "original": "constants.c",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "constants"
@@ -3110,7 +3110,7 @@
                 "name": "f",
                 "expr": {
                   "original": "C.f",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "C"
@@ -3153,7 +3153,7 @@
                 "name": "h",
                 "expr": {
                   "original": "constants.h",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "constants"
@@ -3196,7 +3196,7 @@
                 "name": "i",
                 "expr": {
                   "original": "C.i",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "C"
@@ -3239,7 +3239,7 @@
                 "name": "hi",
                 "expr": {
                   "original": "V.h + V.i",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "V"
@@ -3344,7 +3344,7 @@
             "variables": {
               "a": {
                 "original": "constants.a",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "constants"
@@ -3384,7 +3384,7 @@
               },
               "d": {
                 "original": "C.d",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "C"
@@ -3424,7 +3424,7 @@
               },
               "e": {
                 "original": "constants.e",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "constants"
@@ -3464,7 +3464,7 @@
               },
               "j": {
                 "original": "constants.j",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "constants"
@@ -3506,7 +3506,7 @@
             "condition": {
               "expr": {
                 "original": "V.a + V.d + V.e == V.j",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "V"
@@ -3686,7 +3686,7 @@
                 "name": "a",
                 "expr": {
                   "original": "constants.a",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "constants"
@@ -3729,7 +3729,7 @@
                 "name": "d",
                 "expr": {
                   "original": "C.d",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "C"
@@ -3772,7 +3772,7 @@
                 "name": "e",
                 "expr": {
                   "original": "constants.e",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "constants"
@@ -3815,7 +3815,7 @@
                 "name": "j",
                 "expr": {
                   "original": "constants.j",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "constants"
@@ -3867,7 +3867,7 @@
         "variables": {
           "a": {
             "original": "constants.a",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "constants"
@@ -3907,7 +3907,7 @@
           },
           "ab": {
             "original": "V.a + V.b",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "V"
@@ -3995,7 +3995,7 @@
           },
           "abc": {
             "original": "variables.ab + variables.c",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "variables"
@@ -4083,7 +4083,7 @@
           },
           "abcl": {
             "original": "variables.abc + variables.l",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "variables"
@@ -4171,7 +4171,7 @@
           },
           "b": {
             "original": "C.b",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "C"
@@ -4211,7 +4211,7 @@
           },
           "c": {
             "original": "constants.c",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "constants"
@@ -4251,7 +4251,7 @@
           },
           "l": {
             "original": "constants.l",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "constants"
@@ -4291,7 +4291,7 @@
           },
           "m": {
             "original": "C.m",
-            "checkedV2": {
+            "checked": {
               "referenceMap": {
                 "1": {
                   "name": "C"
@@ -4342,7 +4342,7 @@
             "condition": {
               "expr": {
                 "original": "variables.m > constants.z",
-                "checkedV2": {
+                "checked": {
                   "referenceMap": {
                     "1": {
                       "name": "variables"
@@ -4439,7 +4439,7 @@
               "when": {
                 "ruleActivated": {
                   "original": "V.abcl",
-                  "checkedV2": {
+                  "checked": {
                     "referenceMap": {
                       "1": {
                         "name": "V"
@@ -4498,7 +4498,7 @@
             "name": "a",
             "expr": {
               "original": "constants.a",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "constants"
@@ -4541,7 +4541,7 @@
             "name": "b",
             "expr": {
               "original": "C.b",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "C"
@@ -4584,7 +4584,7 @@
             "name": "ab",
             "expr": {
               "original": "V.a + V.b",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "V"
@@ -4675,7 +4675,7 @@
             "name": "c",
             "expr": {
               "original": "constants.c",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "constants"
@@ -4718,7 +4718,7 @@
             "name": "abc",
             "expr": {
               "original": "variables.ab + variables.c",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "variables"
@@ -4809,7 +4809,7 @@
             "name": "l",
             "expr": {
               "original": "constants.l",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "constants"
@@ -4852,7 +4852,7 @@
             "name": "abcl",
             "expr": {
               "original": "variables.abc + variables.l",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "variables"
@@ -4943,7 +4943,7 @@
             "name": "m",
             "expr": {
               "original": "C.m",
-              "checkedV2": {
+              "checked": {
                 "referenceMap": {
                   "1": {
                     "name": "C"

--- a/private/compile/compile.go
+++ b/private/compile/compile.go
@@ -14,7 +14,6 @@ import (
 
 	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
 	internalcompile "github.com/cerbos/cerbos/internal/compile"
-	"github.com/cerbos/cerbos/internal/conditions"
 	"github.com/cerbos/cerbos/internal/observability/logging"
 	"github.com/cerbos/cerbos/internal/parser"
 	"github.com/cerbos/cerbos/internal/policy"
@@ -128,7 +127,6 @@ func Files(ctx context.Context, fsys fs.FS, schemaResolverMaker SchemaResolverMa
 					}
 				}
 			} else {
-				conditions.WalkExprs(artefact.PolicySet, conditions.MakeExprBackwardsCompatible)
 				log.Debug("Compilation succeeded")
 			}
 

--- a/private/ruletable/compile/compile.go
+++ b/private/ruletable/compile/compile.go
@@ -10,7 +10,6 @@ import (
 
 	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
 	internalcompile "github.com/cerbos/cerbos/internal/compile"
-	"github.com/cerbos/cerbos/internal/conditions"
 	"github.com/cerbos/cerbos/internal/ruletable"
 	"github.com/cerbos/cerbos/internal/storage/disk"
 	"github.com/cerbos/cerbos/private/compile"
@@ -38,8 +37,6 @@ func Compile(ctx context.Context, fsys fs.FS, attrs ...compile.SourceAttribute) 
 	if err := ruletable.LoadSchemas(ctx, rt, idx); err != nil {
 		return nil, fmt.Errorf("failed to load schemas: %w", err)
 	}
-
-	conditions.WalkExprs(rt, conditions.MakeExprBackwardsCompatible)
 
 	return rt, nil
 }


### PR DESCRIPTION
This PR partially reverts https://github.com/cerbos/cerbos/pull/2902 because it turns out that https://github.com/cerbos/cerbos/pull/2858 did not actually break backwards compatibility for Hub users 😳

It seems that CEL ignores the inability to find the type and happily carries on reading values from the underlying map. It turns out the test that broke that made me think it was a problem was exercising a different code path 😅 

The net change is now just to migrate old bundles forwards so that the variables are correctly typed as `cerbos.Variables` so that we can implement lazy evaluation.

![Phew](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNHBodmpvdGFkZWd4NWF4Z2Ewb281cHZycTVib3d2dTU5OGtmMWRhbCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/e9hRgPKipZqgy8sYFP/giphy.gif)