### PR TITLE
Set `Content-Type` to `application/x-ndjson` on streaming responses

### DIFF
--- a/.changelog/20260428_1000.txt
+++ b/.changelog/20260428_1000.txt
@@ -1,0 +1,3 @@
+type:fix
+Set `Content-Type` to `application/x-ndjson` on streaming responses
+The `ListAuditLogEntries` is a streaming RPC, which returns newline-delimited JSON when accessed via HTTP. Previously, responses from this RPC had a `Content-Type` of `application/json`, which meant that the API explorer UI failed to render them. Now, responses from this RPC have the correct `Content-Type` of `application/x-ndjson`, and the API explorer UI renders them correctly.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -492,17 +492,31 @@ func mkGatewayMux(grpcConn grpc.ClientConnInterface) *grpcruntime.ServeMux {
 	return grpcruntime.NewServeMux(
 		grpcruntime.WithForwardResponseOption(customHTTPResponseCode),
 		grpcruntime.WithIncomingHeaderMatcher(incomingHeaderMatcher),
-		grpcruntime.WithMarshalerOption("application/json+pretty", &grpcruntime.JSONPb{
-			MarshalOptions:   protojson.MarshalOptions{Indent: "  "},
-			UnmarshalOptions: protojson.UnmarshalOptions{DiscardUnknown: false},
+		grpcruntime.WithMarshalerOption("application/json+pretty", &grpcJSONPb{
+			JSONPb: grpcruntime.JSONPb{
+				MarshalOptions:   protojson.MarshalOptions{Indent: "  "},
+				UnmarshalOptions: protojson.UnmarshalOptions{DiscardUnknown: false},
+			},
 		}),
-		grpcruntime.WithMarshalerOption(grpcruntime.MIMEWildcard, &grpcruntime.JSONPb{
-			UnmarshalOptions: protojson.UnmarshalOptions{DiscardUnknown: false},
+		grpcruntime.WithMarshalerOption(grpcruntime.MIMEWildcard, &grpcJSONPb{
+			JSONPb: grpcruntime.JSONPb{
+				UnmarshalOptions: protojson.UnmarshalOptions{DiscardUnknown: false},
+			},
 		}),
 		grpcruntime.WithMetadata(setPeerMetadata),
 		grpcruntime.WithRoutingErrorHandler(handleRoutingError),
 		grpcruntime.WithHealthEndpointAt(healthpb.NewHealthClient(grpcConn), healthEndpoint),
 	)
+}
+
+type grpcJSONPb struct {
+	grpcruntime.JSONPb
+}
+
+var _ grpcruntime.StreamContentType = (*grpcJSONPb)(nil)
+
+func (*grpcJSONPb) StreamContentType(any) string {
+	return "application/x-ndjson"
 }
 
 func defaultGRPCDialOpts() []grpc.DialOption {


### PR DESCRIPTION
Fixes #3102

<img width="1042" height="326" alt="Screenshot 2026-04-28 at 10 58 00" src="https://github.com/user-attachments/assets/3cf88974-d90e-4fe3-8756-c2fad91cd749" />

