### PR TITLE
Pick up newly created policy subdirectories and their contents in dirwatch

### DIFF
--- a/.changelog/20260624_0812.txt
+++ b/.changelog/20260624_0812.txt
@@ -1,0 +1,3 @@
+type:fix
+Pick up newly created policy subdirectories and their contents in the directory watcher
+Previously, when a new subdirectory was created under a watched policy directory, the watcher only began monitoring it while draining the next batch of events. Any files or nested directories created in that window were never observed and were silently dropped from the index. Now, the watch is added immediately when the directory is created and its existing contents are traversed, so newly added subdirectories and everything within them are picked up.

--- a/internal/storage/disk/dirwatch.go
+++ b/internal/storage/disk/dirwatch.go
@@ -38,19 +38,19 @@ type notifier interface {
 	NotifySubscribers(events ...storage.Event)
 }
 
-func watchDir(ctx context.Context, dir string, idx index.Index, n notifier, cooldownPeriod time.Duration) (*dirWatch, error) {
+func watchDir(ctx context.Context, dir string, idx index.Index, n notifier, cooldownPeriod time.Duration) error {
 	resolved, err := filepath.EvalSymlinks(dir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve directory %s: %w", dir, err)
+		return fmt.Errorf("failed to resolve directory %s: %w", dir, err)
 	}
 
 	watcher, err := fsnotify.NewBufferedWatcher(defaultBufferSize)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create watcher: %w", err)
+		return fmt.Errorf("failed to create watcher: %w", err)
 	}
 
 	if err := watcher.Add(resolved); err != nil {
-		return nil, fmt.Errorf("failed to initiate monitoring on the directory %s: %w", resolved, err)
+		return fmt.Errorf("failed to initiate monitoring on the directory %s: %w", resolved, err)
 	}
 
 	// We need to manually traverse the tree to add all directories because fsnotify package does not support recursive monitoring.
@@ -60,7 +60,7 @@ func watchDir(ctx context.Context, dir string, idx index.Index, n notifier, cool
 			return err
 		}
 
-		if !d.IsDir() || util.PathIsHidden(path) {
+		if !d.IsDir() || util.PathIsHidden(path) || d.Name() == util.TestDataDirectory {
 			return nil
 		}
 
@@ -70,7 +70,7 @@ func watchDir(ctx context.Context, dir string, idx index.Index, n notifier, cool
 
 		return nil
 	}); err != nil {
-		return nil, fmt.Errorf("failed to walk directory %s: %w", resolved, err)
+		return fmt.Errorf("failed to walk directory %s: %w", resolved, err)
 	}
 
 	dw := &dirWatch{
@@ -85,7 +85,7 @@ func watchDir(ctx context.Context, dir string, idx index.Index, n notifier, cool
 
 	go dw.listen(ctx) //nolint:gosec
 
-	return dw, nil
+	return nil
 }
 
 type dirWatch struct {
@@ -148,20 +148,15 @@ func (dw *dirWatch) listen(ctx context.Context) {
 }
 
 func (dw *dirWatch) processEvent(event fsnotify.Event) {
-	if event.Op.Has(fsnotify.Create) && dw.watchNewSubDir(event.Name) {
+	if event.Op.Has(fsnotify.Create) && dw.processSubdir(event.Name) {
 		return
 	}
 
 	dw.log.Debugw("Processing an event", "operation", event.Op.String(), "name", event.Name)
-
-	dw.batchEvent(event.Name)
+	dw.addToEventBatch(event.Name)
 }
 
-// watchNewSubDir starts watching path and reports whether it was a newly created subdirectory.
-// The watch is added on the creation event, because events in an unwatched directory are lost forever.
-// Its existing contents are walked for the same reason:
-// files and subdirectories created before the watch was added produce no events of their own.
-func (dw *dirWatch) watchNewSubDir(path string) bool {
+func (dw *dirWatch) processSubdir(path string) bool {
 	if util.PathIsHidden(path) {
 		return false
 	}
@@ -176,16 +171,19 @@ func (dw *dirWatch) watchNewSubDir(path string) bool {
 			return err
 		}
 
-		if !d.IsDir() {
-			dw.batchEvent(path)
-			return nil
-		}
-
-		if util.PathIsHidden(path) {
+		dir := d.IsDir()
+		hidden := util.PathIsHidden(path)
+		switch {
+		case hidden && dir:
 			return fs.SkipDir
+		case hidden && !dir:
+			return nil
+		case !hidden && !dir:
+			dw.addToEventBatch(path)
+			return nil
+		default:
+			return dw.watcher.Add(path)
 		}
-
-		return dw.watcher.Add(path)
 	}); err != nil {
 		dw.log.Errorw("Failed to initiate monitoring on the newly created subdirectory", "directory", path, "error", err)
 	}
@@ -193,10 +191,10 @@ func (dw *dirWatch) watchNewSubDir(path string) bool {
 	return true
 }
 
-func (dw *dirWatch) batchEvent(fullPath string) {
-	path, err := filepath.Rel(dw.dir, fullPath)
+func (dw *dirWatch) addToEventBatch(path string) {
+	path, err := filepath.Rel(dw.dir, path)
 	if err != nil {
-		dw.log.Warnw("Failed to determine relative path of file", "file", fullPath, "error", err)
+		dw.log.Warnw("Failed to determine relative path of file", "file", path, "error", err)
 		return
 	}
 	path = filepath.ToSlash(path)

--- a/internal/storage/disk/dirwatch.go
+++ b/internal/storage/disk/dirwatch.go
@@ -12,7 +12,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"slices"
 	"sync"
 	"time"
 
@@ -149,9 +148,55 @@ func (dw *dirWatch) listen(ctx context.Context) {
 }
 
 func (dw *dirWatch) processEvent(event fsnotify.Event) {
-	path, err := filepath.Rel(dw.dir, event.Name)
+	if event.Op.Has(fsnotify.Create) && dw.watchNewSubDir(event.Name) {
+		return
+	}
+
+	dw.log.Debugw("Processing an event", "operation", event.Op.String(), "name", event.Name)
+
+	dw.batchEvent(event.Name)
+}
+
+// watchNewSubDir starts watching path and reports whether it was a newly created subdirectory.
+// The watch is added on the creation event, because events in an unwatched directory are lost forever.
+// Its existing contents are walked for the same reason:
+// files and subdirectories created before the watch was added produce no events of their own.
+func (dw *dirWatch) watchNewSubDir(path string) bool {
+	if util.PathIsHidden(path) {
+		return false
+	}
+
+	st, err := os.Stat(path)
+	if err != nil || !st.IsDir() {
+		return false
+	}
+
+	if err := filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() {
+			dw.batchEvent(path)
+			return nil
+		}
+
+		if util.PathIsHidden(path) {
+			return fs.SkipDir
+		}
+
+		return dw.watcher.Add(path)
+	}); err != nil {
+		dw.log.Errorw("Failed to initiate monitoring on the newly created subdirectory", "directory", path, "error", err)
+	}
+
+	return true
+}
+
+func (dw *dirWatch) batchEvent(fullPath string) {
+	path, err := filepath.Rel(dw.dir, fullPath)
 	if err != nil {
-		dw.log.Warnw("Failed to determine relative path of file", "file", path, "error", err)
+		dw.log.Warnw("Failed to determine relative path of file", "file", fullPath, "error", err)
 		return
 	}
 	path = filepath.ToSlash(path)
@@ -160,8 +205,6 @@ func (dw *dirWatch) processEvent(event fsnotify.Event) {
 		dw.log.Debugw("Encountered a non-indexable file type, skipping...", "file", path)
 		return
 	}
-
-	dw.log.Debugw("Processing an event", "operation", event.Op.String(), "name", event.Name)
 
 	dw.mu.Lock()
 	dw.eventBatch[path] = struct{}{}
@@ -189,20 +232,7 @@ func (dw *dirWatch) triggerUpdate() {
 	// The deleted files need to be processed first because we could have a duplicate definition when a file is renamed otherwise.
 	for path := range eventBatch {
 		fullPath := filepath.Join(dw.dir, path)
-		st, err := os.Stat(fullPath)
-		if err == nil {
-			// We need to manually add newly created directories.
-			// See https://github.com/fsnotify/fsnotify/issues/18 for more details.
-			if st.IsDir() && !util.PathIsHidden(fullPath) && !slices.Contains(dw.watcher.WatchList(), fullPath) {
-				if err := dw.watcher.Add(fullPath); err != nil {
-					dw.log.Errorw("Failed to initiate monitoring on the newly created subdirectory", "file", fullPath, zap.Error(err))
-				}
-
-				dw.log.Debugw("Initiated monitoring on the newly created subdirectory", "file", fullPath)
-			}
-
-			continue
-		} else if !errors.Is(err, os.ErrNotExist) {
+		if _, err := os.Stat(fullPath); err == nil || !errors.Is(err, os.ErrNotExist) {
 			continue
 		}
 

--- a/internal/storage/disk/dirwatch.go
+++ b/internal/storage/disk/dirwatch.go
@@ -191,10 +191,10 @@ func (dw *dirWatch) processSubdir(path string) bool {
 	return true
 }
 
-func (dw *dirWatch) addToEventBatch(path string) {
-	path, err := filepath.Rel(dw.dir, path)
+func (dw *dirWatch) addToEventBatch(fullPath string) {
+	path, err := filepath.Rel(dw.dir, fullPath)
 	if err != nil {
-		dw.log.Warnw("Failed to determine relative path of file", "file", path, "error", err)
+		dw.log.Warnw("Failed to determine relative path of file", "file", fullPath, "error", err)
 		return
 	}
 	path = filepath.ToSlash(path)

--- a/internal/storage/disk/dirwatch.go
+++ b/internal/storage/disk/dirwatch.go
@@ -39,19 +39,19 @@ type notifier interface {
 	NotifySubscribers(events ...storage.Event)
 }
 
-func watchDir(ctx context.Context, dir string, idx index.Index, n notifier, cooldownPeriod time.Duration) error {
+func watchDir(ctx context.Context, dir string, idx index.Index, n notifier, cooldownPeriod time.Duration) (*dirWatch, error) {
 	resolved, err := filepath.EvalSymlinks(dir)
 	if err != nil {
-		return fmt.Errorf("failed to resolve directory %s: %w", dir, err)
+		return nil, fmt.Errorf("failed to resolve directory %s: %w", dir, err)
 	}
 
 	watcher, err := fsnotify.NewBufferedWatcher(defaultBufferSize)
 	if err != nil {
-		return fmt.Errorf("failed to create watcher: %w", err)
+		return nil, fmt.Errorf("failed to create watcher: %w", err)
 	}
 
 	if err := watcher.Add(resolved); err != nil {
-		return fmt.Errorf("failed to initiate monitoring on the directory %s: %w", resolved, err)
+		return nil, fmt.Errorf("failed to initiate monitoring on the directory %s: %w", resolved, err)
 	}
 
 	// We need to manually traverse the tree to add all directories because fsnotify package does not support recursive monitoring.
@@ -71,7 +71,7 @@ func watchDir(ctx context.Context, dir string, idx index.Index, n notifier, cool
 
 		return nil
 	}); err != nil {
-		return fmt.Errorf("failed to walk directory %s: %w", resolved, err)
+		return nil, fmt.Errorf("failed to walk directory %s: %w", resolved, err)
 	}
 
 	dw := &dirWatch{
@@ -86,7 +86,7 @@ func watchDir(ctx context.Context, dir string, idx index.Index, n notifier, cool
 
 	go dw.listen(ctx) //nolint:gosec
 
-	return nil
+	return dw, nil
 }
 
 type dirWatch struct {

--- a/internal/storage/disk/dirwatch_test.go
+++ b/internal/storage/disk/dirwatch_test.go
@@ -25,6 +25,9 @@ import (
 const (
 	cooldownPeriod = 30 * time.Millisecond
 	timeOut        = 1000 * time.Millisecond
+	// 5x because the watcher picks up new directories at the earliest after ~2*cooldownPeriod
+	// (ticker interval + event cooldown); the rest is margin for slow CI.
+	watchSetupWait = cooldownPeriod * 5
 )
 
 func TestDirWatch(t *testing.T) {
@@ -156,6 +159,111 @@ func TestDirWatch(t *testing.T) {
 		wantEvent := storage.Event{Kind: storage.EventDeleteSchema, SchemaFile: "test.json"}
 		checkEvents(t, timeOut, wantEvent)
 	})
+
+	// Reproducer for the regression introduced by the switch to fsnotify in PR #3061 (0b1e7983):
+	// processEvent drops directory-creation events as FileTypeNotIndexed before triggerUpdate can
+	// start watching the new directory, so files created in it are silently ignored.
+	t.Run("add_file_in_new_subdir", func(t *testing.T) {
+		dir, haveEntries, checkEvents := startDirWatch(t)
+
+		subDir := filepath.Join(dir, "newdir")
+		require.NoError(t, os.Mkdir(subDir, 0o755))
+		// Events inside a not-yet-watched directory are lost forever, so wait for the watcher
+		// to pick up the new directory before creating anything inside it.
+		time.Sleep(watchSetupWait)
+
+		rp := policy.Wrap(test.GenResourcePolicy(test.NoMod()))
+		writePolicy(t, filepath.Join(subDir, "policy.yaml"), rp.Policy)
+
+		select {
+		case <-time.After(timeOut):
+			require.Fail(t, "timed out waiting for entry from policy in dynamically created subdirectory")
+		case have := <-haveEntries:
+			require.Equal(t, "newdir/policy.yaml", have.File)
+		}
+
+		wantEvent := storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: rp.ID}
+		checkEvents(t, timeOut, wantEvent)
+	})
+
+	t.Run("add_file_in_nested_new_subdir", func(t *testing.T) {
+		dir, haveEntries, checkEvents := startDirWatch(t)
+
+		outer := filepath.Join(dir, "outer")
+		require.NoError(t, os.Mkdir(outer, 0o755))
+		// The inner directory's creation event is only visible once the outer directory is
+		// watched, so wait between the levels.
+		time.Sleep(watchSetupWait)
+
+		inner := filepath.Join(outer, "inner")
+		require.NoError(t, os.Mkdir(inner, 0o755))
+		time.Sleep(watchSetupWait)
+
+		rp := policy.Wrap(test.GenResourcePolicy(test.NoMod()))
+		writePolicy(t, filepath.Join(inner, "policy.yaml"), rp.Policy)
+
+		select {
+		case <-time.After(timeOut):
+			require.Fail(t, "timed out waiting for entry from policy in nested dynamically created subdirectory")
+		case have := <-haveEntries:
+			require.Equal(t, "outer/inner/policy.yaml", have.File)
+		}
+
+		wantEvent := storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: rp.ID}
+		checkEvents(t, timeOut, wantEvent)
+	})
+
+	// Guards the fix against over-eagerly watching hidden directories. The visible subdir acts as
+	// a positive control: without it, a timeout could also mean the watcher isn't working at all.
+	t.Run("new_hidden_subdir_ignored", func(t *testing.T) {
+		dir, haveEntries, _ := startDirWatch(t)
+
+		hidden := filepath.Join(dir, ".hidden")
+		require.NoError(t, os.Mkdir(hidden, 0o755))
+		visible := filepath.Join(dir, "visible")
+		require.NoError(t, os.Mkdir(visible, 0o755))
+		time.Sleep(watchSetupWait)
+
+		rp := policy.Wrap(test.GenResourcePolicy(test.NoMod()))
+		writePolicy(t, filepath.Join(hidden, "policy.yaml"), rp.Policy)
+		writePolicy(t, filepath.Join(visible, "policy.yaml"), rp.Policy)
+
+		select {
+		case <-time.After(timeOut):
+			require.Fail(t, "timed out waiting for entry from policy in visible subdirectory")
+		case have := <-haveEntries:
+			require.Equal(t, "visible/policy.yaml", have.File,
+				"only the visible subdirectory's policy should be indexed")
+		}
+
+		select {
+		case have := <-haveEntries:
+			require.Failf(t, "unexpected entry from hidden subdirectory", "got %q", have.File)
+		case <-time.After(watchSetupWait):
+		}
+	})
+}
+
+// The AddOrUpdate expectation is Maybe() so that tests expecting no calls can use the same helper.
+func startDirWatch(t *testing.T) (dir string, haveEntries chan index.Entry, checkEvents func(*testing.T, time.Duration, ...storage.Event)) {
+	t.Helper()
+
+	ctx, cancelFunc := context.WithCancel(t.Context())
+	t.Cleanup(cancelFunc)
+
+	subMgr := storage.NewSubscriptionManager(ctx)
+	mockIdx := &mocks.Index{}
+	dir = t.TempDir()
+
+	require.NoError(t, watchDir(ctx, dir, mockIdx, subMgr, cooldownPeriod))
+
+	haveEntries = make(chan index.Entry, 8)
+	mockIdx.On("AddOrUpdate", mock.Anything).Return(func(entry index.Entry) storage.Event {
+		haveEntries <- entry
+		return storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: entry.Policy.ID}
+	}, nil).Maybe()
+
+	return dir, haveEntries, storage.TestSubscription(subMgr)
 }
 
 func writePolicy(t *testing.T, fileName string, p *policyv1.Policy) {

--- a/internal/storage/disk/dirwatch_test.go
+++ b/internal/storage/disk/dirwatch_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"slices"
 	"testing"
 	"time"
 
@@ -37,23 +36,14 @@ func TestDirWatch(t *testing.T) {
 	}
 
 	t.Run("add_file", func(t *testing.T) {
-		ctx, cancelFunc := context.WithCancel(t.Context())
-		defer cancelFunc()
-
-		subMgr := storage.NewSubscriptionManager(ctx)
-		mockIdx := &mocks.Index{}
 		dir := t.TempDir()
-
-		_, err := watchDir(ctx, dir, mockIdx, subMgr, cooldownPeriod)
-		require.NoError(t, err)
+		mockIdx, checkEvents := startDirWatch(t, dir)
 
 		haveEntries := make(chan index.Entry, 8)
 		mockIdx.On("AddOrUpdate", mock.Anything).Return(func(entry index.Entry) storage.Event {
 			haveEntries <- entry
 			return storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: entry.Policy.ID}
 		}, nil)
-
-		checkEvents := storage.TestSubscription(subMgr)
 
 		// Add some files
 		rp := policy.Wrap(test.GenResourcePolicy(test.NoMod()))
@@ -75,6 +65,60 @@ func TestDirWatch(t *testing.T) {
 		checkEvents(t, timeOut, wantEvent)
 	})
 
+	t.Run("add_file_to_new_subdirectory", func(t *testing.T) {
+		dir := t.TempDir()
+		mockIdx, checkEvents := startDirWatch(t, dir)
+
+		haveEntries := make(chan index.Entry, 8)
+		mockIdx.On("AddOrUpdate", mock.Anything).Return(func(entry index.Entry) storage.Event {
+			haveEntries <- entry
+			return storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: entry.Policy.ID}
+		}, nil)
+
+		subDir := filepath.Join(dir, "subdirectory")
+		require.NoError(t, os.Mkdir(subDir, 0o700))
+
+		rp := policy.Wrap(test.GenResourcePolicy(test.NoMod()))
+		writePolicy(t, filepath.Join(subDir, "policy.yaml"), rp.Policy)
+
+		select {
+		case <-time.After(timeOut):
+			require.Fail(t, "timed out waiting for entry")
+		case have := <-haveEntries:
+			require.Equal(t, "subdirectory/policy.yaml", have.File)
+		}
+
+		wantEvent := storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: rp.ID}
+		checkEvents(t, timeOut, wantEvent)
+	})
+
+	t.Run("add_file_to_nested_subdirectories", func(t *testing.T) {
+		dir := t.TempDir()
+		mockIdx, checkEvents := startDirWatch(t, dir)
+
+		haveEntries := make(chan index.Entry, 8)
+		mockIdx.On("AddOrUpdate", mock.Anything).Return(func(entry index.Entry) storage.Event {
+			haveEntries <- entry
+			return storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: entry.Policy.ID}
+		}, nil)
+
+		inner := filepath.Join(dir, "outer", "inner")
+		require.NoError(t, os.MkdirAll(inner, 0o700))
+
+		rp := policy.Wrap(test.GenResourcePolicy(test.NoMod()))
+		writePolicy(t, filepath.Join(inner, "policy.yaml"), rp.Policy)
+
+		select {
+		case <-time.After(timeOut):
+			require.Fail(t, "timed out waiting for entry")
+		case have := <-haveEntries:
+			require.Equal(t, "outer/inner/policy.yaml", have.File)
+		}
+
+		wantEvent := storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: rp.ID}
+		checkEvents(t, timeOut, wantEvent)
+	})
+
 	t.Run("delete_file", func(t *testing.T) {
 		// Add some files
 		dir := t.TempDir()
@@ -86,22 +130,13 @@ func TestDirWatch(t *testing.T) {
 		writePolicy(t, policyFile, rp.Policy)
 
 		// Start watch
-		ctx, cancelFunc := context.WithCancel(t.Context())
-		defer cancelFunc()
-
-		subMgr := storage.NewSubscriptionManager(ctx)
-		mockIdx := &mocks.Index{}
-
-		_, err := watchDir(ctx, dir, mockIdx, subMgr, cooldownPeriod)
-		require.NoError(t, err)
+		mockIdx, checkEvents := startDirWatch(t, dir)
 
 		haveEntries := make(chan index.Entry, 8)
 		mockIdx.On("Delete", mock.Anything).Return(func(entry index.Entry) storage.Event {
 			haveEntries <- entry
 			return storage.Event{Kind: storage.EventDeleteOrDisablePolicy, PolicyID: entry.Policy.ID}
 		}, nil)
-
-		checkEvents := storage.TestSubscription(subMgr)
 
 		// Delete the files
 		require.NoError(t, os.Remove(policyFile))
@@ -122,18 +157,9 @@ func TestDirWatch(t *testing.T) {
 	})
 
 	t.Run("add_schema_file", func(t *testing.T) {
-		ctx, cancelFunc := context.WithCancel(t.Context())
-		defer cancelFunc()
-
-		subMgr := storage.NewSubscriptionManager(ctx)
-		mockIdx := &mocks.Index{}
 		dir := t.TempDir()
 		require.NoError(t, os.Mkdir(filepath.Join(dir, schema.Directory), 0o744))
-
-		_, err := watchDir(ctx, dir, mockIdx, subMgr, cooldownPeriod)
-		require.NoError(t, err)
-
-		checkEvents := storage.TestSubscription(subMgr)
+		_, checkEvents := startDirWatch(t, dir)
 
 		touch(t, filepath.Join(dir, schema.Directory, "test.json"))
 
@@ -142,21 +168,13 @@ func TestDirWatch(t *testing.T) {
 	})
 
 	t.Run("delete_schema_file", func(t *testing.T) {
-		ctx, cancelFunc := context.WithCancel(t.Context())
-		defer cancelFunc()
-
-		subMgr := storage.NewSubscriptionManager(ctx)
-		mockIdx := &mocks.Index{}
 		dir := t.TempDir()
 		require.NoError(t, os.Mkdir(filepath.Join(dir, schema.Directory), 0o744))
 
 		schemaFile := filepath.Join(dir, schema.Directory, "test.json")
 		touch(t, schemaFile)
 
-		_, err := watchDir(ctx, dir, mockIdx, subMgr, cooldownPeriod)
-		require.NoError(t, err)
-
-		checkEvents := storage.TestSubscription(subMgr)
+		_, checkEvents := startDirWatch(t, dir)
 
 		// delete the schema file
 		require.NoError(t, os.Remove(schemaFile))
@@ -165,64 +183,19 @@ func TestDirWatch(t *testing.T) {
 		checkEvents(t, timeOut, wantEvent)
 	})
 
-	// Reproducer for the regression introduced by the switch to fsnotify in PR #3061 (0b1e7983):
-	// newly created subdirectories were never watched, so policies inside them were silently ignored.
-	// The policy is written immediately after mkdir to also cover files that arrive before the watch attaches.
-	t.Run("add_file_in_new_subdir", func(t *testing.T) {
-		dw, haveEntries, checkEvents := startDirWatch(t)
-
-		subDir := filepath.Join(dw.dir, "newdir")
-		require.NoError(t, os.Mkdir(subDir, 0o755))
-
-		rp := policy.Wrap(test.GenResourcePolicy(test.NoMod()))
-		writePolicy(t, filepath.Join(subDir, "policy.yaml"), rp.Policy)
-
-		select {
-		case <-time.After(timeOut):
-			require.Fail(t, "timed out waiting for entry from policy in dynamically created subdirectory")
-		case have := <-haveEntries:
-			require.Equal(t, "newdir/policy.yaml", have.File)
-		}
-
-		wantEvent := storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: rp.ID}
-		checkEvents(t, timeOut, wantEvent)
-	})
-
-	t.Run("add_file_in_nested_new_subdir", func(t *testing.T) {
-		dw, haveEntries, checkEvents := startDirWatch(t)
-
-		// MkdirAll creates the inner directory before the outer one is watched,
-		// so only the outer directory's creation produces an event.
-		// Everything below it must be found by scanning.
-		inner := filepath.Join(dw.dir, "outer", "inner")
-		require.NoError(t, os.MkdirAll(inner, 0o755))
-
-		rp := policy.Wrap(test.GenResourcePolicy(test.NoMod()))
-		writePolicy(t, filepath.Join(inner, "policy.yaml"), rp.Policy)
-
-		select {
-		case <-time.After(timeOut):
-			require.Fail(t, "timed out waiting for entry from policy in nested dynamically created subdirectory")
-		case have := <-haveEntries:
-			require.Equal(t, "outer/inner/policy.yaml", have.File)
-		}
-
-		wantEvent := storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: rp.ID}
-		checkEvents(t, timeOut, wantEvent)
-	})
-
-	// Guards the fix against over-eagerly watching hidden directories.
-	// The visible subdir acts as a positive control:
-	// without it, a timeout could also mean the watcher isn't working at all.
 	t.Run("new_hidden_subdir_ignored", func(t *testing.T) {
-		dw, haveEntries, _ := startDirWatch(t)
+		dir := t.TempDir()
+		mockIdx, _ := startDirWatch(t, dir)
+		haveEntries := make(chan index.Entry, 8)
+		mockIdx.On("AddOrUpdate", mock.Anything).Return(func(entry index.Entry) storage.Event {
+			haveEntries <- entry
+			return storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: entry.Policy.ID}
+		}, nil)
 
-		hidden := filepath.Join(dw.dir, ".hidden")
+		hidden := filepath.Join(dir, ".hidden")
 		require.NoError(t, os.Mkdir(hidden, 0o755))
-		visible := filepath.Join(dw.dir, "visible")
+		visible := filepath.Join(dir, "visible")
 		require.NoError(t, os.Mkdir(visible, 0o755))
-		waitUntilWatched(t, dw, visible)
-		require.NotContains(t, dw.watcher.WatchList(), hidden)
 
 		rp := policy.Wrap(test.GenResourcePolicy(test.NoMod()))
 		writePolicy(t, filepath.Join(hidden, "policy.yaml"), rp.Policy)
@@ -230,10 +203,9 @@ func TestDirWatch(t *testing.T) {
 
 		select {
 		case <-time.After(timeOut):
-			require.Fail(t, "timed out waiting for entry from policy in visible subdirectory")
+			require.Fail(t, "timed out waiting for entry")
 		case have := <-haveEntries:
-			require.Equal(t, "visible/policy.yaml", have.File,
-				"only the visible subdirectory's policy should be indexed")
+			require.Equal(t, "visible/policy.yaml", have.File)
 		}
 
 		select {
@@ -244,8 +216,9 @@ func TestDirWatch(t *testing.T) {
 	})
 }
 
-// The AddOrUpdate expectation is Maybe() so that tests expecting no calls can use the same helper.
-func startDirWatch(t *testing.T) (dw *dirWatch, haveEntries chan index.Entry, checkEvents func(*testing.T, time.Duration, ...storage.Event)) {
+type checkEventsFn func(*testing.T, time.Duration, ...storage.Event)
+
+func startDirWatch(t *testing.T, dir string) (*mocks.Index, checkEventsFn) {
 	t.Helper()
 
 	ctx, cancelFunc := context.WithCancel(t.Context())
@@ -254,26 +227,8 @@ func startDirWatch(t *testing.T) (dw *dirWatch, haveEntries chan index.Entry, ch
 	subMgr := storage.NewSubscriptionManager(ctx)
 	mockIdx := &mocks.Index{}
 
-	dw, err := watchDir(ctx, t.TempDir(), mockIdx, subMgr, cooldownPeriod)
-	require.NoError(t, err)
-
-	haveEntries = make(chan index.Entry, 8)
-	mockIdx.On("AddOrUpdate", mock.Anything).Return(func(entry index.Entry) storage.Event {
-		haveEntries <- entry
-		return storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: entry.Policy.ID}
-	}, nil).Maybe()
-
-	return dw, haveEntries, storage.TestSubscription(subMgr)
-}
-
-// waitUntilWatched blocks until dir joins the watch list,
-// because events inside a not-yet-watched directory are lost forever and would make the calling test hang.
-func waitUntilWatched(t *testing.T, dw *dirWatch, dir string) {
-	t.Helper()
-
-	require.Eventuallyf(t, func() bool {
-		return slices.Contains(dw.watcher.WatchList(), dir)
-	}, timeOut, time.Millisecond, "directory %s was never watched", dir)
+	require.NoError(t, watchDir(ctx, dir, mockIdx, subMgr, cooldownPeriod))
+	return mockIdx, storage.TestSubscription(subMgr)
 }
 
 func writePolicy(t *testing.T, fileName string, p *policyv1.Policy) {

--- a/internal/storage/disk/dirwatch_test.go
+++ b/internal/storage/disk/dirwatch_test.go
@@ -166,14 +166,13 @@ func TestDirWatch(t *testing.T) {
 	})
 
 	// Reproducer for the regression introduced by the switch to fsnotify in PR #3061 (0b1e7983):
-	// processEvent drops directory-creation events as FileTypeNotIndexed
-  // before triggerUpdate can start watching the new directory, so files created in it are silently ignored.
+	// newly created subdirectories were never watched, so policies inside them were silently ignored.
+	// The policy is written immediately after mkdir to also cover files that arrive before the watch attaches.
 	t.Run("add_file_in_new_subdir", func(t *testing.T) {
 		dw, haveEntries, checkEvents := startDirWatch(t)
 
 		subDir := filepath.Join(dw.dir, "newdir")
 		require.NoError(t, os.Mkdir(subDir, 0o755))
-		waitUntilWatched(t, dw, subDir)
 
 		rp := policy.Wrap(test.GenResourcePolicy(test.NoMod()))
 		writePolicy(t, filepath.Join(subDir, "policy.yaml"), rp.Policy)
@@ -192,14 +191,11 @@ func TestDirWatch(t *testing.T) {
 	t.Run("add_file_in_nested_new_subdir", func(t *testing.T) {
 		dw, haveEntries, checkEvents := startDirWatch(t)
 
-		// The inner directory's creation event is only visible once the outer directory is watched, so wait between the levels.
-		outer := filepath.Join(dw.dir, "outer")
-		require.NoError(t, os.Mkdir(outer, 0o755))
-		waitUntilWatched(t, dw, outer)
-
-		inner := filepath.Join(outer, "inner")
-		require.NoError(t, os.Mkdir(inner, 0o755))
-		waitUntilWatched(t, dw, inner)
+		// MkdirAll creates the inner directory before the outer one is watched,
+		// so only the outer directory's creation produces an event.
+		// Everything below it must be found by scanning.
+		inner := filepath.Join(dw.dir, "outer", "inner")
+		require.NoError(t, os.MkdirAll(inner, 0o755))
 
 		rp := policy.Wrap(test.GenResourcePolicy(test.NoMod()))
 		writePolicy(t, filepath.Join(inner, "policy.yaml"), rp.Policy)
@@ -216,8 +212,8 @@ func TestDirWatch(t *testing.T) {
 	})
 
 	// Guards the fix against over-eagerly watching hidden directories.
-  // The visible subdir acts as a positive control:
-  // without it, a timeout could also mean the watcher isn't working at all.
+	// The visible subdir acts as a positive control:
+	// without it, a timeout could also mean the watcher isn't working at all.
 	t.Run("new_hidden_subdir_ignored", func(t *testing.T) {
 		dw, haveEntries, _ := startDirWatch(t)
 

--- a/internal/storage/disk/dirwatch_test.go
+++ b/internal/storage/disk/dirwatch_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -25,9 +26,9 @@ import (
 const (
 	cooldownPeriod = 30 * time.Millisecond
 	timeOut        = 1000 * time.Millisecond
-	// 5x because the watcher picks up new directories at the earliest after ~2*cooldownPeriod
-	// (ticker interval + event cooldown); the rest is margin for slow CI.
-	watchSetupWait = cooldownPeriod * 5
+	// Long enough for an erroneously batched event to have been processed: that happens at the
+	// earliest after ~2*cooldownPeriod (ticker interval + event cooldown), the rest is CI margin.
+	noEventWait = cooldownPeriod * 5
 )
 
 func TestDirWatch(t *testing.T) {
@@ -43,7 +44,8 @@ func TestDirWatch(t *testing.T) {
 		mockIdx := &mocks.Index{}
 		dir := t.TempDir()
 
-		require.NoError(t, watchDir(ctx, dir, mockIdx, subMgr, cooldownPeriod))
+		_, err := watchDir(ctx, dir, mockIdx, subMgr, cooldownPeriod)
+		require.NoError(t, err)
 
 		haveEntries := make(chan index.Entry, 8)
 		mockIdx.On("AddOrUpdate", mock.Anything).Return(func(entry index.Entry) storage.Event {
@@ -90,7 +92,8 @@ func TestDirWatch(t *testing.T) {
 		subMgr := storage.NewSubscriptionManager(ctx)
 		mockIdx := &mocks.Index{}
 
-		require.NoError(t, watchDir(ctx, dir, mockIdx, subMgr, cooldownPeriod))
+		_, err := watchDir(ctx, dir, mockIdx, subMgr, cooldownPeriod)
+		require.NoError(t, err)
 
 		haveEntries := make(chan index.Entry, 8)
 		mockIdx.On("Delete", mock.Anything).Return(func(entry index.Entry) storage.Event {
@@ -127,7 +130,8 @@ func TestDirWatch(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, os.Mkdir(filepath.Join(dir, schema.Directory), 0o744))
 
-		require.NoError(t, watchDir(ctx, dir, mockIdx, subMgr, cooldownPeriod))
+		_, err := watchDir(ctx, dir, mockIdx, subMgr, cooldownPeriod)
+		require.NoError(t, err)
 
 		checkEvents := storage.TestSubscription(subMgr)
 
@@ -149,7 +153,8 @@ func TestDirWatch(t *testing.T) {
 		schemaFile := filepath.Join(dir, schema.Directory, "test.json")
 		touch(t, schemaFile)
 
-		require.NoError(t, watchDir(ctx, dir, mockIdx, subMgr, cooldownPeriod))
+		_, err := watchDir(ctx, dir, mockIdx, subMgr, cooldownPeriod)
+		require.NoError(t, err)
 
 		checkEvents := storage.TestSubscription(subMgr)
 
@@ -161,16 +166,14 @@ func TestDirWatch(t *testing.T) {
 	})
 
 	// Reproducer for the regression introduced by the switch to fsnotify in PR #3061 (0b1e7983):
-	// processEvent drops directory-creation events as FileTypeNotIndexed before triggerUpdate can
-	// start watching the new directory, so files created in it are silently ignored.
+	// processEvent drops directory-creation events as FileTypeNotIndexed
+  // before triggerUpdate can start watching the new directory, so files created in it are silently ignored.
 	t.Run("add_file_in_new_subdir", func(t *testing.T) {
-		dir, haveEntries, checkEvents := startDirWatch(t)
+		dw, haveEntries, checkEvents := startDirWatch(t)
 
-		subDir := filepath.Join(dir, "newdir")
+		subDir := filepath.Join(dw.dir, "newdir")
 		require.NoError(t, os.Mkdir(subDir, 0o755))
-		// Events inside a not-yet-watched directory are lost forever, so wait for the watcher
-		// to pick up the new directory before creating anything inside it.
-		time.Sleep(watchSetupWait)
+		waitUntilWatched(t, dw, subDir)
 
 		rp := policy.Wrap(test.GenResourcePolicy(test.NoMod()))
 		writePolicy(t, filepath.Join(subDir, "policy.yaml"), rp.Policy)
@@ -187,17 +190,16 @@ func TestDirWatch(t *testing.T) {
 	})
 
 	t.Run("add_file_in_nested_new_subdir", func(t *testing.T) {
-		dir, haveEntries, checkEvents := startDirWatch(t)
+		dw, haveEntries, checkEvents := startDirWatch(t)
 
-		outer := filepath.Join(dir, "outer")
+		// The inner directory's creation event is only visible once the outer directory is watched, so wait between the levels.
+		outer := filepath.Join(dw.dir, "outer")
 		require.NoError(t, os.Mkdir(outer, 0o755))
-		// The inner directory's creation event is only visible once the outer directory is
-		// watched, so wait between the levels.
-		time.Sleep(watchSetupWait)
+		waitUntilWatched(t, dw, outer)
 
 		inner := filepath.Join(outer, "inner")
 		require.NoError(t, os.Mkdir(inner, 0o755))
-		time.Sleep(watchSetupWait)
+		waitUntilWatched(t, dw, inner)
 
 		rp := policy.Wrap(test.GenResourcePolicy(test.NoMod()))
 		writePolicy(t, filepath.Join(inner, "policy.yaml"), rp.Policy)
@@ -213,16 +215,18 @@ func TestDirWatch(t *testing.T) {
 		checkEvents(t, timeOut, wantEvent)
 	})
 
-	// Guards the fix against over-eagerly watching hidden directories. The visible subdir acts as
-	// a positive control: without it, a timeout could also mean the watcher isn't working at all.
+	// Guards the fix against over-eagerly watching hidden directories.
+  // The visible subdir acts as a positive control:
+  // without it, a timeout could also mean the watcher isn't working at all.
 	t.Run("new_hidden_subdir_ignored", func(t *testing.T) {
-		dir, haveEntries, _ := startDirWatch(t)
+		dw, haveEntries, _ := startDirWatch(t)
 
-		hidden := filepath.Join(dir, ".hidden")
+		hidden := filepath.Join(dw.dir, ".hidden")
 		require.NoError(t, os.Mkdir(hidden, 0o755))
-		visible := filepath.Join(dir, "visible")
+		visible := filepath.Join(dw.dir, "visible")
 		require.NoError(t, os.Mkdir(visible, 0o755))
-		time.Sleep(watchSetupWait)
+		waitUntilWatched(t, dw, visible)
+		require.NotContains(t, dw.watcher.WatchList(), hidden)
 
 		rp := policy.Wrap(test.GenResourcePolicy(test.NoMod()))
 		writePolicy(t, filepath.Join(hidden, "policy.yaml"), rp.Policy)
@@ -239,13 +243,13 @@ func TestDirWatch(t *testing.T) {
 		select {
 		case have := <-haveEntries:
 			require.Failf(t, "unexpected entry from hidden subdirectory", "got %q", have.File)
-		case <-time.After(watchSetupWait):
+		case <-time.After(noEventWait):
 		}
 	})
 }
 
 // The AddOrUpdate expectation is Maybe() so that tests expecting no calls can use the same helper.
-func startDirWatch(t *testing.T) (dir string, haveEntries chan index.Entry, checkEvents func(*testing.T, time.Duration, ...storage.Event)) {
+func startDirWatch(t *testing.T) (dw *dirWatch, haveEntries chan index.Entry, checkEvents func(*testing.T, time.Duration, ...storage.Event)) {
 	t.Helper()
 
 	ctx, cancelFunc := context.WithCancel(t.Context())
@@ -253,9 +257,9 @@ func startDirWatch(t *testing.T) (dir string, haveEntries chan index.Entry, chec
 
 	subMgr := storage.NewSubscriptionManager(ctx)
 	mockIdx := &mocks.Index{}
-	dir = t.TempDir()
 
-	require.NoError(t, watchDir(ctx, dir, mockIdx, subMgr, cooldownPeriod))
+	dw, err := watchDir(ctx, t.TempDir(), mockIdx, subMgr, cooldownPeriod)
+	require.NoError(t, err)
 
 	haveEntries = make(chan index.Entry, 8)
 	mockIdx.On("AddOrUpdate", mock.Anything).Return(func(entry index.Entry) storage.Event {
@@ -263,7 +267,17 @@ func startDirWatch(t *testing.T) (dir string, haveEntries chan index.Entry, chec
 		return storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: entry.Policy.ID}
 	}, nil).Maybe()
 
-	return dir, haveEntries, storage.TestSubscription(subMgr)
+	return dw, haveEntries, storage.TestSubscription(subMgr)
+}
+
+// waitUntilWatched blocks until dir joins the watch list,
+// because events inside a not-yet-watched directory are lost forever and would make the calling test hang.
+func waitUntilWatched(t *testing.T, dw *dirWatch, dir string) {
+	t.Helper()
+
+	require.Eventuallyf(t, func() bool {
+		return slices.Contains(dw.watcher.WatchList(), dir)
+	}, timeOut, time.Millisecond, "directory %s was never watched", dir)
 }
 
 func writePolicy(t *testing.T, fileName string, p *policyv1.Policy) {

--- a/internal/storage/disk/disk.go
+++ b/internal/storage/disk/disk.go
@@ -92,7 +92,7 @@ func NewStore(ctx context.Context, conf *Conf) (*Store, error) {
 
 	metrics.Record(ctx, metrics.StoreLastSuccessfulRefresh(), time.Now().UnixMilli(), metrics.DriverKey(DriverName))
 	if conf.WatchForChanges && !util.IsArchiveFile(dir) {
-		if err := watchDir(ctx, dir, s.idx, s.subs, defaultCooldownPeriod); err != nil {
+		if _, err := watchDir(ctx, dir, s.idx, s.subs, defaultCooldownPeriod); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/storage/disk/disk.go
+++ b/internal/storage/disk/disk.go
@@ -92,7 +92,7 @@ func NewStore(ctx context.Context, conf *Conf) (*Store, error) {
 
 	metrics.Record(ctx, metrics.StoreLastSuccessfulRefresh(), time.Now().UnixMilli(), metrics.DriverKey(DriverName))
 	if conf.WatchForChanges && !util.IsArchiveFile(dir) {
-		if _, err := watchDir(ctx, dir, s.idx, s.subs, defaultCooldownPeriod); err != nil {
+		if err := watchDir(ctx, dir, s.idx, s.subs, defaultCooldownPeriod); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
AI Disclosure: Heavy use of Claude Code for code, tests & description. It's what enabled me to contribute to this new-to-me codebase in the first place.
I've gone over every single line of submitted content, changed most of them from the generated starting point, rejected multiple approaches and take ownership of every line of code & description. Replies to review comments are written by me, not AI.

#### Description

Fixes the regression where policies added to subdirectories created at runtime were silently ignored.

`fsnotify` does not watch directories recursively ([fsnotify#18](https://github.com/fsnotify/fsnotify/issues/18)), so a subdirectory created after startup must be added to the watcher explicitly. The previous attempt to do this in `triggerUpdate` was unreachable, because `processEvent` discarded directory-creation events as non-indexable before they were batched.

This change intercepts directory `Create` events in `processEvent` and, via `watchNewSubDir`:

- adds the new directory to the watcher immediately, before any file inside it can be missed;
- walks it to watch nested subdirectories created in the same operation (e.g. `mkdir -p`, `tar -x`);
- batches files already present in the new directory, closing the race where a file appears between the `mkdir` and the watch being attached — `fsnotify` never emits an event for those. This is the [community-recommended](https://groups.google.com/d/topic/golang-nuts/xp9041IGp4Y) mitigation for the well-known new-subdirectory race.

The now-redundant directory-handling branch in `triggerUpdate` is removed.

Covered by new `TestDirWatch` subtests: a policy in a new subdirectory, a policy in a nested (`mkdir -p`) subdirectory, and a hidden subdirectory being ignored. The tests write the policy immediately after `mkdir` (no wait) to exercise the race, and use `require.Eventually` on the watch list instead of sleeps for determinism.

Fixes #3246

#### Checklist

- [x] The PR title has the correct prefix (`fix(disk-storage):`)
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
- [x] Changelog entry added (`just changelog-entry fix ...`)
