### PR TITLE
Prevent Renovate from updating the Helm chart values file

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -95,6 +95,16 @@
                 "major"
             ],
             "enabled": false
+        },
+        {
+            "description": "Prevent Renovate from incorrectly updating the Helm chart values.yaml",
+            "matchPackageNames": [
+                "ghcr.io/cerbos/cerbos"
+            ],
+            "matchFileNames": [
+                "deploy/charts/cerbos/*"
+            ],
+            "enabled": false
         }
     ],
     "labels": [


### PR DESCRIPTION
Renovate insists on updating the values file with the hash of the
current Cerbos container.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
