### PR TITLE
Shrink rule table memory with interned bindings and structured eval keys

### DIFF
--- a/.changelog/20260615_0330.txt
+++ b/.changelog/20260615_0330.txt
@@ -1,0 +1,2 @@
+type:enhancement
+Reduce rule table memory usage by interning binding fields and replacing string evaluation keys with a structured form

--- a/api/genpb/cerbos/runtime/v1/hashpb_helpers.pb.go
+++ b/api/genpb/cerbos/runtime/v1/hashpb_helpers.pb.go
@@ -177,6 +177,11 @@ func cerbos_runtime_v1_BitmapIndex_Binding_hashpb_sum(m *BitmapIndex_Binding, ha
 		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetEvaluationKey()))))
 		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetEvaluationKey()), len(m.GetEvaluationKey())))
 	}
+	if _, ok := ignore["cerbos.runtime.v1.BitmapIndex.Binding.evaluation_key_tuple"]; !ok {
+		if m.GetEvaluationKeyTuple() != nil {
+			cerbos_runtime_v1_EvaluationKeyTuple_hashpb_sum(m.GetEvaluationKeyTuple(), hasher, ignore, b)
+		}
+	}
 }
 
 func cerbos_runtime_v1_BitmapIndex_Entry_hashpb_sum(m *BitmapIndex_Entry, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
@@ -500,6 +505,44 @@ func cerbos_runtime_v1_Errors_hashpb_sum(m *Errors, hasher hash.Hash, ignore map
 				}
 			}
 		}
+	}
+}
+
+func cerbos_runtime_v1_EvaluationKeyTuple_hashpb_sum(m *EvaluationKeyTuple, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
+	if _, ok := ignore["cerbos.runtime.v1.EvaluationKeyTuple.prefix"]; !ok {
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetPrefix()))))
+		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetPrefix()), len(m.GetPrefix())))
+	}
+	if _, ok := ignore["cerbos.runtime.v1.EvaluationKeyTuple.resource"]; !ok {
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetResource()))))
+		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetResource()), len(m.GetResource())))
+	}
+	if _, ok := ignore["cerbos.runtime.v1.EvaluationKeyTuple.principal"]; !ok {
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetPrincipal()))))
+		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetPrincipal()), len(m.GetPrincipal())))
+	}
+	if _, ok := ignore["cerbos.runtime.v1.EvaluationKeyTuple.role"]; !ok {
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetRole()))))
+		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetRole()), len(m.GetRole())))
+	}
+	if _, ok := ignore["cerbos.runtime.v1.EvaluationKeyTuple.derived_role"]; !ok {
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetDerivedRole()))))
+		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetDerivedRole()), len(m.GetDerivedRole())))
+	}
+	if _, ok := ignore["cerbos.runtime.v1.EvaluationKeyTuple.version"]; !ok {
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetVersion()))))
+		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetVersion()), len(m.GetVersion())))
+	}
+	if _, ok := ignore["cerbos.runtime.v1.EvaluationKeyTuple.scope"]; !ok {
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetScope()))))
+		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetScope()), len(m.GetScope())))
+	}
+	if _, ok := ignore["cerbos.runtime.v1.EvaluationKeyTuple.rule_name"]; !ok {
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetRuleName()))))
+		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetRuleName()), len(m.GetRuleName())))
+	}
+	if _, ok := ignore["cerbos.runtime.v1.EvaluationKeyTuple.rule_id"]; !ok {
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetRuleId())))
 	}
 }
 
@@ -1033,6 +1076,11 @@ func cerbos_runtime_v1_RuleTable_RuleRow_hashpb_sum(m *RuleTable_RuleRow, hasher
 	}
 	if _, ok := ignore["cerbos.runtime.v1.RuleTable.RuleRow.from_role_policy"]; !ok {
 		_, _ = hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeBool(m.GetFromRolePolicy())))
+	}
+	if _, ok := ignore["cerbos.runtime.v1.RuleTable.RuleRow.evaluation_key_tuple"]; !ok {
+		if m.GetEvaluationKeyTuple() != nil {
+			cerbos_runtime_v1_EvaluationKeyTuple_hashpb_sum(m.GetEvaluationKeyTuple(), hasher, ignore, b)
+		}
 	}
 }
 

--- a/api/genpb/cerbos/runtime/v1/runtime.pb.go
+++ b/api/genpb/cerbos/runtime/v1/runtime.pb.go
@@ -180,6 +180,114 @@ func (*RunnablePolicySet_Variables) isRunnablePolicySet_PolicySet() {}
 
 func (*RunnablePolicySet_RolePolicy) isRunnablePolicySet_PolicySet() {}
 
