### PR TITLE
Fix rendering of wildcard characters

### DIFF
--- a/docs/modules/policies/pages/conditions.adoc
+++ b/docs/modules/policies/pages/conditions.adoc
@@ -441,8 +441,8 @@ NOTE: The path functions are Cerbos-specific extensions to CEL.
 | extPath        | Returns the file extension of a path including the leading dot | extPath("/path/to/file.txt") == ".txt"
 | joinPath       | Joins a list of path segments into a single path               | joinPath(["/path", "to", "file.txt"]) == "/path/to/file.txt"
 | pathHasPrefix  | Returns true if the second path is a prefix of the first path  | pathHasPrefix("/path/to/dir", "/path/to") == true && "/path/to/dir".pathHasPrefix("/path/to") == true
-| pathMatch      | Returns true if path matches a given glob pattern              | pathMatch("/path/to/file.zip", "/path/to/*.zip") == true && "/path/to/file.zip".pathMatch("/path/to/*.zip") == true
-| pathMatchAnyOf | Returns true if path matches any of the given glob patterns    | pathMatchAnyOf("/path/to/file.zip", ["/path/to/*.tar.gz", "/path/to/*.zip"]) == true && "/path/to/file.zip".pathMatchAnyOf(["/path/to/*.tar.gz", "/path/to/*.zip"]) == true
+| pathMatch      | Returns true if path matches a given glob pattern              | pathMatch("/path/to/file.zip", "/path/to/+*+.zip") == true && "/path/to/file.zip".pathMatch("/path/to/+*+.zip") == true
+| pathMatchAnyOf | Returns true if path matches any of the given glob patterns    | pathMatchAnyOf("/path/to/file.zip", ["/path/to/+*+.tar.gz", "/path/to/+*+.zip"]) == true && "/path/to/file.zip".pathMatchAnyOf(["/path/to/+*+.tar.gz", "/path/to/+*+.zip"]) == true
 | relPath        | Returns the relative path from a base path to a target path    | relPath("/path/to", "/path/to/file.txt") == "file.txt"
 | volumeName     | Returns leading volume name for Windows paths                  | volumeName("C:\path\to\dir") == "C:"
 |===


### PR DESCRIPTION
The path examples with wildcards were getting rendered as bold text
without the asterisks because they weren't escaped.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
