### PR TITLE
docs(tutorial): fix typo in sentence

### DIFF
--- a/docs/modules/ROOT/pages/tutorial/06_derived-roles.adoc
+++ b/docs/modules/ROOT/pages/tutorial/06_derived-roles.adoc
@@ -9,7 +9,7 @@ NOTE: The policies for this section can be found link:{tutorial-base}/07-derived
 
 The business requirements for Cerbforce state that only an owner of Contacts and Companies are allowed to delete them from the system. With Cerbos, the aim is to keep policies as simple as possible and not repeat logic across different resources, so in this situation, a xref:policies:derived_roles.adoc[Derived Role] can enable help.
 
-Derived roles are a way of augmenting the broad roles with are attached to the user in the directory of the authentication system with contextual data to provide more fine-grained control at runtime. On every request, all the relevant derived role policies are evaluated and those matching roles are 'attached' to the user as Cerbos computes access.
+Derived roles are a way of augmenting the broad roles which are attached to the user in the directory of the authentication system with contextual data to provide more fine-grained control at runtime. On every request, all the relevant derived role policies are evaluated and those matching roles are 'attached' to the user as Cerbos computes access.
 
 == Owner derived role
 

--- a/docs/modules/policies/pages/evaluation.adoc
+++ b/docs/modules/policies/pages/evaluation.adoc
@@ -36,7 +36,7 @@ For each action in the request, Cerbos evaluates all rules in the matched policy
 
 . The rule's `actions` match the requested action. Wildcards are supported and respect the `:` delimiter (e.g. `view:*` matches `view:public` but not `view`).
 . The rule's `roles` or `derivedRoles` include at least one of the principal's static roles or activated derived roles.
-. If the rule has a xref:conditions.adoc[condition], it evaluates to `true`.
+. If the rule has a xref:conditions.adoc[condition], the condition evaluates to `true`.
 
 
 [#conflict-resolution]


### PR DESCRIPTION
spelling fixes and enhancements:
* `which` instead of `with`
* Clarify that a rule matches only when its condition is true.