+type EvaluationKeyTuple struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Prefix        string                 `protobuf:"bytes,1,opt,name=prefix,proto3" json:"prefix,omitempty"`
+	Resource      string                 `protobuf:"bytes,2,opt,name=resource,proto3" json:"resource,omitempty"`
+	Principal     string                 `protobuf:"bytes,3,opt,name=principal,proto3" json:"principal,omitempty"`
+	Role          string                 `protobuf:"bytes,4,opt,name=role,proto3" json:"role,omitempty"`
+	DerivedRole   string                 `protobuf:"bytes,5,opt,name=derived_role,json=derivedRole,proto3" json:"derived_role,omitempty"`
+	Version       string                 `protobuf:"bytes,6,opt,name=version,proto3" json:"version,omitempty"`
+	Scope         string                 `protobuf:"bytes,7,opt,name=scope,proto3" json:"scope,omitempty"`
+	RuleName      string                 `protobuf:"bytes,8,opt,name=rule_name,json=ruleName,proto3" json:"rule_name,omitempty"`
+	RuleId        uint32                 `protobuf:"varint,9,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EvaluationKeyTuple) Reset() {
+	*x = EvaluationKeyTuple{}
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EvaluationKeyTuple) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EvaluationKeyTuple) ProtoMessage() {}
+
+func (x *EvaluationKeyTuple) ProtoReflect() protoreflect.Message {
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EvaluationKeyTuple.ProtoReflect.Descriptor instead.
+func (*EvaluationKeyTuple) Descriptor() ([]byte, []int) {
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *EvaluationKeyTuple) GetPrefix() string {
+	if x != nil {
+		return x.Prefix
+	}
+	return ""
+}
+
+func (x *EvaluationKeyTuple) GetResource() string {
+	if x != nil {
+		return x.Resource
+	}
+	return ""
+}
+
+func (x *EvaluationKeyTuple) GetPrincipal() string {
+	if x != nil {
+		return x.Principal
+	}
+	return ""
+}
+
+func (x *EvaluationKeyTuple) GetRole() string {
+	if x != nil {
+		return x.Role
+	}
+	return ""
+}
+
+func (x *EvaluationKeyTuple) GetDerivedRole() string {
+	if x != nil {
+		return x.DerivedRole
+	}
+	return ""
+}
+
+func (x *EvaluationKeyTuple) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+func (x *EvaluationKeyTuple) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
+func (x *EvaluationKeyTuple) GetRuleName() string {
+	if x != nil {
+		return x.RuleName
+	}
+	return ""
+}
+
+func (x *EvaluationKeyTuple) GetRuleId() uint32 {
+	if x != nil {
+		return x.RuleId
+	}
+	return 0
+}
+
 type RuleTable struct {
 	state              protoimpl.MessageState                   `protogen:"open.v1"`
 	Rules              []*RuleTable_RuleRow                     `protobuf:"bytes,1,rep,name=rules,proto3" json:"rules,omitempty"`
@@ -196,7 +304,7 @@ type RuleTable struct {
 
 func (x *RuleTable) Reset() {
 	*x = RuleTable{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[1]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -208,7 +316,7 @@ func (x *RuleTable) String() string {
 func (*RuleTable) ProtoMessage() {}
 
 func (x *RuleTable) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[1]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -221,7 +329,7 @@ func (x *RuleTable) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuleTable.ProtoReflect.Descriptor instead.
 func (*RuleTable) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{1}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *RuleTable) GetRules() []*RuleTable_RuleRow {
@@ -298,7 +406,7 @@ type RuleTableMetadata struct {
 
 func (x *RuleTableMetadata) Reset() {
 	*x = RuleTableMetadata{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[2]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -310,7 +418,7 @@ func (x *RuleTableMetadata) String() string {
 func (*RuleTableMetadata) ProtoMessage() {}
 
 func (x *RuleTableMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[2]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -323,7 +431,7 @@ func (x *RuleTableMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuleTableMetadata.ProtoReflect.Descriptor instead.
 func (*RuleTableMetadata) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{2}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *RuleTableMetadata) GetFqn() string {
@@ -429,7 +537,7 @@ type RunnableRolePolicySet struct {
 
 func (x *RunnableRolePolicySet) Reset() {
 	*x = RunnableRolePolicySet{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[3]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -441,7 +549,7 @@ func (x *RunnableRolePolicySet) String() string {
 func (*RunnableRolePolicySet) ProtoMessage() {}
 
 func (x *RunnableRolePolicySet) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[3]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -454,7 +562,7 @@ func (x *RunnableRolePolicySet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunnableRolePolicySet.ProtoReflect.Descriptor instead.
 func (*RunnableRolePolicySet) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{3}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *RunnableRolePolicySet) GetMeta() *RunnableRolePolicySet_Metadata {
@@ -539,7 +647,7 @@ type RunnableResourcePolicySet struct {
 
 func (x *RunnableResourcePolicySet) Reset() {
 	*x = RunnableResourcePolicySet{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[4]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -551,7 +659,7 @@ func (x *RunnableResourcePolicySet) String() string {
 func (*RunnableResourcePolicySet) ProtoMessage() {}
 
 func (x *RunnableResourcePolicySet) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[4]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -564,7 +672,7 @@ func (x *RunnableResourcePolicySet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunnableResourcePolicySet.ProtoReflect.Descriptor instead.
 func (*RunnableResourcePolicySet) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{4}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *RunnableResourcePolicySet) GetMeta() *RunnableResourcePolicySet_Metadata {
@@ -604,7 +712,7 @@ type RunnableDerivedRole struct {
 
 func (x *RunnableDerivedRole) Reset() {
 	*x = RunnableDerivedRole{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[5]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -616,7 +724,7 @@ func (x *RunnableDerivedRole) String() string {
 func (*RunnableDerivedRole) ProtoMessage() {}
 
 func (x *RunnableDerivedRole) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[5]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -629,7 +737,7 @@ func (x *RunnableDerivedRole) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunnableDerivedRole.ProtoReflect.Descriptor instead.
 func (*RunnableDerivedRole) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{5}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *RunnableDerivedRole) GetName() string {
@@ -693,7 +801,7 @@ type RunnableDerivedRolesSet struct {
 
 func (x *RunnableDerivedRolesSet) Reset() {
 	*x = RunnableDerivedRolesSet{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[6]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -705,7 +813,7 @@ func (x *RunnableDerivedRolesSet) String() string {
 func (*RunnableDerivedRolesSet) ProtoMessage() {}
 
 func (x *RunnableDerivedRolesSet) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[6]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -718,7 +826,7 @@ func (x *RunnableDerivedRolesSet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunnableDerivedRolesSet.ProtoReflect.Descriptor instead.
 func (*RunnableDerivedRolesSet) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{6}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *RunnableDerivedRolesSet) GetMeta() *RunnableDerivedRolesSet_Metadata {
@@ -746,7 +854,7 @@ type RunnableVariablesSet struct {
 
 func (x *RunnableVariablesSet) Reset() {
 	*x = RunnableVariablesSet{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[7]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -758,7 +866,7 @@ func (x *RunnableVariablesSet) String() string {
 func (*RunnableVariablesSet) ProtoMessage() {}
 
 func (x *RunnableVariablesSet) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[7]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -771,7 +879,7 @@ func (x *RunnableVariablesSet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunnableVariablesSet.ProtoReflect.Descriptor instead.
 func (*RunnableVariablesSet) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{7}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *RunnableVariablesSet) GetMeta() *RunnableVariablesSet_Metadata {
@@ -801,7 +909,7 @@ type RunnablePrincipalPolicySet struct {
 
 func (x *RunnablePrincipalPolicySet) Reset() {
 	*x = RunnablePrincipalPolicySet{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[8]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -813,7 +921,7 @@ func (x *RunnablePrincipalPolicySet) String() string {
 func (*RunnablePrincipalPolicySet) ProtoMessage() {}
 
 func (x *RunnablePrincipalPolicySet) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[8]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -826,7 +934,7 @@ func (x *RunnablePrincipalPolicySet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunnablePrincipalPolicySet.ProtoReflect.Descriptor instead.
 func (*RunnablePrincipalPolicySet) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{8}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *RunnablePrincipalPolicySet) GetMeta() *RunnablePrincipalPolicySet_Metadata {
@@ -853,7 +961,7 @@ type Expr struct {
 
 func (x *Expr) Reset() {
 	*x = Expr{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[9]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -865,7 +973,7 @@ func (x *Expr) String() string {
 func (*Expr) ProtoMessage() {}
 
 func (x *Expr) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[9]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -878,7 +986,7 @@ func (x *Expr) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Expr.ProtoReflect.Descriptor instead.
 func (*Expr) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{9}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *Expr) GetOriginal() string {
@@ -904,7 +1012,7 @@ type Output struct {
 
 func (x *Output) Reset() {
 	*x = Output{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[10]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -916,7 +1024,7 @@ func (x *Output) String() string {
 func (*Output) ProtoMessage() {}
 
 func (x *Output) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[10]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -929,7 +1037,7 @@ func (x *Output) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Output.ProtoReflect.Descriptor instead.
 func (*Output) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{10}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *Output) GetWhen() *Output_When {
@@ -949,7 +1057,7 @@ type Variable struct {
 
 func (x *Variable) Reset() {
 	*x = Variable{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[11]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -961,7 +1069,7 @@ func (x *Variable) String() string {
 func (*Variable) ProtoMessage() {}
 
 func (x *Variable) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[11]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -974,7 +1082,7 @@ func (x *Variable) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Variable.ProtoReflect.Descriptor instead.
 func (*Variable) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{11}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *Variable) GetName() string {
@@ -1006,7 +1114,7 @@ type Condition struct {
 
 func (x *Condition) Reset() {
 	*x = Condition{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[12]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1018,7 +1126,7 @@ func (x *Condition) String() string {
 func (*Condition) ProtoMessage() {}
 
 func (x *Condition) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[12]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1031,7 +1139,7 @@ func (x *Condition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Condition.ProtoReflect.Descriptor instead.
 func (*Condition) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{12}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *Condition) GetOp() isCondition_Op {
@@ -1114,7 +1222,7 @@ type CompileErrors struct {
 
 func (x *CompileErrors) Reset() {
 	*x = CompileErrors{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[13]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1126,7 +1234,7 @@ func (x *CompileErrors) String() string {
 func (*CompileErrors) ProtoMessage() {}
 
 func (x *CompileErrors) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[13]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1139,7 +1247,7 @@ func (x *CompileErrors) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CompileErrors.ProtoReflect.Descriptor instead.
 func (*CompileErrors) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{13}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *CompileErrors) GetErrors() []*CompileErrors_Err {
@@ -1167,7 +1275,7 @@ type IndexBuildErrors struct {
 
 func (x *IndexBuildErrors) Reset() {
 	*x = IndexBuildErrors{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[14]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1179,7 +1287,7 @@ func (x *IndexBuildErrors) String() string {
 func (*IndexBuildErrors) ProtoMessage() {}
 
 func (x *IndexBuildErrors) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[14]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1192,7 +1300,7 @@ func (x *IndexBuildErrors) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IndexBuildErrors.ProtoReflect.Descriptor instead.
 func (*IndexBuildErrors) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{14}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{15}
 }
 
 // Deprecated: Marked as deprecated in cerbos/runtime/v1/runtime.proto.
@@ -1266,7 +1374,7 @@ type Errors struct {
 
 func (x *Errors) Reset() {
 	*x = Errors{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[15]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1278,7 +1386,7 @@ func (x *Errors) String() string {
 func (*Errors) ProtoMessage() {}
 
 func (x *Errors) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[15]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1291,7 +1399,7 @@ func (x *Errors) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Errors.ProtoReflect.Descriptor instead.
 func (*Errors) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{15}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *Errors) GetKind() isErrors_Kind {
@@ -1358,7 +1466,7 @@ type BitmapIndex struct {
 
 func (x *BitmapIndex) Reset() {
 	*x = BitmapIndex{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[16]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1370,7 +1478,7 @@ func (x *BitmapIndex) String() string {
 func (*BitmapIndex) ProtoMessage() {}
 
 func (x *BitmapIndex) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[16]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1383,7 +1491,7 @@ func (x *BitmapIndex) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BitmapIndex.ProtoReflect.Descriptor instead.
 func (*BitmapIndex) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{16}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *BitmapIndex) GetVersion() []*BitmapIndex_Entry {
@@ -1495,13 +1603,14 @@ type RuleTable_RuleRow struct {
 	EvaluationKey        string                        `protobuf:"bytes,18,opt,name=evaluation_key,json=evaluationKey,proto3" json:"evaluation_key,omitempty"`
 	PolicyKind           v1.Kind                       `protobuf:"varint,19,opt,name=policy_kind,json=policyKind,proto3,enum=cerbos.policy.v1.Kind" json:"policy_kind,omitempty"`
 	FromRolePolicy       bool                          `protobuf:"varint,20,opt,name=from_role_policy,json=fromRolePolicy,proto3" json:"from_role_policy,omitempty"`
+	EvaluationKeyTuple   *EvaluationKeyTuple           `protobuf:"bytes,21,opt,name=evaluation_key_tuple,json=evaluationKeyTuple,proto3" json:"evaluation_key_tuple,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
 
 func (x *RuleTable_RuleRow) Reset() {
 	*x = RuleTable_RuleRow{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[17]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1513,7 +1622,7 @@ func (x *RuleTable_RuleRow) String() string {
 func (*RuleTable_RuleRow) ProtoMessage() {}
 
 func (x *RuleTable_RuleRow) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[17]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1526,7 +1635,7 @@ func (x *RuleTable_RuleRow) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuleTable_RuleRow.ProtoReflect.Descriptor instead.
 func (*RuleTable_RuleRow) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{1, 0}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{2, 0}
 }
 
 func (x *RuleTable_RuleRow) GetOriginFqn() string {
@@ -1680,6 +1789,13 @@ func (x *RuleTable_RuleRow) GetFromRolePolicy() bool {
 	return false
 }
 
+func (x *RuleTable_RuleRow) GetEvaluationKeyTuple() *EvaluationKeyTuple {
+	if x != nil {
+		return x.EvaluationKeyTuple
+	}
+	return nil
+}
+
 type isRuleTable_RuleRow_ActionSet interface {
 	isRuleTable_RuleRow_ActionSet()
 }
@@ -1705,7 +1821,7 @@ type RuleTable_RoleParentRoles struct {
 
 func (x *RuleTable_RoleParentRoles) Reset() {
 	*x = RuleTable_RoleParentRoles{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[18]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1717,7 +1833,7 @@ func (x *RuleTable_RoleParentRoles) String() string {
 func (*RuleTable_RoleParentRoles) ProtoMessage() {}
 
 func (x *RuleTable_RoleParentRoles) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[18]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1730,7 +1846,7 @@ func (x *RuleTable_RoleParentRoles) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuleTable_RoleParentRoles.ProtoReflect.Descriptor instead.
 func (*RuleTable_RoleParentRoles) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{1, 1}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{2, 1}
 }
 
 func (x *RuleTable_RoleParentRoles) GetRoleParentRoles() map[string]*RuleTable_RoleParentRoles_ParentRoles {
@@ -1749,7 +1865,7 @@ type RuleTable_PolicyDerivedRoles struct {
 
 func (x *RuleTable_PolicyDerivedRoles) Reset() {
 	*x = RuleTable_PolicyDerivedRoles{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[19]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1761,7 +1877,7 @@ func (x *RuleTable_PolicyDerivedRoles) String() string {
 func (*RuleTable_PolicyDerivedRoles) ProtoMessage() {}
 
 func (x *RuleTable_PolicyDerivedRoles) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[19]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1774,7 +1890,7 @@ func (x *RuleTable_PolicyDerivedRoles) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuleTable_PolicyDerivedRoles.ProtoReflect.Descriptor instead.
 func (*RuleTable_PolicyDerivedRoles) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{1, 2}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{2, 2}
 }
 
 func (x *RuleTable_PolicyDerivedRoles) GetDerivedRoles() map[string]*RunnableDerivedRole {
@@ -1793,7 +1909,7 @@ type RuleTable_JSONSchema struct {
 
 func (x *RuleTable_JSONSchema) Reset() {
 	*x = RuleTable_JSONSchema{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[20]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1805,7 +1921,7 @@ func (x *RuleTable_JSONSchema) String() string {
 func (*RuleTable_JSONSchema) ProtoMessage() {}
 
 func (x *RuleTable_JSONSchema) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[20]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1818,7 +1934,7 @@ func (x *RuleTable_JSONSchema) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuleTable_JSONSchema.ProtoReflect.Descriptor instead.
 func (*RuleTable_JSONSchema) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{1, 3}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{2, 3}
 }
 
 func (x *RuleTable_JSONSchema) GetContent() []byte {
@@ -1837,7 +1953,7 @@ type RuleTable_Manifest struct {
 
 func (x *RuleTable_Manifest) Reset() {
 	*x = RuleTable_Manifest{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[21]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1849,7 +1965,7 @@ func (x *RuleTable_Manifest) String() string {
 func (*RuleTable_Manifest) ProtoMessage() {}
 
 func (x *RuleTable_Manifest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[21]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1862,7 +1978,7 @@ func (x *RuleTable_Manifest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuleTable_Manifest.ProtoReflect.Descriptor instead.
 func (*RuleTable_Manifest) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{1, 4}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{2, 4}
 }
 
 func (x *RuleTable_Manifest) GetBundleId() string {
@@ -1881,7 +1997,7 @@ type RuleTable_RuleRow_AllowActions struct {
 
 func (x *RuleTable_RuleRow_AllowActions) Reset() {
 	*x = RuleTable_RuleRow_AllowActions{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[27]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1893,7 +2009,7 @@ func (x *RuleTable_RuleRow_AllowActions) String() string {
 func (*RuleTable_RuleRow_AllowActions) ProtoMessage() {}
 
 func (x *RuleTable_RuleRow_AllowActions) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[27]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1906,7 +2022,7 @@ func (x *RuleTable_RuleRow_AllowActions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuleTable_RuleRow_AllowActions.ProtoReflect.Descriptor instead.
 func (*RuleTable_RuleRow_AllowActions) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{1, 0, 0}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{2, 0, 0}
 }
 
 func (x *RuleTable_RuleRow_AllowActions) GetActions() map[string]*emptypb.Empty {
@@ -1926,7 +2042,7 @@ type RuleTable_RuleRow_Params struct {
 
 func (x *RuleTable_RuleRow_Params) Reset() {
 	*x = RuleTable_RuleRow_Params{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[28]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1938,7 +2054,7 @@ func (x *RuleTable_RuleRow_Params) String() string {
 func (*RuleTable_RuleRow_Params) ProtoMessage() {}
 
 func (x *RuleTable_RuleRow_Params) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[28]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1951,7 +2067,7 @@ func (x *RuleTable_RuleRow_Params) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuleTable_RuleRow_Params.ProtoReflect.Descriptor instead.
 func (*RuleTable_RuleRow_Params) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{1, 0, 1}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{2, 0, 1}
 }
 
 func (x *RuleTable_RuleRow_Params) GetOrderedVariables() []*Variable {
@@ -1977,7 +2093,7 @@ type RuleTable_RoleParentRoles_ParentRoles struct {
 
 func (x *RuleTable_RoleParentRoles_ParentRoles) Reset() {
 	*x = RuleTable_RoleParentRoles_ParentRoles{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[31]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1989,7 +2105,7 @@ func (x *RuleTable_RoleParentRoles_ParentRoles) String() string {
 func (*RuleTable_RoleParentRoles_ParentRoles) ProtoMessage() {}
 
 func (x *RuleTable_RoleParentRoles_ParentRoles) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[31]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2002,7 +2118,7 @@ func (x *RuleTable_RoleParentRoles_ParentRoles) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use RuleTable_RoleParentRoles_ParentRoles.ProtoReflect.Descriptor instead.
 func (*RuleTable_RoleParentRoles_ParentRoles) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{1, 1, 0}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{2, 1, 0}
 }
 
 func (x *RuleTable_RoleParentRoles_ParentRoles) GetRoles() []string {
@@ -2024,7 +2140,7 @@ type RunnableRolePolicySet_Metadata struct {
 
 func (x *RunnableRolePolicySet_Metadata) Reset() {
 	*x = RunnableRolePolicySet_Metadata{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[36]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2036,7 +2152,7 @@ func (x *RunnableRolePolicySet_Metadata) String() string {
 func (*RunnableRolePolicySet_Metadata) ProtoMessage() {}
 
 func (x *RunnableRolePolicySet_Metadata) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[36]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2049,7 +2165,7 @@ func (x *RunnableRolePolicySet_Metadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunnableRolePolicySet_Metadata.ProtoReflect.Descriptor instead.
 func (*RunnableRolePolicySet_Metadata) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{3, 0}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{4, 0}
 }
 
 func (x *RunnableRolePolicySet_Metadata) GetFqn() string {
@@ -2093,7 +2209,7 @@ type RunnableRolePolicySet_Rule struct {
 
 func (x *RunnableRolePolicySet_Rule) Reset() {
 	*x = RunnableRolePolicySet_Rule{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[37]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2105,7 +2221,7 @@ func (x *RunnableRolePolicySet_Rule) String() string {
 func (*RunnableRolePolicySet_Rule) ProtoMessage() {}
 
 func (x *RunnableRolePolicySet_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[37]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2118,7 +2234,7 @@ func (x *RunnableRolePolicySet_Rule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunnableRolePolicySet_Rule.ProtoReflect.Descriptor instead.
 func (*RunnableRolePolicySet_Rule) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{3, 1}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{4, 1}
 }
 
 func (x *RunnableRolePolicySet_Rule) GetResource() string {
@@ -2165,7 +2281,7 @@ type RunnableRolePolicySet_RuleList struct {
 
 func (x *RunnableRolePolicySet_RuleList) Reset() {
 	*x = RunnableRolePolicySet_RuleList{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[38]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2177,7 +2293,7 @@ func (x *RunnableRolePolicySet_RuleList) String() string {
 func (*RunnableRolePolicySet_RuleList) ProtoMessage() {}
 
 func (x *RunnableRolePolicySet_RuleList) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[38]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2190,7 +2306,7 @@ func (x *RunnableRolePolicySet_RuleList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunnableRolePolicySet_RuleList.ProtoReflect.Descriptor instead.
 func (*RunnableRolePolicySet_RuleList) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{3, 2}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{4, 2}
 }
 
 func (x *RunnableRolePolicySet_RuleList) GetRules() []*RunnableRolePolicySet_Rule {
@@ -2213,7 +2329,7 @@ type RunnableResourcePolicySet_Metadata struct {
 
 func (x *RunnableResourcePolicySet_Metadata) Reset() {
 	*x = RunnableResourcePolicySet_Metadata{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[44]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2225,7 +2341,7 @@ func (x *RunnableResourcePolicySet_Metadata) String() string {
 func (*RunnableResourcePolicySet_Metadata) ProtoMessage() {}
 
 func (x *RunnableResourcePolicySet_Metadata) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[44]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2238,7 +2354,7 @@ func (x *RunnableResourcePolicySet_Metadata) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use RunnableResourcePolicySet_Metadata.ProtoReflect.Descriptor instead.
 func (*RunnableResourcePolicySet_Metadata) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{4, 0}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{5, 0}
 }
 
 func (x *RunnableResourcePolicySet_Metadata) GetFqn() string {
@@ -2293,7 +2409,7 @@ type RunnableResourcePolicySet_Policy struct {
 
 func (x *RunnableResourcePolicySet_Policy) Reset() {
 	*x = RunnableResourcePolicySet_Policy{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[45]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2305,7 +2421,7 @@ func (x *RunnableResourcePolicySet_Policy) String() string {
 func (*RunnableResourcePolicySet_Policy) ProtoMessage() {}
 
 func (x *RunnableResourcePolicySet_Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[45]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2318,7 +2434,7 @@ func (x *RunnableResourcePolicySet_Policy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunnableResourcePolicySet_Policy.ProtoReflect.Descriptor instead.
 func (*RunnableResourcePolicySet_Policy) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{4, 1}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{5, 1}
 }
 
 func (x *RunnableResourcePolicySet_Policy) GetScope() string {
@@ -2395,7 +2511,7 @@ type RunnableResourcePolicySet_Policy_Rule struct {
 
 func (x *RunnableResourcePolicySet_Policy_Rule) Reset() {
 	*x = RunnableResourcePolicySet_Policy_Rule{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[48]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2407,7 +2523,7 @@ func (x *RunnableResourcePolicySet_Policy_Rule) String() string {
 func (*RunnableResourcePolicySet_Policy_Rule) ProtoMessage() {}
 
 func (x *RunnableResourcePolicySet_Policy_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[48]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2420,7 +2536,7 @@ func (x *RunnableResourcePolicySet_Policy_Rule) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use RunnableResourcePolicySet_Policy_Rule.ProtoReflect.Descriptor instead.
 func (*RunnableResourcePolicySet_Policy_Rule) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{4, 1, 0}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{5, 1, 0}
 }
 
 func (x *RunnableResourcePolicySet_Policy_Rule) GetName() string {
@@ -2490,7 +2606,7 @@ type RunnableDerivedRolesSet_Metadata struct {
 
 func (x *RunnableDerivedRolesSet_Metadata) Reset() {
 	*x = RunnableDerivedRolesSet_Metadata{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[58]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2502,7 +2618,7 @@ func (x *RunnableDerivedRolesSet_Metadata) String() string {
 func (*RunnableDerivedRolesSet_Metadata) ProtoMessage() {}
 
 func (x *RunnableDerivedRolesSet_Metadata) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[58]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2515,7 +2631,7 @@ func (x *RunnableDerivedRolesSet_Metadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunnableDerivedRolesSet_Metadata.ProtoReflect.Descriptor instead.
 func (*RunnableDerivedRolesSet_Metadata) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{6, 0}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{7, 0}
 }
 
 func (x *RunnableDerivedRolesSet_Metadata) GetFqn() string {
@@ -2542,7 +2658,7 @@ type RunnableVariablesSet_Metadata struct {
 
 func (x *RunnableVariablesSet_Metadata) Reset() {
 	*x = RunnableVariablesSet_Metadata{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[61]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2554,7 +2670,7 @@ func (x *RunnableVariablesSet_Metadata) String() string {
 func (*RunnableVariablesSet_Metadata) ProtoMessage() {}
 
 func (x *RunnableVariablesSet_Metadata) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[61]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2567,7 +2683,7 @@ func (x *RunnableVariablesSet_Metadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunnableVariablesSet_Metadata.ProtoReflect.Descriptor instead.
 func (*RunnableVariablesSet_Metadata) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{7, 0}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{8, 0}
 }
 
 func (x *RunnableVariablesSet_Metadata) GetFqn() string {
@@ -2597,7 +2713,7 @@ type RunnablePrincipalPolicySet_Metadata struct {
 
 func (x *RunnablePrincipalPolicySet_Metadata) Reset() {
 	*x = RunnablePrincipalPolicySet_Metadata{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[64]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2609,7 +2725,7 @@ func (x *RunnablePrincipalPolicySet_Metadata) String() string {
 func (*RunnablePrincipalPolicySet_Metadata) ProtoMessage() {}
 
 func (x *RunnablePrincipalPolicySet_Metadata) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[64]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2622,7 +2738,7 @@ func (x *RunnablePrincipalPolicySet_Metadata) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use RunnablePrincipalPolicySet_Metadata.ProtoReflect.Descriptor instead.
 func (*RunnablePrincipalPolicySet_Metadata) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{8, 0}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{9, 0}
 }
 
 func (x *RunnablePrincipalPolicySet_Metadata) GetFqn() string {
@@ -2675,7 +2791,7 @@ type RunnablePrincipalPolicySet_Policy struct {
 
 func (x *RunnablePrincipalPolicySet_Policy) Reset() {
 	*x = RunnablePrincipalPolicySet_Policy{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[65]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2687,7 +2803,7 @@ func (x *RunnablePrincipalPolicySet_Policy) String() string {
 func (*RunnablePrincipalPolicySet_Policy) ProtoMessage() {}
 
 func (x *RunnablePrincipalPolicySet_Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[65]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2700,7 +2816,7 @@ func (x *RunnablePrincipalPolicySet_Policy) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use RunnablePrincipalPolicySet_Policy.ProtoReflect.Descriptor instead.
 func (*RunnablePrincipalPolicySet_Policy) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{8, 1}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{9, 1}
 }
 
 func (x *RunnablePrincipalPolicySet_Policy) GetScope() string {
@@ -2761,7 +2877,7 @@ type RunnablePrincipalPolicySet_Policy_ActionRule struct {
 
 func (x *RunnablePrincipalPolicySet_Policy_ActionRule) Reset() {
 	*x = RunnablePrincipalPolicySet_Policy_ActionRule{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[68]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2773,7 +2889,7 @@ func (x *RunnablePrincipalPolicySet_Policy_ActionRule) String() string {
 func (*RunnablePrincipalPolicySet_Policy_ActionRule) ProtoMessage() {}
 
 func (x *RunnablePrincipalPolicySet_Policy_ActionRule) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[68]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2786,7 +2902,7 @@ func (x *RunnablePrincipalPolicySet_Policy_ActionRule) ProtoReflect() protorefle
 
 // Deprecated: Use RunnablePrincipalPolicySet_Policy_ActionRule.ProtoReflect.Descriptor instead.
 func (*RunnablePrincipalPolicySet_Policy_ActionRule) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{8, 1, 0}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{9, 1, 0}
 }
 
 func (x *RunnablePrincipalPolicySet_Policy_ActionRule) GetAction() string {
@@ -2841,7 +2957,7 @@ type RunnablePrincipalPolicySet_Policy_ResourceRules struct {
 
 func (x *RunnablePrincipalPolicySet_Policy_ResourceRules) Reset() {
 	*x = RunnablePrincipalPolicySet_Policy_ResourceRules{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[69]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2853,7 +2969,7 @@ func (x *RunnablePrincipalPolicySet_Policy_ResourceRules) String() string {
 func (*RunnablePrincipalPolicySet_Policy_ResourceRules) ProtoMessage() {}
 
 func (x *RunnablePrincipalPolicySet_Policy_ResourceRules) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[69]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2866,7 +2982,7 @@ func (x *RunnablePrincipalPolicySet_Policy_ResourceRules) ProtoReflect() protore
 
 // Deprecated: Use RunnablePrincipalPolicySet_Policy_ResourceRules.ProtoReflect.Descriptor instead.
 func (*RunnablePrincipalPolicySet_Policy_ResourceRules) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{8, 1, 1}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{9, 1, 1}
 }
 
 func (x *RunnablePrincipalPolicySet_Policy_ResourceRules) GetActionRules() []*RunnablePrincipalPolicySet_Policy_ActionRule {
@@ -2886,7 +3002,7 @@ type Output_When struct {
 
 func (x *Output_When) Reset() {
 	*x = Output_When{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[73]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2898,7 +3014,7 @@ func (x *Output_When) String() string {
 func (*Output_When) ProtoMessage() {}
 
 func (x *Output_When) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[73]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2911,7 +3027,7 @@ func (x *Output_When) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Output_When.ProtoReflect.Descriptor instead.
 func (*Output_When) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{10, 0}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{11, 0}
 }
 
 func (x *Output_When) GetRuleActivated() *Expr {
@@ -2937,7 +3053,7 @@ type Condition_ExprList struct {
 
 func (x *Condition_ExprList) Reset() {
 	*x = Condition_ExprList{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[74]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2949,7 +3065,7 @@ func (x *Condition_ExprList) String() string {
 func (*Condition_ExprList) ProtoMessage() {}
 
 func (x *Condition_ExprList) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[74]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2962,7 +3078,7 @@ func (x *Condition_ExprList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Condition_ExprList.ProtoReflect.Descriptor instead.
 func (*Condition_ExprList) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{12, 0}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{13, 0}
 }
 
 func (x *Condition_ExprList) GetExpr() []*Condition {
@@ -2985,7 +3101,7 @@ type CompileErrors_Err struct {
 
 func (x *CompileErrors_Err) Reset() {
 	*x = CompileErrors_Err{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[75]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2997,7 +3113,7 @@ func (x *CompileErrors_Err) String() string {
 func (*CompileErrors_Err) ProtoMessage() {}
 
 func (x *CompileErrors_Err) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[75]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3010,7 +3126,7 @@ func (x *CompileErrors_Err) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CompileErrors_Err.ProtoReflect.Descriptor instead.
 func (*CompileErrors_Err) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{13, 0}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{14, 0}
 }
 
 func (x *CompileErrors_Err) GetFile() string {
@@ -3060,7 +3176,7 @@ type IndexBuildErrors_DuplicateDef struct {
 
 func (x *IndexBuildErrors_DuplicateDef) Reset() {
 	*x = IndexBuildErrors_DuplicateDef{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[76]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3072,7 +3188,7 @@ func (x *IndexBuildErrors_DuplicateDef) String() string {
 func (*IndexBuildErrors_DuplicateDef) ProtoMessage() {}
 
 func (x *IndexBuildErrors_DuplicateDef) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[76]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3085,7 +3201,7 @@ func (x *IndexBuildErrors_DuplicateDef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IndexBuildErrors_DuplicateDef.ProtoReflect.Descriptor instead.
 func (*IndexBuildErrors_DuplicateDef) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{14, 0}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{15, 0}
 }
 
 func (x *IndexBuildErrors_DuplicateDef) GetFile() string {
@@ -3131,7 +3247,7 @@ type IndexBuildErrors_MissingImport struct {
 
 func (x *IndexBuildErrors_MissingImport) Reset() {
 	*x = IndexBuildErrors_MissingImport{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[77]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3143,7 +3259,7 @@ func (x *IndexBuildErrors_MissingImport) String() string {
 func (*IndexBuildErrors_MissingImport) ProtoMessage() {}
 
 func (x *IndexBuildErrors_MissingImport) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[77]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3156,7 +3272,7 @@ func (x *IndexBuildErrors_MissingImport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IndexBuildErrors_MissingImport.ProtoReflect.Descriptor instead.
 func (*IndexBuildErrors_MissingImport) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{14, 1}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{15, 1}
 }
 
 func (x *IndexBuildErrors_MissingImport) GetImportingFile() string {
@@ -3218,7 +3334,7 @@ type IndexBuildErrors_MissingScope struct {
 
 func (x *IndexBuildErrors_MissingScope) Reset() {
 	*x = IndexBuildErrors_MissingScope{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[78]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3230,7 +3346,7 @@ func (x *IndexBuildErrors_MissingScope) String() string {
 func (*IndexBuildErrors_MissingScope) ProtoMessage() {}
 
 func (x *IndexBuildErrors_MissingScope) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[78]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3243,7 +3359,7 @@ func (x *IndexBuildErrors_MissingScope) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IndexBuildErrors_MissingScope.ProtoReflect.Descriptor instead.
 func (*IndexBuildErrors_MissingScope) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{14, 2}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{15, 2}
 }
 
 func (x *IndexBuildErrors_MissingScope) GetMissingPolicy() string {
@@ -3269,7 +3385,7 @@ type IndexBuildErrors_ScopePermissionsConflicts struct {
 
 func (x *IndexBuildErrors_ScopePermissionsConflicts) Reset() {
 	*x = IndexBuildErrors_ScopePermissionsConflicts{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[79]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3281,7 +3397,7 @@ func (x *IndexBuildErrors_ScopePermissionsConflicts) String() string {
 func (*IndexBuildErrors_ScopePermissionsConflicts) ProtoMessage() {}
 
 func (x *IndexBuildErrors_ScopePermissionsConflicts) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[79]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3294,7 +3410,7 @@ func (x *IndexBuildErrors_ScopePermissionsConflicts) ProtoReflect() protoreflect
 
 // Deprecated: Use IndexBuildErrors_ScopePermissionsConflicts.ProtoReflect.Descriptor instead.
 func (*IndexBuildErrors_ScopePermissionsConflicts) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{14, 3}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{15, 3}
 }
 
 func (x *IndexBuildErrors_ScopePermissionsConflicts) GetScope() string {
@@ -3316,7 +3432,7 @@ type IndexBuildErrors_LoadFailure struct {
 
 func (x *IndexBuildErrors_LoadFailure) Reset() {
 	*x = IndexBuildErrors_LoadFailure{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[80]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3328,7 +3444,7 @@ func (x *IndexBuildErrors_LoadFailure) String() string {
 func (*IndexBuildErrors_LoadFailure) ProtoMessage() {}
 
 func (x *IndexBuildErrors_LoadFailure) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[80]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3341,7 +3457,7 @@ func (x *IndexBuildErrors_LoadFailure) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IndexBuildErrors_LoadFailure.ProtoReflect.Descriptor instead.
 func (*IndexBuildErrors_LoadFailure) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{14, 4}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{15, 4}
 }
 
 func (x *IndexBuildErrors_LoadFailure) GetFile() string {
@@ -3377,7 +3493,7 @@ type IndexBuildErrors_Disabled struct {
 
 func (x *IndexBuildErrors_Disabled) Reset() {
 	*x = IndexBuildErrors_Disabled{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[81]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3389,7 +3505,7 @@ func (x *IndexBuildErrors_Disabled) String() string {
 func (*IndexBuildErrors_Disabled) ProtoMessage() {}
 
 func (x *IndexBuildErrors_Disabled) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[81]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3402,7 +3518,7 @@ func (x *IndexBuildErrors_Disabled) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IndexBuildErrors_Disabled.ProtoReflect.Descriptor instead.
 func (*IndexBuildErrors_Disabled) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{14, 5}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{15, 5}
 }
 
 func (x *IndexBuildErrors_Disabled) GetFile() string {
@@ -3436,7 +3552,7 @@ type BitmapIndex_Entry struct {
 
 func (x *BitmapIndex_Entry) Reset() {
 	*x = BitmapIndex_Entry{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[82]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3448,7 +3564,7 @@ func (x *BitmapIndex_Entry) String() string {
 func (*BitmapIndex_Entry) ProtoMessage() {}
 
 func (x *BitmapIndex_Entry) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[82]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3461,7 +3577,7 @@ func (x *BitmapIndex_Entry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BitmapIndex_Entry.ProtoReflect.Descriptor instead.
 func (*BitmapIndex_Entry) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{16, 0}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{17, 0}
 }
 
 func (x *BitmapIndex_Entry) GetKey() string {
@@ -3488,7 +3604,7 @@ type BitmapIndex_GlobDimension struct {
 
 func (x *BitmapIndex_GlobDimension) Reset() {
 	*x = BitmapIndex_GlobDimension{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[83]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3500,7 +3616,7 @@ func (x *BitmapIndex_GlobDimension) String() string {
 func (*BitmapIndex_GlobDimension) ProtoMessage() {}
 
 func (x *BitmapIndex_GlobDimension) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[83]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3513,7 +3629,7 @@ func (x *BitmapIndex_GlobDimension) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BitmapIndex_GlobDimension.ProtoReflect.Descriptor instead.
 func (*BitmapIndex_GlobDimension) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{16, 1}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{17, 1}
 }
 
 func (x *BitmapIndex_GlobDimension) GetLiterals() []*BitmapIndex_Entry {
@@ -3539,7 +3655,7 @@ type BitmapIndex_AllowActions struct {
 
 func (x *BitmapIndex_AllowActions) Reset() {
 	*x = BitmapIndex_AllowActions{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[84]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3551,7 +3667,7 @@ func (x *BitmapIndex_AllowActions) String() string {
 func (*BitmapIndex_AllowActions) ProtoMessage() {}
 
 func (x *BitmapIndex_AllowActions) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[84]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3564,7 +3680,7 @@ func (x *BitmapIndex_AllowActions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BitmapIndex_AllowActions.ProtoReflect.Descriptor instead.
 func (*BitmapIndex_AllowActions) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{16, 2}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{17, 2}
 }
 
 func (x *BitmapIndex_AllowActions) GetActions() []string {
@@ -3575,18 +3691,19 @@ func (x *BitmapIndex_AllowActions) GetActions() []string {
 }
 
 type BitmapIndex_Binding struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	Id                uint32                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	CoreIndex         uint32                 `protobuf:"varint,2,opt,name=core_index,json=coreIndex,proto3" json:"core_index,omitempty"`
-	Role              string                 `protobuf:"bytes,3,opt,name=role,proto3" json:"role,omitempty"`
-	Scope             string                 `protobuf:"bytes,4,opt,name=scope,proto3" json:"scope,omitempty"`
-	Version           string                 `protobuf:"bytes,5,opt,name=version,proto3" json:"version,omitempty"`
-	Resource          string                 `protobuf:"bytes,6,opt,name=resource,proto3" json:"resource,omitempty"`
-	Principal         string                 `protobuf:"bytes,8,opt,name=principal,proto3" json:"principal,omitempty"`
-	OriginFqn         string                 `protobuf:"bytes,9,opt,name=origin_fqn,json=originFqn,proto3" json:"origin_fqn,omitempty"`
-	OriginDerivedRole string                 `protobuf:"bytes,10,opt,name=origin_derived_role,json=originDerivedRole,proto3" json:"origin_derived_role,omitempty"`
-	Name              string                 `protobuf:"bytes,11,opt,name=name,proto3" json:"name,omitempty"`
-	EvaluationKey     string                 `protobuf:"bytes,12,opt,name=evaluation_key,json=evaluationKey,proto3" json:"evaluation_key,omitempty"`
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	Id                 uint32                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	CoreIndex          uint32                 `protobuf:"varint,2,opt,name=core_index,json=coreIndex,proto3" json:"core_index,omitempty"`
+	Role               string                 `protobuf:"bytes,3,opt,name=role,proto3" json:"role,omitempty"`
+	Scope              string                 `protobuf:"bytes,4,opt,name=scope,proto3" json:"scope,omitempty"`
+	Version            string                 `protobuf:"bytes,5,opt,name=version,proto3" json:"version,omitempty"`
+	Resource           string                 `protobuf:"bytes,6,opt,name=resource,proto3" json:"resource,omitempty"`
+	Principal          string                 `protobuf:"bytes,8,opt,name=principal,proto3" json:"principal,omitempty"`
+	OriginFqn          string                 `protobuf:"bytes,9,opt,name=origin_fqn,json=originFqn,proto3" json:"origin_fqn,omitempty"`
+	OriginDerivedRole  string                 `protobuf:"bytes,10,opt,name=origin_derived_role,json=originDerivedRole,proto3" json:"origin_derived_role,omitempty"`
+	Name               string                 `protobuf:"bytes,11,opt,name=name,proto3" json:"name,omitempty"`
+	EvaluationKey      string                 `protobuf:"bytes,12,opt,name=evaluation_key,json=evaluationKey,proto3" json:"evaluation_key,omitempty"`
+	EvaluationKeyTuple *EvaluationKeyTuple    `protobuf:"bytes,14,opt,name=evaluation_key_tuple,json=evaluationKeyTuple,proto3" json:"evaluation_key_tuple,omitempty"`
 	// Types that are valid to be assigned to ActionSet:
 	//
 	//	*BitmapIndex_Binding_Action
@@ -3598,7 +3715,7 @@ type BitmapIndex_Binding struct {
 
 func (x *BitmapIndex_Binding) Reset() {
 	*x = BitmapIndex_Binding{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[85]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3610,7 +3727,7 @@ func (x *BitmapIndex_Binding) String() string {
 func (*BitmapIndex_Binding) ProtoMessage() {}
 
 func (x *BitmapIndex_Binding) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[85]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3623,7 +3740,7 @@ func (x *BitmapIndex_Binding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BitmapIndex_Binding.ProtoReflect.Descriptor instead.
 func (*BitmapIndex_Binding) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{16, 3}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{17, 3}
 }
 
 func (x *BitmapIndex_Binding) GetId() uint32 {
@@ -3703,6 +3820,13 @@ func (x *BitmapIndex_Binding) GetEvaluationKey() string {
 	return ""
 }
 
+func (x *BitmapIndex_Binding) GetEvaluationKeyTuple() *EvaluationKeyTuple {
+	if x != nil {
+		return x.EvaluationKeyTuple
+	}
+	return nil
+}
+
 func (x *BitmapIndex_Binding) GetActionSet() isBitmapIndex_Binding_ActionSet {
 	if x != nil {
 		return x.ActionSet
@@ -3764,7 +3888,7 @@ type BitmapIndex_FunctionalCore struct {
 
 func (x *BitmapIndex_FunctionalCore) Reset() {
 	*x = BitmapIndex_FunctionalCore{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[86]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3776,7 +3900,7 @@ func (x *BitmapIndex_FunctionalCore) String() string {
 func (*BitmapIndex_FunctionalCore) ProtoMessage() {}
 
 func (x *BitmapIndex_FunctionalCore) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[86]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3789,7 +3913,7 @@ func (x *BitmapIndex_FunctionalCore) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BitmapIndex_FunctionalCore.ProtoReflect.Descriptor instead.
 func (*BitmapIndex_FunctionalCore) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{16, 4}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{17, 4}
 }
 
 func (x *BitmapIndex_FunctionalCore) GetEffect() v11.Effect {
@@ -3864,7 +3988,7 @@ type BitmapIndex_Parents struct {
 
 func (x *BitmapIndex_Parents) Reset() {
 	*x = BitmapIndex_Parents{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[87]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3876,7 +4000,7 @@ func (x *BitmapIndex_Parents) String() string {
 func (*BitmapIndex_Parents) ProtoMessage() {}
 
 func (x *BitmapIndex_Parents) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[87]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3889,7 +4013,7 @@ func (x *BitmapIndex_Parents) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BitmapIndex_Parents.ProtoReflect.Descriptor instead.
 func (*BitmapIndex_Parents) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{16, 5}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{17, 5}
 }
 
 func (x *BitmapIndex_Parents) GetParents() []string {
@@ -3908,7 +4032,7 @@ type BitmapIndex_RoleParents struct {
 
 func (x *BitmapIndex_RoleParents) Reset() {
 	*x = BitmapIndex_RoleParents{}
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[88]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3920,7 +4044,7 @@ func (x *BitmapIndex_RoleParents) String() string {
 func (*BitmapIndex_RoleParents) ProtoMessage() {}
 
 func (x *BitmapIndex_RoleParents) ProtoReflect() protoreflect.Message {
-	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[88]
+	mi := &file_cerbos_runtime_v1_runtime_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3933,7 +4057,7 @@ func (x *BitmapIndex_RoleParents) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BitmapIndex_RoleParents.ProtoReflect.Descriptor instead.
 func (*BitmapIndex_RoleParents) Descriptor() ([]byte, []int) {
-	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{16, 6}
+	return file_cerbos_runtime_v1_runtime_proto_rawDescGZIP(), []int{17, 6}
 }
 
 func (x *BitmapIndex_RoleParents) GetRoles() map[string]*BitmapIndex_Parents {
@@ -3958,7 +4082,17 @@ const file_cerbos_runtime_v1_runtime_proto_rawDesc = "" +
 	"rolePolicy\x12)\n" +
 	"\x10compiler_version\x18\x06 \x01(\rR\x0fcompilerVersionB\f\n" +
 	"\n" +
-	"policy_set\"\xe9\x18\n" +
+	"policy_set\"\x83\x02\n" +
+	"\x12EvaluationKeyTuple\x12\x16\n" +
+	"\x06prefix\x18\x01 \x01(\tR\x06prefix\x12\x1a\n" +
+	"\bresource\x18\x02 \x01(\tR\bresource\x12\x1c\n" +
+	"\tprincipal\x18\x03 \x01(\tR\tprincipal\x12\x12\n" +
+	"\x04role\x18\x04 \x01(\tR\x04role\x12!\n" +
+	"\fderived_role\x18\x05 \x01(\tR\vderivedRole\x12\x18\n" +
+	"\aversion\x18\x06 \x01(\tR\aversion\x12\x14\n" +
+	"\x05scope\x18\a \x01(\tR\x05scope\x12\x1b\n" +
+	"\trule_name\x18\b \x01(\tR\bruleName\x12\x17\n" +
+	"\arule_id\x18\t \x01(\rR\x06ruleId\"\xc2\x19\n" +
 	"\tRuleTable\x12:\n" +
 	"\x05rules\x18\x01 \x03(\v2$.cerbos.runtime.v1.RuleTable.RuleRowR\x05rules\x12C\n" +
 	"\aschemas\x18\x02 \x03(\v2).cerbos.runtime.v1.RuleTable.SchemasEntryR\aschemas\x12:\n" +
@@ -3967,7 +4101,7 @@ const file_cerbos_runtime_v1_runtime_proto_rawDesc = "" +
 	"\x14policy_derived_roles\x18\x05 \x03(\v24.cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntryR\x12policyDerivedRoles\x12P\n" +
 	"\fjson_schemas\x18\x06 \x03(\v2-.cerbos.runtime.v1.RuleTable.JsonSchemasEntryR\vjsonSchemas\x12A\n" +
 	"\bmanifest\x18\a \x01(\v2%.cerbos.runtime.v1.RuleTable.ManifestR\bmanifest\x12)\n" +
-	"\x10compiler_version\x18\b \x01(\rR\x0fcompilerVersion\x1a\xab\v\n" +
+	"\x10compiler_version\x18\b \x01(\rR\x0fcompilerVersion\x1a\x84\f\n" +
 	"\aRuleRow\x12\x1d\n" +
 	"\n" +
 	"origin_fqn\x18\x01 \x01(\tR\toriginFqn\x12\x1a\n" +
@@ -3992,7 +4126,8 @@ const file_cerbos_runtime_v1_runtime_proto_rawDesc = "" +
 	"\x0eevaluation_key\x18\x12 \x01(\tR\revaluationKey\x127\n" +
 	"\vpolicy_kind\x18\x13 \x01(\x0e2\x16.cerbos.policy.v1.KindR\n" +
 	"policyKind\x12(\n" +
-	"\x10from_role_policy\x18\x14 \x01(\bR\x0efromRolePolicy\x1a\xbc\x01\n" +
+	"\x10from_role_policy\x18\x14 \x01(\bR\x0efromRolePolicy\x12W\n" +
+	"\x14evaluation_key_tuple\x18\x15 \x01(\v2%.cerbos.runtime.v1.EvaluationKeyTupleR\x12evaluationKeyTuple\x1a\xbc\x01\n" +
 	"\fAllowActions\x12X\n" +
 	"\aactions\x18\x01 \x03(\v2>.cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntryR\aactions\x1aR\n" +
 	"\fActionsEntry\x12\x10\n" +
@@ -4297,7 +4432,7 @@ const file_cerbos_runtime_v1_runtime_proto_rawDesc = "" +
 	"\x06Errors\x12S\n" +
 	"\x12index_build_errors\x18\x01 \x01(\v2#.cerbos.runtime.v1.IndexBuildErrorsH\x00R\x10indexBuildErrors\x12I\n" +
 	"\x0ecompile_errors\x18\x02 \x01(\v2 .cerbos.runtime.v1.CompileErrorsH\x00R\rcompileErrorsB\x06\n" +
-	"\x04kind\"\xbd\x13\n" +
+	"\x04kind\"\x96\x14\n" +
 	"\vBitmapIndex\x12>\n" +
 	"\aversion\x18\x01 \x03(\v2$.cerbos.runtime.v1.BitmapIndex.EntryR\aversion\x12:\n" +
 	"\x05scope\x18\x02 \x03(\v2$.cerbos.runtime.v1.BitmapIndex.EntryR\x05scope\x12@\n" +
@@ -4320,7 +4455,7 @@ const file_cerbos_runtime_v1_runtime_proto_rawDesc = "" +
 	"\bliterals\x18\x01 \x03(\v2$.cerbos.runtime.v1.BitmapIndex.EntryR\bliterals\x12:\n" +
 	"\x05globs\x18\x02 \x03(\v2$.cerbos.runtime.v1.BitmapIndex.EntryR\x05globs\x1a(\n" +
 	"\fAllowActions\x12\x18\n" +
-	"\aactions\x18\x01 \x03(\tR\aactions\x1a\xbc\x03\n" +
+	"\aactions\x18\x01 \x03(\tR\aactions\x1a\x95\x04\n" +
 	"\aBinding\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\rR\x02id\x12\x1d\n" +
 	"\n" +
@@ -4335,7 +4470,8 @@ const file_cerbos_runtime_v1_runtime_proto_rawDesc = "" +
 	"\x13origin_derived_role\x18\n" +
 	" \x01(\tR\x11originDerivedRole\x12\x12\n" +
 	"\x04name\x18\v \x01(\tR\x04name\x12%\n" +
-	"\x0eevaluation_key\x18\f \x01(\tR\revaluationKey\x12\x18\n" +
+	"\x0eevaluation_key\x18\f \x01(\tR\revaluationKey\x12W\n" +
+	"\x14evaluation_key_tuple\x18\x0e \x01(\v2%.cerbos.runtime.v1.EvaluationKeyTupleR\x12evaluationKeyTuple\x12\x18\n" +
 	"\x06action\x18\a \x01(\tH\x00R\x06action\x12R\n" +
 	"\rallow_actions\x18\r \x01(\v2+.cerbos.runtime.v1.BitmapIndex.AllowActionsH\x00R\fallowActionsB\f\n" +
 	"\n" +
@@ -4379,278 +4515,281 @@ func file_cerbos_runtime_v1_runtime_proto_rawDescGZIP() []byte {
 	return file_cerbos_runtime_v1_runtime_proto_rawDescData
 }
 
-var file_cerbos_runtime_v1_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 92)
+var file_cerbos_runtime_v1_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 93)
 var file_cerbos_runtime_v1_runtime_proto_goTypes = []any{
 	(*RunnablePolicySet)(nil),              // 0: cerbos.runtime.v1.RunnablePolicySet
-	(*RuleTable)(nil),                      // 1: cerbos.runtime.v1.RuleTable
-	(*RuleTableMetadata)(nil),              // 2: cerbos.runtime.v1.RuleTableMetadata
-	(*RunnableRolePolicySet)(nil),          // 3: cerbos.runtime.v1.RunnableRolePolicySet
-	(*RunnableResourcePolicySet)(nil),      // 4: cerbos.runtime.v1.RunnableResourcePolicySet
-	(*RunnableDerivedRole)(nil),            // 5: cerbos.runtime.v1.RunnableDerivedRole
-	(*RunnableDerivedRolesSet)(nil),        // 6: cerbos.runtime.v1.RunnableDerivedRolesSet
-	(*RunnableVariablesSet)(nil),           // 7: cerbos.runtime.v1.RunnableVariablesSet
-	(*RunnablePrincipalPolicySet)(nil),     // 8: cerbos.runtime.v1.RunnablePrincipalPolicySet
-	(*Expr)(nil),                           // 9: cerbos.runtime.v1.Expr
-	(*Output)(nil),                         // 10: cerbos.runtime.v1.Output
-	(*Variable)(nil),                       // 11: cerbos.runtime.v1.Variable
-	(*Condition)(nil),                      // 12: cerbos.runtime.v1.Condition
-	(*CompileErrors)(nil),                  // 13: cerbos.runtime.v1.CompileErrors
-	(*IndexBuildErrors)(nil),               // 14: cerbos.runtime.v1.IndexBuildErrors
-	(*Errors)(nil),                         // 15: cerbos.runtime.v1.Errors
-	(*BitmapIndex)(nil),                    // 16: cerbos.runtime.v1.BitmapIndex
-	(*RuleTable_RuleRow)(nil),              // 17: cerbos.runtime.v1.RuleTable.RuleRow
-	(*RuleTable_RoleParentRoles)(nil),      // 18: cerbos.runtime.v1.RuleTable.RoleParentRoles
-	(*RuleTable_PolicyDerivedRoles)(nil),   // 19: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles
-	(*RuleTable_JSONSchema)(nil),           // 20: cerbos.runtime.v1.RuleTable.JSONSchema
-	(*RuleTable_Manifest)(nil),             // 21: cerbos.runtime.v1.RuleTable.Manifest
-	nil,                                    // 22: cerbos.runtime.v1.RuleTable.SchemasEntry
-	nil,                                    // 23: cerbos.runtime.v1.RuleTable.MetaEntry
-	nil,                                    // 24: cerbos.runtime.v1.RuleTable.ScopeParentRolesEntry
-	nil,                                    // 25: cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntry
-	nil,                                    // 26: cerbos.runtime.v1.RuleTable.JsonSchemasEntry
-	(*RuleTable_RuleRow_AllowActions)(nil), // 27: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions
-	(*RuleTable_RuleRow_Params)(nil),       // 28: cerbos.runtime.v1.RuleTable.RuleRow.Params
-	nil,                                    // 29: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry
-	nil,                                    // 30: cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry
-	(*RuleTable_RoleParentRoles_ParentRoles)(nil), // 31: cerbos.runtime.v1.RuleTable.RoleParentRoles.ParentRoles
-	nil,                                    // 32: cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry
-	nil,                                    // 33: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry
-	nil,                                    // 34: cerbos.runtime.v1.RuleTableMetadata.SourceAttributesEntry
-	nil,                                    // 35: cerbos.runtime.v1.RuleTableMetadata.AnnotationsEntry
-	(*RunnableRolePolicySet_Metadata)(nil), // 36: cerbos.runtime.v1.RunnableRolePolicySet.Metadata
-	(*RunnableRolePolicySet_Rule)(nil),     // 37: cerbos.runtime.v1.RunnableRolePolicySet.Rule
-	(*RunnableRolePolicySet_RuleList)(nil), // 38: cerbos.runtime.v1.RunnableRolePolicySet.RuleList
-	nil,                                    // 39: cerbos.runtime.v1.RunnableRolePolicySet.ResourcesEntry
-	nil,                                    // 40: cerbos.runtime.v1.RunnableRolePolicySet.ConstantsEntry
-	nil,                                    // 41: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry
-	nil,                                    // 42: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.AnnotationsEntry
-	nil,                                    // 43: cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry
-	(*RunnableResourcePolicySet_Metadata)(nil), // 44: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata
-	(*RunnableResourcePolicySet_Policy)(nil),   // 45: cerbos.runtime.v1.RunnableResourcePolicySet.Policy
-	nil,                                        // 46: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry
-	nil,                                        // 47: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.AnnotationsEntry
-	(*RunnableResourcePolicySet_Policy_Rule)(nil), // 48: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule
-	nil,                                      // 49: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry
-	nil,                                      // 50: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry
-	nil,                                      // 51: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry
-	nil,                                      // 52: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry
-	nil,                                      // 53: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry
-	nil,                                      // 54: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry
-	nil,                                      // 55: cerbos.runtime.v1.RunnableDerivedRole.ParentRolesEntry
-	nil,                                      // 56: cerbos.runtime.v1.RunnableDerivedRole.VariablesEntry
-	nil,                                      // 57: cerbos.runtime.v1.RunnableDerivedRole.ConstantsEntry
-	(*RunnableDerivedRolesSet_Metadata)(nil), // 58: cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata
-	nil,                                      // 59: cerbos.runtime.v1.RunnableDerivedRolesSet.DerivedRolesEntry
-	nil,                                      // 60: cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.AnnotationsEntry
-	(*RunnableVariablesSet_Metadata)(nil),    // 61: cerbos.runtime.v1.RunnableVariablesSet.Metadata
-	nil,                                      // 62: cerbos.runtime.v1.RunnableVariablesSet.VariablesEntry
-	nil,                                      // 63: cerbos.runtime.v1.RunnableVariablesSet.Metadata.AnnotationsEntry
-	(*RunnablePrincipalPolicySet_Metadata)(nil), // 64: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata
-	(*RunnablePrincipalPolicySet_Policy)(nil),   // 65: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy
-	nil, // 66: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry
-	nil, // 67: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.AnnotationsEntry
-	(*RunnablePrincipalPolicySet_Policy_ActionRule)(nil),    // 68: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule
-	(*RunnablePrincipalPolicySet_Policy_ResourceRules)(nil), // 69: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules
-	nil,                                    // 70: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry
-	nil,                                    // 71: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry
-	nil,                                    // 72: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry
-	(*Output_When)(nil),                    // 73: cerbos.runtime.v1.Output.When
-	(*Condition_ExprList)(nil),             // 74: cerbos.runtime.v1.Condition.ExprList
-	(*CompileErrors_Err)(nil),              // 75: cerbos.runtime.v1.CompileErrors.Err
-	(*IndexBuildErrors_DuplicateDef)(nil),  // 76: cerbos.runtime.v1.IndexBuildErrors.DuplicateDef
-	(*IndexBuildErrors_MissingImport)(nil), // 77: cerbos.runtime.v1.IndexBuildErrors.MissingImport
-	(*IndexBuildErrors_MissingScope)(nil),  // 78: cerbos.runtime.v1.IndexBuildErrors.MissingScope
-	(*IndexBuildErrors_ScopePermissionsConflicts)(nil), // 79: cerbos.runtime.v1.IndexBuildErrors.ScopePermissionsConflicts
-	(*IndexBuildErrors_LoadFailure)(nil),               // 80: cerbos.runtime.v1.IndexBuildErrors.LoadFailure
-	(*IndexBuildErrors_Disabled)(nil),                  // 81: cerbos.runtime.v1.IndexBuildErrors.Disabled
-	(*BitmapIndex_Entry)(nil),                          // 82: cerbos.runtime.v1.BitmapIndex.Entry
-	(*BitmapIndex_GlobDimension)(nil),                  // 83: cerbos.runtime.v1.BitmapIndex.GlobDimension
-	(*BitmapIndex_AllowActions)(nil),                   // 84: cerbos.runtime.v1.BitmapIndex.AllowActions
-	(*BitmapIndex_Binding)(nil),                        // 85: cerbos.runtime.v1.BitmapIndex.Binding
-	(*BitmapIndex_FunctionalCore)(nil),                 // 86: cerbos.runtime.v1.BitmapIndex.FunctionalCore
-	(*BitmapIndex_Parents)(nil),                        // 87: cerbos.runtime.v1.BitmapIndex.Parents
-	(*BitmapIndex_RoleParents)(nil),                    // 88: cerbos.runtime.v1.BitmapIndex.RoleParents
-	nil,                                                // 89: cerbos.runtime.v1.BitmapIndex.PolicyKindEntry
-	nil,                                                // 90: cerbos.runtime.v1.BitmapIndex.ParentRolesEntry
-	nil,                                                // 91: cerbos.runtime.v1.BitmapIndex.RoleParents.RolesEntry
-	(v1.ScopePermissions)(0),                           // 92: cerbos.policy.v1.ScopePermissions
-	(*v1.Schemas)(nil),                                 // 93: cerbos.policy.v1.Schemas
-	(*v1alpha1.CheckedExpr)(nil),                       // 94: google.api.expr.v1alpha1.CheckedExpr
-	(v11.Effect)(0),                                    // 95: cerbos.effect.v1.Effect
-	(v1.Kind)(0),                                       // 96: cerbos.policy.v1.Kind
-	(*emptypb.Empty)(nil),                              // 97: google.protobuf.Empty
-	(*structpb.Value)(nil),                             // 98: google.protobuf.Value
-	(*v1.SourceAttributes)(nil),                        // 99: cerbos.policy.v1.SourceAttributes
-	(*v12.Position)(nil),                               // 100: cerbos.source.v1.Position
-	(*v12.Error)(nil),                                  // 101: cerbos.source.v1.Error
+	(*EvaluationKeyTuple)(nil),             // 1: cerbos.runtime.v1.EvaluationKeyTuple
+	(*RuleTable)(nil),                      // 2: cerbos.runtime.v1.RuleTable
+	(*RuleTableMetadata)(nil),              // 3: cerbos.runtime.v1.RuleTableMetadata
+	(*RunnableRolePolicySet)(nil),          // 4: cerbos.runtime.v1.RunnableRolePolicySet
+	(*RunnableResourcePolicySet)(nil),      // 5: cerbos.runtime.v1.RunnableResourcePolicySet
+	(*RunnableDerivedRole)(nil),            // 6: cerbos.runtime.v1.RunnableDerivedRole
+	(*RunnableDerivedRolesSet)(nil),        // 7: cerbos.runtime.v1.RunnableDerivedRolesSet
+	(*RunnableVariablesSet)(nil),           // 8: cerbos.runtime.v1.RunnableVariablesSet
+	(*RunnablePrincipalPolicySet)(nil),     // 9: cerbos.runtime.v1.RunnablePrincipalPolicySet
+	(*Expr)(nil),                           // 10: cerbos.runtime.v1.Expr
+	(*Output)(nil),                         // 11: cerbos.runtime.v1.Output
+	(*Variable)(nil),                       // 12: cerbos.runtime.v1.Variable
+	(*Condition)(nil),                      // 13: cerbos.runtime.v1.Condition
+	(*CompileErrors)(nil),                  // 14: cerbos.runtime.v1.CompileErrors
+	(*IndexBuildErrors)(nil),               // 15: cerbos.runtime.v1.IndexBuildErrors
+	(*Errors)(nil),                         // 16: cerbos.runtime.v1.Errors
+	(*BitmapIndex)(nil),                    // 17: cerbos.runtime.v1.BitmapIndex
+	(*RuleTable_RuleRow)(nil),              // 18: cerbos.runtime.v1.RuleTable.RuleRow
+	(*RuleTable_RoleParentRoles)(nil),      // 19: cerbos.runtime.v1.RuleTable.RoleParentRoles
+	(*RuleTable_PolicyDerivedRoles)(nil),   // 20: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles
+	(*RuleTable_JSONSchema)(nil),           // 21: cerbos.runtime.v1.RuleTable.JSONSchema
+	(*RuleTable_Manifest)(nil),             // 22: cerbos.runtime.v1.RuleTable.Manifest
+	nil,                                    // 23: cerbos.runtime.v1.RuleTable.SchemasEntry
+	nil,                                    // 24: cerbos.runtime.v1.RuleTable.MetaEntry
+	nil,                                    // 25: cerbos.runtime.v1.RuleTable.ScopeParentRolesEntry
+	nil,                                    // 26: cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntry
+	nil,                                    // 27: cerbos.runtime.v1.RuleTable.JsonSchemasEntry
+	(*RuleTable_RuleRow_AllowActions)(nil), // 28: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions
+	(*RuleTable_RuleRow_Params)(nil),       // 29: cerbos.runtime.v1.RuleTable.RuleRow.Params
+	nil,                                    // 30: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry
+	nil,                                    // 31: cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry
+	(*RuleTable_RoleParentRoles_ParentRoles)(nil), // 32: cerbos.runtime.v1.RuleTable.RoleParentRoles.ParentRoles
+	nil,                                    // 33: cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry
+	nil,                                    // 34: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry
+	nil,                                    // 35: cerbos.runtime.v1.RuleTableMetadata.SourceAttributesEntry
+	nil,                                    // 36: cerbos.runtime.v1.RuleTableMetadata.AnnotationsEntry
+	(*RunnableRolePolicySet_Metadata)(nil), // 37: cerbos.runtime.v1.RunnableRolePolicySet.Metadata
+	(*RunnableRolePolicySet_Rule)(nil),     // 38: cerbos.runtime.v1.RunnableRolePolicySet.Rule
+	(*RunnableRolePolicySet_RuleList)(nil), // 39: cerbos.runtime.v1.RunnableRolePolicySet.RuleList
+	nil,                                    // 40: cerbos.runtime.v1.RunnableRolePolicySet.ResourcesEntry
+	nil,                                    // 41: cerbos.runtime.v1.RunnableRolePolicySet.ConstantsEntry
+	nil,                                    // 42: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry
+	nil,                                    // 43: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.AnnotationsEntry
+	nil,                                    // 44: cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry
+	(*RunnableResourcePolicySet_Metadata)(nil), // 45: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata
+	(*RunnableResourcePolicySet_Policy)(nil),   // 46: cerbos.runtime.v1.RunnableResourcePolicySet.Policy
+	nil,                                        // 47: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry
+	nil,                                        // 48: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.AnnotationsEntry
+	(*RunnableResourcePolicySet_Policy_Rule)(nil), // 49: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule
+	nil,                                      // 50: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry
+	nil,                                      // 51: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry
+	nil,                                      // 52: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry
+	nil,                                      // 53: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry
+	nil,                                      // 54: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry
+	nil,                                      // 55: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry
+	nil,                                      // 56: cerbos.runtime.v1.RunnableDerivedRole.ParentRolesEntry
+	nil,                                      // 57: cerbos.runtime.v1.RunnableDerivedRole.VariablesEntry
+	nil,                                      // 58: cerbos.runtime.v1.RunnableDerivedRole.ConstantsEntry
+	(*RunnableDerivedRolesSet_Metadata)(nil), // 59: cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata
+	nil,                                      // 60: cerbos.runtime.v1.RunnableDerivedRolesSet.DerivedRolesEntry
+	nil,                                      // 61: cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.AnnotationsEntry
+	(*RunnableVariablesSet_Metadata)(nil),    // 62: cerbos.runtime.v1.RunnableVariablesSet.Metadata
+	nil,                                      // 63: cerbos.runtime.v1.RunnableVariablesSet.VariablesEntry
+	nil,                                      // 64: cerbos.runtime.v1.RunnableVariablesSet.Metadata.AnnotationsEntry
+	(*RunnablePrincipalPolicySet_Metadata)(nil), // 65: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata
+	(*RunnablePrincipalPolicySet_Policy)(nil),   // 66: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy
+	nil, // 67: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry
+	nil, // 68: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.AnnotationsEntry
+	(*RunnablePrincipalPolicySet_Policy_ActionRule)(nil),    // 69: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule
+	(*RunnablePrincipalPolicySet_Policy_ResourceRules)(nil), // 70: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules
+	nil,                                    // 71: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry
+	nil,                                    // 72: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry
+	nil,                                    // 73: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry
+	(*Output_When)(nil),                    // 74: cerbos.runtime.v1.Output.When
+	(*Condition_ExprList)(nil),             // 75: cerbos.runtime.v1.Condition.ExprList
+	(*CompileErrors_Err)(nil),              // 76: cerbos.runtime.v1.CompileErrors.Err
+	(*IndexBuildErrors_DuplicateDef)(nil),  // 77: cerbos.runtime.v1.IndexBuildErrors.DuplicateDef
+	(*IndexBuildErrors_MissingImport)(nil), // 78: cerbos.runtime.v1.IndexBuildErrors.MissingImport
+	(*IndexBuildErrors_MissingScope)(nil),  // 79: cerbos.runtime.v1.IndexBuildErrors.MissingScope
+	(*IndexBuildErrors_ScopePermissionsConflicts)(nil), // 80: cerbos.runtime.v1.IndexBuildErrors.ScopePermissionsConflicts
+	(*IndexBuildErrors_LoadFailure)(nil),               // 81: cerbos.runtime.v1.IndexBuildErrors.LoadFailure
+	(*IndexBuildErrors_Disabled)(nil),                  // 82: cerbos.runtime.v1.IndexBuildErrors.Disabled
+	(*BitmapIndex_Entry)(nil),                          // 83: cerbos.runtime.v1.BitmapIndex.Entry
+	(*BitmapIndex_GlobDimension)(nil),                  // 84: cerbos.runtime.v1.BitmapIndex.GlobDimension
+	(*BitmapIndex_AllowActions)(nil),                   // 85: cerbos.runtime.v1.BitmapIndex.AllowActions
+	(*BitmapIndex_Binding)(nil),                        // 86: cerbos.runtime.v1.BitmapIndex.Binding
+	(*BitmapIndex_FunctionalCore)(nil),                 // 87: cerbos.runtime.v1.BitmapIndex.FunctionalCore
+	(*BitmapIndex_Parents)(nil),                        // 88: cerbos.runtime.v1.BitmapIndex.Parents
+	(*BitmapIndex_RoleParents)(nil),                    // 89: cerbos.runtime.v1.BitmapIndex.RoleParents
+	nil,                                                // 90: cerbos.runtime.v1.BitmapIndex.PolicyKindEntry
+	nil,                                                // 91: cerbos.runtime.v1.BitmapIndex.ParentRolesEntry
+	nil,                                                // 92: cerbos.runtime.v1.BitmapIndex.RoleParents.RolesEntry
+	(v1.ScopePermissions)(0),                           // 93: cerbos.policy.v1.ScopePermissions
+	(*v1.Schemas)(nil),                                 // 94: cerbos.policy.v1.Schemas
+	(*v1alpha1.CheckedExpr)(nil),                       // 95: google.api.expr.v1alpha1.CheckedExpr
+	(v11.Effect)(0),                                    // 96: cerbos.effect.v1.Effect
+	(v1.Kind)(0),                                       // 97: cerbos.policy.v1.Kind
+	(*emptypb.Empty)(nil),                              // 98: google.protobuf.Empty
+	(*structpb.Value)(nil),                             // 99: google.protobuf.Value
+	(*v1.SourceAttributes)(nil),                        // 100: cerbos.policy.v1.SourceAttributes
+	(*v12.Position)(nil),                               // 101: cerbos.source.v1.Position
+	(*v12.Error)(nil),                                  // 102: cerbos.source.v1.Error
 }
 var file_cerbos_runtime_v1_runtime_proto_depIdxs = []int32{
-	4,   // 0: cerbos.runtime.v1.RunnablePolicySet.resource_policy:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet
-	8,   // 1: cerbos.runtime.v1.RunnablePolicySet.principal_policy:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet
-	6,   // 2: cerbos.runtime.v1.RunnablePolicySet.derived_roles:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet
-	7,   // 3: cerbos.runtime.v1.RunnablePolicySet.variables:type_name -> cerbos.runtime.v1.RunnableVariablesSet
-	3,   // 4: cerbos.runtime.v1.RunnablePolicySet.role_policy:type_name -> cerbos.runtime.v1.RunnableRolePolicySet
-	17,  // 5: cerbos.runtime.v1.RuleTable.rules:type_name -> cerbos.runtime.v1.RuleTable.RuleRow
-	22,  // 6: cerbos.runtime.v1.RuleTable.schemas:type_name -> cerbos.runtime.v1.RuleTable.SchemasEntry
-	23,  // 7: cerbos.runtime.v1.RuleTable.meta:type_name -> cerbos.runtime.v1.RuleTable.MetaEntry
-	24,  // 8: cerbos.runtime.v1.RuleTable.scope_parent_roles:type_name -> cerbos.runtime.v1.RuleTable.ScopeParentRolesEntry
-	25,  // 9: cerbos.runtime.v1.RuleTable.policy_derived_roles:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntry
-	26,  // 10: cerbos.runtime.v1.RuleTable.json_schemas:type_name -> cerbos.runtime.v1.RuleTable.JsonSchemasEntry
-	21,  // 11: cerbos.runtime.v1.RuleTable.manifest:type_name -> cerbos.runtime.v1.RuleTable.Manifest
-	34,  // 12: cerbos.runtime.v1.RuleTableMetadata.source_attributes:type_name -> cerbos.runtime.v1.RuleTableMetadata.SourceAttributesEntry
-	35,  // 13: cerbos.runtime.v1.RuleTableMetadata.annotations:type_name -> cerbos.runtime.v1.RuleTableMetadata.AnnotationsEntry
-	36,  // 14: cerbos.runtime.v1.RunnableRolePolicySet.meta:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata
-	92,  // 15: cerbos.runtime.v1.RunnableRolePolicySet.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
-	39,  // 16: cerbos.runtime.v1.RunnableRolePolicySet.resources:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.ResourcesEntry
-	11,  // 17: cerbos.runtime.v1.RunnableRolePolicySet.ordered_variables:type_name -> cerbos.runtime.v1.Variable
-	40,  // 18: cerbos.runtime.v1.RunnableRolePolicySet.constants:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.ConstantsEntry
-	44,  // 19: cerbos.runtime.v1.RunnableResourcePolicySet.meta:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata
-	45,  // 20: cerbos.runtime.v1.RunnableResourcePolicySet.policies:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy
-	93,  // 21: cerbos.runtime.v1.RunnableResourcePolicySet.schemas:type_name -> cerbos.policy.v1.Schemas
-	55,  // 22: cerbos.runtime.v1.RunnableDerivedRole.parent_roles:type_name -> cerbos.runtime.v1.RunnableDerivedRole.ParentRolesEntry
-	56,  // 23: cerbos.runtime.v1.RunnableDerivedRole.variables:type_name -> cerbos.runtime.v1.RunnableDerivedRole.VariablesEntry
-	12,  // 24: cerbos.runtime.v1.RunnableDerivedRole.condition:type_name -> cerbos.runtime.v1.Condition
-	11,  // 25: cerbos.runtime.v1.RunnableDerivedRole.ordered_variables:type_name -> cerbos.runtime.v1.Variable
-	57,  // 26: cerbos.runtime.v1.RunnableDerivedRole.constants:type_name -> cerbos.runtime.v1.RunnableDerivedRole.ConstantsEntry
-	58,  // 27: cerbos.runtime.v1.RunnableDerivedRolesSet.meta:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata
-	59,  // 28: cerbos.runtime.v1.RunnableDerivedRolesSet.derived_roles:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet.DerivedRolesEntry
-	61,  // 29: cerbos.runtime.v1.RunnableVariablesSet.meta:type_name -> cerbos.runtime.v1.RunnableVariablesSet.Metadata
-	62,  // 30: cerbos.runtime.v1.RunnableVariablesSet.variables:type_name -> cerbos.runtime.v1.RunnableVariablesSet.VariablesEntry
-	64,  // 31: cerbos.runtime.v1.RunnablePrincipalPolicySet.meta:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata
-	65,  // 32: cerbos.runtime.v1.RunnablePrincipalPolicySet.policies:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy
-	94,  // 33: cerbos.runtime.v1.Expr.checked:type_name -> google.api.expr.v1alpha1.CheckedExpr
-	73,  // 34: cerbos.runtime.v1.Output.when:type_name -> cerbos.runtime.v1.Output.When
-	9,   // 35: cerbos.runtime.v1.Variable.expr:type_name -> cerbos.runtime.v1.Expr
-	74,  // 36: cerbos.runtime.v1.Condition.all:type_name -> cerbos.runtime.v1.Condition.ExprList
-	74,  // 37: cerbos.runtime.v1.Condition.any:type_name -> cerbos.runtime.v1.Condition.ExprList
-	74,  // 38: cerbos.runtime.v1.Condition.none:type_name -> cerbos.runtime.v1.Condition.ExprList
-	9,   // 39: cerbos.runtime.v1.Condition.expr:type_name -> cerbos.runtime.v1.Expr
-	75,  // 40: cerbos.runtime.v1.CompileErrors.errors:type_name -> cerbos.runtime.v1.CompileErrors.Err
-	76,  // 41: cerbos.runtime.v1.IndexBuildErrors.duplicate_defs:type_name -> cerbos.runtime.v1.IndexBuildErrors.DuplicateDef
-	80,  // 42: cerbos.runtime.v1.IndexBuildErrors.load_failures:type_name -> cerbos.runtime.v1.IndexBuildErrors.LoadFailure
-	77,  // 43: cerbos.runtime.v1.IndexBuildErrors.missing_imports:type_name -> cerbos.runtime.v1.IndexBuildErrors.MissingImport
-	81,  // 44: cerbos.runtime.v1.IndexBuildErrors.disabled_defs:type_name -> cerbos.runtime.v1.IndexBuildErrors.Disabled
-	78,  // 45: cerbos.runtime.v1.IndexBuildErrors.missing_scope_details:type_name -> cerbos.runtime.v1.IndexBuildErrors.MissingScope
-	79,  // 46: cerbos.runtime.v1.IndexBuildErrors.scope_permissions_conflicts:type_name -> cerbos.runtime.v1.IndexBuildErrors.ScopePermissionsConflicts
-	14,  // 47: cerbos.runtime.v1.Errors.index_build_errors:type_name -> cerbos.runtime.v1.IndexBuildErrors
-	13,  // 48: cerbos.runtime.v1.Errors.compile_errors:type_name -> cerbos.runtime.v1.CompileErrors
-	82,  // 49: cerbos.runtime.v1.BitmapIndex.version:type_name -> cerbos.runtime.v1.BitmapIndex.Entry
-	82,  // 50: cerbos.runtime.v1.BitmapIndex.scope:type_name -> cerbos.runtime.v1.BitmapIndex.Entry
-	83,  // 51: cerbos.runtime.v1.BitmapIndex.role:type_name -> cerbos.runtime.v1.BitmapIndex.GlobDimension
-	83,  // 52: cerbos.runtime.v1.BitmapIndex.action:type_name -> cerbos.runtime.v1.BitmapIndex.GlobDimension
-	83,  // 53: cerbos.runtime.v1.BitmapIndex.resource:type_name -> cerbos.runtime.v1.BitmapIndex.GlobDimension
-	89,  // 54: cerbos.runtime.v1.BitmapIndex.policy_kind:type_name -> cerbos.runtime.v1.BitmapIndex.PolicyKindEntry
-	82,  // 55: cerbos.runtime.v1.BitmapIndex.principal:type_name -> cerbos.runtime.v1.BitmapIndex.Entry
-	85,  // 56: cerbos.runtime.v1.BitmapIndex.bindings:type_name -> cerbos.runtime.v1.BitmapIndex.Binding
-	86,  // 57: cerbos.runtime.v1.BitmapIndex.cores:type_name -> cerbos.runtime.v1.BitmapIndex.FunctionalCore
-	90,  // 58: cerbos.runtime.v1.BitmapIndex.parent_roles:type_name -> cerbos.runtime.v1.BitmapIndex.ParentRolesEntry
-	27,  // 59: cerbos.runtime.v1.RuleTable.RuleRow.allow_actions:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.AllowActions
-	12,  // 60: cerbos.runtime.v1.RuleTable.RuleRow.condition:type_name -> cerbos.runtime.v1.Condition
-	12,  // 61: cerbos.runtime.v1.RuleTable.RuleRow.derived_role_condition:type_name -> cerbos.runtime.v1.Condition
-	95,  // 62: cerbos.runtime.v1.RuleTable.RuleRow.effect:type_name -> cerbos.effect.v1.Effect
-	92,  // 63: cerbos.runtime.v1.RuleTable.RuleRow.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
-	10,  // 64: cerbos.runtime.v1.RuleTable.RuleRow.emit_output:type_name -> cerbos.runtime.v1.Output
-	28,  // 65: cerbos.runtime.v1.RuleTable.RuleRow.params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
-	28,  // 66: cerbos.runtime.v1.RuleTable.RuleRow.derived_role_params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
-	96,  // 67: cerbos.runtime.v1.RuleTable.RuleRow.policy_kind:type_name -> cerbos.policy.v1.Kind
-	32,  // 68: cerbos.runtime.v1.RuleTable.RoleParentRoles.role_parent_roles:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry
-	33,  // 69: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.derived_roles:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry
-	93,  // 70: cerbos.runtime.v1.RuleTable.SchemasEntry.value:type_name -> cerbos.policy.v1.Schemas
-	2,   // 71: cerbos.runtime.v1.RuleTable.MetaEntry.value:type_name -> cerbos.runtime.v1.RuleTableMetadata
-	18,  // 72: cerbos.runtime.v1.RuleTable.ScopeParentRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles
-	19,  // 73: cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRoles
-	20,  // 74: cerbos.runtime.v1.RuleTable.JsonSchemasEntry.value:type_name -> cerbos.runtime.v1.RuleTable.JSONSchema
-	29,  // 75: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.actions:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry
-	11,  // 76: cerbos.runtime.v1.RuleTable.RuleRow.Params.ordered_variables:type_name -> cerbos.runtime.v1.Variable
-	30,  // 77: cerbos.runtime.v1.RuleTable.RuleRow.Params.constants:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry
-	97,  // 78: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry.value:type_name -> google.protobuf.Empty
-	98,  // 79: cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry.value:type_name -> google.protobuf.Value
-	31,  // 80: cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles.ParentRoles
-	5,   // 81: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
-	99,  // 82: cerbos.runtime.v1.RuleTableMetadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
-	41,  // 83: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry
-	42,  // 84: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata.AnnotationsEntry
-	43,  // 85: cerbos.runtime.v1.RunnableRolePolicySet.Rule.allow_actions:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry
-	12,  // 86: cerbos.runtime.v1.RunnableRolePolicySet.Rule.condition:type_name -> cerbos.runtime.v1.Condition
-	10,  // 87: cerbos.runtime.v1.RunnableRolePolicySet.Rule.emit_output:type_name -> cerbos.runtime.v1.Output
-	37,  // 88: cerbos.runtime.v1.RunnableRolePolicySet.RuleList.rules:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Rule
-	38,  // 89: cerbos.runtime.v1.RunnableRolePolicySet.ResourcesEntry.value:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.RuleList
-	98,  // 90: cerbos.runtime.v1.RunnableRolePolicySet.ConstantsEntry.value:type_name -> google.protobuf.Value
-	99,  // 91: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
-	97,  // 92: cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry.value:type_name -> google.protobuf.Empty
-	46,  // 93: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry
-	47,  // 94: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.AnnotationsEntry
-	49,  // 95: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.derived_roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry
-	50,  // 96: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.variables:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry
-	48,  // 97: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.rules:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule
-	93,  // 98: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.schemas:type_name -> cerbos.policy.v1.Schemas
-	11,  // 99: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ordered_variables:type_name -> cerbos.runtime.v1.Variable
-	92,  // 100: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
-	51,  // 101: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.constants:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry
-	99,  // 102: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
-	52,  // 103: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.actions:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry
-	53,  // 104: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.derived_roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry
-	54,  // 105: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry
-	12,  // 106: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.condition:type_name -> cerbos.runtime.v1.Condition
-	95,  // 107: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.effect:type_name -> cerbos.effect.v1.Effect
-	9,   // 108: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.output:type_name -> cerbos.runtime.v1.Expr
-	10,  // 109: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.emit_output:type_name -> cerbos.runtime.v1.Output
-	5,   // 110: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
-	9,   // 111: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
-	98,  // 112: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry.value:type_name -> google.protobuf.Value
-	97,  // 113: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry.value:type_name -> google.protobuf.Empty
-	97,  // 114: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry.value:type_name -> google.protobuf.Empty
-	97,  // 115: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry.value:type_name -> google.protobuf.Empty
-	97,  // 116: cerbos.runtime.v1.RunnableDerivedRole.ParentRolesEntry.value:type_name -> google.protobuf.Empty
-	9,   // 117: cerbos.runtime.v1.RunnableDerivedRole.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
-	98,  // 118: cerbos.runtime.v1.RunnableDerivedRole.ConstantsEntry.value:type_name -> google.protobuf.Value
-	60,  // 119: cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.AnnotationsEntry
-	5,   // 120: cerbos.runtime.v1.RunnableDerivedRolesSet.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
-	63,  // 121: cerbos.runtime.v1.RunnableVariablesSet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableVariablesSet.Metadata.AnnotationsEntry
-	9,   // 122: cerbos.runtime.v1.RunnableVariablesSet.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
-	66,  // 123: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry
-	67,  // 124: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.AnnotationsEntry
-	70,  // 125: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.variables:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry
-	71,  // 126: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.resource_rules:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry
-	11,  // 127: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ordered_variables:type_name -> cerbos.runtime.v1.Variable
-	92,  // 128: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
-	72,  // 129: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.constants:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry
-	99,  // 130: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
-	12,  // 131: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.condition:type_name -> cerbos.runtime.v1.Condition
-	95,  // 132: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.effect:type_name -> cerbos.effect.v1.Effect
-	9,   // 133: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.output:type_name -> cerbos.runtime.v1.Expr
-	10,  // 134: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.emit_output:type_name -> cerbos.runtime.v1.Output
-	68,  // 135: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules.action_rules:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule
-	9,   // 136: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
-	69,  // 137: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry.value:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules
-	98,  // 138: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry.value:type_name -> google.protobuf.Value
-	9,   // 139: cerbos.runtime.v1.Output.When.rule_activated:type_name -> cerbos.runtime.v1.Expr
-	9,   // 140: cerbos.runtime.v1.Output.When.condition_not_met:type_name -> cerbos.runtime.v1.Expr
-	12,  // 141: cerbos.runtime.v1.Condition.ExprList.expr:type_name -> cerbos.runtime.v1.Condition
-	100, // 142: cerbos.runtime.v1.CompileErrors.Err.position:type_name -> cerbos.source.v1.Position
-	100, // 143: cerbos.runtime.v1.IndexBuildErrors.DuplicateDef.position:type_name -> cerbos.source.v1.Position
-	100, // 144: cerbos.runtime.v1.IndexBuildErrors.MissingImport.position:type_name -> cerbos.source.v1.Position
-	101, // 145: cerbos.runtime.v1.IndexBuildErrors.LoadFailure.error_details:type_name -> cerbos.source.v1.Error
-	100, // 146: cerbos.runtime.v1.IndexBuildErrors.Disabled.position:type_name -> cerbos.source.v1.Position
-	82,  // 147: cerbos.runtime.v1.BitmapIndex.GlobDimension.literals:type_name -> cerbos.runtime.v1.BitmapIndex.Entry
-	82,  // 148: cerbos.runtime.v1.BitmapIndex.GlobDimension.globs:type_name -> cerbos.runtime.v1.BitmapIndex.Entry
-	84,  // 149: cerbos.runtime.v1.BitmapIndex.Binding.allow_actions:type_name -> cerbos.runtime.v1.BitmapIndex.AllowActions
-	95,  // 150: cerbos.runtime.v1.BitmapIndex.FunctionalCore.effect:type_name -> cerbos.effect.v1.Effect
-	12,  // 151: cerbos.runtime.v1.BitmapIndex.FunctionalCore.condition:type_name -> cerbos.runtime.v1.Condition
-	12,  // 152: cerbos.runtime.v1.BitmapIndex.FunctionalCore.derived_role_condition:type_name -> cerbos.runtime.v1.Condition
-	10,  // 153: cerbos.runtime.v1.BitmapIndex.FunctionalCore.emit_output:type_name -> cerbos.runtime.v1.Output
-	92,  // 154: cerbos.runtime.v1.BitmapIndex.FunctionalCore.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
-	96,  // 155: cerbos.runtime.v1.BitmapIndex.FunctionalCore.policy_kind:type_name -> cerbos.policy.v1.Kind
-	28,  // 156: cerbos.runtime.v1.BitmapIndex.FunctionalCore.params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
-	28,  // 157: cerbos.runtime.v1.BitmapIndex.FunctionalCore.derived_role_params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
-	91,  // 158: cerbos.runtime.v1.BitmapIndex.RoleParents.roles:type_name -> cerbos.runtime.v1.BitmapIndex.RoleParents.RolesEntry
-	88,  // 159: cerbos.runtime.v1.BitmapIndex.ParentRolesEntry.value:type_name -> cerbos.runtime.v1.BitmapIndex.RoleParents
-	87,  // 160: cerbos.runtime.v1.BitmapIndex.RoleParents.RolesEntry.value:type_name -> cerbos.runtime.v1.BitmapIndex.Parents
-	161, // [161:161] is the sub-list for method output_type
-	161, // [161:161] is the sub-list for method input_type
-	161, // [161:161] is the sub-list for extension type_name
-	161, // [161:161] is the sub-list for extension extendee
-	0,   // [0:161] is the sub-list for field type_name
+	5,   // 0: cerbos.runtime.v1.RunnablePolicySet.resource_policy:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet
+	9,   // 1: cerbos.runtime.v1.RunnablePolicySet.principal_policy:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet
+	7,   // 2: cerbos.runtime.v1.RunnablePolicySet.derived_roles:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet
+	8,   // 3: cerbos.runtime.v1.RunnablePolicySet.variables:type_name -> cerbos.runtime.v1.RunnableVariablesSet
+	4,   // 4: cerbos.runtime.v1.RunnablePolicySet.role_policy:type_name -> cerbos.runtime.v1.RunnableRolePolicySet
+	18,  // 5: cerbos.runtime.v1.RuleTable.rules:type_name -> cerbos.runtime.v1.RuleTable.RuleRow
+	23,  // 6: cerbos.runtime.v1.RuleTable.schemas:type_name -> cerbos.runtime.v1.RuleTable.SchemasEntry
+	24,  // 7: cerbos.runtime.v1.RuleTable.meta:type_name -> cerbos.runtime.v1.RuleTable.MetaEntry
+	25,  // 8: cerbos.runtime.v1.RuleTable.scope_parent_roles:type_name -> cerbos.runtime.v1.RuleTable.ScopeParentRolesEntry
+	26,  // 9: cerbos.runtime.v1.RuleTable.policy_derived_roles:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntry
+	27,  // 10: cerbos.runtime.v1.RuleTable.json_schemas:type_name -> cerbos.runtime.v1.RuleTable.JsonSchemasEntry
+	22,  // 11: cerbos.runtime.v1.RuleTable.manifest:type_name -> cerbos.runtime.v1.RuleTable.Manifest
+	35,  // 12: cerbos.runtime.v1.RuleTableMetadata.source_attributes:type_name -> cerbos.runtime.v1.RuleTableMetadata.SourceAttributesEntry
+	36,  // 13: cerbos.runtime.v1.RuleTableMetadata.annotations:type_name -> cerbos.runtime.v1.RuleTableMetadata.AnnotationsEntry
+	37,  // 14: cerbos.runtime.v1.RunnableRolePolicySet.meta:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata
+	93,  // 15: cerbos.runtime.v1.RunnableRolePolicySet.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
+	40,  // 16: cerbos.runtime.v1.RunnableRolePolicySet.resources:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.ResourcesEntry
+	12,  // 17: cerbos.runtime.v1.RunnableRolePolicySet.ordered_variables:type_name -> cerbos.runtime.v1.Variable
+	41,  // 18: cerbos.runtime.v1.RunnableRolePolicySet.constants:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.ConstantsEntry
+	45,  // 19: cerbos.runtime.v1.RunnableResourcePolicySet.meta:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata
+	46,  // 20: cerbos.runtime.v1.RunnableResourcePolicySet.policies:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy
+	94,  // 21: cerbos.runtime.v1.RunnableResourcePolicySet.schemas:type_name -> cerbos.policy.v1.Schemas
+	56,  // 22: cerbos.runtime.v1.RunnableDerivedRole.parent_roles:type_name -> cerbos.runtime.v1.RunnableDerivedRole.ParentRolesEntry
+	57,  // 23: cerbos.runtime.v1.RunnableDerivedRole.variables:type_name -> cerbos.runtime.v1.RunnableDerivedRole.VariablesEntry
+	13,  // 24: cerbos.runtime.v1.RunnableDerivedRole.condition:type_name -> cerbos.runtime.v1.Condition
+	12,  // 25: cerbos.runtime.v1.RunnableDerivedRole.ordered_variables:type_name -> cerbos.runtime.v1.Variable
+	58,  // 26: cerbos.runtime.v1.RunnableDerivedRole.constants:type_name -> cerbos.runtime.v1.RunnableDerivedRole.ConstantsEntry
+	59,  // 27: cerbos.runtime.v1.RunnableDerivedRolesSet.meta:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata
+	60,  // 28: cerbos.runtime.v1.RunnableDerivedRolesSet.derived_roles:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet.DerivedRolesEntry
+	62,  // 29: cerbos.runtime.v1.RunnableVariablesSet.meta:type_name -> cerbos.runtime.v1.RunnableVariablesSet.Metadata
+	63,  // 30: cerbos.runtime.v1.RunnableVariablesSet.variables:type_name -> cerbos.runtime.v1.RunnableVariablesSet.VariablesEntry
+	65,  // 31: cerbos.runtime.v1.RunnablePrincipalPolicySet.meta:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata
+	66,  // 32: cerbos.runtime.v1.RunnablePrincipalPolicySet.policies:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy
+	95,  // 33: cerbos.runtime.v1.Expr.checked:type_name -> google.api.expr.v1alpha1.CheckedExpr
+	74,  // 34: cerbos.runtime.v1.Output.when:type_name -> cerbos.runtime.v1.Output.When
+	10,  // 35: cerbos.runtime.v1.Variable.expr:type_name -> cerbos.runtime.v1.Expr
+	75,  // 36: cerbos.runtime.v1.Condition.all:type_name -> cerbos.runtime.v1.Condition.ExprList
+	75,  // 37: cerbos.runtime.v1.Condition.any:type_name -> cerbos.runtime.v1.Condition.ExprList
+	75,  // 38: cerbos.runtime.v1.Condition.none:type_name -> cerbos.runtime.v1.Condition.ExprList
+	10,  // 39: cerbos.runtime.v1.Condition.expr:type_name -> cerbos.runtime.v1.Expr
+	76,  // 40: cerbos.runtime.v1.CompileErrors.errors:type_name -> cerbos.runtime.v1.CompileErrors.Err
+	77,  // 41: cerbos.runtime.v1.IndexBuildErrors.duplicate_defs:type_name -> cerbos.runtime.v1.IndexBuildErrors.DuplicateDef
+	81,  // 42: cerbos.runtime.v1.IndexBuildErrors.load_failures:type_name -> cerbos.runtime.v1.IndexBuildErrors.LoadFailure
+	78,  // 43: cerbos.runtime.v1.IndexBuildErrors.missing_imports:type_name -> cerbos.runtime.v1.IndexBuildErrors.MissingImport
+	82,  // 44: cerbos.runtime.v1.IndexBuildErrors.disabled_defs:type_name -> cerbos.runtime.v1.IndexBuildErrors.Disabled
+	79,  // 45: cerbos.runtime.v1.IndexBuildErrors.missing_scope_details:type_name -> cerbos.runtime.v1.IndexBuildErrors.MissingScope
+	80,  // 46: cerbos.runtime.v1.IndexBuildErrors.scope_permissions_conflicts:type_name -> cerbos.runtime.v1.IndexBuildErrors.ScopePermissionsConflicts
+	15,  // 47: cerbos.runtime.v1.Errors.index_build_errors:type_name -> cerbos.runtime.v1.IndexBuildErrors
+	14,  // 48: cerbos.runtime.v1.Errors.compile_errors:type_name -> cerbos.runtime.v1.CompileErrors
+	83,  // 49: cerbos.runtime.v1.BitmapIndex.version:type_name -> cerbos.runtime.v1.BitmapIndex.Entry
+	83,  // 50: cerbos.runtime.v1.BitmapIndex.scope:type_name -> cerbos.runtime.v1.BitmapIndex.Entry
+	84,  // 51: cerbos.runtime.v1.BitmapIndex.role:type_name -> cerbos.runtime.v1.BitmapIndex.GlobDimension
+	84,  // 52: cerbos.runtime.v1.BitmapIndex.action:type_name -> cerbos.runtime.v1.BitmapIndex.GlobDimension
+	84,  // 53: cerbos.runtime.v1.BitmapIndex.resource:type_name -> cerbos.runtime.v1.BitmapIndex.GlobDimension
+	90,  // 54: cerbos.runtime.v1.BitmapIndex.policy_kind:type_name -> cerbos.runtime.v1.BitmapIndex.PolicyKindEntry
+	83,  // 55: cerbos.runtime.v1.BitmapIndex.principal:type_name -> cerbos.runtime.v1.BitmapIndex.Entry
+	86,  // 56: cerbos.runtime.v1.BitmapIndex.bindings:type_name -> cerbos.runtime.v1.BitmapIndex.Binding
+	87,  // 57: cerbos.runtime.v1.BitmapIndex.cores:type_name -> cerbos.runtime.v1.BitmapIndex.FunctionalCore
+	91,  // 58: cerbos.runtime.v1.BitmapIndex.parent_roles:type_name -> cerbos.runtime.v1.BitmapIndex.ParentRolesEntry
+	28,  // 59: cerbos.runtime.v1.RuleTable.RuleRow.allow_actions:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.AllowActions
+	13,  // 60: cerbos.runtime.v1.RuleTable.RuleRow.condition:type_name -> cerbos.runtime.v1.Condition
+	13,  // 61: cerbos.runtime.v1.RuleTable.RuleRow.derived_role_condition:type_name -> cerbos.runtime.v1.Condition
+	96,  // 62: cerbos.runtime.v1.RuleTable.RuleRow.effect:type_name -> cerbos.effect.v1.Effect
+	93,  // 63: cerbos.runtime.v1.RuleTable.RuleRow.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
+	11,  // 64: cerbos.runtime.v1.RuleTable.RuleRow.emit_output:type_name -> cerbos.runtime.v1.Output
+	29,  // 65: cerbos.runtime.v1.RuleTable.RuleRow.params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
+	29,  // 66: cerbos.runtime.v1.RuleTable.RuleRow.derived_role_params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
+	97,  // 67: cerbos.runtime.v1.RuleTable.RuleRow.policy_kind:type_name -> cerbos.policy.v1.Kind
+	1,   // 68: cerbos.runtime.v1.RuleTable.RuleRow.evaluation_key_tuple:type_name -> cerbos.runtime.v1.EvaluationKeyTuple
+	33,  // 69: cerbos.runtime.v1.RuleTable.RoleParentRoles.role_parent_roles:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry
+	34,  // 70: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.derived_roles:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry
+	94,  // 71: cerbos.runtime.v1.RuleTable.SchemasEntry.value:type_name -> cerbos.policy.v1.Schemas
+	3,   // 72: cerbos.runtime.v1.RuleTable.MetaEntry.value:type_name -> cerbos.runtime.v1.RuleTableMetadata
+	19,  // 73: cerbos.runtime.v1.RuleTable.ScopeParentRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles
+	20,  // 74: cerbos.runtime.v1.RuleTable.PolicyDerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.PolicyDerivedRoles
+	21,  // 75: cerbos.runtime.v1.RuleTable.JsonSchemasEntry.value:type_name -> cerbos.runtime.v1.RuleTable.JSONSchema
+	30,  // 76: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.actions:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry
+	12,  // 77: cerbos.runtime.v1.RuleTable.RuleRow.Params.ordered_variables:type_name -> cerbos.runtime.v1.Variable
+	31,  // 78: cerbos.runtime.v1.RuleTable.RuleRow.Params.constants:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry
+	98,  // 79: cerbos.runtime.v1.RuleTable.RuleRow.AllowActions.ActionsEntry.value:type_name -> google.protobuf.Empty
+	99,  // 80: cerbos.runtime.v1.RuleTable.RuleRow.Params.ConstantsEntry.value:type_name -> google.protobuf.Value
+	32,  // 81: cerbos.runtime.v1.RuleTable.RoleParentRoles.RoleParentRolesEntry.value:type_name -> cerbos.runtime.v1.RuleTable.RoleParentRoles.ParentRoles
+	6,   // 82: cerbos.runtime.v1.RuleTable.PolicyDerivedRoles.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
+	100, // 83: cerbos.runtime.v1.RuleTableMetadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
+	42,  // 84: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry
+	43,  // 85: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Metadata.AnnotationsEntry
+	44,  // 86: cerbos.runtime.v1.RunnableRolePolicySet.Rule.allow_actions:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry
+	13,  // 87: cerbos.runtime.v1.RunnableRolePolicySet.Rule.condition:type_name -> cerbos.runtime.v1.Condition
+	11,  // 88: cerbos.runtime.v1.RunnableRolePolicySet.Rule.emit_output:type_name -> cerbos.runtime.v1.Output
+	38,  // 89: cerbos.runtime.v1.RunnableRolePolicySet.RuleList.rules:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.Rule
+	39,  // 90: cerbos.runtime.v1.RunnableRolePolicySet.ResourcesEntry.value:type_name -> cerbos.runtime.v1.RunnableRolePolicySet.RuleList
+	99,  // 91: cerbos.runtime.v1.RunnableRolePolicySet.ConstantsEntry.value:type_name -> google.protobuf.Value
+	100, // 92: cerbos.runtime.v1.RunnableRolePolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
+	98,  // 93: cerbos.runtime.v1.RunnableRolePolicySet.Rule.AllowActionsEntry.value:type_name -> google.protobuf.Empty
+	47,  // 94: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry
+	48,  // 95: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.AnnotationsEntry
+	50,  // 96: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.derived_roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry
+	51,  // 97: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.variables:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry
+	49,  // 98: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.rules:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule
+	94,  // 99: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.schemas:type_name -> cerbos.policy.v1.Schemas
+	12,  // 100: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ordered_variables:type_name -> cerbos.runtime.v1.Variable
+	93,  // 101: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
+	52,  // 102: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.constants:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry
+	100, // 103: cerbos.runtime.v1.RunnableResourcePolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
+	53,  // 104: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.actions:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry
+	54,  // 105: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.derived_roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry
+	55,  // 106: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.roles:type_name -> cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry
+	13,  // 107: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.condition:type_name -> cerbos.runtime.v1.Condition
+	96,  // 108: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.effect:type_name -> cerbos.effect.v1.Effect
+	10,  // 109: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.output:type_name -> cerbos.runtime.v1.Expr
+	11,  // 110: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.emit_output:type_name -> cerbos.runtime.v1.Output
+	6,   // 111: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
+	10,  // 112: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
+	99,  // 113: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.ConstantsEntry.value:type_name -> google.protobuf.Value
+	98,  // 114: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.ActionsEntry.value:type_name -> google.protobuf.Empty
+	98,  // 115: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.DerivedRolesEntry.value:type_name -> google.protobuf.Empty
+	98,  // 116: cerbos.runtime.v1.RunnableResourcePolicySet.Policy.Rule.RolesEntry.value:type_name -> google.protobuf.Empty
+	98,  // 117: cerbos.runtime.v1.RunnableDerivedRole.ParentRolesEntry.value:type_name -> google.protobuf.Empty
+	10,  // 118: cerbos.runtime.v1.RunnableDerivedRole.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
+	99,  // 119: cerbos.runtime.v1.RunnableDerivedRole.ConstantsEntry.value:type_name -> google.protobuf.Value
+	61,  // 120: cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableDerivedRolesSet.Metadata.AnnotationsEntry
+	6,   // 121: cerbos.runtime.v1.RunnableDerivedRolesSet.DerivedRolesEntry.value:type_name -> cerbos.runtime.v1.RunnableDerivedRole
+	64,  // 122: cerbos.runtime.v1.RunnableVariablesSet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnableVariablesSet.Metadata.AnnotationsEntry
+	10,  // 123: cerbos.runtime.v1.RunnableVariablesSet.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
+	67,  // 124: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.source_attributes:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry
+	68,  // 125: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.annotations:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.AnnotationsEntry
+	71,  // 126: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.variables:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry
+	72,  // 127: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.resource_rules:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry
+	12,  // 128: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ordered_variables:type_name -> cerbos.runtime.v1.Variable
+	93,  // 129: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
+	73,  // 130: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.constants:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry
+	100, // 131: cerbos.runtime.v1.RunnablePrincipalPolicySet.Metadata.SourceAttributesEntry.value:type_name -> cerbos.policy.v1.SourceAttributes
+	13,  // 132: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.condition:type_name -> cerbos.runtime.v1.Condition
+	96,  // 133: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.effect:type_name -> cerbos.effect.v1.Effect
+	10,  // 134: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.output:type_name -> cerbos.runtime.v1.Expr
+	11,  // 135: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule.emit_output:type_name -> cerbos.runtime.v1.Output
+	69,  // 136: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules.action_rules:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ActionRule
+	10,  // 137: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.VariablesEntry.value:type_name -> cerbos.runtime.v1.Expr
+	70,  // 138: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRulesEntry.value:type_name -> cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ResourceRules
+	99,  // 139: cerbos.runtime.v1.RunnablePrincipalPolicySet.Policy.ConstantsEntry.value:type_name -> google.protobuf.Value
+	10,  // 140: cerbos.runtime.v1.Output.When.rule_activated:type_name -> cerbos.runtime.v1.Expr
+	10,  // 141: cerbos.runtime.v1.Output.When.condition_not_met:type_name -> cerbos.runtime.v1.Expr
+	13,  // 142: cerbos.runtime.v1.Condition.ExprList.expr:type_name -> cerbos.runtime.v1.Condition
+	101, // 143: cerbos.runtime.v1.CompileErrors.Err.position:type_name -> cerbos.source.v1.Position
+	101, // 144: cerbos.runtime.v1.IndexBuildErrors.DuplicateDef.position:type_name -> cerbos.source.v1.Position
+	101, // 145: cerbos.runtime.v1.IndexBuildErrors.MissingImport.position:type_name -> cerbos.source.v1.Position
+	102, // 146: cerbos.runtime.v1.IndexBuildErrors.LoadFailure.error_details:type_name -> cerbos.source.v1.Error
+	101, // 147: cerbos.runtime.v1.IndexBuildErrors.Disabled.position:type_name -> cerbos.source.v1.Position
+	83,  // 148: cerbos.runtime.v1.BitmapIndex.GlobDimension.literals:type_name -> cerbos.runtime.v1.BitmapIndex.Entry
+	83,  // 149: cerbos.runtime.v1.BitmapIndex.GlobDimension.globs:type_name -> cerbos.runtime.v1.BitmapIndex.Entry
+	1,   // 150: cerbos.runtime.v1.BitmapIndex.Binding.evaluation_key_tuple:type_name -> cerbos.runtime.v1.EvaluationKeyTuple
+	85,  // 151: cerbos.runtime.v1.BitmapIndex.Binding.allow_actions:type_name -> cerbos.runtime.v1.BitmapIndex.AllowActions
+	96,  // 152: cerbos.runtime.v1.BitmapIndex.FunctionalCore.effect:type_name -> cerbos.effect.v1.Effect
+	13,  // 153: cerbos.runtime.v1.BitmapIndex.FunctionalCore.condition:type_name -> cerbos.runtime.v1.Condition
+	13,  // 154: cerbos.runtime.v1.BitmapIndex.FunctionalCore.derived_role_condition:type_name -> cerbos.runtime.v1.Condition
+	11,  // 155: cerbos.runtime.v1.BitmapIndex.FunctionalCore.emit_output:type_name -> cerbos.runtime.v1.Output
+	93,  // 156: cerbos.runtime.v1.BitmapIndex.FunctionalCore.scope_permissions:type_name -> cerbos.policy.v1.ScopePermissions
+	97,  // 157: cerbos.runtime.v1.BitmapIndex.FunctionalCore.policy_kind:type_name -> cerbos.policy.v1.Kind
+	29,  // 158: cerbos.runtime.v1.BitmapIndex.FunctionalCore.params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
+	29,  // 159: cerbos.runtime.v1.BitmapIndex.FunctionalCore.derived_role_params:type_name -> cerbos.runtime.v1.RuleTable.RuleRow.Params
+	92,  // 160: cerbos.runtime.v1.BitmapIndex.RoleParents.roles:type_name -> cerbos.runtime.v1.BitmapIndex.RoleParents.RolesEntry
+	89,  // 161: cerbos.runtime.v1.BitmapIndex.ParentRolesEntry.value:type_name -> cerbos.runtime.v1.BitmapIndex.RoleParents
+	88,  // 162: cerbos.runtime.v1.BitmapIndex.RoleParents.RolesEntry.value:type_name -> cerbos.runtime.v1.BitmapIndex.Parents
+	163, // [163:163] is the sub-list for method output_type
+	163, // [163:163] is the sub-list for method input_type
+	163, // [163:163] is the sub-list for extension type_name
+	163, // [163:163] is the sub-list for extension extendee
+	0,   // [0:163] is the sub-list for field type_name
 }
 
 func init() { file_cerbos_runtime_v1_runtime_proto_init() }
@@ -4665,26 +4804,26 @@ func file_cerbos_runtime_v1_runtime_proto_init() {
 		(*RunnablePolicySet_Variables)(nil),
 		(*RunnablePolicySet_RolePolicy)(nil),
 	}
-	file_cerbos_runtime_v1_runtime_proto_msgTypes[2].OneofWrappers = []any{
+	file_cerbos_runtime_v1_runtime_proto_msgTypes[3].OneofWrappers = []any{
 		(*RuleTableMetadata_Resource)(nil),
 		(*RuleTableMetadata_Role)(nil),
 		(*RuleTableMetadata_Principal)(nil),
 	}
-	file_cerbos_runtime_v1_runtime_proto_msgTypes[12].OneofWrappers = []any{
+	file_cerbos_runtime_v1_runtime_proto_msgTypes[13].OneofWrappers = []any{
 		(*Condition_All)(nil),
 		(*Condition_Any)(nil),
 		(*Condition_None)(nil),
 		(*Condition_Expr)(nil),
 	}
-	file_cerbos_runtime_v1_runtime_proto_msgTypes[15].OneofWrappers = []any{
+	file_cerbos_runtime_v1_runtime_proto_msgTypes[16].OneofWrappers = []any{
 		(*Errors_IndexBuildErrors)(nil),
 		(*Errors_CompileErrors)(nil),
 	}
-	file_cerbos_runtime_v1_runtime_proto_msgTypes[17].OneofWrappers = []any{
+	file_cerbos_runtime_v1_runtime_proto_msgTypes[18].OneofWrappers = []any{
 		(*RuleTable_RuleRow_Action)(nil),
 		(*RuleTable_RuleRow_AllowActions_)(nil),
 	}
-	file_cerbos_runtime_v1_runtime_proto_msgTypes[85].OneofWrappers = []any{
+	file_cerbos_runtime_v1_runtime_proto_msgTypes[86].OneofWrappers = []any{
 		(*BitmapIndex_Binding_Action)(nil),
 		(*BitmapIndex_Binding_AllowActions)(nil),
 	}
@@ -4694,7 +4833,7 @@ func file_cerbos_runtime_v1_runtime_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerbos_runtime_v1_runtime_proto_rawDesc), len(file_cerbos_runtime_v1_runtime_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   92,
+			NumMessages:   93,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/genpb/cerbos/runtime/v1/runtime_hashpb.pb.go
+++ b/api/genpb/cerbos/runtime/v1/runtime_hashpb.pb.go
@@ -20,6 +20,16 @@ func (m *RunnablePolicySet) HashPB(hasher hash.Hash, ignore map[string]struct{})
 
 // HashPB computes a hash of the message using the given hash function
 // The ignore set must contain fully-qualified field names (pkg.msg.field) that should be ignored from the hash
+func (m *EvaluationKeyTuple) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
+	if m != nil {
+		b := hashpb_bufPool.Get().(*[10]byte)
+		cerbos_runtime_v1_EvaluationKeyTuple_hashpb_sum(m, hasher, ignore, b)
+		hashpb_bufPool.Put(b)
+	}
+}
+
+// HashPB computes a hash of the message using the given hash function
+// The ignore set must contain fully-qualified field names (pkg.msg.field) that should be ignored from the hash
 func (m *RuleTable) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
 	if m != nil {
 		b := hashpb_bufPool.Get().(*[10]byte)

--- a/api/genpb/cerbos/runtime/v1/runtime_vtproto.pb.go
+++ b/api/genpb/cerbos/runtime/v1/runtime_vtproto.pb.go
@@ -196,6 +196,100 @@ func (m *RunnablePolicySet_RolePolicy) MarshalToSizedBufferVT(dAtA []byte) (int,
 	}
 	return len(dAtA) - i, nil
 }
+func (m *EvaluationKeyTuple) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *EvaluationKeyTuple) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *EvaluationKeyTuple) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.RuleId != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.RuleId))
+		i--
+		dAtA[i] = 0x48
+	}
+	if len(m.RuleName) > 0 {
+		i -= len(m.RuleName)
+		copy(dAtA[i:], m.RuleName)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RuleName)))
+		i--
+		dAtA[i] = 0x42
+	}
+	if len(m.Scope) > 0 {
+		i -= len(m.Scope)
+		copy(dAtA[i:], m.Scope)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Scope)))
+		i--
+		dAtA[i] = 0x3a
+	}
+	if len(m.Version) > 0 {
+		i -= len(m.Version)
+		copy(dAtA[i:], m.Version)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Version)))
+		i--
+		dAtA[i] = 0x32
+	}
+	if len(m.DerivedRole) > 0 {
+		i -= len(m.DerivedRole)
+		copy(dAtA[i:], m.DerivedRole)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DerivedRole)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.Role) > 0 {
+		i -= len(m.Role)
+		copy(dAtA[i:], m.Role)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Role)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.Principal) > 0 {
+		i -= len(m.Principal)
+		copy(dAtA[i:], m.Principal)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Principal)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Resource) > 0 {
+		i -= len(m.Resource)
+		copy(dAtA[i:], m.Resource)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Resource)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Prefix) > 0 {
+		i -= len(m.Prefix)
+		copy(dAtA[i:], m.Prefix)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Prefix)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *RuleTable_RuleRow_AllowActions) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -356,6 +450,18 @@ func (m *RuleTable_RuleRow) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 			return 0, err
 		}
 		i -= size
+	}
+	if m.EvaluationKeyTuple != nil {
+		size, err := m.EvaluationKeyTuple.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xaa
 	}
 	if m.FromRolePolicy {
 		i--
@@ -4053,6 +4159,16 @@ func (m *BitmapIndex_Binding) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		}
 		i -= size
 	}
+	if m.EvaluationKeyTuple != nil {
+		size, err := m.EvaluationKeyTuple.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x72
+	}
 	if len(m.EvaluationKey) > 0 {
 		i -= len(m.EvaluationKey)
 		copy(dAtA[i:], m.EvaluationKey)
@@ -4637,6 +4753,51 @@ func (m *RunnablePolicySet_RolePolicy) SizeVT() (n int) {
 	}
 	return n
 }
+func (m *EvaluationKeyTuple) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Prefix)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Resource)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Principal)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Role)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.DerivedRole)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Version)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Scope)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.RuleName)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.RuleId != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.RuleId))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *RuleTable_RuleRow_AllowActions) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -4765,6 +4926,10 @@ func (m *RuleTable_RuleRow) SizeVT() (n int) {
 	}
 	if m.FromRolePolicy {
 		n += 3
+	}
+	if m.EvaluationKeyTuple != nil {
+		l = m.EvaluationKeyTuple.SizeVT()
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -6372,6 +6537,10 @@ func (m *BitmapIndex_Binding) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if m.EvaluationKeyTuple != nil {
+		l = m.EvaluationKeyTuple.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -6848,6 +7017,332 @@ func (m *RunnablePolicySet) UnmarshalVT(dAtA []byte) error {
 				m.PolicySet = &RunnablePolicySet_RolePolicy{RolePolicy: v}
 			}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *EvaluationKeyTuple) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: EvaluationKeyTuple: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: EvaluationKeyTuple: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Prefix", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Prefix = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Resource", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Resource = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Principal", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Principal = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Role", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Role = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DerivedRole", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DerivedRole = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Version", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Version = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Scope", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Scope = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RuleName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RuleName = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RuleId", wireType)
+			}
+			m.RuleId = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.RuleId |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -7911,6 +8406,42 @@ func (m *RuleTable_RuleRow) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.FromRolePolicy = bool(v != 0)
+		case 21:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EvaluationKeyTuple", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.EvaluationKeyTuple == nil {
+				m.EvaluationKeyTuple = &EvaluationKeyTuple{}
+			}
+			if err := m.EvaluationKeyTuple.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -18879,6 +19410,42 @@ func (m *BitmapIndex_Binding) UnmarshalVT(dAtA []byte) error {
 					return err
 				}
 				m.ActionSet = &BitmapIndex_Binding_AllowActions{AllowActions: v}
+			}
+			iNdEx = postIndex
+		case 14:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EvaluationKeyTuple", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.EvaluationKeyTuple == nil {
+				m.EvaluationKeyTuple = &EvaluationKeyTuple{}
+			}
+			if err := m.EvaluationKeyTuple.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
 			iNdEx = postIndex
 		default:

--- a/api/private/cerbos/runtime/v1/runtime.proto
+++ b/api/private/cerbos/runtime/v1/runtime.proto
@@ -26,6 +26,18 @@ message RunnablePolicySet {
   uint32 compiler_version = 6;
 }
 
+message EvaluationKeyTuple {
+  string prefix = 1;
+  string resource = 2;
+  string principal = 3;
+  string role = 4;
+  string derived_role = 5;
+  string version = 6;
+  string scope = 7;
+  string rule_name = 8;
+  uint32 rule_id = 9;
+}
+
 message RuleTable {
   message RuleRow {
     message AllowActions {
@@ -59,6 +71,7 @@ message RuleTable {
     string evaluation_key = 18;
     cerbos.policy.v1.Kind policy_kind = 19;
     bool from_role_policy = 20;
+    EvaluationKeyTuple evaluation_key_tuple = 21;
   }
 
   message RoleParentRoles {
@@ -386,6 +399,7 @@ message BitmapIndex {
     string origin_derived_role = 10;
     string name = 11;
     string evaluation_key = 12;
+    EvaluationKeyTuple evaluation_key_tuple = 14;
     oneof action_set {
       string action = 7;
       AllowActions allow_actions = 13;

--- a/hack/loadtest/.gitignore
+++ b/hack/loadtest/.gitignore
@@ -1,3 +1,4 @@
 bin/
 results/
 work/
+*.txt

--- a/hack/loadtest/cerbos-go-run.sh
+++ b/hack/loadtest/cerbos-go-run.sh
@@ -5,10 +5,9 @@
 
 set -euo pipefail
 
-# Run from the main module root. hack/loadtest has its own nested go.mod, so
-# `go run` must be invoked from here to build the local cerbos code.
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" && pwd)  
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+
 cd "$REPO_ROOT"
 
 STORE=${STORE:-"disk"}

--- a/hack/loadtest/cerbos-go-run.sh
+++ b/hack/loadtest/cerbos-go-run.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2021-2026 Zenauth Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# Run from the main module root. hack/loadtest has its own nested go.mod, so
+# `go run` must be invoked from here to build the local cerbos code.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" && pwd)  
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+STORE=${STORE:-"disk"}
+AUDIT_ENABLED=${AUDIT_ENABLED:-"false"}
+SCHEMA_ENFORCEMENT=${SCHEMA_ENFORCEMENT:-"none"}
+WORK_DIR=${WORK_DIR:-"${SCRIPT_DIR}/work/"}
+CONFIG=${CONFIG:-"${SCRIPT_DIR}/conf/cerbos/.cerbos.yaml"}
+DEBUG_LISTEN_ADDR=":6666"
+HEALTH_ATTEMPTS=${HEALTH_ATTEMPTS:-90}
+HEALTH_INTERVAL=${HEALTH_INTERVAL:-5}
+
+err() {
+  printf "[%s] ERROR: %s\n" "$(date '+%H:%M:%S')" "$*" >&2
+}
+
+pkill -9 -f -- "--debug-listen-addr=${DEBUG_LISTEN_ADDR}" 2>/dev/null || true
+pidwait -f -- "--debug-listen-addr=${DEBUG_LISTEN_ADDR}" 2>/dev/null || true
+
+mkdir -p "${WORK_DIR}/policies"
+
+AUDIT_ENABLED="$AUDIT_ENABLED" SCHEMA_ENFORCEMENT="$SCHEMA_ENFORCEMENT" STORE="$STORE" \
+  go run ./cmd/cerbos server \
+  --config="$CONFIG" \
+  --set=storage.disk.directory="${WORK_DIR}/policies" \
+  --log-level=debug \
+  --debug-listen-addr="${DEBUG_LISTEN_ADDR}" > "${WORK_DIR}/cerbos.log" 2>&1 &
+
+echo "Cerbos (go run) launcher PID: $!"
+
+echo "Waiting for Cerbos to become healthy..."
+healthy=false
+for i in $(seq 1 "$HEALTH_ATTEMPTS"); do
+  sleep "$HEALTH_INTERVAL"
+  if curl -sf http://localhost:3592/_cerbos/health >/dev/null 2>&1; then
+    echo "Cerbos is healthy"
+    healthy=true
+    break
+  fi
+done
+if [ "$healthy" != "true" ]; then
+  err "Cerbos health check failed after ${HEALTH_ATTEMPTS} attempts (see ${WORK_DIR}/cerbos.log)"
+  exit 1
+fi

--- a/hack/loadtest/collect-unique-samples.sh
+++ b/hack/loadtest/collect-unique-samples.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Collect K cold-start memory samples of the current build, for a median-of-K
+# comparison. Each sample is a fresh `cerbos-go-run` launch (kills the prior
+# instance, rebuilds from source, waits for health) scraped right after the
+# index build + post-init FreeOSMemory.
+#
+#   PREFIX=srcattr K=4 hack/loadtest/collect-unique-samples.sh
+#
+# Writes hack/loadtest/${PREFIX}-${n}.txt for n in START_IDX..START_IDX+K-1.
+# heap_inuse has ~13-20 MiB run-to-run variance, so compare medians, not singles.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE}")" && pwd)  
+cd "$SCRIPT_DIR"
+
+K=${K:-4}
+START_IDX=${START_IDX:-1}
+PREFIX=${PREFIX:-"sample"}
+OUT_DIR=${OUT_DIR:-"."}
+
+for i in $(seq 0 $((K - 1))); do
+  n=$((START_IDX + i))
+  echo "=== cold start, sample ${n} ==="
+  # The launcher hard-kills the prior instance and waits up to its (generous,
+  # slow-cold-build-tolerant) HEALTH_ATTEMPTS window for health.
+  ./cerbos-go-run.sh
+  ./scrape.sh "${OUT_DIR}/${PREFIX}-${n}.txt"
+done
+echo "=== done collecting ${K} samples ==="

--- a/hack/loadtest/collect-unique-samples.sh
+++ b/hack/loadtest/collect-unique-samples.sh
@@ -21,8 +21,7 @@ OUT_DIR=${OUT_DIR:-"."}
 for i in $(seq 0 $((K - 1))); do
   n=$((START_IDX + i))
   echo "=== cold start, sample ${n} ==="
-  # The launcher hard-kills the prior instance and waits up to its (generous,
-  # slow-cold-build-tolerant) HEALTH_ATTEMPTS window for health.
+  # The launcher hard-kills the prior instance and waits for it get healthy.
   ./cerbos-go-run.sh
   ./scrape.sh "${OUT_DIR}/${PREFIX}-${n}.txt"
 done

--- a/hack/loadtest/scrape.sh
+++ b/hack/loadtest/scrape.sh
@@ -59,10 +59,6 @@ for m in "${PDP_METRICS[@]}"; do
   esac
 done
 
-# Derived fragmentation: in-use span memory per byte of live heap object.
-# 1.00 = perfect packing; higher means more span slack. Most meaningful sampled
-# after a GC, since heap_alloc otherwise includes unswept garbage. Not written to
-# the snapshot file — it is derivable from the two raw values already there.
 if [[ -n "${heapInuse:-}" && -n "${heapAlloc:-}" && "$heapAlloc" -gt 0 ]]; then
   ratio=$(awk -v a="$heapInuse" -v b="$heapAlloc" 'BEGIN { printf "%.3f", a / b }')
   slack=$((heapInuse - heapAlloc))

--- a/internal/inspect/ruletable.go
+++ b/internal/inspect/ruletable.go
@@ -18,7 +18,7 @@ import (
 // BindingSource provides access to index bindings for inspection.
 // It exists here to prevent a circular dependency between `inspect`, `ruletable` and `storage`.
 type BindingSource interface {
-	GetAllRows() []*index.Binding
+	GetAllRows() []*index.BindingHandle
 }
 
 func RuleTables(src BindingSource) *RuleTable {
@@ -53,7 +53,7 @@ func (rt *RuleTable) Inspect() error {
 	derivedRoleSets := make(map[string]util.StringSet)
 	variableSets := make(map[string]util.StringSet)
 	for _, b := range rows {
-		policyKey := namer.PolicyKeyFromFQN(b.OriginFqn)
+		policyKey := namer.PolicyKeyFromFQN(index.HandleStr(b.OriginFqn))
 
 		result, ok := results[policyKey]
 		if !ok {
@@ -79,7 +79,7 @@ func (rt *RuleTable) Inspect() error {
 }
 
 func (rt *RuleTable) inspectBinding(
-	b *index.Binding,
+	b *index.BindingHandle,
 	actionSet util.StringSet,
 	attrSet util.StringSet,
 	constantSet util.StringSet,
@@ -193,18 +193,19 @@ func getOrInitStringSet(m map[string]util.StringSet, key string) util.StringSet 
 	return s
 }
 
-func listActions(b *index.Binding) []string {
+func listActions(b *index.BindingHandle) []string {
+	hasAction := b.Action != index.EmptyHandle
 	n := len(b.AllowActions)
-	if b.Action != "" {
+	if hasAction {
 		n++
 	}
 
 	actions := make([]string, 0, n)
-	if b.Action != "" {
-		actions = append(actions, b.Action)
+	if hasAction {
+		actions = append(actions, b.Action.Value())
 	}
-	for action := range b.AllowActions {
-		actions = append(actions, action)
+	for a := range b.AllowActions {
+		actions = append(actions, a.Value())
 	}
 
 	if len(actions) > 1 {
@@ -216,7 +217,7 @@ func listActions(b *index.Binding) []string {
 
 // Results are cached per-Core because many bindings share the same Core pointer
 // (they differ only in routing dimensions) and structpb conversion is non-trivial.
-func (rt *RuleTable) listConstants(b *index.Binding) ([]*responsev1.InspectPoliciesResponse_Constant, error) {
+func (rt *RuleTable) listConstants(b *index.BindingHandle) ([]*responsev1.InspectPoliciesResponse_Constant, error) {
 	if cached, ok := rt.constantsCache[b.Core]; ok {
 		return cached, nil
 	}
@@ -271,20 +272,20 @@ func (rt *RuleTable) listConstants(b *index.Binding) ([]*responsev1.InspectPolic
 	return constants, nil
 }
 
-func getDerivedRole(b *index.Binding) *responsev1.InspectPoliciesResponse_DerivedRole {
-	if b.OriginDerivedRole == "" {
+func getDerivedRole(b *index.BindingHandle) *responsev1.InspectPoliciesResponse_DerivedRole {
+	if b.OriginDerivedRole == index.EmptyHandle {
 		return nil
 	}
 
 	return &responsev1.InspectPoliciesResponse_DerivedRole{
-		Name: b.OriginDerivedRole,
+		Name: b.OriginDerivedRole.Value(),
 		Kind: responsev1.InspectPoliciesResponse_DerivedRole_KIND_IMPORTED,
 	}
 }
 
 // Results are cached per-Core because many bindings share the same Core pointer
 // (they differ only in routing dimensions).
-func (rt *RuleTable) listVariables(b *index.Binding) []*responsev1.InspectPoliciesResponse_Variable {
+func (rt *RuleTable) listVariables(b *index.BindingHandle) []*responsev1.InspectPoliciesResponse_Variable {
 	if cached, ok := rt.variablesCache[b.Core]; ok {
 		return cached
 	}

--- a/internal/inspect/visit.go
+++ b/internal/inspect/visit.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/cel-go/common/ast"
 )
 
-func visitBinding(b *index.Binding, visitor ast.Visitor) error {
+func visitBinding(b *index.BindingHandle, visitor ast.Visitor) error {
 	if err := visitCompiledCondition(b.Core.Condition, visitor); err != nil {
 		return fmt.Errorf("failed to visit condition: %w", err)
 	}

--- a/internal/ruletable/check.go
+++ b/internal/ruletable/check.go
@@ -285,6 +285,7 @@ func (rt *RuleTable) check(ctx context.Context, tctx tracer.Context, schemaMgr s
 						bName := index.HandleStr(b.Name)
 						bOriginFqn := index.HandleStr(b.OriginFqn)
 						bScope := index.HandleStr(b.Scope)
+						bEvalKey := rt.idx.EvalKey(b.ID)
 						rulectx := sctx.StartRule(bName)
 
 						if m := rt.GetMeta(bOriginFqn); m != nil && m.GetSourceAttributes() != nil {
@@ -309,7 +310,7 @@ func (rt *RuleTable) check(ctx context.Context, tctx tracer.Context, schemaMgr s
 						}
 
 						var satisfiesCondition bool
-						if c, ok := conditionCache[b.EvaluationKey]; ok { //nolint:nestif
+						if c, ok := conditionCache[bEvalKey]; ok { //nolint:nestif
 							satisfiesCondition = c
 						} else {
 							// We evaluate the derived role condition (if any) first, as this leads to a more sane engine trace output.
@@ -344,7 +345,7 @@ func (rt *RuleTable) check(ctx context.Context, tctx tracer.Context, schemaMgr s
 								// terminate early if the derived role condition isn't satisfied, which is consistent with the pre-rule table implementation
 								if !drSatisfied {
 									rulectx.Skipped(err, "No matching derived roles")
-									conditionCache[b.EvaluationKey] = false
+									conditionCache[bEvalKey] = false
 									continue
 								}
 							}
@@ -355,7 +356,7 @@ func (rt *RuleTable) check(ctx context.Context, tctx tracer.Context, schemaMgr s
 								continue
 							}
 
-							conditionCache[b.EvaluationKey] = isSatisfied
+							conditionCache[bEvalKey] = isSatisfied
 							satisfiesCondition = isSatisfied
 						}
 

--- a/internal/ruletable/check.go
+++ b/internal/ruletable/check.go
@@ -220,7 +220,7 @@ func (rt *RuleTable) check(ctx context.Context, tctx tracer.Context, schemaMgr s
 
 				parentRoles := rt.idx.AddParentRoles([]string{resourceScope}, []string{role})
 
-				var bindings []*index.Binding
+				var bindings []*index.BindingHandle
 			scopesLoop:
 				for _, scope := range scopes {
 					sctx := actx.StartScope(scope)
@@ -282,9 +282,12 @@ func (rt *RuleTable) check(ctx context.Context, tctx tracer.Context, schemaMgr s
 					}
 					bindings = rt.idx.Query(resourceVersion, sanitizedResource, scope, action, parentRoles, pt, pid, bindings[:0])
 					for _, b := range bindings {
-						rulectx := sctx.StartRule(b.Name)
+						bName := index.HandleStr(b.Name)
+						bOriginFqn := index.HandleStr(b.OriginFqn)
+						bScope := index.HandleStr(b.Scope)
+						rulectx := sctx.StartRule(bName)
 
-						if m := rt.GetMeta(b.OriginFqn); m != nil && m.GetSourceAttributes() != nil {
+						if m := rt.GetMeta(bOriginFqn); m != nil && m.GetSourceAttributes() != nil {
 							maps.Copy(result.auditTrail.EffectivePolicies, m.GetSourceAttributes())
 						}
 
@@ -311,7 +314,7 @@ func (rt *RuleTable) check(ctx context.Context, tctx tracer.Context, schemaMgr s
 						} else {
 							// We evaluate the derived role condition (if any) first, as this leads to a more sane engine trace output.
 							if b.Core.DerivedRoleCondition != nil {
-								drctx := rulectx.StartDerivedRole(b.OriginDerivedRole)
+								drctx := rulectx.StartDerivedRole(index.HandleStr(b.OriginDerivedRole))
 								var derivedRoleConstants map[string]any
 								var derivedRoleVariables map[string]any
 								if b.Core.DerivedRoleParams != nil {
@@ -363,7 +366,7 @@ func (rt *RuleTable) check(ctx context.Context, tctx tracer.Context, schemaMgr s
 							}
 
 							if outputExpr != nil {
-								result.outputs = append(result.outputs, evalCtx.evaluateOutput(ctx, rulectx, b.Name, namer.RuleFQN(rt.GetMeta(b.OriginFqn), b.Scope, b.Name), action, outputExpr, constants, variables))
+								result.outputs = append(result.outputs, evalCtx.evaluateOutput(ctx, rulectx, bName, namer.RuleFQN(rt.GetMeta(bOriginFqn), bScope, bName), action, outputExpr, constants, variables))
 							}
 
 							if b.Core.Effect == effectv1.Effect_EFFECT_ALLOW {
@@ -375,7 +378,7 @@ func (rt *RuleTable) check(ctx context.Context, tctx tracer.Context, schemaMgr s
 								if b.Core.FromRolePolicy {
 									// Implicit DENY generated as a result of no matching role policy action
 									// needs to be attributed to said role policy
-									roleEffectInfo.Policy = namer.PolicyKeyFromFQN(b.OriginFqn)
+									roleEffectInfo.Policy = namer.PolicyKeyFromFQN(bOriginFqn)
 								}
 								break scopesLoop
 							} else if b.NoMatchForScopePermissions {
@@ -384,7 +387,7 @@ func (rt *RuleTable) check(ctx context.Context, tctx tracer.Context, schemaMgr s
 							}
 						} else {
 							if b.Core.EmitOutput != nil && b.Core.EmitOutput.When != nil && b.Core.EmitOutput.When.ConditionNotMet != nil {
-								result.outputs = append(result.outputs, evalCtx.evaluateOutput(ctx, rulectx, b.Name, namer.RuleFQN(rt.GetMeta(b.OriginFqn), b.Scope, b.Name), action, b.Core.EmitOutput.When.ConditionNotMet, constants, variables))
+								result.outputs = append(result.outputs, evalCtx.evaluateOutput(ctx, rulectx, bName, namer.RuleFQN(rt.GetMeta(bOriginFqn), bScope, bName), action, b.Core.EmitOutput.When.ConditionNotMet, constants, variables))
 							}
 							rulectx.Skipped(nil, conditionNotSatisfied)
 						}

--- a/internal/ruletable/check.go
+++ b/internal/ruletable/check.go
@@ -176,7 +176,7 @@ func (rt *RuleTable) check(ctx context.Context, tctx tracer.Context, schemaMgr s
 	varCache := make(map[uint64]map[string]any)
 	// We can cache evaluated conditions for combinations of parameters and conditions.
 	// We use a compound key comprising the parameter origin and the rule FQN.
-	conditionCache := make(map[string]bool)
+	conditionCache := make(map[index.EvaluationKeyTuple]bool)
 
 	processedScopedDerivedRoles := make(map[string]struct{})
 	policyTypes := []policyv1.Kind{policyv1.Kind_KIND_PRINCIPAL, policyv1.Kind_KIND_RESOURCE}

--- a/internal/ruletable/index/bitmap_index.go
+++ b/internal/ruletable/index/bitmap_index.go
@@ -107,7 +107,7 @@ func (idx *bitmapIndex) addBinding(b *BindingHandle, evalKey EvaluationKeyTuple)
 	// Scope "" is a valid literal (root scope), always indexed. Other dimensions
 	// skip "" to avoid leaking empties from policies that don't participate in
 	// them (e.g. principal-policy noop rows have no role/resource).
-	idx.scope.Add(stringHandleValue(b.Scope), id)
+	idx.scope.Add(HandleStr(b.Scope), id)
 	if b.Version != EmptyHandle {
 		idx.version.Add(b.Version.Value(), id)
 	}
@@ -130,7 +130,7 @@ func (idx *bitmapIndex) addBinding(b *BindingHandle, evalKey EvaluationKeyTuple)
 		idx.principal.Add(b.Principal.Value(), id)
 	}
 
-	idx.fqnBindings.Add(stringHandleValue(b.OriginFqn), id)
+	idx.fqnBindings.Add(HandleStr(b.OriginFqn), id)
 }
 
 // removeBinding removes the binding from the slice and all dimension bitmaps,
@@ -141,11 +141,11 @@ func (idx *bitmapIndex) removeBinding(b *BindingHandle) {
 	id := b.ID
 
 	idx.universe.Remove(id)
-	idx.version.Remove(stringHandleValue(b.Version), id)
-	idx.scope.Remove(stringHandleValue(b.Scope), id)
+	idx.version.Remove(HandleStr(b.Version), id)
+	idx.scope.Remove(HandleStr(b.Scope), id)
 
-	idx.role.Remove(stringHandleValue(b.Role), id)
-	idx.resource.Remove(stringHandleValue(b.Resource), id)
+	idx.role.Remove(HandleStr(b.Role), id)
+	idx.resource.Remove(HandleStr(b.Resource), id)
 
 	if b.AllowActions != nil {
 		idx.allowActionsBitmap.Remove(id)
@@ -154,7 +154,7 @@ func (idx *bitmapIndex) removeBinding(b *BindingHandle) {
 	}
 
 	idx.policyKind.Remove(b.Core.PolicyKind, id)
-	idx.principal.Remove(stringHandleValue(b.Principal), id)
+	idx.principal.Remove(HandleStr(b.Principal), id)
 
 	idx.freeID(id)
 }

--- a/internal/ruletable/index/bitmap_index.go
+++ b/internal/ruletable/index/bitmap_index.go
@@ -23,7 +23,7 @@ type bitmapIndex struct {
 	universe           *Bitmap
 	allowActionsBitmap *Bitmap
 	freeIDs            []uint32
-	bindings           []*Binding
+	bindings           []*BindingHandle
 }
 
 func newBitmapIndex() *bitmapIndex {
@@ -79,7 +79,7 @@ func (idx *bitmapIndex) compact() {
 	idx.allowActionsBitmap.shrinkToFit()
 }
 
-func (idx *bitmapIndex) addBinding(b *Binding) {
+func (idx *bitmapIndex) addBinding(b *BindingHandle) {
 	id := idx.allocID()
 	b.ID = id
 	if int(id) < len(idx.bindings) {
@@ -93,59 +93,59 @@ func (idx *bitmapIndex) addBinding(b *Binding) {
 	// Scope "" is a valid literal (root scope), always indexed. Other dimensions
 	// skip "" to avoid leaking empties from policies that don't participate in
 	// them (e.g. principal-policy noop rows have no role/resource).
-	idx.scope.Add(b.Scope, id)
-	if b.Version != "" {
-		idx.version.Add(b.Version, id)
+	idx.scope.Add(stringHandleValue(b.Scope), id)
+	if b.Version != EmptyHandle {
+		idx.version.Add(b.Version.Value(), id)
 	}
-	if b.Role != "" {
-		idx.role.Set(b.Role, id)
+	if b.Role != EmptyHandle {
+		idx.role.Set(b.Role.Value(), id)
 	}
-	if b.Resource != "" {
-		idx.resource.Set(b.Resource, id)
+	if b.Resource != EmptyHandle {
+		idx.resource.Set(b.Resource.Value(), id)
 	}
 
 	if b.AllowActions != nil {
 		idx.allowActionsBitmap.Add(id)
-	} else if b.Action != "" {
-		idx.action.Set(b.Action, id)
+	} else if b.Action != EmptyHandle {
+		idx.action.Set(b.Action.Value(), id)
 	}
 
 	idx.policyKind.Add(b.Core.PolicyKind, id)
 
-	if b.Principal != "" {
-		idx.principal.Add(b.Principal, id)
+	if b.Principal != EmptyHandle {
+		idx.principal.Add(b.Principal.Value(), id)
 	}
 
-	idx.fqnBindings.Add(b.OriginFqn, id)
+	idx.fqnBindings.Add(stringHandleValue(b.OriginFqn), id)
 }
 
 // removeBinding removes the binding from the slice and all dimension bitmaps,
 // and returns the ID to the free list.
 // It does NOT touch fqnBindings. That is managed by DeletePolicy, which needs
 // to inspect fqnBindings across origins before deciding whether to remove the binding.
-func (idx *bitmapIndex) removeBinding(b *Binding) {
+func (idx *bitmapIndex) removeBinding(b *BindingHandle) {
 	id := b.ID
 
 	idx.universe.Remove(id)
-	idx.version.Remove(b.Version, id)
-	idx.scope.Remove(b.Scope, id)
+	idx.version.Remove(stringHandleValue(b.Version), id)
+	idx.scope.Remove(stringHandleValue(b.Scope), id)
 
-	idx.role.Remove(b.Role, id)
-	idx.resource.Remove(b.Resource, id)
+	idx.role.Remove(stringHandleValue(b.Role), id)
+	idx.resource.Remove(stringHandleValue(b.Resource), id)
 
 	if b.AllowActions != nil {
 		idx.allowActionsBitmap.Remove(id)
-	} else if b.Action != "" {
-		idx.action.Remove(b.Action, id)
+	} else if b.Action != EmptyHandle {
+		idx.action.Remove(b.Action.Value(), id)
 	}
 
 	idx.policyKind.Remove(b.Core.PolicyKind, id)
-	idx.principal.Remove(b.Principal, id)
+	idx.principal.Remove(stringHandleValue(b.Principal), id)
 
 	idx.freeID(id)
 }
 
-func (idx *bitmapIndex) getBinding(id uint32) *Binding {
+func (idx *bitmapIndex) getBinding(id uint32) *BindingHandle {
 	return idx.bindings[id]
 }
 

--- a/internal/ruletable/index/bitmap_index.go
+++ b/internal/ruletable/index/bitmap_index.go
@@ -24,7 +24,11 @@ type bitmapIndex struct {
 	allowActionsBitmap *Bitmap
 	freeIDs            []uint32
 	bindings           []*BindingHandle
+	evalKeys           []EvaluationKeyTuple
 }
+
+// noEvalKey is the sentinel binding ID meaning "no evaluation key".
+const noEvalKey = ^uint32(0)
 
 func newBitmapIndex() *bitmapIndex {
 	return &bitmapIndex{
@@ -56,7 +60,15 @@ func (idx *bitmapIndex) allocID() uint32 {
 
 func (idx *bitmapIndex) freeID(id uint32) {
 	idx.bindings[id] = nil
+	idx.evalKeys[id] = EvaluationKeyTuple{} // release the slot's interned handles
 	idx.freeIDs = append(idx.freeIDs, id)
+}
+
+func (idx *bitmapIndex) evalKey(id uint32) EvaluationKeyTuple {
+	if id == noEvalKey {
+		return EvaluationKeyTuple{}
+	}
+	return idx.evalKeys[id]
 }
 
 // compact drops the per-bitmap capacity slack left by exponential growth across
@@ -79,13 +91,15 @@ func (idx *bitmapIndex) compact() {
 	idx.allowActionsBitmap.shrinkToFit()
 }
 
-func (idx *bitmapIndex) addBinding(b *BindingHandle) {
+func (idx *bitmapIndex) addBinding(b *BindingHandle, evalKey EvaluationKeyTuple) {
 	id := idx.allocID()
 	b.ID = id
 	if int(id) < len(idx.bindings) {
 		idx.bindings[id] = b
+		idx.evalKeys[id] = evalKey
 	} else {
 		idx.bindings = append(idx.bindings, b)
+		idx.evalKeys = append(idx.evalKeys, evalKey)
 	}
 
 	idx.universe.Add(id)

--- a/internal/ruletable/index/checksum_test.go
+++ b/internal/ruletable/index/checksum_test.go
@@ -23,10 +23,11 @@ var routingRuleRowFields = map[protoreflect.Name]struct{}{
 }
 
 var metadataOnlyFields = map[protoreflect.Name]struct{}{
-	"origin_fqn":          {},
-	"origin_derived_role": {},
-	"evaluation_key":      {},
-	"name":                {},
+	"origin_fqn":           {},
+	"origin_derived_role":  {},
+	"evaluation_key":       {},
+	"evaluation_key_tuple": {},
+	"name":                 {},
 }
 
 func TestAllRuleRowFieldsClassified(t *testing.T) {

--- a/internal/ruletable/index/core.go
+++ b/internal/ruletable/index/core.go
@@ -124,7 +124,7 @@ func makeStringHandle(s string) unique.Handle[string] {
 	return unique.Make(s)
 }
 
-// TODO: replace with HandleStr
+// TODO: replace with HandleStr.
 func stringHandleValue(h unique.Handle[string]) string {
 	if h == EmptyHandle {
 		return ""

--- a/internal/ruletable/index/core.go
+++ b/internal/ruletable/index/core.go
@@ -73,12 +73,11 @@ type BindingHandle struct {
 	OriginFqn                  unique.Handle[string]
 	OriginDerivedRole          unique.Handle[string]
 	Name                       unique.Handle[string]
-	EvaluationKey              EvaluationKeyTuple
 	ID                         uint32
 	NoMatchForScopePermissions bool
 }
 
-func (b *BindingHandle) ToBinding() *Binding {
+func (b *BindingHandle) toBinding(evalKey EvaluationKeyTuple) *Binding {
 	if b == nil {
 		return nil
 	}
@@ -101,7 +100,7 @@ func (b *BindingHandle) ToBinding() *Binding {
 		OriginFqn:                  stringHandleValue(b.OriginFqn),
 		OriginDerivedRole:          stringHandleValue(b.OriginDerivedRole),
 		Name:                       stringHandleValue(b.Name),
-		EvaluationKey:              b.EvaluationKey,
+		EvaluationKey:              evalKey,
 		ID:                         b.ID,
 		NoMatchForScopePermissions: b.NoMatchForScopePermissions,
 	}

--- a/internal/ruletable/index/core.go
+++ b/internal/ruletable/index/core.go
@@ -106,7 +106,7 @@ func (b *BindingHandle) toBinding(evalKey EvaluationKeyTuple) *Binding {
 	}
 }
 
-// IsZero reports whether the tuple is empty, which equivalent to the old empty
+// IsZero reports whether the tuple is empty, which is equivalent to the old empty
 // evaluation-key string.
 func (t EvaluationKeyTuple) IsZero() bool {
 	return t == EvaluationKeyTuple{}

--- a/internal/ruletable/index/core.go
+++ b/internal/ruletable/index/core.go
@@ -91,15 +91,15 @@ func (b *BindingHandle) toBinding(evalKey EvaluationKeyTuple) *Binding {
 	return &Binding{
 		Core:                       b.Core,
 		AllowActions:               allow,
-		Role:                       stringHandleValue(b.Role),
-		Scope:                      stringHandleValue(b.Scope),
-		Version:                    stringHandleValue(b.Version),
-		Resource:                   stringHandleValue(b.Resource),
-		Action:                     stringHandleValue(b.Action),
-		Principal:                  stringHandleValue(b.Principal),
-		OriginFqn:                  stringHandleValue(b.OriginFqn),
-		OriginDerivedRole:          stringHandleValue(b.OriginDerivedRole),
-		Name:                       stringHandleValue(b.Name),
+		Role:                       HandleStr(b.Role),
+		Scope:                      HandleStr(b.Scope),
+		Version:                    HandleStr(b.Version),
+		Resource:                   HandleStr(b.Resource),
+		Action:                     HandleStr(b.Action),
+		Principal:                  HandleStr(b.Principal),
+		OriginFqn:                  HandleStr(b.OriginFqn),
+		OriginDerivedRole:          HandleStr(b.OriginDerivedRole),
+		Name:                       HandleStr(b.Name),
 		EvaluationKey:              evalKey,
 		ID:                         b.ID,
 		NoMatchForScopePermissions: b.NoMatchForScopePermissions,
@@ -123,17 +123,12 @@ func makeStringHandle(s string) unique.Handle[string] {
 	return unique.Make(s)
 }
 
-// TODO: replace with HandleStr.
-func stringHandleValue(h unique.Handle[string]) string {
+// HandleStr returns the interned string for a handle, or "" for the zero handle.
+func HandleStr(h unique.Handle[string]) string {
 	if h == EmptyHandle {
 		return ""
 	}
 	return h.Value()
-}
-
-// HandleStr returns the interned string for a handle, or "" for the zero handle.
-func HandleStr(h unique.Handle[string]) string {
-	return stringHandleValue(h)
 }
 
 func makeEvaluationKeyTuple(pb *runtimev1.EvaluationKeyTuple, fallbackKey string) EvaluationKeyTuple {
@@ -155,14 +150,14 @@ func makeEvaluationKeyTuple(pb *runtimev1.EvaluationKeyTuple, fallbackKey string
 
 func (t EvaluationKeyTuple) toProto() *runtimev1.EvaluationKeyTuple {
 	return &runtimev1.EvaluationKeyTuple{
-		Prefix:      stringHandleValue(t.Prefix),
-		Resource:    stringHandleValue(t.Resource),
-		Principal:   stringHandleValue(t.Principal),
-		Role:        stringHandleValue(t.Role),
-		DerivedRole: stringHandleValue(t.DerivedRole),
-		Version:     stringHandleValue(t.Version),
-		Scope:       stringHandleValue(t.Scope),
-		RuleName:    stringHandleValue(t.RuleName),
+		Prefix:      HandleStr(t.Prefix),
+		Resource:    HandleStr(t.Resource),
+		Principal:   HandleStr(t.Principal),
+		Role:        HandleStr(t.Role),
+		DerivedRole: HandleStr(t.DerivedRole),
+		Version:     HandleStr(t.Version),
+		Scope:       HandleStr(t.Scope),
+		RuleName:    HandleStr(t.RuleName),
 		RuleId:      t.RuleID,
 	}
 }

--- a/internal/ruletable/index/core.go
+++ b/internal/ruletable/index/core.go
@@ -61,25 +61,80 @@ type Binding struct {
 	NoMatchForScopePermissions bool
 }
 
+type BindingHandle struct {
+	Core                       *FunctionalCore
+	AllowActions               map[unique.Handle[string]]struct{}
+	Role                       unique.Handle[string]
+	Scope                      unique.Handle[string]
+	Version                    unique.Handle[string]
+	Resource                   unique.Handle[string]
+	Action                     unique.Handle[string]
+	Principal                  unique.Handle[string]
+	OriginFqn                  unique.Handle[string]
+	OriginDerivedRole          unique.Handle[string]
+	Name                       unique.Handle[string]
+	EvaluationKey              EvaluationKeyTuple
+	ID                         uint32
+	NoMatchForScopePermissions bool
+}
+
+func (b *BindingHandle) ToBinding() *Binding {
+	if b == nil {
+		return nil
+	}
+	var allow map[string]struct{}
+	if b.AllowActions != nil {
+		allow = make(map[string]struct{}, len(b.AllowActions))
+		for a := range b.AllowActions {
+			allow[a.Value()] = struct{}{}
+		}
+	}
+	return &Binding{
+		Core:                       b.Core,
+		AllowActions:               allow,
+		Role:                       stringHandleValue(b.Role),
+		Scope:                      stringHandleValue(b.Scope),
+		Version:                    stringHandleValue(b.Version),
+		Resource:                   stringHandleValue(b.Resource),
+		Action:                     stringHandleValue(b.Action),
+		Principal:                  stringHandleValue(b.Principal),
+		OriginFqn:                  stringHandleValue(b.OriginFqn),
+		OriginDerivedRole:          stringHandleValue(b.OriginDerivedRole),
+		Name:                       stringHandleValue(b.Name),
+		EvaluationKey:              b.EvaluationKey,
+		ID:                         b.ID,
+		NoMatchForScopePermissions: b.NoMatchForScopePermissions,
+	}
+}
+
 // IsZero reports whether the tuple is empty, which equivalent to the old empty
 // evaluation-key string.
 func (t EvaluationKeyTuple) IsZero() bool {
 	return t == EvaluationKeyTuple{}
 }
 
+// EmptyHandle is the zero unique.Handle[string]. Is equivalent of "".
+var EmptyHandle unique.Handle[string]
+
+// makeStringHandle interns s, returning the zero handle for "".
 func makeStringHandle(s string) unique.Handle[string] {
 	if s == "" {
-		return unique.Handle[string]{}
+		return EmptyHandle
 	}
 	return unique.Make(s)
 }
 
+// TODO: replace with HandleStr
 func stringHandleValue(h unique.Handle[string]) string {
-	var zero unique.Handle[string]
-	if h == zero {
+	if h == EmptyHandle {
 		return ""
 	}
 	return h.Value()
+}
+
+// HandleStr returns the interned string for a handle, or "" for the zero handle.
+func HandleStr(h unique.Handle[string]) string {
+	return stringHandleValue(h)
 }
 
 func makeEvaluationKeyTuple(pb *runtimev1.EvaluationKeyTuple, fallbackKey string) EvaluationKeyTuple {

--- a/internal/ruletable/index/core.go
+++ b/internal/ruletable/index/core.go
@@ -4,6 +4,8 @@
 package index
 
 import (
+	"unique"
+
 	effectv1 "github.com/cerbos/cerbos/api/genpb/cerbos/effect/v1"
 	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
 	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
@@ -26,6 +28,20 @@ type FunctionalCore struct {
 	FromRolePolicy       bool
 }
 
+// EvaluationKeyTuple is the structured form of a rule's evaluation
+// key. Its components are interned.
+type EvaluationKeyTuple struct {
+	Prefix      unique.Handle[string]
+	Resource    unique.Handle[string]
+	Principal   unique.Handle[string]
+	Role        unique.Handle[string]
+	DerivedRole unique.Handle[string]
+	Version     unique.Handle[string]
+	Scope       unique.Handle[string]
+	RuleName    unique.Handle[string]
+	RuleID      uint32
+}
+
 // Binding ties a routing tuple to a FunctionalCore. Each Binding gets a unique
 // uint32 ID used as a position in the bitmap index.
 type Binding struct {
@@ -40,9 +56,61 @@ type Binding struct {
 	OriginFqn                  string
 	OriginDerivedRole          string
 	Name                       string
-	EvaluationKey              string
+	EvaluationKey              EvaluationKeyTuple
 	ID                         uint32
 	NoMatchForScopePermissions bool
+}
+
+// IsZero reports whether the tuple is empty, which equivalent to the old empty
+// evaluation-key string.
+func (t EvaluationKeyTuple) IsZero() bool {
+	return t == EvaluationKeyTuple{}
+}
+
+func makeStringHandle(s string) unique.Handle[string] {
+	if s == "" {
+		return unique.Handle[string]{}
+	}
+	return unique.Make(s)
+}
+
+func stringHandleValue(h unique.Handle[string]) string {
+	var zero unique.Handle[string]
+	if h == zero {
+		return ""
+	}
+	return h.Value()
+}
+
+func makeEvaluationKeyTuple(pb *runtimev1.EvaluationKeyTuple, fallbackKey string) EvaluationKeyTuple {
+	if pb == nil {
+		return EvaluationKeyTuple{RuleName: makeStringHandle(fallbackKey)}
+	}
+	return EvaluationKeyTuple{
+		Prefix:      makeStringHandle(pb.Prefix),
+		Resource:    makeStringHandle(pb.Resource),
+		Principal:   makeStringHandle(pb.Principal),
+		Role:        makeStringHandle(pb.Role),
+		DerivedRole: makeStringHandle(pb.DerivedRole),
+		Version:     makeStringHandle(pb.Version),
+		Scope:       makeStringHandle(pb.Scope),
+		RuleName:    makeStringHandle(pb.RuleName),
+		RuleID:      pb.RuleId,
+	}
+}
+
+func (t EvaluationKeyTuple) toProto() *runtimev1.EvaluationKeyTuple {
+	return &runtimev1.EvaluationKeyTuple{
+		Prefix:      stringHandleValue(t.Prefix),
+		Resource:    stringHandleValue(t.Resource),
+		Principal:   stringHandleValue(t.Principal),
+		Role:        stringHandleValue(t.Role),
+		DerivedRole: stringHandleValue(t.DerivedRole),
+		Version:     stringHandleValue(t.Version),
+		Scope:       stringHandleValue(t.Scope),
+		RuleName:    stringHandleValue(t.RuleName),
+		RuleId:      t.RuleID,
+	}
 }
 
 // RowParams holds compiled parameters for a rule or derived role.

--- a/internal/ruletable/index/core.go
+++ b/internal/ruletable/index/core.go
@@ -115,8 +115,8 @@ func (t EvaluationKeyTuple) IsZero() bool {
 // EmptyHandle is the zero unique.Handle[string]. Is equivalent of "".
 var EmptyHandle unique.Handle[string]
 
-// makeStringHandle interns s, returning the zero handle for "".
-func makeStringHandle(s string) unique.Handle[string] {
+// mkStringHandle interns s, returning the zero handle for "".
+func mkStringHandle(s string) unique.Handle[string] {
 	if s == "" {
 		return EmptyHandle
 	}
@@ -133,17 +133,17 @@ func HandleStr(h unique.Handle[string]) string {
 
 func makeEvaluationKeyTuple(pb *runtimev1.EvaluationKeyTuple, fallbackKey string) EvaluationKeyTuple {
 	if pb == nil {
-		return EvaluationKeyTuple{RuleName: makeStringHandle(fallbackKey)}
+		return EvaluationKeyTuple{RuleName: mkStringHandle(fallbackKey)}
 	}
 	return EvaluationKeyTuple{
-		Prefix:      makeStringHandle(pb.Prefix),
-		Resource:    makeStringHandle(pb.Resource),
-		Principal:   makeStringHandle(pb.Principal),
-		Role:        makeStringHandle(pb.Role),
-		DerivedRole: makeStringHandle(pb.DerivedRole),
-		Version:     makeStringHandle(pb.Version),
-		Scope:       makeStringHandle(pb.Scope),
-		RuleName:    makeStringHandle(pb.RuleName),
+		Prefix:      mkStringHandle(pb.Prefix),
+		Resource:    mkStringHandle(pb.Resource),
+		Principal:   mkStringHandle(pb.Principal),
+		Role:        mkStringHandle(pb.Role),
+		DerivedRole: mkStringHandle(pb.DerivedRole),
+		Version:     mkStringHandle(pb.Version),
+		Scope:       mkStringHandle(pb.Scope),
+		RuleName:    mkStringHandle(pb.RuleName),
 		RuleID:      pb.RuleId,
 	}
 }

--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -373,7 +373,7 @@ func (m *Index) appendRolePolicyDenies(
 		if b == nil {
 			continue
 		}
-		role := stringHandleValue(b.Role)
+		role := HandleStr(b.Role)
 		if _, ok := rolePolicyRep[role]; !ok {
 			roleOrder = append(roleOrder, role)
 			rolePolicyRep[role] = b
@@ -400,7 +400,7 @@ func (m *Index) appendRolePolicyDenies(
 			if b == nil {
 				continue
 			}
-			role := stringHandleValue(b.Role)
+			role := HandleStr(b.Role)
 			resourceMatchedByRole[role] = append(resourceMatchedByRole[role], b)
 		}
 
@@ -421,7 +421,7 @@ func (m *Index) appendRolePolicyDenies(
 			// role policy exists, but no resource bindings present
 			if len(roleBindings) == 0 {
 				for _, action := range resourceActions {
-					res = append(res, newNoMatchRolePolicyDeny(role, stringHandleValue(rep.Version), stringHandleValue(rep.Scope), resource, action))
+					res = append(res, newNoMatchRolePolicyDeny(role, HandleStr(rep.Version), HandleStr(rep.Scope), resource, action))
 				}
 				continue
 			}
@@ -430,7 +430,7 @@ func (m *Index) appendRolePolicyDenies(
 				matched = matched[:0]
 				for _, rb := range roleBindings {
 					for a := range rb.AllowActions {
-						av := stringHandleValue(a)
+						av := HandleStr(a)
 						if av == action || util.MatchesGlob(av, action) {
 							matched = append(matched, rb)
 							break
@@ -441,7 +441,7 @@ func (m *Index) appendRolePolicyDenies(
 				// role policy exists with resource bindings, but action not specified
 				if len(matched) == 0 {
 					rep := roleBindings[0]
-					res = append(res, newNoMatchRolePolicyDeny(role, stringHandleValue(rep.Version), stringHandleValue(rep.Scope), stringHandleValue(rep.Resource), action))
+					res = append(res, newNoMatchRolePolicyDeny(role, HandleStr(rep.Version), HandleStr(rep.Scope), HandleStr(rep.Resource), action))
 					continue
 				}
 
@@ -553,7 +553,7 @@ func collectResourceActions(arena *bitmapArena, bi *bitmapIndex, resBM, versionB
 			actionSet[b.Action.Value()] = struct{}{}
 		}
 		for a := range b.AllowActions {
-			actionSet[stringHandleValue(a)] = struct{}{}
+			actionSet[HandleStr(a)] = struct{}{}
 		}
 	}
 

--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -80,6 +80,7 @@ func (m *Index) IndexRules(rules []*runtimev1.RuleTable_RuleRow) error {
 
 	if newBindings := len(rules) - len(m.bi.freeIDs); newBindings > 0 {
 		m.bi.bindings = slices.Grow(m.bi.bindings, newBindings)
+		m.bi.evalKeys = slices.Grow(m.bi.evalKeys, newBindings)
 	}
 
 	paramsCache := make(map[uint64]*RowParams)
@@ -168,15 +169,18 @@ func (m *Index) IndexRules(rules []*runtimev1.RuleTable_RuleRow) error {
 			OriginFqn:         makeStringHandle(rule.OriginFqn),
 			OriginDerivedRole: makeStringHandle(rule.OriginDerivedRole),
 			Name:              makeStringHandle(rule.Name),
-			EvaluationKey:     makeEvaluationKeyTuple(rule.EvaluationKeyTuple, rule.EvaluationKey),
 			AllowActions:      allowActions,
 			Core:              core,
 		}
 
-		m.bi.addBinding(b)
+		m.bi.addBinding(b, makeEvaluationKeyTuple(rule.EvaluationKeyTuple, rule.EvaluationKey))
 	}
 
 	return nil
+}
+
+func (m *Index) EvalKey(id uint32) EvaluationKeyTuple {
+	return m.bi.evalKey(id)
 }
 
 func (m *Index) GetAllRows() []*BindingHandle {
@@ -454,14 +458,14 @@ func (m *Index) appendRolePolicyDenies(
 									FromRolePolicy: true,
 									Params:         mb.Core.Params,
 								},
-								Action:        makeStringHandle(action),
-								Name:          mb.Name,
-								OriginFqn:     mb.OriginFqn,
-								Resource:      mb.Resource,
-								Role:          mb.Role,
-								Scope:         mb.Scope,
-								Version:       mb.Version,
-								EvaluationKey: mb.EvaluationKey,
+								Action:    makeStringHandle(action),
+								Name:      mb.Name,
+								OriginFqn: mb.OriginFqn,
+								Resource:  mb.Resource,
+								Role:      mb.Role,
+								Scope:     mb.Scope,
+								Version:   mb.Version,
+								ID:        mb.ID,
 							})
 						}
 						continue
@@ -493,14 +497,14 @@ func (m *Index) appendRolePolicyDenies(
 							FromRolePolicy:   true,
 							Params:           mb.Core.Params,
 						},
-						Action:        makeStringHandle(action),
-						Name:          mb.Name,
-						OriginFqn:     mb.OriginFqn,
-						Resource:      mb.Resource,
-						Role:          mb.Role,
-						Scope:         mb.Scope,
-						Version:       mb.Version,
-						EvaluationKey: mb.EvaluationKey,
+						Action:    makeStringHandle(action),
+						Name:      mb.Name,
+						OriginFqn: mb.OriginFqn,
+						Resource:  mb.Resource,
+						Role:      mb.Role,
+						Scope:     mb.Scope,
+						Version:   mb.Version,
+						ID:        mb.ID,
 					})
 				}
 			}
@@ -574,6 +578,7 @@ func newNoMatchRolePolicyDeny(role, version, scope, resource, action string) *Bi
 		Scope:                      makeStringHandle(scope),
 		Version:                    makeStringHandle(version),
 		NoMatchForScopePermissions: true,
+		ID:                         noEvalKey, // No condition to cache.
 	}
 }
 
@@ -657,7 +662,7 @@ func (m *Index) QueryMulti(versions, resources, scopes, roles, actions []string,
 	// string-typed Bindings for outside consumers.
 	out := make([]*Binding, len(res))
 	for i, b := range res {
-		out[i] = b.ToBinding()
+		out[i] = b.toBinding(bi.evalKey(b.ID))
 	}
 	return out
 }

--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -153,22 +153,22 @@ func (m *Index) IndexRules(rules []*runtimev1.RuleTable_RuleRow) error {
 		case *runtimev1.RuleTable_RuleRow_AllowActions_:
 			allowActions = make(map[unique.Handle[string]]struct{}, len(v.AllowActions.GetActions()))
 			for a := range v.AllowActions.GetActions() {
-				allowActions[makeStringHandle(a)] = struct{}{}
+				allowActions[mkStringHandle(a)] = struct{}{}
 			}
 		case *runtimev1.RuleTable_RuleRow_Action:
-			action = makeStringHandle(v.Action)
+			action = mkStringHandle(v.Action)
 		}
 
 		b := &BindingHandle{
-			Scope:             makeStringHandle(rule.Scope),
-			Version:           makeStringHandle(rule.Version),
-			Resource:          makeStringHandle(rule.Resource),
-			Role:              makeStringHandle(rule.Role),
+			Scope:             mkStringHandle(rule.Scope),
+			Version:           mkStringHandle(rule.Version),
+			Resource:          mkStringHandle(rule.Resource),
+			Role:              mkStringHandle(rule.Role),
 			Action:            action,
-			Principal:         makeStringHandle(rule.Principal),
-			OriginFqn:         makeStringHandle(rule.OriginFqn),
-			OriginDerivedRole: makeStringHandle(rule.OriginDerivedRole),
-			Name:              makeStringHandle(rule.Name),
+			Principal:         mkStringHandle(rule.Principal),
+			OriginFqn:         mkStringHandle(rule.OriginFqn),
+			OriginDerivedRole: mkStringHandle(rule.OriginDerivedRole),
+			Name:              mkStringHandle(rule.Name),
 			AllowActions:      allowActions,
 			Core:              core,
 		}
@@ -458,7 +458,7 @@ func (m *Index) appendRolePolicyDenies(
 									FromRolePolicy: true,
 									Params:         mb.Core.Params,
 								},
-								Action:    makeStringHandle(action),
+								Action:    mkStringHandle(action),
 								Name:      mb.Name,
 								OriginFqn: mb.OriginFqn,
 								Resource:  mb.Resource,
@@ -497,7 +497,7 @@ func (m *Index) appendRolePolicyDenies(
 							FromRolePolicy:   true,
 							Params:           mb.Core.Params,
 						},
-						Action:    makeStringHandle(action),
+						Action:    mkStringHandle(action),
 						Name:      mb.Name,
 						OriginFqn: mb.OriginFqn,
 						Resource:  mb.Resource,
@@ -571,12 +571,12 @@ func newNoMatchRolePolicyDeny(role, version, scope, resource, action string) *Bi
 			PolicyKind:     policyv1.Kind_KIND_RESOURCE,
 			FromRolePolicy: true,
 		},
-		Action:                     makeStringHandle(action),
-		OriginFqn:                  makeStringHandle(namer.RolePolicyFQN(role, version, scope)),
-		Resource:                   makeStringHandle(resource),
-		Role:                       makeStringHandle(role),
-		Scope:                      makeStringHandle(scope),
-		Version:                    makeStringHandle(version),
+		Action:                     mkStringHandle(action),
+		OriginFqn:                  mkStringHandle(namer.RolePolicyFQN(role, version, scope)),
+		Resource:                   mkStringHandle(resource),
+		Role:                       mkStringHandle(role),
+		Scope:                      mkStringHandle(scope),
+		Version:                    mkStringHandle(version),
 		NoMatchForScopePermissions: true,
 		ID:                         noEvalKey, // No condition to cache.
 	}

--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -167,7 +167,7 @@ func (m *Index) IndexRules(rules []*runtimev1.RuleTable_RuleRow) error {
 			OriginFqn:         rule.OriginFqn,
 			OriginDerivedRole: rule.OriginDerivedRole,
 			Name:              rule.Name,
-			EvaluationKey:     rule.EvaluationKey,
+			EvaluationKey:     makeEvaluationKeyTuple(rule.EvaluationKeyTuple, rule.EvaluationKey),
 			AllowActions:      allowActions,
 			Core:              core,
 		}

--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -5,6 +5,7 @@ package index
 
 import (
 	"slices"
+	"unique"
 
 	"github.com/cespare/xxhash/v2"
 
@@ -145,28 +146,28 @@ func (m *Index) IndexRules(rules []*runtimev1.RuleTable_RuleRow) error {
 		}
 		core.origins[rule.OriginFqn] = struct{}{}
 
-		action := ""
-		var allowActions map[string]struct{}
+		var action unique.Handle[string]
+		var allowActions map[unique.Handle[string]]struct{}
 		switch v := rule.ActionSet.(type) {
 		case *runtimev1.RuleTable_RuleRow_AllowActions_:
-			allowActions = make(map[string]struct{}, len(v.AllowActions.GetActions()))
+			allowActions = make(map[unique.Handle[string]]struct{}, len(v.AllowActions.GetActions()))
 			for a := range v.AllowActions.GetActions() {
-				allowActions[a] = struct{}{}
+				allowActions[makeStringHandle(a)] = struct{}{}
 			}
 		case *runtimev1.RuleTable_RuleRow_Action:
-			action = v.Action
+			action = makeStringHandle(v.Action)
 		}
 
-		b := &Binding{
-			Scope:             rule.Scope,
-			Version:           rule.Version,
-			Resource:          rule.Resource,
-			Role:              rule.Role,
+		b := &BindingHandle{
+			Scope:             makeStringHandle(rule.Scope),
+			Version:           makeStringHandle(rule.Version),
+			Resource:          makeStringHandle(rule.Resource),
+			Role:              makeStringHandle(rule.Role),
 			Action:            action,
-			Principal:         rule.Principal,
-			OriginFqn:         rule.OriginFqn,
-			OriginDerivedRole: rule.OriginDerivedRole,
-			Name:              rule.Name,
+			Principal:         makeStringHandle(rule.Principal),
+			OriginFqn:         makeStringHandle(rule.OriginFqn),
+			OriginDerivedRole: makeStringHandle(rule.OriginDerivedRole),
+			Name:              makeStringHandle(rule.Name),
 			EvaluationKey:     makeEvaluationKeyTuple(rule.EvaluationKeyTuple, rule.EvaluationKey),
 			AllowActions:      allowActions,
 			Core:              core,
@@ -178,8 +179,8 @@ func (m *Index) IndexRules(rules []*runtimev1.RuleTable_RuleRow) error {
 	return nil
 }
 
-func (m *Index) GetAllRows() []*Binding {
-	res := make([]*Binding, 0, m.bi.universe.GetCardinality())
+func (m *Index) GetAllRows() []*BindingHandle {
+	res := make([]*BindingHandle, 0, m.bi.universe.GetCardinality())
 	for _, b := range m.bi.bindings {
 		if b != nil {
 			res = append(res, b)
@@ -191,7 +192,7 @@ func (m *Index) GetAllRows() []*Binding {
 // Query returns bindings matching the given dimensions. Nil or zero-values mean
 // "match all" for that dimension. Synthetic DENYs from role policy AllowActions
 // are prepended when querying for a specific action with KIND_RESOURCE.
-func (m *Index) Query(version, resource, scope, action string, roles []string, policyKind policyv1.Kind, principalID string, buf []*Binding) []*Binding {
+func (m *Index) Query(version, resource, scope, action string, roles []string, policyKind policyv1.Kind, principalID string, buf []*BindingHandle) []*BindingHandle {
 	bi := m.bi
 
 	if bi.universe.IsEmpty() {
@@ -333,8 +334,8 @@ func (m *Index) appendRolePolicyDenies(
 	arena *bitmapArena, bi *bitmapIndex,
 	resources, roles, targetActions []string,
 	versionBM, scopeBM, roleBM *Bitmap,
-	res []*Binding,
-) []*Binding {
+	res []*BindingHandle,
+) []*BindingHandle {
 	// candidateBM deliberately omits resource so we can spot roles whose
 	// policy exists but doesn't cover the requested resource.
 	candidateDims := make([]*Bitmap, 0, 4) //nolint:mnd
@@ -360,7 +361,7 @@ func (m *Index) appendRolePolicyDenies(
 	}
 
 	// Retrieve one sample binding per role for version/scope
-	rolePolicyRep := make(map[string]*Binding)
+	rolePolicyRep := make(map[string]*BindingHandle)
 	var roleOrder []string
 	policyIter := candidateBM.Iterator()
 	for policyIter.HasNext() {
@@ -368,9 +369,10 @@ func (m *Index) appendRolePolicyDenies(
 		if b == nil {
 			continue
 		}
-		if _, ok := rolePolicyRep[b.Role]; !ok {
-			roleOrder = append(roleOrder, b.Role)
-			rolePolicyRep[b.Role] = b
+		role := stringHandleValue(b.Role)
+		if _, ok := rolePolicyRep[role]; !ok {
+			roleOrder = append(roleOrder, role)
+			rolePolicyRep[role] = b
 		}
 	}
 
@@ -379,7 +381,7 @@ func (m *Index) appendRolePolicyDenies(
 		roles = roleOrder
 	}
 
-	var matched []*Binding
+	var matched []*BindingHandle
 	for _, resource := range resources {
 		resBM := bi.resource.Query(arena, resource)
 		resourceMatchedBM := emptyBitmap
@@ -387,14 +389,15 @@ func (m *Index) appendRolePolicyDenies(
 			resourceMatchedBM = arena.and2(candidateBM, resBM)
 		}
 
-		resourceMatchedByRole := make(map[string][]*Binding)
+		resourceMatchedByRole := make(map[string][]*BindingHandle)
 		matchedIter := resourceMatchedBM.Iterator()
 		for matchedIter.HasNext() {
 			b := bi.getBinding(matchedIter.Next())
 			if b == nil {
 				continue
 			}
-			resourceMatchedByRole[b.Role] = append(resourceMatchedByRole[b.Role], b)
+			role := stringHandleValue(b.Role)
+			resourceMatchedByRole[role] = append(resourceMatchedByRole[role], b)
 		}
 
 		resourceActions := targetActions
@@ -414,7 +417,7 @@ func (m *Index) appendRolePolicyDenies(
 			// role policy exists, but no resource bindings present
 			if len(roleBindings) == 0 {
 				for _, action := range resourceActions {
-					res = append(res, newNoMatchRolePolicyDeny(role, rep.Version, rep.Scope, resource, action))
+					res = append(res, newNoMatchRolePolicyDeny(role, stringHandleValue(rep.Version), stringHandleValue(rep.Scope), resource, action))
 				}
 				continue
 			}
@@ -423,7 +426,8 @@ func (m *Index) appendRolePolicyDenies(
 				matched = matched[:0]
 				for _, rb := range roleBindings {
 					for a := range rb.AllowActions {
-						if a == action || util.MatchesGlob(a, action) {
+						av := stringHandleValue(a)
+						if av == action || util.MatchesGlob(av, action) {
 							matched = append(matched, rb)
 							break
 						}
@@ -433,7 +437,7 @@ func (m *Index) appendRolePolicyDenies(
 				// role policy exists with resource bindings, but action not specified
 				if len(matched) == 0 {
 					rep := roleBindings[0]
-					res = append(res, newNoMatchRolePolicyDeny(role, rep.Version, rep.Scope, rep.Resource, action))
+					res = append(res, newNoMatchRolePolicyDeny(role, stringHandleValue(rep.Version), stringHandleValue(rep.Scope), stringHandleValue(rep.Resource), action))
 					continue
 				}
 
@@ -443,14 +447,14 @@ func (m *Index) appendRolePolicyDenies(
 						// otherwise dropped here, so emit any output via a no-effect
 						// binding.
 						if mb.Core.EmitOutput != nil {
-							res = append(res, &Binding{
+							res = append(res, &BindingHandle{
 								Core: &FunctionalCore{
 									EmitOutput:     mb.Core.EmitOutput,
 									PolicyKind:     policyv1.Kind_KIND_RESOURCE,
 									FromRolePolicy: true,
 									Params:         mb.Core.Params,
 								},
-								Action:        action,
+								Action:        makeStringHandle(action),
 								Name:          mb.Name,
 								OriginFqn:     mb.OriginFqn,
 								Resource:      mb.Resource,
@@ -473,7 +477,7 @@ func (m *Index) appendRolePolicyDenies(
 							},
 						}
 					}
-					res = append(res, &Binding{
+					res = append(res, &BindingHandle{
 						Core: &FunctionalCore{
 							Effect: effectv1.Effect_EFFECT_DENY,
 							Condition: &runtimev1.Condition{
@@ -489,7 +493,7 @@ func (m *Index) appendRolePolicyDenies(
 							FromRolePolicy:   true,
 							Params:           mb.Core.Params,
 						},
-						Action:        action,
+						Action:        makeStringHandle(action),
 						Name:          mb.Name,
 						OriginFqn:     mb.OriginFqn,
 						Resource:      mb.Resource,
@@ -541,11 +545,11 @@ func collectResourceActions(arena *bitmapArena, bi *bitmapIndex, resBM, versionB
 		if b == nil || b.Core.PolicyKind == policyv1.Kind_KIND_PRINCIPAL {
 			continue
 		}
-		if b.Action != "" {
-			actionSet[b.Action] = struct{}{}
+		if b.Action != EmptyHandle {
+			actionSet[b.Action.Value()] = struct{}{}
 		}
 		for a := range b.AllowActions {
-			actionSet[a] = struct{}{}
+			actionSet[stringHandleValue(a)] = struct{}{}
 		}
 	}
 
@@ -556,19 +560,19 @@ func collectResourceActions(arena *bitmapArena, bi *bitmapIndex, resBM, versionB
 	return actions
 }
 
-func newNoMatchRolePolicyDeny(role, version, scope, resource, action string) *Binding {
-	return &Binding{
+func newNoMatchRolePolicyDeny(role, version, scope, resource, action string) *BindingHandle {
+	return &BindingHandle{
 		Core: &FunctionalCore{
 			Effect:         effectv1.Effect_EFFECT_DENY,
 			PolicyKind:     policyv1.Kind_KIND_RESOURCE,
 			FromRolePolicy: true,
 		},
-		Action:                     action,
-		OriginFqn:                  namer.RolePolicyFQN(role, version, scope),
-		Resource:                   resource,
-		Role:                       role,
-		Scope:                      scope,
-		Version:                    version,
+		Action:                     makeStringHandle(action),
+		OriginFqn:                  makeStringHandle(namer.RolePolicyFQN(role, version, scope)),
+		Resource:                   makeStringHandle(resource),
+		Role:                       makeStringHandle(role),
+		Scope:                      makeStringHandle(scope),
+		Version:                    makeStringHandle(version),
 		NoMatchForScopePermissions: true,
 	}
 }
@@ -631,11 +635,11 @@ func (m *Index) QueryMulti(versions, resources, scopes, roles, actions []string,
 		baseBM = arena.andInto(dims)
 	}
 
-	var res []*Binding
+	var res []*BindingHandle
 	if !baseBM.IsEmpty() {
 		resultBM := m.applyActionFilter(arena, baseBM, actions)
 		if !resultBM.IsEmpty() {
-			res = make([]*Binding, 0, resultBM.GetCardinality())
+			res = make([]*BindingHandle, 0, resultBM.GetCardinality())
 			iter := resultBM.Iterator()
 			for iter.HasNext() {
 				if b := bi.getBinding(iter.Next()); b != nil {
@@ -645,10 +649,17 @@ func (m *Index) QueryMulti(versions, resources, scopes, roles, actions []string,
 		}
 	}
 
-	if !withRolePolicyDenies {
-		return res
+	if withRolePolicyDenies {
+		res = m.appendRolePolicyDenies(arena, bi, resources, roles, actions, versionBM, scopeBM, roleBM, res)
 	}
-	return m.appendRolePolicyDenies(arena, bi, resources, roles, actions, versionBM, scopeBM, roleBM, res)
+
+	// QueryMulti is the external boundary: materialise interned handles back into
+	// string-typed Bindings for outside consumers.
+	out := make([]*Binding, len(res))
+	for i, b := range res {
+		out[i] = b.ToBinding()
+	}
+	return out
 }
 
 func (m *Index) applyActionFilter(arena *bitmapArena, baseBM *Bitmap, actions []string) *Bitmap {

--- a/internal/ruletable/index/index_test.go
+++ b/internal/ruletable/index/index_test.go
@@ -1110,7 +1110,7 @@ func TestQueryAllowActionsSyntheticDeny(t *testing.T) {
 		// editor has edit in its AllowActions with no condition, so no synthetic DENY
 		require.Len(t, res, 1)
 		require.True(t, res[0].NoMatchForScopePermissions)
-		require.Equal(t, "viewer", res[0].Role)
+		require.Equal(t, "viewer", index.HandleStr(res[0].Role))
 	})
 }
 

--- a/internal/ruletable/index/lazy_bench_test.go
+++ b/internal/ruletable/index/lazy_bench_test.go
@@ -82,7 +82,7 @@ func buildScatteredResourceIndex(tb testing.TB) *index.Index {
 
 func BenchmarkQueryByResourceHit(b *testing.B) {
 	impl := buildScatteredResourceIndex(b)
-	var buf []*index.Binding
+	var buf []*index.BindingHandle
 	b.ReportAllocs()
 	for b.Loop() {
 		buf = impl.Query("default", "res_01000", "", "view", nil, policyv1.Kind_KIND_RESOURCE, "", buf[:0])
@@ -94,7 +94,7 @@ func BenchmarkQueryByResourceHit(b *testing.B) {
 
 func BenchmarkQueryByResourceMiss(b *testing.B) {
 	impl := buildScatteredResourceIndex(b)
-	var buf []*index.Binding
+	var buf []*index.BindingHandle
 	b.ReportAllocs()
 	for b.Loop() {
 		buf = impl.Query("default", "res_99999", "", "view", nil, policyv1.Kind_KIND_RESOURCE, "", buf[:0])
@@ -112,7 +112,7 @@ func BenchmarkQueryByResourceParallel(b *testing.B) {
 	impl.Query("default", "res_01000", "", "view", nil, policyv1.Kind_KIND_RESOURCE, "", nil) // warm
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
-		var buf []*index.Binding
+		var buf []*index.BindingHandle
 		for pb.Next() {
 			buf = impl.Query("default", "res_01000", "", "view", nil, policyv1.Kind_KIND_RESOURCE, "", buf[:0])
 		}

--- a/internal/ruletable/index/marshal.go
+++ b/internal/ruletable/index/marshal.go
@@ -41,7 +41,7 @@ func (m *Index) Marshal() ([]byte, error) {
 		if b == nil {
 			continue
 		}
-		pbBindings = append(pbBindings, marshalBinding(b, coreIndex))
+		pbBindings = append(pbBindings, marshalBinding(b, coreIndex, bi.evalKey(b.ID)))
 	}
 
 	version, err := marshalEntries(bi.version.m)
@@ -154,7 +154,7 @@ func marshalRowParams(rp *RowParams) (*runtimev1.RuleTable_RuleRow_Params, error
 	}, nil
 }
 
-func marshalBinding(b *BindingHandle, coreIndex map[*FunctionalCore]uint32) *runtimev1.BitmapIndex_Binding {
+func marshalBinding(b *BindingHandle, coreIndex map[*FunctionalCore]uint32, evalKey EvaluationKeyTuple) *runtimev1.BitmapIndex_Binding {
 	pb := &runtimev1.BitmapIndex_Binding{
 		Id:                 b.ID,
 		CoreIndex:          coreIndex[b.Core],
@@ -166,7 +166,7 @@ func marshalBinding(b *BindingHandle, coreIndex map[*FunctionalCore]uint32) *run
 		OriginFqn:          stringHandleValue(b.OriginFqn),
 		OriginDerivedRole:  stringHandleValue(b.OriginDerivedRole),
 		Name:               stringHandleValue(b.Name),
-		EvaluationKeyTuple: b.EvaluationKey.toProto(),
+		EvaluationKeyTuple: evalKey.toProto(),
 	}
 
 	if b.AllowActions != nil {
@@ -249,7 +249,7 @@ func Unmarshal(data []byte) (*Index, error) {
 	}
 
 	bi := newBitmapIndex()
-	bi.bindings = unmarshalBindings(msg.Bindings, cores)
+	bi.bindings, bi.evalKeys = unmarshalBindings(msg.Bindings, cores)
 
 	bi.version, err = unmarshalEntries(msg.Version)
 	if err != nil {
@@ -346,9 +346,9 @@ func unmarshalCores(pbCores []*runtimev1.BitmapIndex_FunctionalCore) ([]*Functio
 	return cores, nil
 }
 
-func unmarshalBindings(pbBindings []*runtimev1.BitmapIndex_Binding, cores []*FunctionalCore) []*BindingHandle {
+func unmarshalBindings(pbBindings []*runtimev1.BitmapIndex_Binding, cores []*FunctionalCore) ([]*BindingHandle, []EvaluationKeyTuple) {
 	if len(pbBindings) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// find the max ID to size the bindings slice.
@@ -360,6 +360,7 @@ func unmarshalBindings(pbBindings []*runtimev1.BitmapIndex_Binding, cores []*Fun
 	}
 
 	bindings := make([]*BindingHandle, maxID+1)
+	evalKeys := make([]EvaluationKeyTuple, maxID+1)
 	for _, pb := range pbBindings {
 		b := &BindingHandle{
 			ID:                pb.Id,
@@ -372,7 +373,6 @@ func unmarshalBindings(pbBindings []*runtimev1.BitmapIndex_Binding, cores []*Fun
 			OriginFqn:         makeStringHandle(pb.OriginFqn),
 			OriginDerivedRole: makeStringHandle(pb.OriginDerivedRole),
 			Name:              makeStringHandle(pb.Name),
-			EvaluationKey:     makeEvaluationKeyTuple(pb.EvaluationKeyTuple, pb.EvaluationKey),
 		}
 
 		switch v := pb.ActionSet.(type) {
@@ -387,9 +387,10 @@ func unmarshalBindings(pbBindings []*runtimev1.BitmapIndex_Binding, cores []*Fun
 		}
 
 		bindings[pb.Id] = b
+		evalKeys[pb.Id] = makeEvaluationKeyTuple(pb.EvaluationKeyTuple, pb.EvaluationKey)
 	}
 
-	return bindings
+	return bindings, evalKeys
 }
 
 func unmarshalEntries(entries []*runtimev1.BitmapIndex_Entry) (dimension[string], error) {

--- a/internal/ruletable/index/marshal.go
+++ b/internal/ruletable/index/marshal.go
@@ -158,21 +158,21 @@ func marshalBinding(b *BindingHandle, coreIndex map[*FunctionalCore]uint32, eval
 	pb := &runtimev1.BitmapIndex_Binding{
 		Id:                 b.ID,
 		CoreIndex:          coreIndex[b.Core],
-		Role:               stringHandleValue(b.Role),
-		Scope:              stringHandleValue(b.Scope),
-		Version:            stringHandleValue(b.Version),
-		Resource:           stringHandleValue(b.Resource),
-		Principal:          stringHandleValue(b.Principal),
-		OriginFqn:          stringHandleValue(b.OriginFqn),
-		OriginDerivedRole:  stringHandleValue(b.OriginDerivedRole),
-		Name:               stringHandleValue(b.Name),
+		Role:               HandleStr(b.Role),
+		Scope:              HandleStr(b.Scope),
+		Version:            HandleStr(b.Version),
+		Resource:           HandleStr(b.Resource),
+		Principal:          HandleStr(b.Principal),
+		OriginFqn:          HandleStr(b.OriginFqn),
+		OriginDerivedRole:  HandleStr(b.OriginDerivedRole),
+		Name:               HandleStr(b.Name),
 		EvaluationKeyTuple: evalKey.toProto(),
 	}
 
 	if b.AllowActions != nil {
 		actions := make([]string, 0, len(b.AllowActions))
 		for a := range b.AllowActions {
-			actions = append(actions, stringHandleValue(a))
+			actions = append(actions, HandleStr(a))
 		}
 		pb.ActionSet = &runtimev1.BitmapIndex_Binding_AllowActions{
 			AllowActions: &runtimev1.BitmapIndex_AllowActions{

--- a/internal/ruletable/index/marshal.go
+++ b/internal/ruletable/index/marshal.go
@@ -155,17 +155,17 @@ func marshalRowParams(rp *RowParams) (*runtimev1.RuleTable_RuleRow_Params, error
 
 func marshalBinding(b *Binding, coreIndex map[*FunctionalCore]uint32) *runtimev1.BitmapIndex_Binding {
 	pb := &runtimev1.BitmapIndex_Binding{
-		Id:                b.ID,
-		CoreIndex:         coreIndex[b.Core],
-		Role:              b.Role,
-		Scope:             b.Scope,
-		Version:           b.Version,
-		Resource:          b.Resource,
-		Principal:         b.Principal,
-		OriginFqn:         b.OriginFqn,
-		OriginDerivedRole: b.OriginDerivedRole,
-		Name:              b.Name,
-		EvaluationKey:     b.EvaluationKey,
+		Id:                 b.ID,
+		CoreIndex:          coreIndex[b.Core],
+		Role:               b.Role,
+		Scope:              b.Scope,
+		Version:            b.Version,
+		Resource:           b.Resource,
+		Principal:          b.Principal,
+		OriginFqn:          b.OriginFqn,
+		OriginDerivedRole:  b.OriginDerivedRole,
+		Name:               b.Name,
+		EvaluationKeyTuple: b.EvaluationKey.toProto(),
 	}
 
 	if b.AllowActions != nil {
@@ -371,7 +371,7 @@ func unmarshalBindings(pbBindings []*runtimev1.BitmapIndex_Binding, cores []*Fun
 			OriginFqn:         pb.OriginFqn,
 			OriginDerivedRole: pb.OriginDerivedRole,
 			Name:              pb.Name,
-			EvaluationKey:     pb.EvaluationKey,
+			EvaluationKey:     makeEvaluationKeyTuple(pb.EvaluationKeyTuple, pb.EvaluationKey),
 		}
 
 		switch v := pb.ActionSet.(type) {

--- a/internal/ruletable/index/marshal.go
+++ b/internal/ruletable/index/marshal.go
@@ -8,6 +8,7 @@ package index
 import (
 	"fmt"
 	"slices"
+	"unique"
 
 	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
 	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
@@ -153,34 +154,34 @@ func marshalRowParams(rp *RowParams) (*runtimev1.RuleTable_RuleRow_Params, error
 	}, nil
 }
 
-func marshalBinding(b *Binding, coreIndex map[*FunctionalCore]uint32) *runtimev1.BitmapIndex_Binding {
+func marshalBinding(b *BindingHandle, coreIndex map[*FunctionalCore]uint32) *runtimev1.BitmapIndex_Binding {
 	pb := &runtimev1.BitmapIndex_Binding{
 		Id:                 b.ID,
 		CoreIndex:          coreIndex[b.Core],
-		Role:               b.Role,
-		Scope:              b.Scope,
-		Version:            b.Version,
-		Resource:           b.Resource,
-		Principal:          b.Principal,
-		OriginFqn:          b.OriginFqn,
-		OriginDerivedRole:  b.OriginDerivedRole,
-		Name:               b.Name,
+		Role:               stringHandleValue(b.Role),
+		Scope:              stringHandleValue(b.Scope),
+		Version:            stringHandleValue(b.Version),
+		Resource:           stringHandleValue(b.Resource),
+		Principal:          stringHandleValue(b.Principal),
+		OriginFqn:          stringHandleValue(b.OriginFqn),
+		OriginDerivedRole:  stringHandleValue(b.OriginDerivedRole),
+		Name:               stringHandleValue(b.Name),
 		EvaluationKeyTuple: b.EvaluationKey.toProto(),
 	}
 
 	if b.AllowActions != nil {
 		actions := make([]string, 0, len(b.AllowActions))
 		for a := range b.AllowActions {
-			actions = append(actions, a)
+			actions = append(actions, stringHandleValue(a))
 		}
 		pb.ActionSet = &runtimev1.BitmapIndex_Binding_AllowActions{
 			AllowActions: &runtimev1.BitmapIndex_AllowActions{
 				Actions: actions,
 			},
 		}
-	} else if b.Action != "" {
+	} else if b.Action != EmptyHandle {
 		pb.ActionSet = &runtimev1.BitmapIndex_Binding_Action{
-			Action: b.Action,
+			Action: b.Action.Value(),
 		}
 	}
 
@@ -345,7 +346,7 @@ func unmarshalCores(pbCores []*runtimev1.BitmapIndex_FunctionalCore) ([]*Functio
 	return cores, nil
 }
 
-func unmarshalBindings(pbBindings []*runtimev1.BitmapIndex_Binding, cores []*FunctionalCore) []*Binding {
+func unmarshalBindings(pbBindings []*runtimev1.BitmapIndex_Binding, cores []*FunctionalCore) []*BindingHandle {
 	if len(pbBindings) == 0 {
 		return nil
 	}
@@ -358,31 +359,31 @@ func unmarshalBindings(pbBindings []*runtimev1.BitmapIndex_Binding, cores []*Fun
 		}
 	}
 
-	bindings := make([]*Binding, maxID+1)
+	bindings := make([]*BindingHandle, maxID+1)
 	for _, pb := range pbBindings {
-		b := &Binding{
+		b := &BindingHandle{
 			ID:                pb.Id,
 			Core:              cores[pb.CoreIndex],
-			Role:              pb.Role,
-			Scope:             pb.Scope,
-			Version:           pb.Version,
-			Resource:          pb.Resource,
-			Principal:         pb.Principal,
-			OriginFqn:         pb.OriginFqn,
-			OriginDerivedRole: pb.OriginDerivedRole,
-			Name:              pb.Name,
+			Role:              makeStringHandle(pb.Role),
+			Scope:             makeStringHandle(pb.Scope),
+			Version:           makeStringHandle(pb.Version),
+			Resource:          makeStringHandle(pb.Resource),
+			Principal:         makeStringHandle(pb.Principal),
+			OriginFqn:         makeStringHandle(pb.OriginFqn),
+			OriginDerivedRole: makeStringHandle(pb.OriginDerivedRole),
+			Name:              makeStringHandle(pb.Name),
 			EvaluationKey:     makeEvaluationKeyTuple(pb.EvaluationKeyTuple, pb.EvaluationKey),
 		}
 
 		switch v := pb.ActionSet.(type) {
 		case *runtimev1.BitmapIndex_Binding_AllowActions:
-			aa := make(map[string]struct{}, len(v.AllowActions.Actions))
+			aa := make(map[unique.Handle[string]]struct{}, len(v.AllowActions.Actions))
 			for _, a := range v.AllowActions.Actions {
-				aa[a] = struct{}{}
+				aa[makeStringHandle(a)] = struct{}{}
 			}
 			b.AllowActions = aa
 		case *runtimev1.BitmapIndex_Binding_Action:
-			b.Action = v.Action
+			b.Action = makeStringHandle(v.Action)
 		}
 
 		bindings[pb.Id] = b

--- a/internal/ruletable/index/marshal.go
+++ b/internal/ruletable/index/marshal.go
@@ -365,25 +365,25 @@ func unmarshalBindings(pbBindings []*runtimev1.BitmapIndex_Binding, cores []*Fun
 		b := &BindingHandle{
 			ID:                pb.Id,
 			Core:              cores[pb.CoreIndex],
-			Role:              makeStringHandle(pb.Role),
-			Scope:             makeStringHandle(pb.Scope),
-			Version:           makeStringHandle(pb.Version),
-			Resource:          makeStringHandle(pb.Resource),
-			Principal:         makeStringHandle(pb.Principal),
-			OriginFqn:         makeStringHandle(pb.OriginFqn),
-			OriginDerivedRole: makeStringHandle(pb.OriginDerivedRole),
-			Name:              makeStringHandle(pb.Name),
+			Role:              mkStringHandle(pb.Role),
+			Scope:             mkStringHandle(pb.Scope),
+			Version:           mkStringHandle(pb.Version),
+			Resource:          mkStringHandle(pb.Resource),
+			Principal:         mkStringHandle(pb.Principal),
+			OriginFqn:         mkStringHandle(pb.OriginFqn),
+			OriginDerivedRole: mkStringHandle(pb.OriginDerivedRole),
+			Name:              mkStringHandle(pb.Name),
 		}
 
 		switch v := pb.ActionSet.(type) {
 		case *runtimev1.BitmapIndex_Binding_AllowActions:
 			aa := make(map[unique.Handle[string]]struct{}, len(v.AllowActions.Actions))
 			for _, a := range v.AllowActions.Actions {
-				aa[makeStringHandle(a)] = struct{}{}
+				aa[mkStringHandle(a)] = struct{}{}
 			}
 			b.AllowActions = aa
 		case *runtimev1.BitmapIndex_Binding_Action:
-			b.Action = makeStringHandle(v.Action)
+			b.Action = mkStringHandle(v.Action)
 		}
 
 		bindings[pb.Id] = b

--- a/internal/ruletable/index/string_dedup.go
+++ b/internal/ruletable/index/string_dedup.go
@@ -136,7 +136,7 @@ func (idx *bitmapIndex) dedupStringsWith(s *StringDeduper) {
 		s.Intern(&b.OriginFqn)
 		s.Intern(&b.OriginDerivedRole)
 		s.Intern(&b.Name)
-		s.Intern(&b.EvaluationKey)
+
 		b.AllowActions = s.dedupSet(b.AllowActions)
 		if b.Core != nil {
 			if _, done := visitedCores[b.Core]; !done {

--- a/internal/ruletable/index/string_dedup.go
+++ b/internal/ruletable/index/string_dedup.go
@@ -4,6 +4,7 @@
 package index
 
 import (
+	"strings"
 	"unique"
 
 	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
@@ -73,18 +74,40 @@ func (s *StringDeduper) dedupOutput(o *runtimev1.Output) {
 	s.dedupExpr(o.When.ConditionNotMet)
 }
 
-// dedupConstants rebuilds a string-keyed map with interned keys, values
-// are left as-is.
-func (s *StringDeduper) dedupConstants(m map[string]any) map[string]any {
+// RelocateConstants rebuilds a constant map with interned keys and relocated,
+// deep-copied values.
+func (s *StringDeduper) RelocateConstants(m map[string]any) map[string]any {
 	if m == nil {
 		return nil
 	}
 	out := make(map[string]any, len(m))
 	for k, v := range m {
 		s.Intern(&k)
-		out[k] = v
+		out[k] = s.relocateAny(v)
 	}
 	return out
+}
+
+func (s *StringDeduper) relocateAny(v any) any {
+	switch x := v.(type) {
+	case string:
+		return strings.Clone(x)
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, e := range x {
+			s.Intern(&k)
+			out[k] = s.relocateAny(e)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, e := range x {
+			out[i] = s.relocateAny(e)
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 func (s *StringDeduper) dedupCore(c *FunctionalCore) {
@@ -107,7 +130,7 @@ func (s *StringDeduper) dedupParams(p *RowParams) {
 	if p == nil {
 		return
 	}
-	p.Constants = s.dedupConstants(p.Constants)
+	p.Constants = s.RelocateConstants(p.Constants)
 	for _, v := range p.Variables {
 		s.Intern(&v.Name)
 		s.dedupExpr(v.Expr)

--- a/internal/ruletable/index/string_dedup.go
+++ b/internal/ruletable/index/string_dedup.go
@@ -73,18 +73,6 @@ func (s *StringDeduper) dedupOutput(o *runtimev1.Output) {
 	s.dedupExpr(o.When.ConditionNotMet)
 }
 
-func (s *StringDeduper) dedupSet(m map[string]struct{}) map[string]struct{} {
-	if m == nil {
-		return nil
-	}
-	out := make(map[string]struct{}, len(m))
-	for k := range m {
-		s.Intern(&k)
-		out[k] = struct{}{}
-	}
-	return out
-}
-
 // dedupConstants rebuilds a string-keyed map with interned keys, values
 // are left as-is.
 func (s *StringDeduper) dedupConstants(m map[string]any) map[string]any {
@@ -132,12 +120,6 @@ func (idx *bitmapIndex) dedupStringsWith(s *StringDeduper) {
 		if b == nil {
 			continue
 		}
-		s.Intern(&b.Scope)
-		s.Intern(&b.OriginFqn)
-		s.Intern(&b.OriginDerivedRole)
-		s.Intern(&b.Name)
-
-		b.AllowActions = s.dedupSet(b.AllowActions)
 		if b.Core != nil {
 			if _, done := visitedCores[b.Core]; !done {
 				visitedCores[b.Core] = struct{}{}

--- a/internal/ruletable/plan.go
+++ b/internal/ruletable/plan.go
@@ -130,7 +130,7 @@ func (rt *RuleTable) planWithAuditTrail(
 
 				rolesIncludingParents := rt.idx.AddParentRoles([]string{resourceScope}, []string{role})
 
-				var bindings []*index.Binding
+				var bindings []*index.BindingHandle
 				for _, scope := range scopes {
 					// Once a child OVERRIDE_PARENT scope has matched an unconditional ALLOW, no
 					// parent-scope rule can change the outcome, so we skip
@@ -192,7 +192,7 @@ func (rt *RuleTable) planWithAuditTrail(
 					}
 					bindings = rt.idx.Query(resourceVersion, sanitizedResource, scope, action, rolesIncludingParents, pt, pid, bindings[:0])
 					for _, b := range bindings {
-						if m := rt.GetMeta(b.OriginFqn); m != nil && m.GetSourceAttributes() != nil {
+						if m := rt.GetMeta(index.HandleStr(b.OriginFqn)); m != nil && m.GetSourceAttributes() != nil {
 							maps.Copy(effectivePolicies, m.GetSourceAttributes())
 						}
 

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -752,6 +752,10 @@ func (rt *RuleTable) GetAllRows() []*index.BindingHandle {
 	return rt.idx.GetAllRows()
 }
 
+func (rt *RuleTable) EvalKey(id uint32) index.EvaluationKeyTuple {
+	return rt.idx.EvalKey(id)
+}
+
 func (rt *RuleTable) GetDerivedRoles(fqn string) map[string]*WrappedRunnableDerivedRole {
 	return rt.policyDerivedRoles[namer.GenModuleIDFromFQN(fqn)]
 }

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -178,7 +178,14 @@ func addPrincipalPolicy(rt *runtimev1.RuleTable, rpps *runtimev1.RunnablePrincip
 					Constants:        p.Constants,
 				},
 				EvaluationKey: evaluationKey,
-				PolicyKind:    policyv1.Kind_KIND_PRINCIPAL,
+				EvaluationKeyTuple: &runtimev1.EvaluationKeyTuple{
+					Prefix:    namer.PrincipalPoliciesPrefix,
+					Principal: principalID,
+					Version:   rpps.Meta.Version,
+					Scope:     p.Scope,
+					RuleName:  rule.Name,
+				},
+				PolicyKind: policyv1.Kind_KIND_PRINCIPAL,
 			}
 
 			if p.ScopePermissions == policyv1.ScopePermissions_SCOPE_PERMISSIONS_REQUIRE_PARENTAL_CONSENT_FOR_ALLOWS &&
@@ -284,7 +291,14 @@ func addResourcePolicy(rt *runtimev1.RuleTable, rrps *runtimev1.RunnableResource
 						Constants:        p.Constants,
 					},
 					EvaluationKey: evaluationKey,
-					PolicyKind:    policyv1.Kind_KIND_RESOURCE,
+					EvaluationKeyTuple: &runtimev1.EvaluationKeyTuple{
+						Prefix:   namer.ResourcePoliciesPrefix,
+						Resource: sanitizedResource,
+						Version:  rrps.Meta.Version,
+						Scope:    p.Scope,
+						RuleName: rule.Name,
+					},
+					PolicyKind: policyv1.Kind_KIND_RESOURCE,
 				}
 
 				if p.ScopePermissions == policyv1.ScopePermissions_SCOPE_PERMISSIONS_REQUIRE_PARENTAL_CONSENT_FOR_ALLOWS &&
@@ -333,7 +347,15 @@ func addResourcePolicy(rt *runtimev1.RuleTable, rrps *runtimev1.RunnableResource
 								Constants:        rdr.Constants,
 							},
 							EvaluationKey: evaluationKey,
-							PolicyKind:    policyv1.Kind_KIND_RESOURCE,
+							EvaluationKeyTuple: &runtimev1.EvaluationKeyTuple{
+								Prefix:      namer.DerivedRolesPrefix,
+								Resource:    sanitizedResource,
+								DerivedRole: dr,
+								Version:     rrps.Meta.Version,
+								Scope:       p.Scope,
+								RuleName:    rule.Name,
+							},
+							PolicyKind: policyv1.Kind_KIND_RESOURCE,
 						}
 
 						if p.ScopePermissions == policyv1.ScopePermissions_SCOPE_PERMISSIONS_REQUIRE_PARENTAL_CONSENT_FOR_ALLOWS &&
@@ -388,7 +410,14 @@ func addRolePolicy(rt *runtimev1.RuleTable, p *runtimev1.RunnableRolePolicySet) 
 					OrderedVariables: p.OrderedVariables,
 					Constants:        p.Constants,
 				},
-				EvaluationKey:  fmt.Sprintf("%s#%s_rule-%03d", namer.PolicyKeyFromFQN(namer.RolePolicyFQN(p.Role, p.Meta.Version, p.Scope)), p.Role, idx),
+				EvaluationKey: fmt.Sprintf("%s#%s_rule-%03d", namer.PolicyKeyFromFQN(namer.RolePolicyFQN(p.Role, p.Meta.Version, p.Scope)), p.Role, idx),
+				EvaluationKeyTuple: &runtimev1.EvaluationKeyTuple{
+					Prefix:  namer.RolePoliciesPrefix,
+					Role:    p.Role,
+					Version: p.Meta.Version,
+					Scope:   p.Scope,
+					RuleId:  uint32(idx), //nolint:gosec
+				},
 				PolicyKind:     policyv1.Kind_KIND_RESOURCE,
 				FromRolePolicy: true,
 			})

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -411,6 +411,9 @@ func addRolePolicy(rt *runtimev1.RuleTable, p *runtimev1.RunnableRolePolicySet) 
 					Constants:        p.Constants,
 				},
 				EvaluationKey: fmt.Sprintf("%s#%s_rule-%03d", namer.PolicyKeyFromFQN(namer.RolePolicyFQN(p.Role, p.Meta.Version, p.Scope)), p.Role, idx),
+				// idx restarts at 0 for each resource, and the resource itself is left
+				// out of the key on purpose so this stays identical to the legacy
+				// evaluation_key string.
 				EvaluationKeyTuple: &runtimev1.EvaluationKeyTuple{
 					Prefix:  namer.RolePoliciesPrefix,
 					Role:    p.Role,

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -748,7 +748,7 @@ func (rt *RuleTable) indexRules(rules []*runtimev1.RuleTable_RuleRow) error {
 	return rt.idx.IndexParentRoles(rt.ScopeParentRoles)
 }
 
-func (rt *RuleTable) GetAllRows() []*index.Binding {
+func (rt *RuleTable) GetAllRows() []*index.BindingHandle {
 	return rt.idx.GetAllRows()
 }
 

--- a/internal/ruletable/string_dedup.go
+++ b/internal/ruletable/string_dedup.go
@@ -4,6 +4,8 @@
 package ruletable
 
 import (
+	"strings"
+
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -68,7 +70,8 @@ func dedupMeta(s *index.StringDeduper, m *runtimev1.RuleTableMetadata) {
 	}
 }
 
-// dedupSourceAttributes dedupes only keys.
+// dedupSourceAttributes interns keys and relocates each attribute value into a
+// fresh, interned deep copy.
 func dedupSourceAttributes(s *index.StringDeduper, sa *policyv1.SourceAttributes) {
 	if sa == nil || len(sa.Attributes) == 0 {
 		return
@@ -76,9 +79,45 @@ func dedupSourceAttributes(s *index.StringDeduper, sa *policyv1.SourceAttributes
 	out := make(map[string]*structpb.Value, len(sa.Attributes))
 	for k, v := range sa.Attributes {
 		s.Intern(&k)
-		out[k] = v
+		out[k] = relocateValue(s, v)
 	}
 	sa.Attributes = out
+}
+
+// relocateValue returns a freshly-allocated deep copy of v with string leaves
+// interned.
+func relocateValue(s *index.StringDeduper, v *structpb.Value) *structpb.Value {
+	if v == nil {
+		return nil
+	}
+	switch k := v.GetKind().(type) {
+	case *structpb.Value_StringValue:
+		// Clone (not intern): attribute values are mostly unique (file paths).
+		return structpb.NewStringValue(strings.Clone(k.StringValue))
+	case *structpb.Value_NumberValue:
+		return structpb.NewNumberValue(k.NumberValue)
+	case *structpb.Value_BoolValue:
+		return structpb.NewBoolValue(k.BoolValue)
+	case *structpb.Value_NullValue:
+		return structpb.NewNullValue()
+	case *structpb.Value_StructValue:
+		fields := k.StructValue.GetFields()
+		out := make(map[string]*structpb.Value, len(fields))
+		for fk, fv := range fields {
+			s.Intern(&fk)
+			out[fk] = relocateValue(s, fv)
+		}
+		return structpb.NewStructValue(&structpb.Struct{Fields: out})
+	case *structpb.Value_ListValue:
+		vals := k.ListValue.GetValues()
+		out := make([]*structpb.Value, len(vals))
+		for i, e := range vals {
+			out[i] = relocateValue(s, e)
+		}
+		return structpb.NewListValue(&structpb.ListValue{Values: out})
+	default:
+		return v
+	}
 }
 
 func dedupScopeParentRoles(s *index.StringDeduper, m map[string]*runtimev1.RuleTable_RoleParentRoles) map[string]*runtimev1.RuleTable_RoleParentRoles {

--- a/internal/ruletable/string_dedup.go
+++ b/internal/ruletable/string_dedup.go
@@ -85,7 +85,7 @@ func dedupSourceAttributes(s *index.StringDeduper, sa *policyv1.SourceAttributes
 }
 
 // relocateValue returns a freshly-allocated deep copy of v with string leaves
-// interned.
+// cloned.
 func relocateValue(s *index.StringDeduper, v *structpb.Value) *structpb.Value {
 	if v == nil {
 		return nil
@@ -161,7 +161,7 @@ func dedupDerivedRoleMap(s *index.StringDeduper, shared map[uint64]*runtimev1.Ru
 					shared[v.VarCacheKey] = v.RunnableDerivedRole
 				}
 			}
-			v.Constants = dedupAnyMap(s, v.Constants)
+			v.Constants = s.RelocateConstants(v.Constants)
 		}
 		out[k] = v
 	}
@@ -185,11 +185,7 @@ func dedupRunnableDerivedRole(s *index.StringDeduper, rdr *runtimev1.RunnableDer
 		out := make(map[string]*structpb.Value, len(rdr.Constants))
 		for k, v := range rdr.Constants {
 			s.Intern(&k)
-			if vs := v.GetStringValue(); vs != "" {
-				s.Intern(&vs)
-				v = structpb.NewStringValue(vs)
-			}
-			out[k] = v
+			out[k] = relocateValue(s, v)
 		}
 		rdr.Constants = out
 	}
@@ -207,18 +203,6 @@ func dedupRunnableDerivedRole(s *index.StringDeduper, rdr *runtimev1.RunnableDer
 	if rdr.Condition != nil {
 		rdr.Condition = proto.Clone(rdr.Condition).(*runtimev1.Condition) //nolint:forcetypeassert
 	}
-}
-
-func dedupAnyMap(s *index.StringDeduper, m map[string]any) map[string]any {
-	if len(m) == 0 {
-		return m
-	}
-	out := make(map[string]any, len(m))
-	for k, v := range m {
-		s.Intern(&k)
-		out[k] = v
-	}
-	return out
 }
 
 func dedupJSONSchemas(s *index.StringDeduper, m map[string]*runtimev1.RuleTable_JSONSchema) map[string]*runtimev1.RuleTable_JSONSchema {

--- a/internal/storage/hub/ruletable_bundle.go
+++ b/internal/storage/hub/ruletable_bundle.go
@@ -198,7 +198,7 @@ func (rtb *RuleTableBundle) RepoStats(ctx context.Context) storage.RepoStats {
 
 	stats := newStatsCollector()
 	for _, row := range rows {
-		stats.addRow(row)
+		stats.addRow(row, rtb.ruleTable.EvalKey(row.ID))
 	}
 
 	for _, schemas := range rtb.ruleTable.GetSchemas() {

--- a/internal/storage/hub/stats.go
+++ b/internal/storage/hub/stats.go
@@ -21,7 +21,7 @@ const numPolicyKinds = 4
 
 type statsCollector struct {
 	policies          map[uint64]*stats
-	uniqueRules       map[uint64]struct{}
+	uniqueRules       map[index.EvaluationKeyTuple]struct{}
 	uniqueResources   map[uint64]struct{}
 	uniqueActions     map[uint64]struct{}
 	schemaRefs        map[uint64]struct{}
@@ -44,7 +44,7 @@ type policyStats struct {
 func newStatsCollector() *statsCollector {
 	return &statsCollector{
 		policies:        make(map[uint64]*stats),
-		uniqueRules:     make(map[uint64]struct{}),
+		uniqueRules:     make(map[index.EvaluationKeyTuple]struct{}),
 		uniqueResources: make(map[uint64]struct{}),
 		uniqueActions:   make(map[uint64]struct{}),
 		schemaRefs:      make(map[uint64]struct{}),
@@ -123,12 +123,12 @@ func (s *statsCollector) addRow(row *index.Binding) {
 		s.hasScopedPolicies = true
 	}
 
-	if row.EvaluationKey == "" {
+	if row.EvaluationKey.IsZero() {
 		return
 	}
 
-	if _, ok := s.uniqueRules[util.HashStr(row.EvaluationKey)]; !ok {
-		s.uniqueRules[util.HashStr(row.EvaluationKey)] = struct{}{}
+	if _, ok := s.uniqueRules[row.EvaluationKey]; !ok {
+		s.uniqueRules[row.EvaluationKey] = struct{}{}
 		s.policies[mID].ruleCount++
 	}
 

--- a/internal/storage/hub/stats.go
+++ b/internal/storage/hub/stats.go
@@ -96,8 +96,8 @@ func (s *statsCollector) collate() storage.RepoStats {
 	return is
 }
 
-func (s *statsCollector) addRow(row *index.Binding) {
-	fqn := row.OriginFqn
+func (s *statsCollector) addRow(row *index.BindingHandle) {
+	fqn := index.HandleStr(row.OriginFqn)
 	kind := policy.KindFromFQN(fqn)
 	mID := namer.GenModuleIDFromFQN(fqn).RawValue()
 
@@ -108,18 +108,18 @@ func (s *statsCollector) addRow(row *index.Binding) {
 	}
 
 	if kind == policy.ResourceKind {
-		s.uniqueResources[util.HashStr(row.Resource)] = struct{}{}
+		s.uniqueResources[util.HashStr(index.HandleStr(row.Resource))] = struct{}{}
 	}
 
-	if row.Action != "" && kind == policy.ResourceKind {
-		s.uniqueActions[util.HashStr(row.Action)] = struct{}{}
+	if row.Action != index.EmptyHandle && kind == policy.ResourceKind {
+		s.uniqueActions[util.HashStr(row.Action.Value())] = struct{}{}
 	}
 
 	if row.Core.EmitOutput != nil {
 		s.hasOutput = true
 	}
 
-	if row.Scope != "" {
+	if row.Scope != index.EmptyHandle {
 		s.hasScopedPolicies = true
 	}
 

--- a/internal/storage/hub/stats.go
+++ b/internal/storage/hub/stats.go
@@ -96,7 +96,7 @@ func (s *statsCollector) collate() storage.RepoStats {
 	return is
 }
 
-func (s *statsCollector) addRow(row *index.BindingHandle) {
+func (s *statsCollector) addRow(row *index.BindingHandle, evalKey index.EvaluationKeyTuple) {
 	fqn := index.HandleStr(row.OriginFqn)
 	kind := policy.KindFromFQN(fqn)
 	mID := namer.GenModuleIDFromFQN(fqn).RawValue()
@@ -123,12 +123,12 @@ func (s *statsCollector) addRow(row *index.BindingHandle) {
 		s.hasScopedPolicies = true
 	}
 
-	if row.EvaluationKey.IsZero() {
+	if evalKey.IsZero() {
 		return
 	}
 
-	if _, ok := s.uniqueRules[row.EvaluationKey]; !ok {
-		s.uniqueRules[row.EvaluationKey] = struct{}{}
+	if _, ok := s.uniqueRules[evalKey]; !ok {
+		s.uniqueRules[evalKey] = struct{}{}
 		s.policies[mID].ruleCount++
 	}
 


### PR DESCRIPTION
This PR does three things to reduce memory consumed by the rule table:
  - Stores binding fields as interned unique.Handle values instead of plain strings.
  - Replaces the formatted evaluation-key string with a structured `EvaluationKeyTuple` whose components are interned, but to avoid increasing the binding size, the eval keys are moved out to the parent structure. `RuleTable_RuleRow.EvaluationKey` is preserved for forward-compatibility.
  - Deep-clones source attributes and constants during the dedup pass.

On a test store with 8,000 policy files:
| Metric | main (`72a094b6`) | binding-handle | delta |
  |---|--:|--:|--:|
  | heap_alloc (MiB) | 51.2 | 44.2 | -7.0 (-13.7%) |
  | heap_inuse (MiB) | 276.9 | 210.5 | -66.4 (-24.0%) |
  | RSS (MiB) | 373.1 | 305.7 | -67.4 (-18.1%) |
  | startup -> healthy (s) | 54.6 | 58.0 | +3.4 (within run-to-run spread) |
