### PR TITLE
docs: Add agent skill link to policies nav

### DIFF
--- a/docs/modules/policies/nav.adoc
+++ b/docs/modules/policies/nav.adoc
@@ -12,3 +12,4 @@
 * xref:schemas.adoc[Schemas]
 * xref:compile.adoc[Validating and testing]
 * xref:best_practices.adoc[Best practices]
+* link:https://github.com/cerbos/skills[Agent skill]


### PR DESCRIPTION
Adds a link to https://github.com/cerbos/skills in the policies section nav, under "Best practices"
