### PR TITLE
Fix panic in E2E blob test

### DIFF
--- a/e2e/blob/blob_test.go
+++ b/e2e/blob/blob_test.go
@@ -133,6 +133,7 @@ func countExpectedPolicies(tb testing.TB, root string) int {
 			return nil
 		}
 
+		tb.Logf(">>> Checking %s", path)
 		if p.Disabled {
 			return nil
 		}

--- a/e2e/blob/blob_test.go
+++ b/e2e/blob/blob_test.go
@@ -112,7 +112,7 @@ func countExpectedPolicies(tb testing.TB, root string) int {
 		}
 
 		if d.IsDir() {
-			if name == schema.Directory {
+			if name == schema.Directory || name == util.TestDataDirectory {
 				return filepath.SkipDir
 			}
 			return nil

--- a/e2e/blob/blob_test.go
+++ b/e2e/blob/blob_test.go
@@ -128,12 +128,11 @@ func countExpectedPolicies(tb testing.TB, root string) int {
 		}
 
 		p, _, err := policy.ReadPolicy(bytes.NewReader(b))
-		if err != nil {
+		if err != nil || p == nil {
 			// ignore invalid policies
 			return nil
 		}
 
-		tb.Logf(">>> Checking %s", path)
 		if p.Disabled {
 			return nil
 		}


### PR DESCRIPTION
Because of the parser switch,  `internal/test/testdata/store/resource_policies/testdata/ignored.yaml` now returns a nil object rather than an error. This PR adds a check for that. The test shouldn't be reading the `testdata` directory looking for policies either. That's been fixed as well. 