### PR TITLE
Stop publishing the Helm chart to OCI registry

### DIFF
--- a/.changelog/20260505_1237.txt
+++ b/.changelog/20260505_1237.txt
@@ -1,0 +1,3 @@
+type:deprecation
+Stop publishing the Helm chart to oci://ghcr.io/cerbos/helm-charts/cerbos
+Starting from v0.54.0, new releases of the Cerbos Helm chart will only be available from the main repository at {app-helm-chart-repo}. The OCI registry at ghcr.io/cerbos/helm-charts/cerbos will no longer be updated to include new chart versions. This is due to low uptake which doesn't justify the complexity of managing the OCI registry publishing workflow.

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -46,11 +46,3 @@ jobs:
           gsutil cp "gs://${{ secrets.DOWNLOAD_GCS_BUCKET }}/helm-charts/index.yaml" "${{ env.CHARTS_DIR }}/index.yaml"
           helm repo index --url=https://download.cerbos.dev/helm-charts --merge=${{ env.CHARTS_DIR }}/index.yaml ${{ env.CHARTS_DIR }}
           gsutil rsync -r ${{ env.CHARTS_DIR }}/ "gs://${{ secrets.DOWNLOAD_GCS_BUCKET }}/helm-charts/"
-
-      - name: Publish to OCI registry
-        run: |-
-          helm registry login ${{ env.OCI_REGISTRY }} -u ${{ secrets.HELM_CHARTS_REPO_USER }} -p ${{ secrets.HELM_CHARTS_REPO_TOKEN }}
-          CHART=$(ls ${{ env.CHARTS_DIR }}/cerbos/*.tgz); helm push "$CHART" oci://${{ env.OCI_REGISTRY }}
-          helm registry logout ${{ env.OCI_REGISTRY }}
-        env:
-          HELM_EXPERIMENTAL_OCI: "1"

--- a/docs/modules/ROOT/pages/installation/helm.adoc
+++ b/docs/modules/ROOT/pages/installation/helm.adoc
@@ -20,18 +20,6 @@ You can view all the available configuration values for the chart by running the
 helm show values cerbos/cerbos --version={app-version}
 ----
 
-[NOTE]
-====
-
-Cerbos Helm chart is also available from an link:https://helm.sh/docs/topics/registries/[OCI registry].
-
-[source,sh,subs="attributes"]
-----
-HELM_EXPERIMENTAL_OCI=1 helm install cerbos oci://ghcr.io/cerbos/helm-charts/cerbos --version={app-version}
-----
-
-====
-
 .Securing Cerbos with TLS
 ****
 


### PR DESCRIPTION
The only way to authenticate is with a PAT and that risk is not
justified by the low usage of the OCI registry.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
