### PR TITLE
fix planner ignoring OVERRIDE_PARENT for parent DENYs

### DIFF
--- a/.changelog/20260430_0746.txt
+++ b/.changelog/20260430_0746.txt
@@ -1,0 +1,3 @@
+type:fix
+Honour OVERRIDE_PARENT scope semantics for parent-scope DENYs in query plans
+This fixes a bug introduced in Cerbos v0.50 where an unconditional `DENY` rule at a parent scope could cause `PlanResources` to return `KIND_ALWAYS_DENIED`, even when a child scope using `SCOPE_PERMISSIONS_OVERRIDE_PARENT` granted the action.

--- a/internal/ruletable/plan.go
+++ b/internal/ruletable/plan.go
@@ -126,11 +126,18 @@ func (rt *RuleTable) planWithAuditTrail(
 				var roleDenyNode *planner.QpN
 				var roleDenyRolePolicyNode *planner.QpN
 				var pendingAllow bool
+				var childOverrideAllow *planner.QpN
 
 				rolesIncludingParents := rt.idx.AddParentRoles([]string{resourceScope}, []string{role})
 
 				var bindings []*index.Binding
 				for _, scope := range scopes {
+					// Once a child OVERRIDE_PARENT scope has matched an unconditional ALLOW, no
+					// parent-scope rule can change the outcome, so we skip
+					if bv, ok := planner.IsNodeConstBool(childOverrideAllow); ok && bv {
+						break
+					}
+
 					var scopeAllowNode *planner.QpN
 					var scopeDenyNode *planner.QpN
 					var scopeDenyRolePolicyNode *planner.QpN
@@ -243,6 +250,10 @@ func (rt *RuleTable) planWithAuditTrail(
 							}
 						}
 					}
+
+					scopeDenyNode = gateByChildOverrideAllow(childOverrideAllow, scopeDenyNode)
+					scopeDenyRolePolicyNode = gateByChildOverrideAllow(childOverrideAllow, scopeDenyRolePolicyNode)
+
 					roleDenyNode = addNode(roleDenyNode, scopeDenyNode, planner.MkOrNode)
 					roleDenyRolePolicyNode = addNode(roleDenyRolePolicyNode, scopeDenyRolePolicyNode, planner.MkOrNode)
 
@@ -266,6 +277,11 @@ func (rt *RuleTable) planWithAuditTrail(
 					if (scopeDenyNode != nil || scopeDenyRolePolicyNode != nil || scopeAllowNode != nil) &&
 						rt.GetScopeScopePermissions(scope) == policyv1.ScopePermissions_SCOPE_PERMISSIONS_OVERRIDE_PARENT {
 						matchedScopes[action] = scope
+					}
+
+					if scopeAllowNode != nil &&
+						rt.GetScopeScopePermissions(scope) == policyv1.ScopePermissions_SCOPE_PERMISSIONS_OVERRIDE_PARENT {
+						childOverrideAllow = addNode(childOverrideAllow, scopeAllowNode, planner.MkOrNode)
 					}
 				}
 
@@ -383,4 +399,17 @@ func addNode(curr, next *planner.QpN, combine func([]*planner.QpN) *planner.QpN)
 		return next
 	}
 	return combine([]*planner.QpN{curr, next})
+}
+
+// gateByChildOverrideAllow narrows a parent-scope DENY to only fire when no child OVERRIDE_PARENT
+// scope has already produced an ALLOW.
+func gateByChildOverrideAllow(childOverrideAllow, deny *planner.QpN) *planner.QpN {
+	if deny == nil || childOverrideAllow == nil {
+		return deny
+	}
+	inv := planner.InvertNodeBooleanValue(childOverrideAllow)
+	if bv, ok := planner.IsNodeConstBool(deny); ok && bv {
+		return inv
+	}
+	return planner.MkAndNode([]*planner.QpN{inv, deny})
 }

--- a/internal/test/testdata/query_planner/policies/resource_policies/additive.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policies/additive.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../../../schema/jsonschema/cerbos/policy/v1/Policy.schema.json
+---
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  resource: "additive"
+  version: "2025_11"
+  rules:
+    - actions: ['*']
+      effect: EFFECT_DENY
+      roles:
+        - '*'

--- a/internal/test/testdata/query_planner/policies/resource_policies/additive_acme.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policies/additive_acme.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../../../../../schema/jsonschema/cerbos/policy/v1/Policy.schema.json
+---
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  resource: "additive"
+  version: "2025_11"
+  scope: "acme"
+  rules:
+    - actions: ['*']
+      effect: EFFECT_DENY
+      roles:
+        - '*'

--- a/internal/test/testdata/query_planner/policies/resource_policies/additive_acme_hr.yaml
+++ b/internal/test/testdata/query_planner/policies/resource_policies/additive_acme_hr.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../../../../../schema/jsonschema/cerbos/policy/v1/Policy.schema.json
+---
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  resource: "additive"
+  version: "2025_11"
+  scope: "acme.hr"
+  rules:
+    - actions: ['*']
+      effect: EFFECT_ALLOW
+      roles:
+        - user

--- a/internal/test/testdata/query_planner/suite/common/additive.yaml
+++ b/internal/test/testdata/query_planner/suite/common/additive.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=../../.jsonschema/QueryPlannerTestSuite.schema.json
+---
+description: A child scope's ALLOW overrides unconditional DENYs at parent scopes under OVERRIDE_PARENT.
+principal:
+    id: alice
+    policyVersion: "2025_11"
+    roles:
+        - user
+tests:
+    - action: read
+      resource:
+        kind: additive
+        scope: acme.hr
+        policyVersion: "2025_11"
+      want:
+        kind: KIND_ALWAYS_ALLOWED


### PR DESCRIPTION
The actual fix was to gate parent-scope DENYs by `NOT childOverrideAllow` so an ALLOW from an OVERRIDE_PARENT child scope suppresses them. The planner was previously OR'ing DENYs flat across scopes with no OVERRIDE_PARENT awareness at all. The early loop return is just an optimisation. I reckon it was introduced in https://github.com/cerbos/cerbos/pull/2849

Fixes https://github.com/cerbos/cerbos-private/issues/1883