### PR TITLE
Build binaries at AMD64 microarchitecture level v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,7 @@ builds:
     id: "cerbos"
     env:
       - CGO_ENABLED=0
+      - GOAMD64=v2
     goos:
       - linux
       - darwin
@@ -41,6 +42,7 @@ builds:
     id: cerbos-aws-lambda-ext
     env:
       - CGO_ENABLED=0
+      - GOAMD64=v2
     goos:
       - linux
     goarch:
@@ -56,6 +58,7 @@ builds:
     id: "cerbos-aws-lambda-func"
     env:
       - CGO_ENABLED=0
+      - GOAMD64=v2
     goos:
       - linux
     goarch:
@@ -73,6 +76,7 @@ builds:
     id: "cerbos-aws"
     env:
       - CGO_ENABLED=0
+      - GOAMD64=v2
     goos:
       - linux
       - darwin
@@ -90,6 +94,7 @@ builds:
     id: "cerbosctl"
     env:
       - CGO_ENABLED=0
+      - GOAMD64=v2
     goos:
       - linux
       - darwin

--- a/.justfile
+++ b/.justfile
@@ -156,7 +156,11 @@ tests PKG='./...' TEST='.*': _gotestsum
     @ gotestsum --format=dots-v2 --format-hide-empty-pkg -- -tags=tests,integration -failfast -count=1 -run='{{ TEST }}' '{{ PKG }}'
 
 test-integration TESTSPLIT_INDEX='0' TESTSPLIT_TOTAL='1': _gotestsum _testsplit
-    @ CGO_ENABLED=1 testsplit split \
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    export CGO_ENABLED=1 # Required for race detector
+    testsplit split \
         --kind=integration \
         --index={{ TESTSPLIT_INDEX }} \
         --total={{ TESTSPLIT_TOTAL }} \

--- a/.justfile
+++ b/.justfile
@@ -10,6 +10,8 @@ testdata_json_schema_dir := join(justfile_directory(), "internal", "test", "test
 testsplit_dir := join(justfile_directory(), "hack", "tools", "testsplit")
 tools_mod_dir := join(justfile_directory(), "tools")
 
+export CGO_ENABLED := '0'
+export GOAMD64 := 'v2'
 export TOOLS_BIN_DIR := join(env_var_or_default("XDG_CACHE_HOME", join(env_var("HOME"), ".cache")), "cerbos/bin")
 export PATH := TOOLS_BIN_DIR + ":" + env_var("PATH")
 
@@ -32,8 +34,8 @@ clean:
     @ rm -rf {{ genpb_dir }}/cerbos {{ genmocks_dir }}  {{ json_schema_dir }} {{ openapi_dir }}
 
 compile:
-    @ CGO_ENABLED=0 go build ./...
-    @ CGO_ENABLED=0 go test -tags=e2e,tests,integration -run=ignore  ./... > /dev/null
+    @ go build ./...
+    @ go test -tags=e2e,tests,integration -run=ignore  ./... > /dev/null
     @ GOOS=js GOARCH=wasm go build ./private/ruletable
 
 cover PKG='./...' TEST='.*': _cover
@@ -60,7 +62,7 @@ generate-confdocs:
     cd {{ justfile_directory() }}
     mkdir -p ./internal/confdocs
     go run -tags confdocs ./hack/tools/confdocs/confdocs.go > ./internal/confdocs/generated.go
-    CGO_ENABLED=0 go run ./internal/confdocs/generated.go
+    go run ./internal/confdocs/generated.go
     rm -rf ./internal/confdocs
 
 generate-helm: _helm-schema

--- a/.justfile
+++ b/.justfile
@@ -156,7 +156,7 @@ tests PKG='./...' TEST='.*': _gotestsum
     @ gotestsum --format=dots-v2 --format-hide-empty-pkg -- -tags=tests,integration -failfast -count=1 -run='{{ TEST }}' '{{ PKG }}'
 
 test-integration TESTSPLIT_INDEX='0' TESTSPLIT_TOTAL='1': _gotestsum _testsplit
-    @ testsplit split \
+    @ CGO_ENABLED=1 testsplit split \
         --kind=integration \
         --index={{ TESTSPLIT_INDEX }} \
         --total={{ TESTSPLIT_TOTAL }} \


### PR DESCRIPTION
Pretty much all modern CPUs should support this.

- https://go.dev/wiki/MinimumRequirements#amd64
- https://lemire.me/blog/2026/06/06/how-much-do-amd64-microarchitecture-levels-help-in-go/

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
