### PR TITLE
Ignore `helm/*` tags when building snapshots

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,8 @@ snapshot:
 
 git:
   ignore_tags:
-    - "api/genpb/*"
+    - api/genpb/*
+    - helm/*
 
 builds:
   - main: ./cmd/cerbos


### PR DESCRIPTION
Fixes

```
current tag is not semver error=invalid semantic version tag=helm/v0.53.0
```