### PR TITLE
Move Helm release to its own workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -166,54 +166,6 @@ jobs:
           auth_token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           site_id: ${{ secrets.NETLIFY_SITE_ID }}
 
-  publishHelm:
-    name: Publish Helm chart
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      id-token: write
-      contents: read
-    env:
-      CHARTS_DIR: deploy/out/helm-charts
-      OCI_REGISTRY: ghcr.io/cerbos/helm-charts
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Install Helm
-        uses: cerbos/actions/install-tools@aff2ae494c8b0f0a9e9faee6d5974221a21617da # main
-        with:
-          tools: helm
-
-      - name: GCloud Auth
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY}}
-
-      - name: Install Cloud SDK
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
-
-      - name: Package Helm chart
-        run: |-
-          mkdir -p ${{ env.CHARTS_DIR }}/cerbos
-          helm package -d ${{ env.CHARTS_DIR }}/cerbos deploy/charts/cerbos
-
-      - name: Publish to download site
-        run: |-
-          gsutil cp "gs://${{ secrets.DOWNLOAD_GCS_BUCKET }}/helm-charts/index.yaml" "${{ env.CHARTS_DIR }}/index.yaml"
-          helm repo index --url=https://download.cerbos.dev/helm-charts --merge=${{ env.CHARTS_DIR }}/index.yaml ${{ env.CHARTS_DIR }}
-          gsutil rsync -r ${{ env.CHARTS_DIR }}/ "gs://${{ secrets.DOWNLOAD_GCS_BUCKET }}/helm-charts/"
-
-      - name: Publish to OCI registry
-        run: |-
-          helm registry login ${{ env.OCI_REGISTRY }} -u ${{ secrets.HELM_CHARTS_REPO_USER }} -p ${{ secrets.HELM_CHARTS_REPO_TOKEN }}
-          CHART=$(ls ${{ env.CHARTS_DIR }}/cerbos/*.tgz); helm push "$CHART" oci://${{ env.OCI_REGISTRY }}
-          helm registry logout ${{ env.OCI_REGISTRY }}
-        env:
-          HELM_EXPERIMENTAL_OCI: "1"
-
   publishLambdaFunction:
     name: Publish AWS Lambda Function to SAR
     runs-on: ubuntu-latest

--- a/deploy/charts/cerbos/Chart.yaml
+++ b/deploy/charts/cerbos/Chart.yaml
@@ -16,6 +16,6 @@ keywords:
   - policies
   - rbac
   - security
-version: "0.52.1"
-appVersion: "0.52.0"
+version: "0.53.0"
+appVersion: "0.53.0"
 kubeVersion: ">=1.23.0-0"

--- a/hack/scripts/prep-release.sh
+++ b/hack/scripts/prep-release.sh
@@ -84,6 +84,7 @@ set_branch "HEAD"
 git -C "$PROJECT_DIR" commit -s -a -m "chore(release): Prepare release $VERSION"
 git tag "v${VERSION}" -m "v${VERSION}"
 git tag "api/genpb/v${VERSION}" -m "api/genpb/v${VERSION}"
+git tag "helm/v${VERSION}" -m "helm/v${VERSION}"
 # Create a release branch
 SEGMENTS=(${VERSION//./ })
 RELEASE_BRANCH="v${SEGMENTS[0]}.${SEGMENTS[1]}"
@@ -97,4 +98,4 @@ set_branch "HEAD"
 git -C "$PROJECT_DIR" commit -s -a -m "chore(version): Bump version to $NEXT_VERSION"
 
 echo "Run the following commands to trigger the release"
-echo "git push --atomic upstream main ${RELEASE_BRANCH} v${VERSION} api/genpb/v${VERSION}"
+echo "git push --atomic upstream main ${RELEASE_BRANCH} v${VERSION} api/genpb/v${VERSION} helm/v${VERSION}"


### PR DESCRIPTION
Avoid duplicating the steps in the `release` workflow and let the Helm
publish workflow be driven by the presence of `helm/vX.Y.Z` tags.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
