### PR TITLE
Exclude filtered tests from total count

### DIFF
--- a/.changelog/20260129_0551.txt
+++ b/.changelog/20260129_0551.txt
@@ -1,2 +1,2 @@
 type:enhancement
-Deprecates the `--run` flag to `cerbos compile` command used to run a sub set of tests in favour of a new flag named `--filter`. It supports filtering tests using wildcards in five dimensions (suite, test, principal, resource and action) which provides much more control over which tests are run. See xref:policies:compile.adoc[] for details.   
+Deprecates the `--run` flag to `cerbos compile` command used to run a sub set of tests in favour of a new flag named `--test-filter`. It supports filtering tests using wildcards in five dimensions (suite, test, principal, resource and action) which provides much more control over which tests are run. See xref:policies:compile.adoc[] for details.   

--- a/.changelog/20260129_0551.txt
+++ b/.changelog/20260129_0551.txt
@@ -1,4 +1,2 @@
-type:feature
-Added a test filter to the `cerbos compile` command
-
-`cerbos compile --test-filter='suite=MySuite;test=album*;principal=alice;resource=my_album;action=view' /path/to/policy/repo`
+type:enhancement
+Deprecates the `--run` flag to `cerbos compile` command used to run a sub set of tests in favour of a new flag named `--filter`. It supports filtering tests using wildcards in five dimensions (suite, test, principal, resource and action) which provides much more control over which tests are run. See xref:policies:compile.adoc[] for details.   

--- a/.changelog/20260129_0551.txt
+++ b/.changelog/20260129_0551.txt
@@ -1,0 +1,4 @@
+type:feature
+Added a test filter to the `cerbos compile` command
+
+`cerbos compile --test-filter='suite=MySuite;test=album*;principal=alice;resource=my_album;action=view' /path/to/policy/repo`

--- a/docs/modules/policies/pages/compile.adoc
+++ b/docs/modules/policies/pages/compile.adoc
@@ -146,38 +146,38 @@ tests: <13>
         actions:
           download: EFFECT_DENY
 ----
-<1> Name of the test suite
-<2> Description of the test suite
+<1> Name of the test suite.
+<2> Description of the test suite.
 <3> Optional RFC3339 timestamp to be used as the return value of the `now` function. Applies to all tests in the suite unless overridden locally.
-<4> Optionally set xref:configuration:engine.adoc#default_policy_version[default policy version] for this test suite
-<5> Optionally set xref:configuration:engine.adoc#default_scope[default scope] for this test suite
-<6> Optionally set xref:configuration:engine.adoc#lenient_scopes[lenient scope search] for this test suite
-<7> Optionally set xref:configuration:engine.adoc#globals[globals] for this test suite
+<4> Optionally set xref:configuration:engine.adoc#default_policy_version[default policy version] for this test suite.
+<5> Optionally set xref:configuration:engine.adoc#default_scope[default scope] for this test suite.
+<6> Optionally set xref:configuration:engine.adoc#lenient_scopes[lenient scope search] for this test suite.
+<7> Optionally set xref:configuration:engine.adoc#globals[globals] for this test suite.
 <8> Map of principal fixtures. The key is a string that can be used to refer to the associated principal.
 <9> Map of principal groups. The key is a string that can be used to refer to the associated group of principal fixtures.
 <10> Map of resource fixtures. The key is a string that can be used to refer to the associated resource.
 <11> Map of resource groups. The key is a string that can be used to refer to the associated group of resource fixtures.
 <12> Map of (optional) auxiliary data fixtures required to evaluate some requests. The key is a string that can be used to refer to the associated auxData.
-<13> List of tests in this suite
-<14> Name of the test
+<13> List of tests in this suite.
+<14> Name of the test.
 <15> Optionally set options that apply to just this test. Test-specific options are not merged with suite-wide options, so any unspecified values revert to the default.
 <16> Optional RFC3339 timestamp to be used as the return value of the `now` function.
 <17> Optionally set xref:configuration:engine.adoc#default_policy_version[default policy version] for this test.
-<18> Optionally set xref:configuration:engine.adoc#default_scope[default scope] for this test suite
+<18> Optionally set xref:configuration:engine.adoc#default_scope[default scope] for this test suite.
 <19> Optionally set xref:configuration:engine.adoc#lenient_scopes[lenient scope search] for this test.
 <20> Optionally set xref:configuration:engine.adoc#globals[globals] for this test.
-<21> Input to the policy engine
-<22> List of keys of principal fixtures to test
-<23> List of keys of resource fixtures to test
-<24> List of actions to test
-<25> Key of auxiliary data fixture to test (optional)
+<21> Input to the policy engine.
+<22> List of keys of principal fixtures to test.
+<23> List of keys of resource fixtures to test.
+<24> List of actions to test.
+<25> Key of auxiliary data fixture to test (optional).
 <26> List of outcomes expected for each principal and resource. If a principal+resource pair specified in `input` is not listed in `expected`, then `EFFECT_DENY` is expected for all actions for that pair.
 <27> Key of the principal fixture under test. Use `principals` instead of `principal` if you want to specify identical expectations for multiple principals.
 <28> Key of the resource fixture under test. Use `resources` instead of `resource` if you want to specify identical expectations for multiple resources.
 <29> Expected outcomes for each action for each principal+resource pair. If an action specified in `input` is not listed, then `EFFECT_DENY` is expected for that action.
