### PR TITLE
Move path functions documentation to correct place

### DIFF
--- a/docs/modules/policies/pages/conditions.adoc
+++ b/docs/modules/policies/pages/conditions.adoc
@@ -277,25 +277,6 @@ Duration values must be specified in one of the following units. Larger units li
 | timeSince | Time elapsed since the given timestamp to current time on the server. This is a Cerbos extension to CEL | timestamp(R.attr.lastAccessed).timeSince() > duration("1h")
 |===
 
-[#paths]
-== Paths
-
-NOTE: The path functions are Cerbos-specific extensions to CEL.
-
-[caption=]
-[%header,cols=".^1m,.^2,4m",grid=rows]
-|===
-| Function       | Description                                                    | Example
-| basePath       | Returns the last element of a path                             | basePath("/path/to/dir") == "dir"
-| dirPath        | Returns the directory portion of a path                        | dirPath("/path/to/file.txt") == "/path/to"
-| extPath        | Returns the file extension of a path including the leading dot | extPath("/path/to/file.txt") == ".txt"
-| joinPath       | Joins a list of path segments into a single path               | joinPath(["/path", "to", "file.txt"]) == "/path/to/file.txt"
-| pathHasPrefix  | Returns true if the second path is a prefix of the first path  | pathHasPrefix("/path/to/dir", "/path/to") == true && "/path/to/dir".pathHasPrefix("/path/to") == true
-| pathMatch      | Returns true if path matches a given glob pattern              | pathMatch("/path/to/file.zip", "/path/to/*.zip") == true && "/path/to/file.zip".pathMatch("/path/to/*.zip") == true
-| pathMatchAnyOf | Returns true if path matches any of the given glob patterns    | pathMatchAnyOf("/path/to/file.zip", ["/path/to/*.tar.gz", "/path/to/*.zip"]) == true && "/path/to/file.zip".pathMatchAnyOf(["/path/to/*.tar.gz", "/path/to/*.zip"]) == true
-| relPath        | Returns the relative path from a base path to a target path    | relPath("/path/to", "/path/to/file.txt") == "file.txt"
-| volumeName     | Returns leading volume name for Windows paths                  | volumeName("C:\path\to\dir") == "C:"
-|===
 
 [#hierarchies]
 == Hierarchies
@@ -444,6 +425,26 @@ NOTE: The IP address functions are Cerbos-specific extensions to CEL.
 | math.round | Rounds the double value to the nearest whole number with ties rounding away from zero, e.g. 1.5 -> 2.0, -1.5 -> -2.0 | math.round(1.2) == 1.0 && math.round(1.5) == 2.0 && math.round(-1.5) == -2.0
 | math.sign | Returns the sign of the numeric type, either -1, 0, 1 | math.sign(1.2) == 1.0 && math.sign(-2) == -1 && math.sign(0) == 0
 | math.trunc | Truncates the fractional portion of the double value | math.trunc(1.2) == 1.0 && math.trunc(-1.2) == -1.0
+|===
+
+[#paths]
+== Paths
+
+NOTE: The path functions are Cerbos-specific extensions to CEL.
+
+[caption=]
+[%header,cols=".^1m,.^2,4m",grid=rows]
+|===
+| Function       | Description                                                    | Example
+| basePath       | Returns the last element of a path                             | basePath("/path/to/dir") == "dir"
+| dirPath        | Returns the directory portion of a path                        | dirPath("/path/to/file.txt") == "/path/to"
+| extPath        | Returns the file extension of a path including the leading dot | extPath("/path/to/file.txt") == ".txt"
+| joinPath       | Joins a list of path segments into a single path               | joinPath(["/path", "to", "file.txt"]) == "/path/to/file.txt"
+| pathHasPrefix  | Returns true if the second path is a prefix of the first path  | pathHasPrefix("/path/to/dir", "/path/to") == true && "/path/to/dir".pathHasPrefix("/path/to") == true
+| pathMatch      | Returns true if path matches a given glob pattern              | pathMatch("/path/to/file.zip", "/path/to/*.zip") == true && "/path/to/file.zip".pathMatch("/path/to/*.zip") == true
+| pathMatchAnyOf | Returns true if path matches any of the given glob patterns    | pathMatchAnyOf("/path/to/file.zip", ["/path/to/*.tar.gz", "/path/to/*.zip"]) == true && "/path/to/file.zip".pathMatchAnyOf(["/path/to/*.tar.gz", "/path/to/*.zip"]) == true
+| relPath        | Returns the relative path from a base path to a target path    | relPath("/path/to", "/path/to/file.txt") == "file.txt"
+| volumeName     | Returns leading volume name for Windows paths                  | volumeName("C:\path\to\dir") == "C:"
 |===
 
 [#spiffe]


### PR DESCRIPTION
The `paths` section is not in the right place alphabetically.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
