### PR TITLE
Streaming source stores

### DIFF
--- a/internal/compile/manager.go
+++ b/internal/compile/manager.go
@@ -120,7 +120,7 @@ func (c *Manager) GetAllStreaming(ctx context.Context, yield func(*runtimev1.Run
 			return err
 		}
 
-		// Drop it as soon as it compiled.
+		// Drop it as soon as it is compiled.
 		cus[i] = nil
 	}
 

--- a/internal/compile/manager.go
+++ b/internal/compile/manager.go
@@ -90,6 +90,43 @@ func (c *Manager) GetAll(ctx context.Context) ([]*runtimev1.RunnablePolicySet, e
 	return rpsSet, nil
 }
 
+// GetAllStreaming compiles compilation units one at a time and yields each compiled
+// policy set.
+func (c *Manager) GetAllStreaming(ctx context.Context, yield func(*runtimev1.RunnablePolicySet) error) error {
+	compileAndYield := func(cu *policy.CompilationUnit) error {
+		rps, err := c.compile(cu)
+		if err != nil {
+			return PolicyCompilationErr{underlying: err}
+		}
+
+		if rps == nil {
+			return nil
+		}
+
+		return yield(rps)
+	}
+
+	if ss, ok := c.store.(storage.StreamingSourceStore); ok {
+		return ss.GetAllStreaming(ctx, compileAndYield)
+	}
+
+	cus, err := c.store.GetAll(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get compilation units: %w", err)
+	}
+
+	for i, cu := range cus {
+		if err := compileAndYield(cu); err != nil {
+			return err
+		}
+
+		// Drop it as soon as it compiled.
+		cus[i] = nil
+	}
+
+	return nil
+}
+
 func (c *Manager) GetAllMatching(ctx context.Context, modIDs []namer.ModuleID) ([]*runtimev1.RunnablePolicySet, error) {
 	res := []*runtimev1.RunnablePolicySet{}
 

--- a/internal/engine/policyloader/policy_loader.go
+++ b/internal/engine/policyloader/policy_loader.go
@@ -17,3 +17,9 @@ type PolicyLoader interface {
 	GetAllMatching(context.Context, []namer.ModuleID) ([]*runtimev1.RunnablePolicySet, error)
 	Source() *auditv1.PolicySource
 }
+
+// StreamingPolicyLoader is an optional interface for loaders that can yield compiled
+// policy sets one at a time.
+type StreamingPolicyLoader interface {
+	GetAllStreaming(ctx context.Context, yield func(*runtimev1.RunnablePolicySet) error) error
+}

--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -1001,11 +1001,6 @@ func (m *Index) ScopedPrincipalExists(version string, scopes []string) bool {
 	return intersectionNonEmpty(versionBM, scopeBM, kindBM)
 }
 
-func (m *Index) Reset() {
-	m.bi = newBitmapIndex()
-	m.parentRoles = nil
-}
-
 // getOrGenerateParams returns cached RowParams for the given proto content hash,
 // compiling CEL programs on miss. Rows with identical params share the same pointer and Key.
 func getOrGenerateParams(cache map[uint64]*RowParams, proto *runtimev1.RuleTable_RuleRow_Params) (*RowParams, error) {

--- a/internal/ruletable/manager.go
+++ b/internal/ruletable/manager.go
@@ -188,16 +188,7 @@ func (mgr *Manager) addPolicy(rps *runtimev1.RunnablePolicySet) error {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 
-	rows := AddPolicy(mgr.RuleTable.RuleTable, rps)
-	if err := mgr.indexRules(rows); err != nil {
-		return fmt.Errorf("failed to index and purge rules: %w", err)
-	}
-
-	for _, row := range rows {
-		conditions.WalkExprs(row, func(e *runtimev1.Expr) { e.Checked = nil })
-	}
-
-	return nil
+	return mgr.RuleTable.ingestPolicy(rps)
 }
 
 func (mgr *Manager) deletePolicy(moduleID namer.ModuleID) error {

--- a/internal/ruletable/manager.go
+++ b/internal/ruletable/manager.go
@@ -188,7 +188,7 @@ func (mgr *Manager) addPolicy(rps *runtimev1.RunnablePolicySet) error {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 
-	return mgr.RuleTable.ingestPolicy(rps)
+	return mgr.ingestPolicy(rps)
 }
 
 func (mgr *Manager) deletePolicy(moduleID namer.ModuleID) error {

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -623,7 +623,7 @@ func newRuleTableFromStreamingLoader(ctx context.Context, spl policyloader.Strea
 		programCache:  NewProgramCache(),
 		planExprCache: planner.NewExprCache(),
 	}
-	rt.resetBuildState()
+	rt.initBuildState()
 
 	if err := spl.GetAllStreaming(ctx, rt.ingestPolicy); err != nil {
 		return nil, fmt.Errorf("failed to load policies: %w", err)
@@ -657,7 +657,7 @@ func (rt *RuleTable) init(protoRT *runtimev1.RuleTable) error {
 		return err
 	}
 
-	rt.resetBuildState()
+	rt.initBuildState()
 
 	if err := rt.indexRules(rt.Rules); err != nil {
 		return err
@@ -668,15 +668,7 @@ func (rt *RuleTable) init(protoRT *runtimev1.RuleTable) error {
 	return nil
 }
 
-func (rt *RuleTable) resetBuildState() {
-	clear(rt.policyDerivedRoles)
-	clear(rt.principalScopeMap)
-	clear(rt.resourceScopeMap)
-	clear(rt.scopeScopePermissions)
-	rt.programCache.Clear()
-	rt.planExprCache.Clear()
-
-	rt.idx.Reset()
+func (rt *RuleTable) initBuildState() {
 	rt.policyDerivedRoles = make(map[namer.ModuleID]map[string]*WrappedRunnableDerivedRole)
 	rt.principalScopeMap = make(map[string]struct{})
 	rt.resourceScopeMap = make(map[string]struct{})

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -603,6 +603,10 @@ func paceBuildGC() (restore func()) {
 func NewRuleTableFromLoader(ctx context.Context, policyLoader policyloader.PolicyLoader) (*RuleTable, error) {
 	defer paceBuildGC()()
 
+	if spl, ok := policyLoader.(policyloader.StreamingPolicyLoader); ok {
+		return newRuleTableFromStreamingLoader(ctx, spl)
+	}
+
 	protoRT := NewProtoRuletable()
 
 	if err := LoadPolicies(ctx, protoRT, policyLoader); err != nil {
@@ -610,6 +614,24 @@ func NewRuleTableFromLoader(ctx context.Context, policyLoader policyloader.Polic
 	}
 
 	return NewRuleTable(protoRT)
+}
+
+func newRuleTableFromStreamingLoader(ctx context.Context, spl policyloader.StreamingPolicyLoader) (*RuleTable, error) {
+	rt := &RuleTable{
+		RuleTable:     NewProtoRuletable(),
+		idx:           index.New(),
+		programCache:  NewProgramCache(),
+		planExprCache: planner.NewExprCache(),
+	}
+	rt.resetBuildState()
+
+	if err := spl.GetAllStreaming(ctx, rt.ingestPolicy); err != nil {
+		return nil, fmt.Errorf("failed to load policies: %w", err)
+	}
+
+	rt.finalizeBuild()
+
+	return rt, nil
 }
 
 func NewRuleTable(protoRT *runtimev1.RuleTable) (*RuleTable, error) {
@@ -635,7 +657,18 @@ func (rt *RuleTable) init(protoRT *runtimev1.RuleTable) error {
 		return err
 	}
 
-	// clear maps prior to creating new ones to reduce memory pressure in reload scenarios
+	rt.resetBuildState()
+
+	if err := rt.indexRules(rt.Rules); err != nil {
+		return err
+	}
+
+	rt.finalizeBuild()
+
+	return nil
+}
+
+func (rt *RuleTable) resetBuildState() {
 	clear(rt.policyDerivedRoles)
 	clear(rt.principalScopeMap)
 	clear(rt.resourceScopeMap)
@@ -648,11 +681,10 @@ func (rt *RuleTable) init(protoRT *runtimev1.RuleTable) error {
 	rt.principalScopeMap = make(map[string]struct{})
 	rt.resourceScopeMap = make(map[string]struct{})
 	rt.scopeScopePermissions = make(map[string]policyv1.ScopePermissions)
+}
 
-	if err := rt.indexRules(rt.Rules); err != nil {
-		return err
-	}
-
+// finalizeBuild releases transient build state once all rows have been indexed.
+func (rt *RuleTable) finalizeBuild() {
 	// rules are now indexed, we can clear up any unnecessary transport state
 	clear(rt.Rules)
 	rt.Rules = []*runtimev1.RuleTable_RuleRow{} // otherwise the empty slice hangs around
@@ -667,8 +699,6 @@ func (rt *RuleTable) init(protoRT *runtimev1.RuleTable) error {
 	rt.releaseCheckedExprs()
 	rt.dedupStrings()
 	debug.FreeOSMemory()
-
-	return nil
 }
 
 // releaseCheckedExprs sets to nil every retained *Expr.Checked.
@@ -711,6 +741,26 @@ func (rt *RuleTable) releaseCheckedExprs() {
 			}
 		}
 	}
+}
+
+// ingestPolicy adds a single compiled policy set to the rule table, indexes its rows,
+// and releases the CheckedExprs of those rows.
+func (rt *RuleTable) ingestPolicy(rps *runtimev1.RunnablePolicySet) error {
+	if rps == nil {
+		return nil
+	}
+
+	rows := AddPolicy(rt.RuleTable, rps)
+	if err := rt.indexRules(rows); err != nil {
+		return fmt.Errorf("failed to index and purge rules: %w", err)
+	}
+
+	nilChecked := func(e *runtimev1.Expr) { e.Checked = nil }
+	for _, row := range rows {
+		conditions.WalkExprs(row, nilChecked)
+	}
+
+	return nil
 }
 
 func (rt *RuleTable) indexRules(rules []*runtimev1.RuleTable_RuleRow) error {

--- a/internal/storage/blob/store.go
+++ b/internal/storage/blob/store.go
@@ -517,6 +517,10 @@ func (s *Store) GetAll(ctx context.Context) ([]*policy.CompilationUnit, error) {
 	return s.idx.GetAll(ctx)
 }
 
+func (s *Store) GetAllStreaming(ctx context.Context, fn func(*policy.CompilationUnit) error) error {
+	return index.StreamAll(ctx, s.idx, fn)
+}
+
 func (s *Store) GetAllMatching(_ context.Context, modIDs []namer.ModuleID) ([]*policy.CompilationUnit, error) {
 	return s.idx.GetAllMatching(modIDs)
 }

--- a/internal/storage/disk/disk.go
+++ b/internal/storage/disk/disk.go
@@ -125,6 +125,10 @@ func (s *Store) GetAll(ctx context.Context) ([]*policy.CompilationUnit, error) {
 	return s.idx.GetAll(ctx)
 }
 
+func (s *Store) GetAllStreaming(ctx context.Context, fn func(*policy.CompilationUnit) error) error {
+	return index.StreamAll(ctx, s.idx, fn)
+}
+
 func (s *Store) GetAllMatching(_ context.Context, modIDs []namer.ModuleID) ([]*policy.CompilationUnit, error) {
 	return s.idx.GetAllMatching(modIDs)
 }

--- a/internal/storage/git/store.go
+++ b/internal/storage/git/store.go
@@ -172,6 +172,10 @@ func (s *Store) GetAll(ctx context.Context) ([]*policy.CompilationUnit, error) {
 	return s.idx.GetAll(ctx)
 }
 
+func (s *Store) GetAllStreaming(ctx context.Context, fn func(*policy.CompilationUnit) error) error {
+	return index.StreamAll(ctx, s.idx, fn)
+}
+
 func (s *Store) GetAllMatching(_ context.Context, modIDs []namer.ModuleID) ([]*policy.CompilationUnit, error) {
 	return s.idx.GetAllMatching(modIDs)
 }

--- a/internal/storage/index/index.go
+++ b/internal/storage/index/index.go
@@ -396,6 +396,24 @@ func (idx *index) GetAllCompilationUnits(ctx context.Context) <-chan *policy.Com
 	return ch
 }
 
+// StreamAll lazily loads each compilation unit from the index and passes it to fn, holding
+// only one unit resident at a time.
+func StreamAll(ctx context.Context, idx Index, fn func(*policy.CompilationUnit) error) error {
+	// Cancel on early return so the producer goroutine started by
+	// GetAllCompilationUnitsWithCount unblocks instead of leaking.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	_, ch := idx.GetAllCompilationUnitsWithCount(ctx)
+	for cu := range ch {
+		if err := fn(cu); err != nil {
+			return err
+		}
+	}
+
+	return ctx.Err()
+}
+
 func (idx *index) GetAllCompilationUnitsWithCount(ctx context.Context) (int, <-chan *policy.CompilationUnit) {
 	idx.mu.RLock()
 	toCompile := make([]namer.ModuleID, 0, len(idx.executables))

--- a/internal/storage/index/index.go
+++ b/internal/storage/index/index.go
@@ -402,14 +402,22 @@ func StreamAll(ctx context.Context, idx Index, fn func(*policy.CompilationUnit) 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	_, ch := idx.GetAllCompilationUnitsWithCount(ctx)
+	n, ch := idx.GetAllCompilationUnitsWithCount(ctx)
+	var count int
 	for cu := range ch {
 		if err := fn(cu); err != nil {
 			return err
 		}
+		count++
 	}
 
-	return ctx.Err()
+	if count < n {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (idx *index) GetAllCompilationUnitsWithCount(ctx context.Context) (int, <-chan *policy.CompilationUnit) {

--- a/internal/storage/index/index.go
+++ b/internal/storage/index/index.go
@@ -399,8 +399,6 @@ func (idx *index) GetAllCompilationUnits(ctx context.Context) <-chan *policy.Com
 // StreamAll lazily loads each compilation unit from the index and passes it to fn, holding
 // only one unit resident at a time.
 func StreamAll(ctx context.Context, idx Index, fn func(*policy.CompilationUnit) error) error {
-	// Cancel on early return so the producer goroutine started by
-	// GetAllCompilationUnitsWithCount unblocks instead of leaking.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -155,6 +155,12 @@ type SourceStore interface {
 	LoadPolicy(context.Context, ...string) ([]*policy.Wrapper, error)
 }
 
+// StreamingSourceStore is an optional interface for source stores that can yield their
+// compilation units one at a time instead of materialising them all into a slice.
+type StreamingSourceStore interface {
+	GetAllStreaming(ctx context.Context, fn func(*policy.CompilationUnit) error) error
+}
+
 // BinaryStore is implemented by stores that have pre-compiled policies in binary format.
 type BinaryStore interface {
 	Store


### PR DESCRIPTION
This PR aims to reduce the (peak) build-time working set by loading and compiling policies one by one. 

On a test (disk) store with 8,000 policy files:
| Metric                  | main | streaming-source-stores | Delta        |
|-------------------------|---------:|---------:|-------------:|
| heap_alloc (MiB)         |    43.43 |    43.61 |  +0.2 (~0%)  |
| heap_inuse (MiB)         |      210 |       58 |  -152 (-72%) |
| RSS (MiB)               |      305 |      128 |  -177 (-58%) |
| **VmHWM / build peak (MiB)**|      **951** |      128 |  -823 (-87%) |
