### PR TITLE
Pool bitmaps

### DIFF
--- a/internal/ruletable/check.go
+++ b/internal/ruletable/check.go
@@ -226,6 +226,7 @@ func (rt *RuleTable) check(ctx context.Context, tctx tracer.Context, schemaMgr s
 
 				parentRoles := rt.idx.AddParentRoles([]string{resourceScope}, []string{role})
 
+				var bindings []*index.Binding
 			scopesLoop:
 				for _, scope := range scopes {
 					sctx := actx.StartScope(scope)
@@ -285,7 +286,7 @@ func (rt *RuleTable) check(ctx context.Context, tctx tracer.Context, schemaMgr s
 					if pt == policyv1.Kind_KIND_PRINCIPAL {
 						pid = input.Principal.Id
 					}
-					bindings := rt.idx.Query(resourceVersion, sanitizedResource, scope, action, parentRoles, pt, pid)
+					bindings = rt.idx.Query(resourceVersion, sanitizedResource, scope, action, parentRoles, pt, pid, bindings[:0])
 					for _, b := range bindings {
 						rulectx := sctx.StartRule(b.Name)
 

--- a/internal/ruletable/index/bitmap_index.go
+++ b/internal/ruletable/index/bitmap_index.go
@@ -172,7 +172,7 @@ func (d dimension[T]) Keys() []T {
 
 // Query returns OR(d[k] for k in keys).
 // The returned bitmap may alias a stored bitmap; callers must not mutate it.
-func (d dimension[T]) Query(keys []T) *roaring.Bitmap {
+func (d dimension[T]) Query(arena *bitmapArena, keys []T) *roaring.Bitmap {
 	parts := make([]*roaring.Bitmap, 0, len(keys))
 	for _, k := range keys {
 		if bm, ok := d.m[k]; ok {
@@ -181,10 +181,10 @@ func (d dimension[T]) Query(keys []T) *roaring.Bitmap {
 	}
 	switch len(parts) {
 	case 0:
-		return roaring.New()
+		return emptyBitmap
 	case 1:
 		return parts[0]
 	default:
-		return roaring.FastOr(parts...)
+		return arena.orInto(parts)
 	}
 }

--- a/internal/ruletable/index/bitmap_pool.go
+++ b/internal/ruletable/index/bitmap_pool.go
@@ -13,8 +13,7 @@ var bitmapPool = sync.Pool{
 	New: func() any { return roaring.New() },
 }
 
-// emptyBitmap is a shared, immutable empty bitmap returned when a query has no
-// matches. Callers must not mutate it.
+// emptyBitmap is a shared. Callers must not mutate it.
 var emptyBitmap = roaring.New()
 
 // bitmapArena tracks pooled bitmaps acquired during a single query so they can
@@ -47,8 +46,10 @@ func (a *bitmapArena) get() *roaring.Bitmap {
 	return bm
 }
 
-// orInto ORs all parts into a fresh pooled bitmap using in-place Or,
-// avoiding the lazy-OR path (and its run→bitmap container conversions).
+// orInto ORs all parts into a pooled bitmap using in-place Or. This avoids
+// roaring.FastOr's lazy-OR path, which allocates N-1 intermediate array
+// containers that become immediate GC pressure. In-place Or merges directly
+// into the destination's containers, which grow once and are reused.
 func (a *bitmapArena) orInto(parts []*roaring.Bitmap) *roaring.Bitmap {
 	bm := a.get()
 	for _, p := range parts {

--- a/internal/ruletable/index/bitmap_pool.go
+++ b/internal/ruletable/index/bitmap_pool.go
@@ -1,0 +1,99 @@
+// Copyright 2021-2026 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package index
+
+import (
+	"sync"
+
+	"github.com/RoaringBitmap/roaring/v2"
+)
+
+var bitmapPool = sync.Pool{
+	New: func() any { return roaring.New() },
+}
+
+// emptyBitmap is a shared, immutable empty bitmap returned when a query has no
+// matches. Callers must not mutate it.
+var emptyBitmap = roaring.New()
+
+// bitmapArena tracks pooled bitmaps acquired during a single query so they can
+// be released in bulk when the query completes.
+type bitmapArena struct {
+	used []*roaring.Bitmap
+}
+
+var arenaPool = sync.Pool{
+	New: func() any { return &bitmapArena{used: make([]*roaring.Bitmap, 0, 8)} }, //nolint:mnd
+}
+
+func acquireArena() *bitmapArena {
+	return arenaPool.Get().(*bitmapArena)
+}
+
+func (a *bitmapArena) release() {
+	for _, bm := range a.used {
+		bm.Clear()
+		bitmapPool.Put(bm)
+	}
+	a.used = a.used[:0]
+	arenaPool.Put(a)
+}
+
+// get returns a cleared bitmap from the pool and tracks it for later release.
+func (a *bitmapArena) get() *roaring.Bitmap {
+	bm := bitmapPool.Get().(*roaring.Bitmap)
+	a.used = append(a.used, bm)
+	return bm
+}
+
+// orInto ORs all parts into a fresh pooled bitmap using in-place Or,
+// avoiding the lazy-OR path (and its run→bitmap container conversions).
+func (a *bitmapArena) orInto(parts []*roaring.Bitmap) *roaring.Bitmap {
+	bm := a.get()
+	for _, p := range parts {
+		bm.Or(p)
+	}
+	return bm
+}
+
+// and2 ANDs exactly two bitmaps into a fresh pooled bitmap, avoiding a
+// heap-allocated slice.
+func (a *bitmapArena) and2(x, y *roaring.Bitmap) *roaring.Bitmap {
+	if x.IsEmpty() || y.IsEmpty() {
+		return emptyBitmap
+	}
+	bm := a.get()
+	if x.GetCardinality() <= y.GetCardinality() {
+		bm.Or(x)
+		bm.And(y)
+	} else {
+		bm.Or(y)
+		bm.And(x)
+	}
+	return bm
+}
+
+// andInto ANDs bitmaps into a fresh pooled bitmap. The smallest bitmap is
+// copied first to minimise intermediate work.
+func (a *bitmapArena) andInto(bitmaps []*roaring.Bitmap) *roaring.Bitmap {
+	minIdx := 0
+	minCard := bitmaps[0].GetCardinality()
+	for i := 1; i < len(bitmaps); i++ {
+		if c := bitmaps[i].GetCardinality(); c < minCard {
+			minCard = c
+			minIdx = i
+		}
+	}
+	if minCard == 0 {
+		return emptyBitmap
+	}
+	bm := a.get()
+	bm.Or(bitmaps[minIdx]) // copy smallest
+	for i, other := range bitmaps {
+		if i != minIdx {
+			bm.And(other)
+		}
+	}
+	return bm
+}

--- a/internal/ruletable/index/bitmap_pool.go
+++ b/internal/ruletable/index/bitmap_pool.go
@@ -13,7 +13,7 @@ var bitmapPool = sync.Pool{
 	New: func() any { return roaring.New() },
 }
 
-// emptyBitmap is a shared. Callers must not mutate it.
+// emptyBitmap is shared. Callers must not mutate it.
 var emptyBitmap = roaring.New()
 
 // bitmapArena tracks pooled bitmaps acquired during a single query so they can

--- a/internal/ruletable/index/bitmap_pool.go
+++ b/internal/ruletable/index/bitmap_pool.go
@@ -22,12 +22,8 @@ type bitmapArena struct {
 	used []*roaring.Bitmap
 }
 
-var arenaPool = sync.Pool{
-	New: func() any { return &bitmapArena{used: make([]*roaring.Bitmap, 0, 8)} }, //nolint:mnd
-}
-
-func acquireArena() *bitmapArena {
-	return arenaPool.Get().(*bitmapArena) //nolint:forcetypeassert
+func newBitmapArena() *bitmapArena {
+	return &bitmapArena{used: make([]*roaring.Bitmap, 0, 8)}
 }
 
 func (a *bitmapArena) release() {
@@ -35,8 +31,6 @@ func (a *bitmapArena) release() {
 		bm.Clear()
 		bitmapPool.Put(bm)
 	}
-	a.used = a.used[:0]
-	arenaPool.Put(a)
 }
 
 // get returns a cleared bitmap from the pool and tracks it for later release.

--- a/internal/ruletable/index/bitmap_pool.go
+++ b/internal/ruletable/index/bitmap_pool.go
@@ -27,7 +27,7 @@ var arenaPool = sync.Pool{
 }
 
 func acquireArena() *bitmapArena {
-	return arenaPool.Get().(*bitmapArena)
+	return arenaPool.Get().(*bitmapArena) //nolint:forcetypeassert
 }
 
 func (a *bitmapArena) release() {
@@ -41,7 +41,7 @@ func (a *bitmapArena) release() {
 
 // get returns a cleared bitmap from the pool and tracks it for later release.
 func (a *bitmapArena) get() *roaring.Bitmap {
-	bm := bitmapPool.Get().(*roaring.Bitmap)
+	bm := bitmapPool.Get().(*roaring.Bitmap) //nolint:forcetypeassert
 	a.used = append(a.used, bm)
 	return bm
 }

--- a/internal/ruletable/index/bitmap_pool.go
+++ b/internal/ruletable/index/bitmap_pool.go
@@ -23,7 +23,7 @@ type bitmapArena struct {
 }
 
 func newBitmapArena() *bitmapArena {
-	return &bitmapArena{used: make([]*roaring.Bitmap, 0, 8)}
+	return &bitmapArena{used: make([]*roaring.Bitmap, 0, 8)} //nolint:mnd
 }
 
 func (a *bitmapArena) release() {

--- a/internal/ruletable/index/glob_dimension.go
+++ b/internal/ruletable/index/glob_dimension.go
@@ -76,17 +76,17 @@ func (gd *globDimension) Remove(key string, id uint32) {
 // Query returns the OR of the literal bitmap for value and all glob bitmaps
 // whose pattern matches value. The returned bitmap may alias a stored bitmap;
 // callers must not mutate it.
-func (gd *globDimension) Query(value string) *roaring.Bitmap {
+func (gd *globDimension) Query(arena *bitmapArena, value string) *roaring.Bitmap {
 	literalBM := gd.literals[value]
 
 	if len(gd.compiled) == 0 {
 		if literalBM != nil {
 			return literalBM
 		}
-		return roaring.New()
+		return emptyBitmap
 	}
 
-	// Collect literal + matching glob bitmaps and combine with FastOr.
+	// Collect literal + matching glob bitmaps and combine with in-place OR.
 	var parts []*roaring.Bitmap
 	if literalBM != nil {
 		parts = append(parts, literalBM)
@@ -99,17 +99,17 @@ func (gd *globDimension) Query(value string) *roaring.Bitmap {
 
 	switch len(parts) {
 	case 0:
-		return roaring.New()
+		return emptyBitmap
 	case 1:
 		return parts[0]
 	default:
-		return roaring.FastOr(parts...)
+		return arena.orInto(parts)
 	}
 }
 
 // QueryMultiple returns OR of all bitmaps matching any of the given values.
 // The returned bitmap may alias a stored bitmap; callers must not mutate it.
-func (gd *globDimension) QueryMultiple(values []string) *roaring.Bitmap {
+func (gd *globDimension) QueryMultiple(arena *bitmapArena, values []string) *roaring.Bitmap {
 	parts := make([]*roaring.Bitmap, 0, len(values))
 	for _, v := range values {
 		if bm, ok := gd.literals[v]; ok {
@@ -123,11 +123,11 @@ func (gd *globDimension) QueryMultiple(values []string) *roaring.Bitmap {
 	}
 	switch len(parts) {
 	case 0:
-		return roaring.New()
+		return emptyBitmap
 	case 1:
 		return parts[0]
 	default:
-		return roaring.FastOr(parts...)
+		return arena.orInto(parts)
 	}
 }
 

--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -204,7 +204,7 @@ func (m *Index) Query(version, resource, scope, action string, roles []string, p
 		return buf
 	}
 
-	arena := acquireArena()
+	arena := newBitmapArena()
 	defer arena.release()
 
 	var scopeBM, versionBM, resourceBM, roleBM, policyKindBM, principalBM *roaring.Bitmap
@@ -461,7 +461,7 @@ func (m *Index) QueryMulti(versions, resources, scopes, roles, actions []string)
 		return nil
 	}
 
-	arena := acquireArena()
+	arena := newBitmapArena()
 	defer arena.release()
 
 	dims := make([]*roaring.Bitmap, 0, 4) //nolint:mnd
@@ -689,7 +689,7 @@ func (m *Index) ScopedResourceExists(version, resource string, scopes []string) 
 		return false, nil
 	}
 
-	arena := acquireArena()
+	arena := newBitmapArena()
 	defer arena.release()
 
 	scopeBM := m.bi.scope.Query(arena, scopes)
@@ -720,7 +720,7 @@ func (m *Index) ScopedPrincipalExists(version string, scopes []string) (bool, er
 		return false, nil
 	}
 
-	arena := acquireArena()
+	arena := newBitmapArena()
 	defer arena.release()
 
 	scopeBM := m.bi.scope.Query(arena, scopes)

--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -197,53 +197,56 @@ func (m *Index) GetAllRows() ([]*Binding, error) {
 // Query returns bindings matching the given dimensions. Nil or zero-values mean
 // "match all" for that dimension. Synthetic DENYs from role policy AllowActions
 // are prepended when querying for a specific action with KIND_RESOURCE.
-func (m *Index) Query(version, resource, scope, action string, roles []string, policyKind policyv1.Kind, principalID string) []*Binding {
+func (m *Index) Query(version, resource, scope, action string, roles []string, policyKind policyv1.Kind, principalID string, buf []*Binding) []*Binding {
 	bi := m.bi
 
 	if bi.universe.IsEmpty() {
-		return nil
+		return buf
 	}
+
+	arena := acquireArena()
+	defer arena.release()
 
 	var scopeBM, versionBM, resourceBM, roleBM, policyKindBM, principalBM *roaring.Bitmap
 
 	// scope is always filtered because "" is a valid literal scope (root scope).
 	bm, ok := bi.scope.Get(scope)
 	if !ok {
-		return nil
+		return buf
 	}
 	scopeBM = bm
 
 	if version != "" {
 		bm, ok := bi.version.Get(version)
 		if !ok {
-			return nil
+			return buf
 		}
 		versionBM = bm
 	}
 	if resource != "" {
-		bm := bi.resource.Query(resource)
+		bm := bi.resource.Query(arena, resource)
 		if bm.IsEmpty() {
-			return nil
+			return buf
 		}
 		resourceBM = bm
 	}
 	if len(roles) > 0 {
-		roleBM = bi.role.QueryMultiple(roles)
+		roleBM = bi.role.QueryMultiple(arena, roles)
 		if roleBM.IsEmpty() {
-			return nil
+			return buf
 		}
 	}
 	if policyKind != 0 {
 		bm, ok := bi.policyKind.Get(policyKind)
 		if !ok {
-			return nil
+			return buf
 		}
 		policyKindBM = bm
 	}
 	if principalID != "" {
 		bm, ok := bi.principal.Get(principalID)
 		if !ok {
-			return nil
+			return buf
 		}
 		principalBM = bm
 	}
@@ -275,30 +278,30 @@ func (m *Index) Query(version, resource, scope, action string, roles []string, p
 		baseBM = bi.universe
 	case 1:
 		baseBM = dims[0]
+	case 2:
+		baseBM = arena.and2(dims[0], dims[1])
 	default:
-		baseBM = fastAnd(dims...)
+		baseBM = arena.andInto(dims)
 	}
 	if baseBM.IsEmpty() {
-		return nil
+		return buf
 	}
 
 	// resultBM = AND(baseBM, actionBM) for regular (non-AllowActions) bindings.
 	resultBM := baseBM
 	if action != "" {
-		actionBM := bi.action.Query(action)
+		actionBM := bi.action.Query(arena, action)
 		if !actionBM.IsEmpty() {
-			resultBM = fastAnd(baseBM, actionBM)
+			resultBM = arena.and2(baseBM, actionBM)
 		} else {
-			resultBM = roaring.New()
+			resultBM = emptyBitmap
 		}
 	}
-
-	var res []*Binding
 
 	// Role policy synthetic DENYs are prepended so the evaluator sees them
 	// before regular ALLOWs, which is required for scope permission semantics.
 	if action != "" && policyKind == policyv1.Kind_KIND_RESOURCE && !bi.allowActionsBitmap.IsEmpty() {
-		res = m.queryAllowActions(bi, version, scope, action, resource, roles, versionBM, scopeBM, roleBM, resourceBM, res)
+		buf = m.queryAllowActions(arena, bi, version, scope, action, resource, roles, versionBM, scopeBM, roleBM, resourceBM, buf)
 	}
 
 	// Regular bindings.
@@ -307,16 +310,16 @@ func (m *Index) Query(version, resource, scope, action string, roles []string, p
 		for iter.HasNext() {
 			id := iter.Next()
 			if b := bi.getBinding(id); b != nil {
-				res = append(res, b)
+				buf = append(buf, b)
 			}
 		}
 	}
 
-	return res
+	return buf
 }
 
 // queryAllowActions generates synthetic DENY bindings from role policy AllowActions.
-func (m *Index) queryAllowActions(bi *bitmapIndex, version, scope, action, resource string, roles []string, versionBM, scopeBM, roleBM, resourceBM *roaring.Bitmap, res []*Binding,
+func (m *Index) queryAllowActions(arena *bitmapArena, bi *bitmapIndex, version, scope, action, resource string, roles []string, versionBM, scopeBM, roleBM, resourceBM *roaring.Bitmap, res []*Binding,
 ) []*Binding {
 	// find candidate role policy bindings.
 	// we ignore `resource` because we need to know which roles have ANY role policies,
@@ -338,17 +341,17 @@ func (m *Index) queryAllowActions(bi *bitmapIndex, version, scope, action, resou
 	if len(candidateDims) == 1 {
 		candidateBM = candidateDims[0]
 	} else {
-		candidateBM = fastAnd(candidateDims...)
+		candidateBM = arena.andInto(candidateDims)
 	}
 	if candidateBM.IsEmpty() {
 		return res
 	}
 
 	// now AND with the resource
-	// (fastAnd returns a new copy so candidateBM isn't mutated).
+	// (andInto returns a pooled copy so candidateBM isn't mutated).
 	resourceMatchedBM := candidateBM
 	if resourceBM != nil {
-		resourceMatchedBM = fastAnd(candidateBM, resourceBM)
+		resourceMatchedBM = arena.and2(candidateBM, resourceBM)
 	}
 
 	// we need two levels because we can't determine "does this role have a role policy"
@@ -380,6 +383,7 @@ func (m *Index) queryAllowActions(bi *bitmapIndex, version, scope, action, resou
 	}
 
 	// process each role in input order.
+	var matched []*Binding
 	for _, role := range roles {
 		// no role policies exist for this role, skip it
 		if _, ok := rolesWithPolicy[role]; !ok {
@@ -387,7 +391,7 @@ func (m *Index) queryAllowActions(bi *bitmapIndex, version, scope, action, resou
 		}
 
 		// find resource-matched bindings that cover the queried action.
-		var matched []*Binding
+		matched = matched[:0]
 		for _, ab := range resourceMatchedByRole[role] {
 			for a := range ab.AllowActions {
 				if a == action || util.MatchesGlob(a, action) {
@@ -457,31 +461,34 @@ func (m *Index) QueryMulti(versions, resources, scopes, roles, actions []string)
 		return nil
 	}
 
+	arena := acquireArena()
+	defer arena.release()
+
 	dims := make([]*roaring.Bitmap, 0, 4) //nolint:mnd
 
 	if len(versions) > 0 {
-		bm := bi.version.Query(versions)
+		bm := bi.version.Query(arena, versions)
 		if bm.IsEmpty() {
 			return nil
 		}
 		dims = append(dims, bm)
 	}
 	if len(scopes) > 0 {
-		bm := bi.scope.Query(scopes)
+		bm := bi.scope.Query(arena, scopes)
 		if bm.IsEmpty() {
 			return nil
 		}
 		dims = append(dims, bm)
 	}
 	if len(resources) > 0 {
-		bm := bi.resource.QueryMultiple(resources)
+		bm := bi.resource.QueryMultiple(arena, resources)
 		if bm.IsEmpty() {
 			return nil
 		}
 		dims = append(dims, bm)
 	}
 	if len(roles) > 0 {
-		bm := bi.role.QueryMultiple(roles)
+		bm := bi.role.QueryMultiple(arena, roles)
 		if bm.IsEmpty() {
 			return nil
 		}
@@ -495,13 +502,13 @@ func (m *Index) QueryMulti(versions, resources, scopes, roles, actions []string)
 	case 1:
 		baseBM = dims[0]
 	default:
-		baseBM = fastAnd(dims...)
+		baseBM = arena.andInto(dims)
 	}
 	if baseBM.IsEmpty() {
 		return nil
 	}
 
-	resultBM := m.applyActionFilter(baseBM, actions)
+	resultBM := m.applyActionFilter(arena, baseBM, actions)
 
 	if resultBM.IsEmpty() {
 		return nil
@@ -517,7 +524,7 @@ func (m *Index) QueryMulti(versions, resources, scopes, roles, actions []string)
 	return res
 }
 
-func (m *Index) applyActionFilter(baseBM *roaring.Bitmap, actions []string) *roaring.Bitmap {
+func (m *Index) applyActionFilter(arena *bitmapArena, baseBM *roaring.Bitmap, actions []string) *roaring.Bitmap {
 	if len(actions) == 0 {
 		return baseBM
 	}
@@ -525,12 +532,12 @@ func (m *Index) applyActionFilter(baseBM *roaring.Bitmap, actions []string) *roa
 	bi := m.bi
 	parts := make([]*roaring.Bitmap, 0, 2) //nolint:mnd
 
-	actionBM := bi.action.QueryMultiple(actions)
+	actionBM := bi.action.QueryMultiple(arena, actions)
 	if !actionBM.IsEmpty() {
-		parts = append(parts, fastAnd(baseBM, actionBM))
+		parts = append(parts, arena.and2(baseBM, actionBM))
 	}
 	if !bi.allowActionsBitmap.IsEmpty() {
-		aaBM := fastAnd(baseBM, bi.allowActionsBitmap)
+		aaBM := arena.and2(baseBM, bi.allowActionsBitmap)
 		if !aaBM.IsEmpty() {
 			parts = append(parts, aaBM)
 		}
@@ -538,11 +545,11 @@ func (m *Index) applyActionFilter(baseBM *roaring.Bitmap, actions []string) *roa
 
 	switch len(parts) {
 	case 0:
-		return roaring.New()
+		return emptyBitmap
 	case 1:
 		return parts[0]
 	default:
-		return roaring.FastOr(parts...)
+		return arena.orInto(parts)
 	}
 }
 
@@ -682,12 +689,15 @@ func (m *Index) ScopedResourceExists(version, resource string, scopes []string) 
 		return false, nil
 	}
 
-	scopeBM := m.bi.scope.Query(scopes)
+	arena := acquireArena()
+	defer arena.release()
+
+	scopeBM := m.bi.scope.Query(arena, scopes)
 	if scopeBM.IsEmpty() {
 		return false, nil
 	}
 
-	resourceBM := m.bi.resource.Query(resource)
+	resourceBM := m.bi.resource.Query(arena, resource)
 	if resourceBM.IsEmpty() {
 		return false, nil
 	}
@@ -710,7 +720,10 @@ func (m *Index) ScopedPrincipalExists(version string, scopes []string) (bool, er
 		return false, nil
 	}
 
-	scopeBM := m.bi.scope.Query(scopes)
+	arena := acquireArena()
+	defer arena.release()
+
+	scopeBM := m.bi.scope.Query(arena, scopes)
 	if scopeBM.IsEmpty() {
 		return false, nil
 	}
@@ -765,32 +778,6 @@ func getCelProgramsFromExpressions(vars []*runtimev1.Variable) ([]*CelProgram, e
 	}
 
 	return progs, nil
-}
-
-// fastAnd swaps the smallest bitmap to position 0 before calling
-// roaring.FastAnd, which processes left-to-right. A full sort would be
-// theoretically optimal (the merge-join scans both sides), but at our
-// slice sizes (<=6) the sort overhead seems to cost more than it saves.
-func fastAnd(bitmaps ...*roaring.Bitmap) *roaring.Bitmap {
-	minIdx := 0
-	minCard := bitmaps[0].GetCardinality()
-	for i := 1; i < len(bitmaps); i++ {
-		if c := bitmaps[i].GetCardinality(); c < minCard {
-			minCard = c
-			minIdx = i
-		}
-	}
-	if minIdx != 0 {
-		bitmaps[0], bitmaps[minIdx] = bitmaps[minIdx], bitmaps[0]
-	}
-	res := roaring.FastAnd(bitmaps...)
-
-	// ensure the passed bitmaps preserve their original ordering by swopping back if changed
-	if minIdx != 0 {
-		bitmaps[0], bitmaps[minIdx] = bitmaps[minIdx], bitmaps[0]
-	}
-
-	return res
 }
 
 // intersectionNonEmpty returns true if the intersection of all bitmaps is

--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -278,7 +278,7 @@ func (m *Index) Query(version, resource, scope, action string, roles []string, p
 		baseBM = bi.universe
 	case 1:
 		baseBM = dims[0]
-	case 2:
+	case 2: //nolint:mnd
 		baseBM = arena.and2(dims[0], dims[1])
 	default:
 		baseBM = arena.andInto(dims)

--- a/internal/ruletable/index/index_test.go
+++ b/internal/ruletable/index/index_test.go
@@ -221,20 +221,20 @@ func TestFunctionalChecksum(t *testing.T) {
 
 		require.NoError(t, impl.IndexRules(rules))
 
-		docRows := impl.Query("default", "document", "", "", nil, 0, "")
+		docRows := impl.Query("default", "document", "", "", nil, 0, "", nil)
 		require.Len(t, docRows, 1)
 
-		imgRows := impl.Query("default", "image", "", "", nil, 0, "")
+		imgRows := impl.Query("default", "image", "", "", nil, 0, "", nil)
 		require.Len(t, imgRows, 1)
 
 		// delete `docPolicyFQN`. Its "document" binding must be removed
 		// even though the shared core still has `imgPolicyFQN` in origins.
 		require.NoError(t, impl.DeletePolicy(docPolicyFQN))
 
-		docRows = impl.Query("default", "document", "", "", nil, 0, "")
+		docRows = impl.Query("default", "document", "", "", nil, 0, "", nil)
 		require.Len(t, docRows, 0, "orphaned binding for deleted policy should be removed from dimensions")
 
-		imgRows = impl.Query("default", "image", "", "", nil, 0, "")
+		imgRows = impl.Query("default", "image", "", "", nil, 0, "", nil)
 		require.Len(t, imgRows, 1, "surviving policy's binding should remain")
 
 		require.NoError(t, impl.DeletePolicy(imgPolicyFQN))
@@ -435,7 +435,7 @@ func TestQueryAllowActionsSyntheticDeny(t *testing.T) {
 			}),
 		}))
 
-		res := impl.Query("default", "document", "", "delete", []string{"viewer"}, policyv1.Kind_KIND_RESOURCE, "")
+		res := impl.Query("default", "document", "", "delete", []string{"viewer"}, policyv1.Kind_KIND_RESOURCE, "", nil)
 		require.Len(t, res, 1)
 		require.Equal(t, effectv1.Effect_EFFECT_DENY, res[0].Core.Effect)
 		require.True(t, res[0].Core.FromRolePolicy)
@@ -456,7 +456,7 @@ func TestQueryAllowActionsSyntheticDeny(t *testing.T) {
 			}),
 		}))
 
-		res := impl.Query("default", "document", "", "view", []string{"viewer"}, policyv1.Kind_KIND_RESOURCE, "")
+		res := impl.Query("default", "document", "", "view", []string{"viewer"}, policyv1.Kind_KIND_RESOURCE, "", nil)
 		require.Len(t, res, 0)
 	})
 
@@ -478,7 +478,7 @@ func TestQueryAllowActionsSyntheticDeny(t *testing.T) {
 			}),
 		}))
 
-		res := impl.Query("default", "document", "", "view", []string{"viewer"}, policyv1.Kind_KIND_RESOURCE, "")
+		res := impl.Query("default", "document", "", "view", []string{"viewer"}, policyv1.Kind_KIND_RESOURCE, "", nil)
 		require.Len(t, res, 1)
 		require.Equal(t, effectv1.Effect_EFFECT_DENY, res[0].Core.Effect)
 		require.True(t, res[0].Core.FromRolePolicy)
@@ -514,7 +514,7 @@ func TestQueryAllowActionsSyntheticDeny(t *testing.T) {
 			}),
 		}))
 
-		res := impl.Query("default", "document", "", "edit", []string{"viewer", "editor"}, policyv1.Kind_KIND_RESOURCE, "")
+		res := impl.Query("default", "document", "", "edit", []string{"viewer", "editor"}, policyv1.Kind_KIND_RESOURCE, "", nil)
 
 		// only viewer should get a synthetic DENY (edit is not in viewer's AllowActions).
 		// editor has edit in its AllowActions with no condition, so no synthetic DENY

--- a/internal/ruletable/plan.go
+++ b/internal/ruletable/plan.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cerbos/cerbos/internal/evaluator"
 	"github.com/cerbos/cerbos/internal/namer"
 	"github.com/cerbos/cerbos/internal/observability/tracing"
+	"github.com/cerbos/cerbos/internal/ruletable/index"
 	"github.com/cerbos/cerbos/internal/ruletable/internal"
 	"github.com/cerbos/cerbos/internal/ruletable/planner"
 	"github.com/cerbos/cerbos/internal/schema"
@@ -128,6 +129,7 @@ func (rt *RuleTable) planWithAuditTrail(
 
 				rolesIncludingParents := rt.idx.AddParentRoles([]string{resourceScope}, []string{role})
 
+				var bindings []*index.Binding
 				for _, scope := range scopes {
 					var scopeAllowNode *planner.QpN
 					var scopeDenyNode *planner.QpN
@@ -181,7 +183,7 @@ func (rt *RuleTable) planWithAuditTrail(
 					if pt == policyv1.Kind_KIND_PRINCIPAL {
 						pid = input.Principal.Id
 					}
-					bindings := rt.idx.Query(resourceVersion, sanitizedResource, scope, action, rolesIncludingParents, pt, pid)
+					bindings = rt.idx.Query(resourceVersion, sanitizedResource, scope, action, rolesIncludingParents, pt, pid, bindings[:0])
 					for _, b := range bindings {
 						if m := rt.GetMeta(b.OriginFqn); m != nil && m.GetSourceAttributes() != nil {
 							maps.Copy(effectivePolicies, m.GetSourceAttributes())
@@ -241,7 +243,6 @@ func (rt *RuleTable) planWithAuditTrail(
 							}
 						}
 					}
-
 					roleDenyNode = addNode(roleDenyNode, scopeDenyNode, planner.MkOrNode)
 					roleDenyRolePolicyNode = addNode(roleDenyRolePolicyNode, scopeDenyRolePolicyNode, planner.MkOrNode)
 


### PR DESCRIPTION
Profiling the CPU under load showed GC works hard. To ease off GC pressure, I attempted to reuse bitmaps. The `FastOr` function allocates quite a few intermediate objects. Both `FastAnd` and `FastOr` were replaced with in-place operations, where an accumulator is allocated from the pool. 

The BenchmarkEvaluator has the same performance, but allocations dropped to 82 (from 100) per operation. The difference under load is significant. The RPS metric in the throughput test more than doubled, the response time distribution has a shorter tail.

Edit: @Sambigeara I can postpone this PR if it interferes with your work.