### PR TITLE
Pace GC during rule table builds

### DIFF
--- a/.changelog/20260612_0020.txt
+++ b/.changelog/20260612_0020.txt
@@ -1,0 +1,2 @@
+type:enhancement
+Reduce steady-state memory usage by pacing the garbage collector during rule table builds. Very large policy stores may take slightly longer to start.

--- a/internal/observability/logging/logging_stub.go
+++ b/internal/observability/logging/logging_stub.go
@@ -24,6 +24,7 @@ func (*Logger) Debugf(string, ...any) {}
 func (*Logger) Warn(string, ...any)   {}
 func (*Logger) Warnw(string, ...any)  {}
 func (*Logger) Info(...any)           {}
+func (*Logger) Infow(string, ...any)  {}
 
 func String(string, string) any {
 	return nil

--- a/internal/ruletable/manager.go
+++ b/internal/ruletable/manager.go
@@ -102,6 +102,7 @@ func (mgr *Manager) reload() error {
 		defer cancelFunc()
 
 		mgr.log.Info("Reloading rule table")
+		defer paceBuildGC()()
 		protoRT := NewProtoRuletable()
 
 		// If compilation fails, maintain the last valid rule table state.

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -507,9 +507,35 @@ func compileFromSource(src string) (cel.Program, error) {
 // reduce garbage/survivor interleaving in build-era spans.
 const buildGCPercent = 10
 
+var buildGCPacer struct {
+	sync.Mutex
+	depth int
+	prev  int
+}
+
+// paceBuildGC lowers the GC percent for the duration of a rule table build and
+// returns a function restoring the original value. It is safe for concurrent or
+// nested builds.
+func paceBuildGC() (restore func()) {
+	buildGCPacer.Lock()
+	if buildGCPacer.depth == 0 {
+		buildGCPacer.prev = debug.SetGCPercent(buildGCPercent)
+	}
+	buildGCPacer.depth++
+	buildGCPacer.Unlock()
+
+	return func() {
+		buildGCPacer.Lock()
+		buildGCPacer.depth--
+		if buildGCPacer.depth == 0 {
+			debug.SetGCPercent(buildGCPacer.prev)
+		}
+		buildGCPacer.Unlock()
+	}
+}
+
 func NewRuleTableFromLoader(ctx context.Context, policyLoader policyloader.PolicyLoader) (*RuleTable, error) {
-	prev := debug.SetGCPercent(buildGCPercent)
-	defer debug.SetGCPercent(prev)
+	defer paceBuildGC()()
 
 	protoRT := NewProtoRuletable()
 
@@ -521,6 +547,8 @@ func NewRuleTableFromLoader(ctx context.Context, policyLoader policyloader.Polic
 }
 
 func NewRuleTable(protoRT *runtimev1.RuleTable) (*RuleTable, error) {
+	defer paceBuildGC()()
+
 	rt := &RuleTable{
 		idx:           index.New(),
 		programCache:  NewProgramCache(),

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -7,12 +7,9 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"runtime/debug"
-	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/google/cel-go/cel"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -506,19 +503,13 @@ func compileFromSource(src string) (cel.Program, error) {
 	)
 }
 
-func NewRuleTableFromLoader(ctx context.Context, policyLoader policyloader.PolicyLoader) (*RuleTable, error) {
-	start := time.Now()
-	defer func() {
-		logging.FromContext(ctx).Sugar().Infow("Rule table build phase completed", "build_seconds", time.Since(start).Seconds())
-	}()
+// buildGCPercent paces the GC during the load+build phase: frequent collections
+// reduce garbage/survivor interleaving in build-era spans.
+const buildGCPercent = 10
 
-	if v := os.Getenv("CERBOS_BUILD_GC_PERCENT"); v != "" {
-		if pct, err := strconv.Atoi(v); err == nil && pct > 0 {
-			logging.FromContext(ctx).Sugar().Infow("Build-phase GC override active", "gc_percent", pct)
-			prev := debug.SetGCPercent(pct)
-			defer debug.SetGCPercent(prev)
-		}
-	}
+func NewRuleTableFromLoader(ctx context.Context, policyLoader policyloader.PolicyLoader) (*RuleTable, error) {
+	prev := debug.SetGCPercent(buildGCPercent)
+	defer debug.SetGCPercent(prev)
 
 	protoRT := NewProtoRuletable()
 

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -513,13 +515,45 @@ var buildGCPacer struct {
 	prev  int
 }
 
+const buildGCPercentEnvVar = "CERBOS_RULE_TABLE_GC_PERCENT"
+
+// targetGCPercent resolves the build GC percent from the environment once.
+// If the env var is unset or unparsable, it defaults to buildGCPercent (10).
+// Values from 1 to 100 pace the GC at that value. Anything else disables pacing.
+var targetGCPercent = sync.OnceValue(func() int {
+	s := os.Getenv(buildGCPercentEnvVar)
+	if s == "" {
+		return buildGCPercent
+	}
+
+	log := logging.NewLogger("ruletable")
+	p, err := strconv.Atoi(s)
+	if err != nil {
+		log.Warnw("Ignoring invalid build GC percent override", "var", buildGCPercentEnvVar, "value", s)
+		return buildGCPercent
+	}
+	if pacingOff(p) {
+		log.Infow("GC pacing for rule table builds disabled", "var", buildGCPercentEnvVar, "value", s)
+	}
+	return p
+})
+
+func pacingOff(target int) bool {
+	return target > 100 || target < 1
+}
+
 // paceBuildGC lowers the GC percent for the duration of a rule table build and
 // returns a function restoring the original value. It is safe for concurrent or
 // nested builds.
 func paceBuildGC() (restore func()) {
+	target := targetGCPercent()
+	if pacingOff(target) {
+		return func() {}
+	}
+
 	buildGCPacer.Lock()
 	if buildGCPacer.depth == 0 {
-		buildGCPacer.prev = debug.SetGCPercent(buildGCPercent)
+		buildGCPacer.prev = debug.SetGCPercent(target)
 	}
 	buildGCPacer.depth++
 	buildGCPacer.Unlock()

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -7,9 +7,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/cel-go/cel"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -504,6 +507,19 @@ func compileFromSource(src string) (cel.Program, error) {
 }
 
 func NewRuleTableFromLoader(ctx context.Context, policyLoader policyloader.PolicyLoader) (*RuleTable, error) {
+	start := time.Now()
+	defer func() {
+		logging.FromContext(ctx).Sugar().Infow("Rule table build phase completed", "build_seconds", time.Since(start).Seconds())
+	}()
+
+	if v := os.Getenv("CERBOS_BUILD_GC_PERCENT"); v != "" {
+		if pct, err := strconv.Atoi(v); err == nil && pct > 0 {
+			logging.FromContext(ctx).Sugar().Infow("Build-phase GC override active", "gc_percent", pct)
+			prev := debug.SetGCPercent(pct)
+			defer debug.SetGCPercent(prev)
+		}
+	}
+
 	protoRT := NewProtoRuletable()
 
 	if err := LoadPolicies(ctx, protoRT, policyLoader); err != nil {


### PR DESCRIPTION
This change sets GOGC to 10 (from the default 100) for the duration of the build and restores the previous value afterwards. Frequent GC runs recycle the holes left by transient allocations while the build is still running, so survivors occupy fewer spans.
Set `CERBOS_RULE_TABLE_GC_PERCENT` to control GC pacing during rule table builds: 1–100 paces the GC at that value. If it is unset or can't be parsed, defaults to 10. Any other value disables pacing.

On a test store with 8,000 policy files with default GC pacing:
| Metric | main | gc-pacing | delta |
|---|--:|--:|--:|
| heap_alloc (MiB) | 51.2 | 51.0 | ~0 |
| heap_inuse (MiB) | 342.6 | 281.8 | -60.8 (-17.8%) |
| RSS (MiB) | 455.2 | 378.4 | -76.8 (-16.9%) |
| startup --> healthy (s) | 54.4 / 48.6 | 55.5 / 55.2 | ~+3.8 (+7%) |