-<30> Optional list of xref:outputs.adoc[output values] to match
-<31> Name of the action that would produce the output
-<32> List of expected output values
+<30> Optional list of xref:outputs.adoc[output values] to match.
+<31> Name of the action that would produce the output.
+<32> List of expected output values.
 <33> List of keys of principal groups to test. You can provide this instead of, or as well as, `principals`.
 <34> List of keys of resource groups to test. You can provide this instead of, or as well as, `resources`.
 <35> Key of the principal group under test. You can provide this instead of, or as well as, `principal` or `principals`.
@@ -335,11 +335,11 @@ By default, all discovered tests are run. Use the `--skip-tests` flag to skip al
 
 The `--test-filter` flag accepts a filter expression with the following dimensions:
 
-* `suite` - filter by test suite name
-* `test` - filter by test name
-* `principal` - filter by principal key
-* `resource` - filter by resource key
-* `action` - filter by action name
+* `suite` - filter by test suite name,
+* `test` - filter by test name,
+* `principal` - filter by principal key,
+* `resource` - filter by resource key,
+* `action` - filter by action name.
 
 Each dimension accepts one or more glob patterns. Multiple dimensions are separated by semicolons, and multiple values within a dimension are separated by commas.
 

--- a/docs/modules/policies/pages/compile.adoc
+++ b/docs/modules/policies/pages/compile.adoc
@@ -331,14 +331,41 @@ docker run -i -t \
 The output format can be controlled using the `--output` flag, which accepts the values `tree` (default), `list` and `json`. The `--color` flag controls the coloring of the output. To produce machine readable output from the tests, pass `--output=json --color=never` to the command.
 
 
-By default, all discovered tests are run. Use the `--skip-tests` flag to skip all tests or use the `--run` flag to run a set of tests that match a regular expression.
+By default, all discovered tests are run. Use the `--skip-tests` flag to skip all tests or use `--test-filter` to run only tests matching specific criteria.
 
-.Example: Running only tests that contain 'Delete' in the name
+The `--test-filter` flag accepts a filter expression with the following dimensions:
+
+* `suite` - filter by test suite name
+* `test` - filter by test name
+* `principal` - filter by principal key
+* `resource` - filter by resource key
+* `action` - filter by action name
+
+Each dimension accepts one or more glob patterns. Multiple dimensions are separated by semicolons, and multiple values within a dimension are separated by commas.
+
+.Example: Running tests for a specific suite and principal
 [source,sh,subs="attributes"]
 ----
 docker run -i -t \
     -v /path/to/policy/dir:/policies \
-    {app-docker-img} compile --run=Delete /policies
+    {app-docker-img} compile --test-filter='suite=AlbumObjectTestSuite;principal=alicia' /policies
+----
+
+.Example: Running tests matching glob patterns
+[source,sh,subs="attributes"]
+----
+docker run -i -t \
+    -v /path/to/policy/dir:/policies \
+    {app-docker-img} compile --test-filter='test=*Delete*;action=view,edit' /policies
+----
+
+Multiple `--test-filter` flags can be combined. All filter dimensions are merged together.
+
+[source,sh,subs="attributes"]
+----
+docker run -i -t \
+    -v /path/to/policy/dir:/policies \
+    {app-docker-img} compile --test-filter='principal=alice,bob' --test-filter='action=view' /policies
 ----
 
 You can mark entire suites or individual tests in a suite with `skip: true` to skip them during test runs.

--- a/internal/verify/test_suite_results.go
+++ b/internal/verify/test_suite_results.go
@@ -7,8 +7,10 @@ import policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
 
 func addResult(suite *policyv1.TestResults_Suite, name *policyv1.Test_TestName, action string, details *policyv1.TestResults_Details) {
 	addAction(addResource(addPrincipal(addTestCase(suite, name.TestTableName), name.PrincipalKey), name.ResourceKey), action).Details = details
-	suite.Summary.TestsCount++
-	incrementTally(suite.Summary, details.Result, 1)
+	if !IsFilterSkipReason(details.GetSkipReason()) {
+		suite.Summary.TestsCount++
+		incrementTally(suite.Summary, details.Result, 1)
+	}
 
 	if details.Result > suite.Summary.OverallResult {
 		suite.Summary.OverallResult = details.Result


### PR DESCRIPTION
Tests skipped due to the test filter are now excluded from TestsCount and the result tally. 

Tests skipped via the deprecated `--run` flag continue to be counted in totals for backwards compatibility.
