### PR TITLE
Update to go1.26

### DIFF
--- a/cmd/cerbos/compile/compile.go
+++ b/cmd/cerbos/compile/compile.go
@@ -95,8 +95,7 @@ func (c *Cmd) Run(k *kong.Kong) error {
 
 	idx, err := index.Build(ctx, fsys, index.WithBuildFailureLogLevel(zap.DebugLevel))
 	if err != nil {
-		idxErr := new(index.BuildError)
-		if errors.As(err, &idxErr) {
+		if idxErr, ok := errors.AsType[*index.BuildError](err); ok {
 			return lint.Display(p, idxErr, c.Output, colorLevel)
 		}
 
@@ -113,8 +112,7 @@ func (c *Cmd) Run(k *kong.Kong) error {
 	schemaMgr := internalschema.NewFromConf(ctx, store, internalschema.NewConf(enforcement))
 
 	if err := compile.BatchCompile(idx.GetAllCompilationUnits(ctx), schemaMgr); err != nil {
-		compErr := new(compile.ErrorSet)
-		if errors.As(err, &compErr) {
+		if compErr, ok := errors.AsType[*compile.ErrorSet](err); ok {
 			return internalcompile.Display(p, *compErr, c.Output, colorLevel)
 		}
 

--- a/cmd/cerbos/repl/internal/repl.go
+++ b/cmd/cerbos/repl/internal/repl.go
@@ -555,8 +555,7 @@ func (r *REPL) printLoadError(err error) {
 		return
 	}
 
-	var unmarshalErr parser.UnmarshalError
-	if errors.As(err, &unmarshalErr) {
+	if unmarshalErr, ok := errors.AsType[parser.UnmarshalError](err); ok {
 		r.output.Println(colored.REPLError(fmt.Sprintf("%+v", unmarshalErr)))
 	} else {
 		r.output.PrintErr("Error:", err)

--- a/cmd/cerbosctl/hub/store/store.go
+++ b/cmd/cerbosctl/hub/store/store.go
@@ -126,8 +126,7 @@ func (o Output) toCommandError(w io.Writer, err error) error {
 		o.format(w, cerr)
 	}()
 
-	valErr := new(hub.InvalidRequestError)
-	if errors.As(err, valErr) {
+	if valErr, ok := errors.AsType[hub.InvalidRequestError](err); ok {
 		cerr.ErrorMessage = "invalid request"
 		cerr.ErrorDetails = make([]any, len(valErr.Violations))
 		for i, v := range valErr.Violations {
@@ -136,8 +135,7 @@ func (o Output) toCommandError(w io.Writer, err error) error {
 		return cerr
 	}
 
-	rpcErr := new(hub.StoreRPCError)
-	if errors.As(err, rpcErr) {
+	if rpcErr, ok := errors.AsType[hub.StoreRPCError](err); ok {
 		switch rpcErr.Kind {
 		case store.RPCErrorAuthenticationFailed:
 			cerr.ErrorMessage = "failed to authenticate to Cerbos Hub"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/cerbos/cerbos
 
-go 1.25.11
-
-toolchain go1.26.4
+go 1.26.4
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1

--- a/internal/audit/hub/hub.go
+++ b/internal/audit/hub/hub.go
@@ -284,8 +284,7 @@ func (l *Log) syncLoop(ctx context.Context) error {
 func (l *Log) schedule() time.Duration {
 	l.logger.Log(zapcore.Level(-3), "Scheduling stream")
 	if err := l.streamLogs(); err != nil {
-		var ingestErr ErrIngestBackoff
-		if errors.As(err, &ingestErr) {
+		if ingestErr, ok := errors.AsType[ErrIngestBackoff](err); ok {
 			l.logger.Warn("svc-ingest issued backoff", zap.Error(err))
 			if ingestErr.Backoff < l.minFlushInterval {
 				return l.minFlushInterval

--- a/internal/compile/errors.go
+++ b/internal/compile/errors.go
@@ -98,13 +98,12 @@ func (e *ErrorSet) Error() string {
 }
 
 func (e *ErrorSet) Add(err error) {
-	if errList := new(ErrorSet); errors.As(err, &errList) {
+	if errList, ok := errors.AsType[*ErrorSet](err); ok {
 		maps.Copy(e.CompileErrors, errList.CompileErrors)
 		return
 	}
 
-	tmpErr := new(Error)
-	if errors.As(err, &tmpErr) {
+	if tmpErr, ok := errors.AsType[*Error](err); ok {
 		key := util.HashStr(fmt.Sprintf("%s:%d:%d:%s", tmpErr.GetFile(), tmpErr.GetPosition().GetLine(), tmpErr.GetPosition().GetColumn(), tmpErr.GetDescription()))
 		e.CompileErrors[key] = tmpErr.CompileErrors_Err
 		return

--- a/internal/compile/manager.go
+++ b/internal/compile/manager.go
@@ -154,5 +154,6 @@ func (pce PolicyCompilationErr) Unwrap() error {
 }
 
 func (pce PolicyCompilationErr) Is(target error) bool {
-	return errors.As(target, &PolicyCompilationErr{})
+	_, ok := errors.AsType[PolicyCompilationErr](target)
+	return ok
 }

--- a/internal/compile/variables.go
+++ b/internal/compile/variables.go
@@ -289,8 +289,7 @@ func (vd *variableDefinitions) All() ([]*runtimev1.Variable, map[string]*runtime
 func (vd *variableDefinitions) list(includeUnused bool) ([]*runtimev1.Variable, map[string]*runtimev1.Expr) {
 	nodes, err := topo.SortStabilized(vd.graph, sortVariablesByName)
 	if err != nil {
-		var cycles topo.Unorderable
-		if errors.As(err, &cycles) {
+		if cycles, ok := errors.AsType[topo.Unorderable](err); ok {
 			vd.reportCyclicalVariables(cycles)
 		} else {
 			vd.modCtx.addErrWithDesc(err, "Unexpected error sorting variable definitions")

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -68,8 +68,7 @@ func TestInspect(t *testing.T) {
 				expectedErrors := testCase.RuleTablesExpectation.Errors
 
 				idx, err := index.Build(ctx, os.DirFS(dir))
-				var haveIdxBuildErr *index.BuildError
-				if errors.As(err, &haveIdxBuildErr) {
+				if haveIdxBuildErr, ok := errors.AsType[*index.BuildError](err); ok {
 					var wantIdxBuildErrs *runtimev1.IndexBuildErrors
 					expectedIdxBuildErrs, ok := expectedErrors.(*privatev1.InspectTestCase_RuleTablesExpectation_IndexBuildErrors)
 					if ok {
@@ -94,8 +93,7 @@ func TestInspect(t *testing.T) {
 
 				protoRT := ruletable.NewProtoRuletable()
 				err = ruletable.LoadPolicies(t.Context(), protoRT, compiler)
-				var haveCompileErrSet *compile.ErrorSet
-				if errors.As(err, &haveCompileErrSet) {
+				if haveCompileErrSet, ok := errors.AsType[*compile.ErrorSet](err); ok {
 					var wantCompileErrs []*runtimev1.CompileErrors_Err
 					expectedCompileErrs, ok := expectedErrors.(*privatev1.InspectTestCase_RuleTablesExpectation_CompileErrors)
 					if ok {
@@ -133,8 +131,7 @@ func TestInspect(t *testing.T) {
 				expectedErrors := testCase.PolicySetsExpectation.Errors
 
 				idx, err := index.Build(ctx, os.DirFS(dir))
-				var haveIdxBuildErr *index.BuildError
-				if errors.As(err, &haveIdxBuildErr) {
+				if haveIdxBuildErr, ok := errors.AsType[*index.BuildError](err); ok {
 					var wantIdxBuildErrs *runtimev1.IndexBuildErrors
 					expectedIdxBuildErrs, ok := expectedErrors.(*privatev1.InspectTestCase_PolicySetsExpectation_IndexBuildErrors)
 					if ok {
@@ -156,8 +153,7 @@ func TestInspect(t *testing.T) {
 				ins := inspect.PolicySets()
 				for unit := range idx.GetAllCompilationUnits(ctx) {
 					rps, err := compile.Compile(unit, mgr)
-					var haveCompileErrSet *compile.ErrorSet
-					if errors.As(err, &haveCompileErrSet) {
+					if haveCompileErrSet, ok := errors.AsType[*compile.ErrorSet](err); ok {
 						var wantCompileErrs []*runtimev1.CompileErrors_Err
 						expectedCompileErrs, ok := expectedErrors.(*privatev1.InspectTestCase_PolicySetsExpectation_CompileErrors)
 						if ok {

--- a/internal/outputcolor/level.go
+++ b/internal/outputcolor/level.go
@@ -70,7 +70,7 @@ func scan(ctx *kong.DecodeContext) (*Level, error) {
 	default:
 	}
 
-	return pointer(Basic), nil
+	return new(Basic), nil
 }
 
 func parse(v any) (*Level, error) {
@@ -84,22 +84,18 @@ func parse(v any) (*Level, error) {
 		return nil, nil
 
 	case "false", "never":
-		return pointer(None), nil
+		return new(None), nil
 
 	case "true", "always":
-		return pointer(Basic), nil
+		return new(Basic), nil
 
 	case "256":
-		return pointer(Ansi256), nil
+		return new(Ansi256), nil
 
 	case "16m", "full", "truecolor":
-		return pointer(Ansi16m), nil
+		return new(Ansi16m), nil
 
 	default:
 		return nil, fmt.Errorf("invalid value for output color level: %q", s)
 	}
-}
-
-func pointer(level Level) *Level {
-	return &level
 }

--- a/internal/outputcolor/level_test.go
+++ b/internal/outputcolor/level_test.go
@@ -239,9 +239,8 @@ func parse(t *testing.T, args []string) (*outputcolor.Level, []string, error) {
 	parser, err := kong.New(&cli, outputcolor.TypeMapper)
 	require.NoError(t, err, "failed to create command-line argument parser")
 
-	var parseError *kong.ParseError
 	_, err = parser.Parse(args)
-	if err == nil || errors.As(err, &parseError) {
+	if _, ok := errors.AsType[*kong.ParseError](err); err == nil || ok {
 		return cli.Color, cli.Leftovers, err
 	}
 	require.NoError(t, err, "failed to parse command-line arguments")

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -235,8 +235,7 @@ func parse(contents []byte, detectProblems bool) (_ *ast.File, outErr error) {
 
 	file, err := parser.Parse(t, parser.ParseComments)
 	if err != nil { //nolint:nestif
-		syntaxErr := new(yaml.SyntaxError)
-		if errors.As(err, &syntaxErr) {
+		if syntaxErr, ok := errors.AsType[*yaml.SyntaxError](err); ok {
 			srcErr := &sourcev1.Error{
 				Kind:    sourcev1.Error_KIND_PARSE_ERROR,
 				Message: syntaxErr.Message,
@@ -1168,8 +1167,8 @@ func (u *unmarshaler[T]) validate(uctx *unmarshalCtx, msg T) (outErr error) {
 		return nil
 	}
 
-	verrs := new(protovalidate.ValidationError)
-	if !errors.As(err, &verrs) {
+	verrs, ok := errors.AsType[*protovalidate.ValidationError](err)
+	if !ok {
 		return err
 	}
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1082,7 +1082,7 @@ func (u *unmarshaler[T]) unmarshalUInt64Value(uctx *unmarshalCtx, n ast.Node, ou
 		switch v := t.Value.(type) {
 		case int64:
 			if v < 0 {
-				return uctx.perrorf(n, "unexpected negative value %q", v)
+				return uctx.perrorf(n, "unexpected negative value '%d'", v)
 			}
 
 			out.Value = uint64(v)

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -100,8 +100,7 @@ func unwrapErrors(t *testing.T, err error) (allErrs []*sourcev1.Error) {
 		return allErrs
 	}
 
-	var unmarshalErr parser.UnmarshalError
-	if errors.As(err, &unmarshalErr) {
+	if unmarshalErr, ok := errors.AsType[parser.UnmarshalError](err); ok {
 		allErrs = append(allErrs, unmarshalErr.Err)
 	} else {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -86,24 +86,23 @@ func (m *manager) LoadSchema(ctx context.Context, schemaURL string) (*jsonschema
 	}
 
 	e := &cacheEntry{}
-	var notFoundErr *notFoundErr
 	e.schema, e.err = m.loadSchemaFromStore(ctx, schemaURL)
-	if e.err != nil && errors.As(e.err, &notFoundErr) {
+	if nfe, ok := errors.AsType[*notFoundErr](e.err); e.err != nil && ok {
 		var absolutePath string
 		var err error
-		if notFoundErr.scheme == fileURLScheme {
+		if nfe.scheme == fileURLScheme {
 			if absolutePath, err = filepath.Abs(schemaURL); err != nil {
 				e.err = fmt.Errorf("failed to resolve schema URL %q: %w", schemaURL, err)
 			}
 		}
 
 		switch {
-		case notFoundErr.scheme == fileURLScheme && notFoundErr.fullPath == absolutePath:
+		case nfe.scheme == fileURLScheme && nfe.fullPath == absolutePath:
 			e.err = fmt.Errorf("schema %s doesn't exist", schemaURL)
-		case notFoundErr.url != schemaURL:
-			e.err = fmt.Errorf("schema %s referenced by %s doesn't exist", notFoundErr.fullPath, schemaURL)
+		case nfe.url != schemaURL:
+			e.err = fmt.Errorf("schema %s referenced by %s doesn't exist", nfe.fullPath, schemaURL)
 		default:
-			e.err = fmt.Errorf("schema %s doesn't exist", notFoundErr.fullPath)
+			e.err = fmt.Errorf("schema %s doesn't exist", nfe.fullPath)
 		}
 	}
 
@@ -172,16 +171,16 @@ func DefaultResolver(loader Loader) Resolver {
 
 func loadFileURL(u *url.URL) (io.ReadCloser, error) {
 	f := u.Path
-	var pathErr *fs.PathError
-	if file, err := os.Open(f); err != nil && errors.Is(err, fs.ErrNotExist) && errors.As(err, &pathErr) { //nolint:gosec
+	file, err := os.Open(f) //nolint:gosec
+	if pathErr, ok := errors.AsType[*fs.PathError](err); err != nil && errors.Is(err, fs.ErrNotExist) && ok {
 		return nil, &notFoundErr{
 			url:      u.String(),
 			scheme:   u.Scheme,
 			fullPath: pathErr.Path,
 		}
-	} else {
-		return file, nil
 	}
+
+	return file, nil
 }
 
 func loadHTTPURL(ctx context.Context, u *url.URL) (io.ReadCloser, error) {

--- a/internal/schema/schema_common.go
+++ b/internal/schema/schema_common.go
@@ -171,16 +171,16 @@ func (m *StaticManager) validate(ctx context.Context, schemas *policyv1.Schemas,
 	defer span.End()
 
 	if err := m.validateAttr(ctx, ErrSourcePrincipal, schemas.PrincipalSchema, principalAttr, actions, nil); err != nil {
-		var principalErrs ValidationErrorList
-		if ok := errors.As(err, &principalErrs); !ok {
+		principalErrs, ok := errors.AsType[ValidationErrorList](err)
+		if !ok {
 			return result, fmt.Errorf("failed to validate the principal: %w", err)
 		}
 		result.add(principalErrs...)
 	}
 
 	if err := m.validateAttr(ctx, ErrSourceResource, schemas.ResourceSchema, resourceAttr, actions, resourceErrorFilter); err != nil {
-		var resourceErrs ValidationErrorList
-		if ok := errors.As(err, &resourceErrs); !ok {
+		resourceErrs, ok := errors.AsType[ValidationErrorList](err)
+		if !ok {
 			return result, fmt.Errorf("failed to validate the resource: %w", err)
 		}
 		result.add(resourceErrs...)
@@ -224,12 +224,11 @@ func (m *StaticManager) validateAttr(ctx context.Context, src ErrSource, schemaR
 	}
 
 	if err := schema.Validate(attrJSON); err != nil {
-		var validationErr *jsonschema.ValidationError
-		if ok := errors.As(err, &validationErr); !ok {
-			return fmt.Errorf("unable to validate %s: %w", src, err)
+		if validationErr, ok := errors.AsType[*jsonschema.ValidationError](err); ok {
+			return newValidationErrorList(validationErr, src, errorFilter)
 		}
 
-		return newValidationErrorList(validationErr, src, errorFilter)
+		return fmt.Errorf("unable to validate %s: %w", src, err)
 	}
 
 	return nil
@@ -265,9 +264,8 @@ func StaticResolver(loader Loader) Resolver {
 
 func loadCerbosURL(ctx context.Context, u *url.URL, loader Loader) (io.ReadCloser, error) {
 	relativePath := strings.TrimPrefix(u.Path, "/")
-	var pathErr *fs.PathError
 	s, err := loader.LoadSchema(ctx, relativePath)
-	if err != nil && errors.Is(err, fs.ErrNotExist) && errors.As(err, &pathErr) {
+	if pathErr, ok := errors.AsType[*fs.PathError](err); err != nil && errors.Is(err, fs.ErrNotExist) && ok {
 		p := pathErr.Path
 		if !strings.HasPrefix(pathErr.Path, util.SchemasDirectory) {
 			p = filepath.Join(util.SchemasDirectory, pathErr.Path)

--- a/internal/storage/blob/conf.go
+++ b/internal/storage/blob/conf.go
@@ -74,16 +74,12 @@ func (conf *Conf) Validate() error {
 	return nil
 }
 
-func pd(d time.Duration) *time.Duration {
-	return &d
-}
-
 func (conf *Conf) SetDefaults() {
 	if conf.RequestTimeout == nil {
-		conf.RequestTimeout = pd(defaultRequestTimeout)
+		conf.RequestTimeout = new(defaultRequestTimeout)
 	}
 	if conf.DownloadTimeout == nil {
-		conf.DownloadTimeout = pd(defaultDownloadTimeout)
+		conf.DownloadTimeout = new(defaultDownloadTimeout)
 	}
 }
 

--- a/internal/storage/db/mysql/mysql.go
+++ b/internal/storage/db/mysql/mysql.go
@@ -179,8 +179,7 @@ func upsertPolicy(ctx context.Context, tx *goqu.TxDatabase, p policy.Wrapper) er
 	}
 
 	if _, err := tx.Insert(internal.PolicyTbl).Prepared(true).Rows(pr).Executor().ExecContext(ctx); err != nil {
-		mysqlErr := new(mysql.MySQLError)
-		if !errors.As(err, &mysqlErr) || mysqlErr.Number != constraintViolationErrCode {
+		if mysqlErr, ok := errors.AsType[*mysql.MySQLError](err); !ok || mysqlErr.Number != constraintViolationErrCode {
 			return fmt.Errorf("failed to insert policy %s: %w", p.FQN, err)
 		}
 

--- a/internal/storage/db/sqlite3/sqlite3.go
+++ b/internal/storage/db/sqlite3/sqlite3.go
@@ -158,8 +158,7 @@ func upsertPolicy(ctx context.Context, tx *goqu.TxDatabase, p policy.Wrapper) er
 	}
 
 	if _, err := tx.Insert(internal.PolicyTbl).Prepared(true).Rows(pr).Executor().ExecContext(ctx); err != nil {
-		sqliteErr := new(gosqlite3.Error)
-		if !errors.As(err, &sqliteErr) || sqliteErr.Code() != gosqlite3lib.SQLITE_CONSTRAINT_PRIMARYKEY {
+		if sqliteErr, ok := errors.AsType[*gosqlite3.Error](err); !ok || sqliteErr.Code() != gosqlite3lib.SQLITE_CONSTRAINT_PRIMARYKEY {
 			return fmt.Errorf("failed to insert policy %s: %w", p.FQN, err)
 		}
 

--- a/internal/storage/index/builder.go
+++ b/internal/storage/index/builder.go
@@ -208,14 +208,12 @@ func (idx *indexBuilder) addLoadFailure(file string, err error) {
 		return
 	}
 
-	var uErr parser.UnmarshalError
-	if errors.As(err, &uErr) {
+	if uErr, ok := errors.AsType[parser.UnmarshalError](err); ok {
 		idx.loadFailures = append(idx.loadFailures, &runtimev1.IndexBuildErrors_LoadFailure{File: file, Error: uErr.Err.GetMessage(), ErrorDetails: uErr.Err})
 		return
 	}
 
-	var vErr policy.ValidationError
-	if errors.As(err, &vErr) {
+	if vErr, ok := errors.AsType[policy.ValidationError](err); ok {
 		idx.loadFailures = append(idx.loadFailures, &runtimev1.IndexBuildErrors_LoadFailure{File: file, Error: vErr.Err.GetMessage(), ErrorDetails: vErr.Err})
 		return
 	}

--- a/internal/storage/index/builder_test.go
+++ b/internal/storage/index/builder_test.go
@@ -4,7 +4,6 @@
 package index
 
 import (
-	"errors"
 	"io"
 	"io/fs"
 	"path/filepath"
@@ -199,7 +198,7 @@ func TestBuildIndex(t *testing.T) {
 			switch {
 			case tc.WantErrList != nil:
 				errList := new(BuildError)
-				require.True(t, errors.As(haveErr, &errList))
+				require.ErrorAs(t, haveErr, &errList)
 				require.Empty(t,
 					cmp.Diff(tc.WantErrList, errList.IndexBuildErrors,
 						protocmp.Transform(),

--- a/internal/svc/admin_svc.go
+++ b/internal/svc/admin_svc.go
@@ -85,8 +85,7 @@ func (cas *CerbosAdminService) AddOrUpdatePolicy(ctx context.Context, req *reque
 			return nil, status.Error(codes.FailedPrecondition, "Policy ID conflict")
 		}
 
-		invalidPolicyErr := new(storage.InvalidPolicyError)
-		if errors.As(err, invalidPolicyErr) {
+		if invalidPolicyErr, ok := errors.AsType[storage.InvalidPolicyError](err); ok {
 			return nil, status.Errorf(codes.InvalidArgument, "Invalid policy: %v", invalidPolicyErr.Message)
 		}
 		return nil, status.Error(codes.Internal, "Failed to add/update policies")
@@ -107,8 +106,7 @@ func (cas *CerbosAdminService) AddOrUpdateSchema(ctx context.Context, req *reque
 
 	if err := ms.AddOrUpdateSchema(ctx, req.Schemas...); err != nil {
 		logging.ReqScopeLog(ctx).Error("Failed to add/update the schema(s)", zap.Error(err))
-		var ise storage.InvalidSchemaError
-		if ok := errors.As(err, &ise); ok {
+		if ise, ok := errors.AsType[storage.InvalidSchemaError](err); ok {
 			return nil, status.Errorf(codes.InvalidArgument, "Invalid schema in request: %s", ise.Message)
 		}
 
@@ -245,8 +243,7 @@ func (cas *CerbosAdminService) DeletePolicy(ctx context.Context, req *requestv1.
 	deletedPolicies, err := ms.Delete(ctx, req.Id...)
 	if err != nil {
 		logging.ReqScopeLog(ctx).Error("Failed to delete policies", zap.Error(err))
-		var integrityErr *db.IntegrityErr
-		if errors.As(err, &integrityErr) {
+		if integrityErr, ok := errors.AsType[*db.IntegrityErr](err); ok {
 			st := status.New(codes.InvalidArgument, "Failed to delete policies")
 			var setDetailsErr error
 			if st, setDetailsErr = st.WithDetails(&responsev1.DeletePolicyErrorDetails{
@@ -284,8 +281,7 @@ func (cas *CerbosAdminService) DisablePolicy(ctx context.Context, req *requestv1
 	disabledPolicies, err := ms.Disable(ctx, req.Id...)
 	if err != nil {
 		logging.ReqScopeLog(ctx).Error("Failed to disable policies", zap.Error(err))
-		var integrityErr *db.IntegrityErr
-		if errors.As(err, &integrityErr) {
+		if integrityErr, ok := errors.AsType[*db.IntegrityErr](err); ok {
 			st := status.New(codes.InvalidArgument, "Failed to disable policies")
 			var setDetailsErr error
 			if st, setDetailsErr = st.WithDetails(&responsev1.DisablePolicyErrorDetails{

--- a/internal/svc/cerbos_svc.go
+++ b/internal/svc/cerbos_svc.go
@@ -55,8 +55,7 @@ func (cs *CerbosService) PlanResources(ctx context.Context, request *requestv1.P
 
 	auxData, err := cs.auxData.Extract(ctx, request.AuxData)
 	if err != nil {
-		var extractErr auxdata.JWTExtractionError
-		if errors.As(err, &extractErr) {
+		if extractErr, ok := errors.AsType[auxdata.JWTExtractionError](err); ok {
 			log.Error(fmt.Sprintf("Failed to extract auxData: %s", extractErr.Description), zap.Error(extractErr.Cause))
 		} else {
 			log.Error("Failed to extract auxData", zap.Error(err))
@@ -134,8 +133,7 @@ func (cs *CerbosService) CheckResourceSet(ctx context.Context, req *requestv1.Ch
 
 	auxData, err := cs.auxData.Extract(ctx, req.AuxData)
 	if err != nil {
-		var extractErr auxdata.JWTExtractionError
-		if errors.As(err, &extractErr) {
+		if extractErr, ok := errors.AsType[auxdata.JWTExtractionError](err); ok {
 			log.Error(fmt.Sprintf("Failed to extract auxData: %s", extractErr.Description), zap.Error(extractErr.Cause))
 		} else {
 			log.Error("Failed to extract auxData", zap.Error(err))
@@ -195,8 +193,7 @@ func (cs *CerbosService) CheckResourceBatch(ctx context.Context, req *requestv1.
 
 	auxData, err := cs.auxData.Extract(ctx, req.AuxData)
 	if err != nil {
-		var extractErr auxdata.JWTExtractionError
-		if errors.As(err, &extractErr) {
+		if extractErr, ok := errors.AsType[auxdata.JWTExtractionError](err); ok {
 			log.Error(fmt.Sprintf("Failed to extract auxData: %s", extractErr.Description), zap.Error(extractErr.Cause))
 		} else {
 			log.Error("Failed to extract auxData", zap.Error(err))
@@ -261,8 +258,7 @@ func (cs *CerbosService) CheckResources(ctx context.Context, req *requestv1.Chec
 
 	auxData, err := cs.auxData.Extract(ctx, req.AuxData)
 	if err != nil {
-		var extractErr auxdata.JWTExtractionError
-		if errors.As(err, &extractErr) {
+		if extractErr, ok := errors.AsType[auxdata.JWTExtractionError](err); ok {
 			log.Error(fmt.Sprintf("Failed to extract auxData: %s", extractErr.Description), zap.Error(extractErr.Cause))
 		} else {
 			log.Error("Failed to extract auxData", zap.Error(err))

--- a/internal/svc/playground_svc.go
+++ b/internal/svc/playground_svc.go
@@ -150,8 +150,7 @@ func (cs *CerbosPlaygroundService) PlaygroundEvaluate(ctx context.Context, req *
 
 	auxData, err := cs.auxData.Extract(ctx, req.AuxData)
 	if err != nil {
-		var extractErr auxdata.JWTExtractionError
-		if errors.As(err, &extractErr) {
+		if extractErr, ok := errors.AsType[auxdata.JWTExtractionError](err); ok {
 			log.Error(fmt.Sprintf("Failed to extract auxData: %s", extractErr.Description), zap.Error(extractErr.Cause))
 		} else {
 			log.Error("Failed to extract auxData", zap.Error(err))
@@ -271,8 +270,7 @@ func (cs *CerbosPlaygroundService) PlaygroundProxy(ctx context.Context, req *req
 func doCompile(ctx context.Context, log *zap.Logger, files []*requestv1.File) (*components, *responsev1.PlaygroundFailure, error) {
 	idx, err := buildIndex(ctx, log, files)
 	if err != nil {
-		idxErr := new(index.BuildError)
-		if errors.As(err, &idxErr) {
+		if idxErr, ok := errors.AsType[*index.BuildError](err); ok {
 			pf := processLintErrors(ctx, idxErr)
 			return nil, pf, nil
 		}
@@ -285,8 +283,7 @@ func doCompile(ctx context.Context, log *zap.Logger, files []*requestv1.File) (*
 	schemaMgr := schema.NewFromConf(ctx, store, schema.NewConf(schema.EnforcementWarn))
 
 	if err := compile.BatchCompile(idx.GetAllCompilationUnits(ctx), schemaMgr); err != nil {
-		compErr := new(compile.ErrorSet)
-		if errors.As(err, &compErr) {
+		if compErr, ok := errors.AsType[*compile.ErrorSet](err); ok {
 			pf := processCompileErrors(ctx, compErr)
 			return nil, pf, nil
 		}

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -69,9 +69,8 @@ func AddSchemasToStore(t *testing.T, dir string, ms storage.MutableStore) {
 		if err := ms.AddOrUpdateSchema(t.Context(), &schemav1.Schema{
 			Id:         path,
 			Definition: ReadSchemaFromFS(t, fsys, path),
-		}); err != nil && !errors.Is(err, &storage.InvalidSchemaError{}) {
-			var ise storage.InvalidSchemaError
-			if ok := errors.As(err, &ise); !ok {
+		}); err != nil {
+			if _, ok := errors.AsType[storage.InvalidSchemaError](err); !ok {
 				return err
 			}
 		}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -23,8 +23,8 @@ type validator func(proto.Message, ...protovalidate.ValidationOption) error
 func (v validator) Validate(msg proto.Message, options ...protovalidate.ValidationOption) error {
 	err := v(msg, options...)
 
-	var validationErr *protovalidate.ValidationError
-	if !errors.As(err, &validationErr) {
+	validationErr, ok := errors.AsType[*protovalidate.ValidationError](err)
+	if !ok {
 		return err
 	}
 
@@ -45,7 +45,7 @@ func (v validator) Validate(msg proto.Message, options ...protovalidate.Validati
 			}
 
 			slices.Sort(allowedNames)
-			violation.Proto.Message = proto.String(fmt.Sprintf("must be one of [%s]", strings.Join(allowedNames, ", ")))
+			violation.Proto.Message = new(fmt.Sprintf("must be one of [%s]", strings.Join(allowedNames, ", ")))
 		}
 	}
 

--- a/private/compile/compile.go
+++ b/private/compile/compile.go
@@ -72,17 +72,17 @@ func BuildIndex(ctx context.Context, fsys fs.FS, attrs ...SourceAttribute) (Inde
 
 	idx, err := index.Build(ctx, fsys, index.WithSourceAttributes(srcAttrs...))
 	if err != nil {
-		idxErrs := new(index.BuildError)
-		if errors.As(err, &idxErrs) {
+		if idxErrs, ok := errors.AsType[*index.BuildError](err); ok {
 			return nil, &Errors{
 				Errors: &runtimev1.Errors{
-					Kind: &runtimev1.Errors_IndexBuildErrors{IndexBuildErrors: idxErrs.IndexBuildErrors},
+					Kind: &runtimev1.Errors_IndexBuildErrors{
+						IndexBuildErrors: idxErrs.IndexBuildErrors,
+					},
 				},
 			}
 		}
 
-		panicErr := new(parser.PanicError)
-		if errors.As(err, panicErr) {
+		if panicErr, ok := errors.AsType[parser.PanicError](err); ok {
 			return nil, PanicError{Cause: panicErr.Cause, Context: panicErr.Context}
 		}
 
@@ -124,8 +124,7 @@ func Files(ctx context.Context, fsys fs.FS, schemaResolverMaker SchemaResolverMa
 
 			if artefact.Error != nil {
 				log.Error("Compilation failed", zap.Error(artefact.Error))
-				compErrs := new(internalcompile.ErrorSet)
-				if errors.As(artefact.Error, &compErrs) {
+				if compErrs, ok := errors.AsType[*internalcompile.ErrorSet](artefact.Error); ok {
 					artefact.Error = &Errors{
 						Errors: &runtimev1.Errors{
 							Kind: &runtimev1.Errors_CompileErrors{CompileErrors: compErrs.Errors()},

--- a/private/policy/policy.go
+++ b/private/policy/policy.go
@@ -43,8 +43,7 @@ func Read(src io.Reader) (*policyv1.Policy, error) {
 	}
 
 	if err := policy.Validate(p, sc); err != nil {
-		var verr policy.ValidationError
-		if errors.As(err, &verr) {
+		if verr, ok := errors.AsType[policy.ValidationError](err); ok {
 			return nil, ReadError{Errors: []*sourcev1.Error{verr.Err}}
 		}
 

--- a/private/verify/verify.go
+++ b/private/verify/verify.go
@@ -34,8 +34,7 @@ func Files(ctx context.Context, fsys fs.FS, idx compile.Index, trace bool) (*pol
 		var err error
 		idx, err = index.Build(ctx, fsys, index.WithBuildFailureLogLevel(zap.DebugLevel))
 		if err != nil {
-			idxErrs := new(index.BuildError)
-			if errors.As(err, &idxErrs) {
+			if idxErrs, ok := errors.AsType[*index.BuildError](err); ok {
 				return nil, &compile.Errors{
 					Errors: &runtimev1.Errors{
 						Kind: &runtimev1.Errors_IndexBuildErrors{IndexBuildErrors: idxErrs.IndexBuildErrors},


### PR DESCRIPTION
# Description

This PR updates Go to `1.26`.
All occurences of `errors.As` are replaced with newly introduced `errors.AsType`.
Additionally, `new()` is used to create pointer to types when possible.