### PR TITLE
Fix Siteline edge function

### DIFF
--- a/docs/edge_functions/siteline.ts
+++ b/docs/edge_functions/siteline.ts
@@ -4,7 +4,7 @@ type NetlifyContext = {
     next: () => Promise<Response>;
 };
 
-const SITELINE_WEBSITE_KEY = process.env.SITELINE_WEBSITE_KEY;
+const SITELINE_WEBSITE_KEY = Netlify.env.get("SITELINE_WEBSITE_KEY");
 const SITELINE_DEBUG = false;
 const SITELINE_ENDPOINT = 'https://api.siteline.ai/v1/intake/pageview'
 

--- a/docs/edge_functions/siteline.ts
+++ b/docs/edge_functions/siteline.ts
@@ -1,4 +1,8 @@
-
+import { Config } from "@netlify/edge-functions"
+export const config: Config = {
+    path: "/*",
+    onError: "bypass"
+}
 
 type NetlifyContext = {
     next: () => Promise<Response>;


### PR DESCRIPTION
Netlify suddenly started rejecting calls to `process.env` in edge functions. 

Also configures an error handler to bypass the function on error but whether it will work for future problems like this is anybody's guess 🤷🏽‍♂️ 