### PR TITLE
Add dimension filters to ruletable index key queries

### DIFF
--- a/internal/ruletable/index/bitmap_index.go
+++ b/internal/ruletable/index/bitmap_index.go
@@ -207,9 +207,20 @@ func (d dimension[T]) Keys() []T {
 	return keys
 }
 
-// Query returns OR(d[k] for k in keys).
+// intersectingKeys returns the keys whose binding IDs intersect filter.
+func (d dimension[T]) intersectingKeys(filter *Bitmap) []T { //nolint:unused
+	keys := make([]T, 0, len(d.m))
+	for k, bm := range d.m {
+		if intersectionNonEmpty(bm, filter) {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// QueryMultiple returns OR(d[k] for k in keys).
 // The returned bitmap may alias a stored bitmap; callers must not mutate it.
-func (d dimension[T]) Query(arena *bitmapArena, keys []T) *Bitmap {
+func (d dimension[T]) QueryMultiple(arena *bitmapArena, keys []T) *Bitmap {
 	parts := make([]*Bitmap, 0, len(keys))
 	for _, k := range keys {
 		if bm, ok := d.m[k]; ok {

--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -821,17 +821,33 @@ func (m *Index) GetResources() []string {
 	return m.bi.resource.GetAllKeys()
 }
 
-// Roles returns role keys matching the filters. An empty filter means
-// match-all on that dimension. Glob keys (e.g. "manager:*") appear verbatim.
-// Principal-policy rows are excluded.
-func (m *Index) Roles(versions, scopes []string) []string {
-	return m.bi.nonPrincipalDimensionKeys(m.bi.role, versions, scopes)
+// Versions returns version keys matching the filters. An empty filter means
+// match-all on that dimension. Principal-policy rows are excluded.
+func (m *Index) Versions(scopes, resources []string) []string {
+	return m.bi.resourceDimensionKeys(m.bi.version, nil, scopes, resources)
 }
 
-// Resources returns resource keys matching the filters.
-// Matches `Roles` semantics above.
+// Scopes returns scope keys matching the filters. Matches `Versions` semantics.
+func (m *Index) Scopes(versions, resources []string) []string {
+	return m.bi.resourceDimensionKeys(m.bi.scope, versions, nil, resources)
+}
+
+// Roles returns role keys matching the filters; glob keys (e.g. "manager:*")
+// appear verbatim. Otherwise matches `Versions` semantics.
+func (m *Index) Roles(versions, scopes, resources []string) []string {
+	return m.bi.resourceDimensionKeys(m.bi.role, versions, scopes, resources)
+}
+
+// Actions returns action keys matching the filters; glob keys (e.g. "view:*")
+// appear verbatim. Otherwise matches `Versions` semantics.
+func (m *Index) Actions(versions, scopes, resources []string) []string {
+	return m.bi.resourceDimensionKeys(m.bi.action, versions, scopes, resources)
+}
+
+// Resources returns resource keys matching the filters; glob keys appear
+// verbatim. Otherwise matches `Versions` semantics.
 func (m *Index) Resources(versions, scopes []string) []string {
-	return m.bi.nonPrincipalDimensionKeys(m.bi.resource, versions, scopes)
+	return m.bi.resourceDimensionKeys(m.bi.resource, versions, scopes, nil)
 }
 
 // ActionsForResource returns distinct actions on resource, filtered by
@@ -857,10 +873,15 @@ func (m *Index) ActionsForResource(resource string, versions, scopes []string) [
 	return collectResourceActions(arena, bi, resBM, versionBM, scopeBM)
 }
 
-// nonPrincipalDimensionKeys returns keys of gd matching the filters,
-// excluding principal-policy bindings. Returns nil if no KIND_RESOURCE
-// bindings are indexed.
-func (bi *bitmapIndex) nonPrincipalDimensionKeys(gd *globDimension, versions, scopes []string) []string {
+// keyDimension enumerates the keys whose bindings intersect a filter bitmap.
+type keyDimension interface {
+	intersectingKeys(filter *Bitmap) []string
+}
+
+// resourceDimensionKeys returns keys of d backed by at least one KIND_RESOURCE binding
+// matching the version/scope/resource filters. Returns nil if no KIND_RESOURCE
+// bindings are indexed or a non-empty filter matches nothing.
+func (bi *bitmapIndex) resourceDimensionKeys(d keyDimension, versions, scopes, resources []string) []string {
 	resourceKindBM, ok := bi.policyKind.Get(policyv1.Kind_KIND_RESOURCE)
 	if !ok {
 		return nil
@@ -874,13 +895,24 @@ func (bi *bitmapIndex) nonPrincipalDimensionKeys(gd *globDimension, versions, sc
 		return nil
 	}
 
-	filters := make([]*Bitmap, 0, 3) //nolint:mnd
+	var resourceBM *Bitmap
+	if len(resources) > 0 {
+		resourceBM = bi.resource.QueryMultiple(arena, resources)
+		if resourceBM.IsEmpty() {
+			return nil
+		}
+	}
+
+	filters := make([]*Bitmap, 0, 4) //nolint:mnd
 	filters = append(filters, resourceKindBM)
 	if versionBM != nil {
 		filters = append(filters, versionBM)
 	}
 	if scopeBM != nil {
 		filters = append(filters, scopeBM)
+	}
+	if resourceBM != nil {
+		filters = append(filters, resourceBM)
 	}
 
 	filterBM := filters[0]
@@ -891,20 +923,20 @@ func (bi *bitmapIndex) nonPrincipalDimensionKeys(gd *globDimension, versions, sc
 		}
 	}
 
-	return gd.intersectingKeys(filterBM)
+	return d.intersectingKeys(filterBM)
 }
 
 // versionScopeFilters builds the filter bitmaps. ok=false means a non-empty
 // input matched nothing. A nil bitmap means "no filter" for that dimension.
 func (bi *bitmapIndex) versionScopeFilters(arena *bitmapArena, versions, scopes []string) (versionBM, scopeBM *Bitmap, ok bool) {
 	if len(versions) > 0 {
-		versionBM = bi.version.Query(arena, versions)
+		versionBM = bi.version.QueryMultiple(arena, versions)
 		if versionBM.IsEmpty() {
 			return nil, nil, false
 		}
 	}
 	if len(scopes) > 0 {
-		scopeBM = bi.scope.Query(arena, scopes)
+		scopeBM = bi.scope.QueryMultiple(arena, scopes)
 		if scopeBM.IsEmpty() {
 			return nil, nil, false
 		}
@@ -925,7 +957,7 @@ func (m *Index) ScopedResourceExists(version, resource string, scopes []string) 
 	arena := newBitmapArena()
 	defer arena.release()
 
-	scopeBM := m.bi.scope.Query(arena, scopes)
+	scopeBM := m.bi.scope.QueryMultiple(arena, scopes)
 	if scopeBM.IsEmpty() {
 		return false
 	}
@@ -956,7 +988,7 @@ func (m *Index) ScopedPrincipalExists(version string, scopes []string) bool {
 	arena := newBitmapArena()
 	defer arena.release()
 
-	scopeBM := m.bi.scope.Query(arena, scopes)
+	scopeBM := m.bi.scope.QueryMultiple(arena, scopes)
 	if scopeBM.IsEmpty() {
 		return false
 	}

--- a/internal/ruletable/index/index_test.go
+++ b/internal/ruletable/index/index_test.go
@@ -428,10 +428,17 @@ func TestRoles(t *testing.T) {
 		impl := index.New()
 		require.NoError(t, impl.IndexRules([]*runtimev1.RuleTable_RuleRow{
 			makeRow(namer.ResourcePolicyFQN("document", "default", ""), func(r *runtimev1.RuleTable_RuleRow) { r.Role = "viewer" }),
-			makeRow(namer.ResourcePolicyFQN("image", "v2", "acme"), func(r *runtimev1.RuleTable_RuleRow) { r.Scope = "acme"; r.Version = "v2"; r.Role = "manager:*" }),
+			makeRow(namer.ResourcePolicyFQN("image", "v2", "acme"), func(r *runtimev1.RuleTable_RuleRow) {
+				r.Scope = "acme"
+				r.Version = "v2"
+				r.Resource = "image"
+				r.Role = "manager:*"
+			}),
 		}))
-		require.ElementsMatch(t, []string{"viewer", "manager:*"}, impl.Roles(nil, nil))
-		require.ElementsMatch(t, []string{"manager:*"}, impl.Roles([]string{"v2"}, nil))
+		require.ElementsMatch(t, []string{"viewer", "manager:*"}, impl.Roles(nil, nil, nil))
+		require.ElementsMatch(t, []string{"manager:*"}, impl.Roles([]string{"v2"}, nil, nil))
+		require.ElementsMatch(t, []string{"viewer"}, impl.Roles(nil, nil, []string{"document"}))
+		require.ElementsMatch(t, []string{"manager:*"}, impl.Roles(nil, nil, []string{"image"}))
 	})
 
 	t.Run("principal-only index returns nothing", func(t *testing.T) {
@@ -449,7 +456,7 @@ func TestRoles(t *testing.T) {
 				Params:     &runtimev1.RuleTable_RuleRow_Params{},
 			},
 		}))
-		require.Empty(t, principalOnly.Roles(nil, nil))
+		require.Empty(t, principalOnly.Roles(nil, nil, nil))
 	})
 
 	t.Run("synthetic * is filtered alongside resource-policy roles", func(t *testing.T) {
@@ -472,7 +479,85 @@ func TestRoles(t *testing.T) {
 				Params:     &runtimev1.RuleTable_RuleRow_Params{},
 			},
 		}))
-		require.ElementsMatch(t, []string{"viewer"}, mixed.Roles(nil, nil))
+		require.ElementsMatch(t, []string{"viewer"}, mixed.Roles(nil, nil, nil))
+	})
+}
+
+func TestScopes(t *testing.T) {
+	impl := index.New()
+	require.NoError(t, impl.IndexRules([]*runtimev1.RuleTable_RuleRow{
+		makeRow(namer.ResourcePolicyFQN("document", "default", ""), func(r *runtimev1.RuleTable_RuleRow) { r.Scope = ""; r.Resource = "document" }),
+		makeRow(namer.ResourcePolicyFQN("document", "default", "acme"), func(r *runtimev1.RuleTable_RuleRow) { r.Scope = "acme"; r.Resource = "document" }),
+		makeRow(namer.ResourcePolicyFQN("image", "v2", "acme.hr"), func(r *runtimev1.RuleTable_RuleRow) { r.Scope = "acme.hr"; r.Version = "v2"; r.Resource = "image" }),
+	}))
+
+	t.Run("empty filters returns all scopes", func(t *testing.T) {
+		require.ElementsMatch(t, []string{"", "acme", "acme.hr"}, impl.Scopes(nil, nil))
+	})
+	t.Run("resource filter restricts scopes", func(t *testing.T) {
+		require.ElementsMatch(t, []string{"", "acme"}, impl.Scopes(nil, []string{"document"}))
+	})
+	t.Run("version filter restricts scopes", func(t *testing.T) {
+		require.ElementsMatch(t, []string{"acme.hr"}, impl.Scopes([]string{"v2"}, nil))
+	})
+	t.Run("version and resource intersect", func(t *testing.T) {
+		require.Empty(t, impl.Scopes([]string{"v2"}, []string{"document"}))
+	})
+	t.Run("unknown resource returns nothing", func(t *testing.T) {
+		require.Empty(t, impl.Scopes(nil, []string{"nope"}))
+	})
+}
+
+func TestVersions(t *testing.T) {
+	impl := index.New()
+	require.NoError(t, impl.IndexRules([]*runtimev1.RuleTable_RuleRow{
+		makeRow(namer.ResourcePolicyFQN("document", "default", "acme"), func(r *runtimev1.RuleTable_RuleRow) { r.Scope = "acme"; r.Resource = "document" }),
+		makeRow(namer.ResourcePolicyFQN("document", "v2", "acme"), func(r *runtimev1.RuleTable_RuleRow) { r.Scope = "acme"; r.Version = "v2"; r.Resource = "document" }),
+		makeRow(namer.ResourcePolicyFQN("image", "v3", ""), func(r *runtimev1.RuleTable_RuleRow) { r.Scope = ""; r.Version = "v3"; r.Resource = "image" }),
+	}))
+
+	t.Run("empty filters returns all versions", func(t *testing.T) {
+		require.ElementsMatch(t, []string{"default", "v2", "v3"}, impl.Versions(nil, nil))
+	})
+	t.Run("resource filter restricts versions", func(t *testing.T) {
+		require.ElementsMatch(t, []string{"default", "v2"}, impl.Versions(nil, []string{"document"}))
+	})
+	t.Run("scope filter restricts versions", func(t *testing.T) {
+		require.ElementsMatch(t, []string{"default", "v2"}, impl.Versions([]string{"acme"}, nil))
+	})
+	t.Run("scope and resource intersect", func(t *testing.T) {
+		require.Empty(t, impl.Versions([]string{"acme"}, []string{"image"}))
+	})
+}
+
+func TestActions(t *testing.T) {
+	impl := index.New()
+	require.NoError(t, impl.IndexRules([]*runtimev1.RuleTable_RuleRow{
+		makeRow(namer.ResourcePolicyFQN("document", "default", ""), func(r *runtimev1.RuleTable_RuleRow) {
+			r.Resource = "document"
+			r.ActionSet = &runtimev1.RuleTable_RuleRow_Action{Action: "view"}
+		}),
+		makeRow(namer.ResourcePolicyFQN("document", "default", ""), func(r *runtimev1.RuleTable_RuleRow) {
+			r.Resource = "document"
+			r.Role = "editor"
+			r.ActionSet = &runtimev1.RuleTable_RuleRow_Action{Action: "edit"}
+		}),
+		makeRow(namer.ResourcePolicyFQN("report", "default", "acme"), func(r *runtimev1.RuleTable_RuleRow) {
+			r.Scope = "acme"
+			r.Resource = "report"
+			r.Role = "admin"
+			r.ActionSet = &runtimev1.RuleTable_RuleRow_Action{Action: "delete"}
+		}),
+	}))
+
+	t.Run("empty filters returns all actions", func(t *testing.T) {
+		require.ElementsMatch(t, []string{"view", "edit", "delete"}, impl.Actions(nil, nil, nil))
+	})
+	t.Run("resource filter restricts actions", func(t *testing.T) {
+		require.ElementsMatch(t, []string{"view", "edit"}, impl.Actions(nil, nil, []string{"document"}))
+	})
+	t.Run("scope filter restricts actions", func(t *testing.T) {
+		require.ElementsMatch(t, []string{"delete"}, impl.Actions(nil, []string{"acme"}, nil))
 	})
 }
 


### PR DESCRIPTION
Adds `Versions`, `Scopes`, and `Actions` to the rule table index's key-listing API, plus a resource filter across the existing `Roles`/`Resources` queries. Each returns the distinct keys for one dimension, optionally narrowed by the others; empty filters mean match-all, and only resource-policy bindings are considered (principal-policy rows are excluded).

The shared key-collection helper is generalised to cover both exact-match and glob-backed dimensions, with tests for each query and its filter combinations.