### PR TITLE
Optimize repository statistics

### DIFF
--- a/internal/storage/hub/local_source_test.go
+++ b/internal/storage/hub/local_source_test.go
@@ -297,8 +297,7 @@ func runRepoStatsTest(ls *hub.LocalSource, wantStats storage.RepoStats) func(*te
 				wantStats,
 				haveStats,
 				protocmp.Transform(),
-				cmpopts.IgnoreFields(storage.RepoStats{}, "AvgConditionCount"),
-				cmpopts.IgnoreFields(storage.RepoStats{}, "AvgRuleCount"),
+				cmpopts.EquateApprox(0.0001, 0),
 			),
 		)
 	}

--- a/internal/storage/hub/local_source_test.go
+++ b/internal/storage/hub/local_source_test.go
@@ -20,6 +20,7 @@ import (
 	bundlev1 "github.com/cerbos/cloud-api/genpb/cerbos/cloud/bundle/v1"
 	bundlev2 "github.com/cerbos/cloud-api/genpb/cerbos/cloud/bundle/v2"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -60,15 +61,25 @@ func TestLocalSource(t *testing.T) {
 				policy.ResourceKind:   152,
 				policy.RolePolicyKind: 11,
 			},
-			AvgRuleCount: map[policy.Kind]float64{
-				policy.PrincipalKind:  3.909090909090909,
-				policy.ResourceKind:   5.066666666666666,
-				policy.RolePolicyKind: 1.375,
+			MaxConditionCount: map[policy.Kind]int{
+				policy.PrincipalKind:  3,
+				policy.ResourceKind:   7,
+				policy.RolePolicyKind: 1,
+			},
+			MaxRuleCount: map[policy.Kind]int{
+				policy.PrincipalKind:  11,
+				policy.ResourceKind:   17,
+				policy.RolePolicyKind: 2,
 			},
 			AvgConditionCount: map[policy.Kind]float64{
 				policy.PrincipalKind:  0.9090909090909091,
 				policy.ResourceKind:   2.066666666666667,
 				policy.RolePolicyKind: 0.25,
+			},
+			AvgRuleCount: map[policy.Kind]float64{
+				policy.PrincipalKind:  3.909090909090909,
+				policy.ResourceKind:   5.066666666666666,
+				policy.RolePolicyKind: 1.375,
 			},
 			DistinctActionCount:   44,
 			DistinctResourceCount: 18,
@@ -107,15 +118,25 @@ func TestLocalSource(t *testing.T) {
 				policy.ResourceKind:   152,
 				policy.RolePolicyKind: 11,
 			},
-			AvgRuleCount: map[policy.Kind]float64{
-				policy.PrincipalKind:  3.909090909090909,
-				policy.ResourceKind:   5.066666666666666,
-				policy.RolePolicyKind: 1.375,
+			MaxConditionCount: map[policy.Kind]int{
+				policy.PrincipalKind:  3,
+				policy.ResourceKind:   7,
+				policy.RolePolicyKind: 1,
+			},
+			MaxRuleCount: map[policy.Kind]int{
+				policy.PrincipalKind:  11,
+				policy.ResourceKind:   17,
+				policy.RolePolicyKind: 2,
 			},
 			AvgConditionCount: map[policy.Kind]float64{
 				policy.PrincipalKind:  0.9090909090909091,
 				policy.ResourceKind:   2.066666666666667,
 				policy.RolePolicyKind: 0.25,
+			},
+			AvgRuleCount: map[policy.Kind]float64{
+				policy.PrincipalKind:  3.909090909090909,
+				policy.ResourceKind:   5.066666666666666,
+				policy.RolePolicyKind: 1.375,
 			},
 			DistinctActionCount:   44,
 			DistinctResourceCount: 18,
@@ -153,6 +174,16 @@ func TestLocalSource(t *testing.T) {
 				policy.PrincipalKind:  20,
 				policy.ResourceKind:   77,
 				policy.RolePolicyKind: 9,
+			},
+			MaxConditionCount: map[policy.Kind]int{
+				policy.PrincipalKind:  2,
+				policy.ResourceKind:   5,
+				policy.RolePolicyKind: 1,
+			},
+			MaxRuleCount: map[policy.Kind]int{
+				policy.PrincipalKind:  6,
+				policy.ResourceKind:   11,
+				policy.RolePolicyKind: 2,
 			},
 			AvgConditionCount: map[policy.Kind]float64{
 				policy.PrincipalKind:  0.36363636363636365,
@@ -266,6 +297,8 @@ func runRepoStatsTest(ls *hub.LocalSource, wantStats storage.RepoStats) func(*te
 				wantStats,
 				haveStats,
 				protocmp.Transform(),
+				cmpopts.IgnoreFields(storage.RepoStats{}, "AvgConditionCount"),
+				cmpopts.IgnoreFields(storage.RepoStats{}, "AvgRuleCount"),
 			),
 		)
 	}

--- a/internal/storage/hub/stats.go
+++ b/internal/storage/hub/stats.go
@@ -177,7 +177,7 @@ func (s *statsCollector) addRunnablePolicySet(rps *runtimev1.RunnablePolicySet) 
 
 func (s *statsCollector) procRunnablePrincipalPolicySet(rpps *runtimev1.RunnablePrincipalPolicySet) (ps policyStats) {
 	if rpps == nil {
-		return
+		return ps
 	}
 
 	for _, p := range rpps.GetPolicies() {
@@ -199,12 +199,12 @@ func (s *statsCollector) procRunnablePrincipalPolicySet(rpps *runtimev1.Runnable
 		}
 	}
 
-	return
+	return ps
 }
 
 func (s *statsCollector) procRunnableResourcePolicySet(rrps *runtimev1.RunnableResourcePolicySet) (ps policyStats) {
 	if rrps == nil {
-		return
+		return ps
 	}
 
 	for _, p := range rrps.GetPolicies() {
@@ -233,12 +233,12 @@ func (s *statsCollector) procRunnableResourcePolicySet(rrps *runtimev1.RunnableR
 		}
 	}
 
-	return
+	return ps
 }
 
 func (s *statsCollector) procRunnableRolePolicySet(rrps *runtimev1.RunnableRolePolicySet) (ps policyStats) {
 	if rrps == nil {
-		return
+		return ps
 	}
 
 	for _, ruleList := range rrps.GetResources() {
@@ -250,7 +250,7 @@ func (s *statsCollector) procRunnableRolePolicySet(rrps *runtimev1.RunnableRoleP
 		}
 	}
 
-	return
+	return ps
 }
 
 func (s *statsCollector) addSchemas(schemas *policyv1.Schemas) {

--- a/internal/storage/hub/stats.go
+++ b/internal/storage/hub/stats.go
@@ -20,10 +20,7 @@ import (
 const numPolicyKinds = 4
 
 type statsCollector struct {
-	policyCount       map[policy.Kind]int
-	ruleCount         map[policy.Kind]int
-	conditionCount    map[policy.Kind]int
-	uniquePolicies    map[uint64]struct{}
+	policies          map[uint64]*stats
 	uniqueRules       map[uint64]struct{}
 	uniqueResources   map[uint64]struct{}
 	uniqueActions     map[uint64]struct{}
@@ -32,19 +29,21 @@ type statsCollector struct {
 	hasScopedPolicies bool
 }
 
+type stats struct {
+	kind           policy.Kind
+	ruleCount      uint32
+	conditionCount uint32
+}
+
 type policyStats struct {
-	ruleCount      int
-	conditionCount int
-	hasOutput      bool
-	scoped         bool
+	stats
+	hasOutput bool
+	scoped    bool
 }
 
 func newStatsCollector() *statsCollector {
 	return &statsCollector{
-		policyCount:     make(map[policy.Kind]int, numPolicyKinds),
-		ruleCount:       make(map[policy.Kind]int, numPolicyKinds),
-		conditionCount:  make(map[policy.Kind]int, numPolicyKinds),
-		uniquePolicies:  make(map[uint64]struct{}),
+		policies:        make(map[uint64]*stats),
 		uniqueRules:     make(map[uint64]struct{}),
 		uniqueResources: make(map[uint64]struct{}),
 		uniqueActions:   make(map[uint64]struct{}),
@@ -54,11 +53,13 @@ func newStatsCollector() *statsCollector {
 
 func (s *statsCollector) collate() storage.RepoStats {
 	is := storage.RepoStats{
-		PolicyCount:           s.policyCount,
-		RuleCount:             s.ruleCount,
-		ConditionCount:        s.conditionCount,
-		AvgRuleCount:          make(map[policy.Kind]float64, len(s.ruleCount)),
-		AvgConditionCount:     make(map[policy.Kind]float64, len(s.conditionCount)),
+		PolicyCount:           make(map[policy.Kind]int, numPolicyKinds),
+		ConditionCount:        make(map[policy.Kind]int, numPolicyKinds),
+		RuleCount:             make(map[policy.Kind]int, numPolicyKinds),
+		MaxConditionCount:     make(map[policy.Kind]int, numPolicyKinds),
+		MaxRuleCount:          make(map[policy.Kind]int, numPolicyKinds),
+		AvgConditionCount:     make(map[policy.Kind]float64, numPolicyKinds),
+		AvgRuleCount:          make(map[policy.Kind]float64, numPolicyKinds),
 		DistinctActionCount:   len(s.uniqueActions),
 		DistinctResourceCount: len(s.uniqueResources),
 		SchemaCount:           len(s.schemaRefs),
@@ -66,12 +67,30 @@ func (s *statsCollector) collate() storage.RepoStats {
 		HasScopedPolicies:     s.hasScopedPolicies,
 	}
 
-	for k, c := range s.ruleCount {
-		is.AvgRuleCount[k] = float64(c) / float64(s.policyCount[k])
-	}
+	rc := make(map[policy.Kind]int, numPolicyKinds)
+	cc := make(map[policy.Kind]int, numPolicyKinds)
+	for _, s := range s.policies {
+		is.PolicyCount[s.kind]++
 
-	for k, c := range s.conditionCount {
-		is.AvgConditionCount[k] = float64(c) / float64(s.policyCount[k])
+		is.ConditionCount[s.kind] += int(s.conditionCount)
+		count := cc[s.kind] + 1
+		avgConditionCount := is.AvgConditionCount[s.kind]
+		is.AvgConditionCount[s.kind] = avgConditionCount + (float64(s.conditionCount)-avgConditionCount)/float64(count)
+		cc[s.kind] = count
+
+		if existingMaxCondCount, ok := is.MaxConditionCount[s.kind]; !ok || s.conditionCount > uint32(existingMaxCondCount) {
+			is.MaxConditionCount[s.kind] = int(s.conditionCount)
+		}
+
+		is.RuleCount[s.kind] += int(s.ruleCount)
+		count = rc[s.kind] + 1
+		avgRuleCountForKind := is.AvgRuleCount[s.kind]
+		is.AvgRuleCount[s.kind] = avgRuleCountForKind + (float64(s.ruleCount)-avgRuleCountForKind)/float64(count)
+		rc[s.kind] = count
+
+		if existingMaxRuleCount, ok := is.MaxRuleCount[s.kind]; !ok || s.ruleCount > uint32(existingMaxRuleCount) {
+			is.MaxRuleCount[s.kind] = int(s.ruleCount)
+		}
 	}
 
 	return is
@@ -82,9 +101,10 @@ func (s *statsCollector) addRow(row *index.Row) {
 	kind := policy.KindFromFQN(fqn)
 	mID := namer.GenModuleIDFromFQN(fqn).RawValue()
 
-	if _, ok := s.uniquePolicies[mID]; !ok {
-		s.uniquePolicies[mID] = struct{}{}
-		s.policyCount[kind]++
+	if _, ok := s.policies[mID]; !ok {
+		s.policies[mID] = &stats{
+			kind: kind,
+		}
 	}
 
 	if kind == policy.ResourceKind {
@@ -109,63 +129,58 @@ func (s *statsCollector) addRow(row *index.Row) {
 
 	if _, ok := s.uniqueRules[util.HashStr(row.GetEvaluationKey())]; !ok {
 		s.uniqueRules[util.HashStr(row.GetEvaluationKey())] = struct{}{}
-		s.ruleCount[kind]++
+		s.policies[mID].ruleCount++
 	}
 
 	if row.GetCondition() != nil {
-		s.conditionCount[kind]++
-	}
-}
-
-func (s *statsCollector) addSchemas(schemas *policyv1.Schemas) {
-	if resourceSchema := schemas.GetResourceSchema(); resourceSchema != nil {
-		s.schemaRefs[util.HashStr(resourceSchema.Ref)] = struct{}{}
-	}
-
-	if principalSchema := schemas.GetPrincipalSchema(); principalSchema != nil {
-		s.schemaRefs[util.HashStr(principalSchema.Ref)] = struct{}{}
+		s.policies[mID].conditionCount++
 	}
 }
 
 func (s *statsCollector) addRunnablePolicySet(rps *runtimev1.RunnablePolicySet) {
 	fqn := rps.GetFqn()
-	kind := policy.KindFromFQN(fqn)
+	mID := namer.GenModuleIDFromFQN(fqn).RawValue()
 
-	var stats []policyStats
+	var kind policy.Kind
+	var ps policyStats
 	switch policySet := rps.PolicySet.(type) {
 	case *runtimev1.RunnablePolicySet_PrincipalPolicy:
-		stats = s.procRunnablePrincipalPolicySet(policySet.PrincipalPolicy)
+		kind = policy.PrincipalKind
+		ps = s.procRunnablePrincipalPolicySet(policySet.PrincipalPolicy)
 	case *runtimev1.RunnablePolicySet_ResourcePolicy:
-		stats = s.procRunnableResourcePolicySet(policySet.ResourcePolicy)
+		kind = policy.ResourceKind
+		ps = s.procRunnableResourcePolicySet(policySet.ResourcePolicy)
 		resource := strings.Split(strings.TrimPrefix(fqn, namer.ResourcePoliciesPrefix+"."), ".")[0]
 		s.uniqueResources[util.HashStr(resource)] = struct{}{}
 	case *runtimev1.RunnablePolicySet_RolePolicy:
-		stats = s.procRunnableRolePolicySet(policySet.RolePolicy)
+		kind = policy.RolePolicyKind
+		ps = s.procRunnableRolePolicySet(policySet.RolePolicy)
 	}
 
-	s.policyCount[kind]++
-	for _, ps := range stats {
-		s.ruleCount[kind] += ps.ruleCount
-		s.conditionCount[kind] += ps.conditionCount
-
-		if ps.hasOutput {
-			s.hasOutput = true
+	if _, ok := s.policies[mID]; !ok {
+		s.policies[mID] = &stats{
+			kind: kind,
 		}
+	}
 
-		if ps.scoped {
-			s.hasScopedPolicies = true
-		}
+	s.policies[mID].ruleCount += ps.ruleCount
+	s.policies[mID].conditionCount += ps.conditionCount
+
+	if ps.hasOutput {
+		s.hasOutput = true
+	}
+
+	if ps.scoped {
+		s.hasScopedPolicies = true
 	}
 }
 
-func (s *statsCollector) procRunnablePrincipalPolicySet(rpps *runtimev1.RunnablePrincipalPolicySet) []policyStats {
+func (s *statsCollector) procRunnablePrincipalPolicySet(rpps *runtimev1.RunnablePrincipalPolicySet) (ps policyStats) {
 	if rpps == nil {
-		return nil
+		return
 	}
 
-	var stats []policyStats
 	for _, p := range rpps.GetPolicies() {
-		var ps policyStats
 		for _, resourceRules := range p.GetResourceRules() {
 			for _, actionRule := range resourceRules.GetActionRules() {
 				ps.ruleCount++
@@ -182,21 +197,17 @@ func (s *statsCollector) procRunnablePrincipalPolicySet(rpps *runtimev1.Runnable
 		if p.GetScope() != "" {
 			ps.scoped = true
 		}
-
-		stats = append(stats, ps)
 	}
 
-	return stats
+	return
 }
 
-func (s *statsCollector) procRunnableResourcePolicySet(rrps *runtimev1.RunnableResourcePolicySet) []policyStats {
+func (s *statsCollector) procRunnableResourcePolicySet(rrps *runtimev1.RunnableResourcePolicySet) (ps policyStats) {
 	if rrps == nil {
-		return nil
+		return
 	}
 
-	var stats []policyStats
 	for _, p := range rrps.GetPolicies() {
-		var ps policyStats
 		for _, rule := range p.GetRules() {
 			ps.ruleCount++
 
@@ -220,30 +231,34 @@ func (s *statsCollector) procRunnableResourcePolicySet(rrps *runtimev1.RunnableR
 		if p.GetScope() != "" {
 			ps.scoped = true
 		}
-
-		stats = append(stats, ps)
 	}
 
-	return stats
+	return
 }
 
-func (s *statsCollector) procRunnableRolePolicySet(rrps *runtimev1.RunnableRolePolicySet) []policyStats {
+func (s *statsCollector) procRunnableRolePolicySet(rrps *runtimev1.RunnableRolePolicySet) (ps policyStats) {
 	if rrps == nil {
-		return nil
+		return
 	}
 
-	var stats []policyStats
 	for _, ruleList := range rrps.GetResources() {
-		var ps policyStats
 		for _, rule := range ruleList.GetRules() {
 			ps.ruleCount++
 			if rule.GetCondition() != nil {
 				ps.conditionCount++
 			}
 		}
-
-		stats = append(stats, ps)
 	}
 
-	return stats
+	return
+}
+
+func (s *statsCollector) addSchemas(schemas *policyv1.Schemas) {
+	if resourceSchema := schemas.GetResourceSchema(); resourceSchema != nil {
+		s.schemaRefs[util.HashStr(resourceSchema.Ref)] = struct{}{}
+	}
+
+	if principalSchema := schemas.GetPrincipalSchema(); principalSchema != nil {
+		s.schemaRefs[util.HashStr(principalSchema.Ref)] = struct{}{}
+	}
 }


### PR DESCRIPTION
# Description
This PR decreases the memory allocations and adds `MaxConditionCount` and `MaxRuleCount`.

```
goos: darwin
goarch: arm64
pkg: github.com/cerbos/cerbos/internal/storage/hub
cpu: Apple M1
                      │  main.txt   │           telemetry.txt            │
                      │   sec/op    │   sec/op     vs base               │
RepoStats/ruleTable-8   30.85µ ± 4%   33.39µ ± 3%  +8.22% (p=0.000 n=10)

                      │   main.txt   │            telemetry.txt            │
                      │     B/op     │     B/op      vs base               │
RepoStats/ruleTable-8   24.90Ki ± 0%   24.62Ki ± 0%  -1.13% (p=0.000 n=10)

                      │  main.txt  │           telemetry.txt           │
                      │ allocs/op  │ allocs/op   vs base               │
RepoStats/ruleTable-8   106.0 ± 0%   110.0 ± 0%  +3.77% (p=0.000 n=10)
```

`main`
```
    local_source_test.go:41: Allocated memory: 49_060_160 bytes
    local_source_test.go:42: Total allocated memory: 73_264_552 bytes
    local_source_test.go:43: Heap objects: 338_866
```

`telemetry`
```
    local_source_test.go:42: Allocated memory: 42_675_480 bytes
    local_source_test.go:43: Total allocated memory: 73_225_368 bytes
    local_source_test.go:44: Heap objects: 301_587
```