### PR TITLE
docs: add Copy as Markdown button to docs toolbar

### DIFF
--- a/docs/supplemental-ui/css/site-extra.css
+++ b/docs/supplemental-ui/css/site-extra.css
@@ -51,3 +51,63 @@
   }
 }
 
+/* Toolbar action buttons: "Copy as Markdown" and "Edit this Page" share one look */
+.toolbar .copy-page-md-wrapper {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  padding-right: 0.7rem;
+}
+
+.toolbar .edit-this-page {
+  display: flex;
+  align-items: center;
+  padding-right: 0.5rem;
+}
+
+.copy-page-md,
+.toolbar .edit-this-page a {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35em;
+  padding: 0.2em 0.6em;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: 1.4;
+  color: #5d5d5d;
+  background-color: #fff;
+  border: 1px solid #dbdbdb;
+  border-radius: 0.25em;
+  cursor: pointer;
+  white-space: nowrap;
+  text-decoration: none;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.copy-page-md:hover:not(:disabled),
+.copy-page-md.is-copied,
+.toolbar .edit-this-page a:hover {
+  background-color: #ffb901;
+  border-color: #ffb901;
+  color: #000;
+}
+
+.copy-page-md.is-error {
+  background-color: #fff;
+  border-color: #cc0f35;
+  color: #cc0f35;
+}
+
+.copy-page-md:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.doc-action-icon {
+  width: 1em;
+  height: 1em;
+  flex: 0 0 auto;
+}
+

--- a/docs/supplemental-ui/helpers/mdUrl.js
+++ b/docs/supplemental-ui/helpers/mdUrl.js
@@ -1,0 +1,11 @@
+'use strict'
+
+// Maps a page URL to its generated Markdown counterpart, matching the
+// llm-generator plugin output: foo.html -> foo.md, and directory/root
+// URLs (ending in "/") -> index.md.
+module.exports = (url) => {
+  if (!url || typeof url !== 'string') return url
+  const clean = url.split(/[?#]/)[0]
+  if (clean.endsWith('.html')) return clean.replace(/\.html$/, '.md')
+  return clean.replace(/\/$/, '') + '/index.md'
+}

--- a/docs/supplemental-ui/js/copy-page-md.js
+++ b/docs/supplemental-ui/js/copy-page-md.js
@@ -1,0 +1,79 @@
+;(function () {
+  'use strict'
+
+  function mdUrlFor (pageUrl) {
+    var base = (pageUrl || window.location.pathname).split(/[?#]/)[0]
+    if (/\.html$/.test(base)) return base.replace(/\.html$/, '.md')
+    // Directory-style URL (root or a path ending in "/") maps to index.md,
+    // matching the llm-generator's foo.html -> foo.md / index.html -> index.md output.
+    return base.replace(/\/$/, '') + '/index.md'
+  }
+
+  function init () {
+    var btn = document.querySelector('.copy-page-md')
+    if (!btn) return
+
+    var label = btn.querySelector('.copy-page-md-label')
+    var defaultText = label ? label.textContent : ''
+    var mdUrl = mdUrlFor(btn.getAttribute('data-page-url'))
+    var resetTimer
+
+    // Lock the width to the initial (longest) label so swapping to
+    // "Copied!" / "Copy failed" doesn't reflow the toolbar.
+    var initialWidth = btn.offsetWidth
+    if (initialWidth) btn.style.minWidth = initialWidth + 'px'
+
+    function flash (text, state) {
+      if (label) label.textContent = text
+      btn.classList.remove('is-copied', 'is-error')
+      if (state) btn.classList.add(state)
+      window.clearTimeout(resetTimer)
+      resetTimer = window.setTimeout(function () {
+        if (label) label.textContent = defaultText
+        btn.classList.remove('is-copied', 'is-error')
+      }, 2000)
+    }
+
+    function copy (text) {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text)
+      }
+      // Fallback for older / non-secure-context browsers.
+      return new Promise(function (resolve, reject) {
+        try {
+          var ta = document.createElement('textarea')
+          ta.value = text
+          ta.setAttribute('readonly', '')
+          ta.style.position = 'absolute'
+          ta.style.left = '-9999px'
+          document.body.appendChild(ta)
+          ta.select()
+          document.execCommand('copy')
+          document.body.removeChild(ta)
+          resolve()
+        } catch (err) {
+          reject(err)
+        }
+      })
+    }
+
+    btn.addEventListener('click', function () {
+      btn.disabled = true
+      fetch(mdUrl)
+        .then(function (res) {
+          if (!res.ok) throw new Error('HTTP ' + res.status)
+          return res.text()
+        })
+        .then(copy)
+        .then(function () { flash('Copied!', 'is-copied') })
+        .catch(function () { flash('Copy failed', 'is-error') })
+        .then(function () { btn.disabled = false })
+    })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init)
+  } else {
+    init()
+  }
+})()

--- a/docs/supplemental-ui/partials/edit-this-page.hbs
+++ b/docs/supplemental-ui/partials/edit-this-page.hbs
@@ -1,0 +1,5 @@
+{{#if (and page.fileUri (not env.CI))}}
+<div class="edit-this-page"><a href="{{page.fileUri}}"><svg class="doc-action-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"></path></svg><span>Edit this Page</span></a></div>
+{{else if (and page.editUrl (or env.FORCE_SHOW_EDIT_PAGE_LINK (not page.origin.private)))}}
+<div class="edit-this-page"><a href="{{page.editUrl}}"><svg class="doc-action-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"></path></svg><span>Edit this Page</span></a></div>
+{{/if}}

--- a/docs/supplemental-ui/partials/footer-content.hbs
+++ b/docs/supplemental-ui/partials/footer-content.hbs
@@ -17,3 +17,4 @@ docsearch({
 </script>
 <script src="{{uiRootPath}}/tabs-block/behaviour.js"></script>
 <!-- End Algolia DocSearch -->
+<script src="{{uiRootPath}}/js/copy-page-md.js"></script>

--- a/docs/supplemental-ui/partials/head-meta.hbs
+++ b/docs/supplemental-ui/partials/head-meta.hbs
@@ -1,6 +1,10 @@
 <link rel="stylesheet" href="{{uiRootPath}}/css/site-extra.css">
 <link rel="stylesheet" href="{{uiRootPath}}/css/tabs-block.css">
 
+{{#if page.url}}
+<link rel="alternate" type="text/markdown" href="{{site.url}}{{mdUrl page.url}}">
+{{/if}}
+
 <link rel="apple-touch-icon" sizes="180x180" href="{{uiRootPath}}/favicon/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="{{uiRootPath}}/favicon/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="{{uiRootPath}}/favicon/favicon-16x16.png">

--- a/docs/supplemental-ui/partials/toolbar.hbs
+++ b/docs/supplemental-ui/partials/toolbar.hbs
@@ -1,0 +1,20 @@
+<div class="toolbar" role="navigation">
+{{> nav-toggle}}
+  {{#with site.homeUrl}}
+  <a href="{{{relativize this}}}" class="home-link{{#if @root.page.home}} is-current{{/if}}"></a>
+  {{/with}}
+{{> breadcrumbs}}
+{{> page-versions}}
+{{> edit-this-page}}
+{{#if page.url}}
+<div class="copy-page-md-wrapper">
+<button class="copy-page-md" type="button" data-page-url="{{page.url}}" title="Copy this page as Markdown" aria-label="Copy this page as Markdown">
+<svg class="doc-action-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+</svg>
+<span class="copy-page-md-label">Copy as Markdown</span>
+</button>
+</div>
+{{/if}}
+</div>


### PR DESCRIPTION
Adds a **Copy as Markdown** button to the docs toolbar, next to **Edit this Page**. Clicking it copies the page's generated `.md` (from the llm-generator plugin) to the clipboard.

<img width="533" height="249" alt="image" src="https://github.com/user-attachments/assets/d3f47456-ea46-475b-be78-de93f84bdb23" />
