### PR TITLE
Remove incorrect default tag value from Helm chart

### DIFF
--- a/deploy/charts/cerbos/values.schema.json
+++ b/deploy/charts/cerbos/values.schema.json
@@ -232,7 +232,7 @@
           "title": "repository"
         },
         "tag": {
-          "default": "@sha256:8d35a64e4a9989d732ff01a4046f879600c8e3b70cae47527236b759b07c3687",
+          "default": "",
           "description": "Image tag to use. Defaults to the chart appVersion.",
           "required": [],
           "title": "tag",

--- a/deploy/charts/cerbos/values.yaml
+++ b/deploy/charts/cerbos/values.yaml
@@ -44,7 +44,7 @@ image:
   # type: [string,null]
   # @schema
   # Image tag to use. Defaults to the chart appVersion.
-  tag: "@sha256:8d35a64e4a9989d732ff01a4046f879600c8e3b70cae47527236b759b07c3687"
+  tag: ""
 
 # @schema
 # type: [array,null]
@@ -145,8 +145,7 @@ securityContext: {}
 # additionalProperties: true
 # @schema
 # Resource limits for the pod. See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources.
-resources:
-  {}
+resources: {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -181,11 +180,11 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
-# @schema
-# type: [object, null]
-# additionalProperties: true
-# @schema
-# Node selector for the pod. See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
+  # @schema
+  # type: [object, null]
+  # additionalProperties: true
+  # @schema
+  # Node selector for the pod. See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
 nodeSelector: {}
 
 # @schema
@@ -211,8 +210,8 @@ affinity: {}
 #   additionalProperties: true
 # @schema
 # Topology Spread Constraints rules. See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
-topologySpreadConstraints:
-  [] # @schema type:[array,null]
+topologySpreadConstraints: []
+  # @schema type:[array,null]
   # - topologyKey: topology.kubernetes.io/zone
   #   maxSkew: 1
   #   whenUnsatisfiable: ScheduleAnyway

--- a/deploy/charts/cerbos/values.yaml
+++ b/deploy/charts/cerbos/values.yaml
@@ -178,13 +178,12 @@ autoscaling:
   minReplicas: 1
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
 
-  # @schema
-  # type: [object, null]
-  # additionalProperties: true
-  # @schema
-  # Node selector for the pod. See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
+# @schema
+# type: [object, null]
+# additionalProperties: true
+# @schema
+# Node selector for the pod. See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
 nodeSelector: {}
 
 # @schema


### PR DESCRIPTION
Renovate updated the default tag value in `values.yaml` to a hash which
breaks the chart.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
