### PR TITLE
Export binary path from npm packages

### DIFF
--- a/npm/packages/cerbos/bin.js
+++ b/npm/packages/cerbos/bin.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require(".").run(...process.argv.slice(2));

--- a/npm/packages/cerbos/index.d.ts
+++ b/npm/packages/cerbos/index.d.ts
@@ -1,0 +1,2 @@
+export const binaryPath: string;
+export function run(...args: string[]): void;

--- a/npm/packages/cerbos/index.js
+++ b/npm/packages/cerbos/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+const { execFileSync } = require("child_process");
 
 const { platform: os, arch } = process;
 const currentPlatform = `${os}-${arch}`;
@@ -31,4 +31,8 @@ Make sure optional dependencies are installed.`, { cause: error });
   }
 })();
 
-require("child_process").execFileSync(binaryPath, process.argv.slice(2), { stdio: "inherit" });
+function run(...args) {
+  execFileSync(binaryPath, args, { stdio: "inherit" });
+}
+
+module.exports = { binaryPath, run };

--- a/npm/packages/cerbos/package.json
+++ b/npm/packages/cerbos/package.json
@@ -14,9 +14,13 @@
   "author": "Cerbos <help@cerbos.dev> (https://cerbos.dev)",
   "license": "Apache-2.0",
   "bin": {
-    "cerbos": "index.js"
+    "cerbos": "bin.js"
   },
+  "main": "index.js",
+  "types": "index.d.ts",
   "files": [
+    "bin.js",
+    "index.d.ts",
     "index.js"
   ],
   "keywords": [

--- a/npm/packages/cerbosctl/bin.js
+++ b/npm/packages/cerbosctl/bin.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require(".").run(...process.argv.slice(2));

--- a/npm/packages/cerbosctl/index.d.ts
+++ b/npm/packages/cerbosctl/index.d.ts
@@ -1,0 +1,2 @@
+export const binaryPath: string;
+export function run(...args: string[]): void;

--- a/npm/packages/cerbosctl/index.js
+++ b/npm/packages/cerbosctl/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+const { execFileSync } = require("child_process");
 
 const { platform: os, arch } = process;
 const currentPlatform = `${os}-${arch}`;
@@ -31,4 +31,8 @@ Make sure optional dependencies are installed.`, { cause: error });
   }
 })();
 
-require("child_process").execFileSync(binaryPath, process.argv.slice(2), { stdio: "inherit" });
+function run(...args) {
+  execFileSync(binaryPath, args, { stdio: "inherit" });
+}
+
+module.exports = { binaryPath, run };

--- a/npm/packages/cerbosctl/package.json
+++ b/npm/packages/cerbosctl/package.json
@@ -14,9 +14,13 @@
   "author": "Cerbos <help@cerbos.dev> (https://cerbos.dev)",
   "license": "Apache-2.0",
   "bin": {
-    "cerbosctl": "index.js"
+    "cerbosctl": "bin.js"
   },
+  "main": "index.js",
+  "types": "index.d.ts",
   "files": [
+    "bin.js",
+    "index.d.ts",
     "index.js"
   ],
   "keywords": [

--- a/npm/test/cases/yarn@2/package.json
+++ b/npm/test/cases/yarn@2/package.json
@@ -1,6 +1,9 @@
 {
   "private": true,
   "packageManager": "yarn@2.4.3+sha512.8dd9fedc5451829619e526c56f42609ad88ae4776d9d3f9456d578ac085115c0c2f0fb02bb7d57fd2e1b6e1ac96efba35e80a20a056668f61c96934f67694fd0",
+  "scripts": {
+    "node": "node"
+  },
   "dependencies": {
     "cerbos": "latest",
     "cerbosctl": "latest"

--- a/npm/test/run.sh
+++ b/npm/test/run.sh
@@ -90,10 +90,7 @@ execute_binary_directly() {
   fi
 }
 
-execute_binary_via_package_manager() {
-  local binary
-  binary="$1"
-
+execute_via_package_manager() {
   local command
 
   case "${test_case}" in
@@ -114,20 +111,32 @@ execute_binary_via_package_manager() {
 execute_binary() {
   local binary
   binary="$1"
+  shift
 
   log_subheading "Executing ${binary}"
 
-  local expected
-  execute_binary_directly "$@"
+  local expected actual
+  execute_binary_directly "${binary}" "$@"
   expected="${expected_output[$binary]}"
+  actual=$(execute_via_package_manager "${binary}" "$@")
+  compare "${expected}" "${actual}" "Executing via package manager"
 
-  local actual
-  actual=$(execute_binary_via_package_manager "$@")
+  local path
+  path=$(execute_via_package_manager node --print "require('${binary}').binaryPath")
+  actual=$("${path}" "$@")
+  compare "${expected}" "${actual}" "Executing via exported path"
+}
+
+compare() {
+  local expected actual message
+  expected="$1"
+  actual="$2"
+  message="$3"
 
   if diff <(printf "%s\n" "${expected}") <(printf "%s\n" "${actual}"); then
-    echo "OK"
+    printf "%s: OK\n" "${message}"
   else
-    log_error "Unexpected output"
+    log_error "${message}: unexpected output"
     exit 1
   fi
 }


### PR DESCRIPTION
This PR exposes the path to the `cerbos`/`cerbosctl` binaries from their respective npm packages, which allows for direct execution when spawning a child process is undesirable.