### PR TITLE
Notify Slack on workflow cancellations as well

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -63,7 +63,7 @@ jobs:
           E2E_PACKAGE: ${{ inputs.package }}
 
       - name: Notify Slack on failure
-        if: failure()
+        if: "!success()"
         uses: cerbos/actions/notify-slack@6e173289a5f7dbcc0a62e6cb761e18f22f0b2070 # main
         with:
           webhook-url: ${{ secrets.SLACK_CI_NOTIFICATIONS_WEBHOOK_URL }}

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -31,7 +31,7 @@ jobs:
         run: just vulnerability-check
 
       - name: Notify Slack on failure
-        if: failure()
+        if: "!success()"
         uses: cerbos/actions/notify-slack@6e173289a5f7dbcc0a62e6cb761e18f22f0b2070 # main
         with:
           webhook-url: ${{ secrets.SLACK_CI_NOTIFICATIONS_WEBHOOK_URL }}


### PR DESCRIPTION
We currently don't get pinged if a job times out rather than failing outright. This PR remedies that by changing the notification condition from `failure()` to `!success()`.