### PR TITLE
Sort validation errors encountered when parsing files

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1177,8 +1177,8 @@ func (u *unmarshaler[T]) validate(uctx *unmarshalCtx, msg T) (outErr error) {
 
 	slices.SortFunc(verrs.Violations, func(a, b *protovalidate.Violation) int {
 		if a.FieldDescriptor != nil && b.FieldDescriptor != nil {
-			if fullName := cmp.Compare(a.FieldDescriptor.FullName(), b.FieldDescriptor.FullName()); fullName != 0 {
-				return fullName
+			if nameComparison := cmp.Compare(a.FieldDescriptor.FullName(), b.FieldDescriptor.FullName()); nameComparison != 0 {
+				return nameComparison
 			}
 		}
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -5,6 +5,7 @@ package parser
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"io/fs"
 	"iter"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -1172,6 +1174,20 @@ func (u *unmarshaler[T]) validate(uctx *unmarshalCtx, msg T) (outErr error) {
 	if !errors.As(err, &verrs) {
 		return err
 	}
+
+	slices.SortFunc(verrs.Violations, func(a, b *protovalidate.Violation) int {
+		if a.FieldDescriptor != nil && b.FieldDescriptor != nil {
+			if fullName := cmp.Compare(a.FieldDescriptor.FullName(), b.FieldDescriptor.FullName()); fullName != 0 {
+				return fullName
+			}
+		}
+
+		if a.FieldValue.IsValid() && b.FieldValue.IsValid() {
+			return cmp.Compare(a.FieldValue.String(), b.FieldValue.String())
+		}
+
+		return 0
+	})
 
 	for _, v := range verrs.Violations {
 		path := fieldPathString(v.Proto.GetField().GetElements())


### PR DESCRIPTION
# Description

One of the `internal/verify` tests were sporidically failing with the error below due to `protovalidate` returning validation errors in random order.

With this PR, we are now sorting the validation errors to fix this behaviour.

<details>
<summary>Error</summary>

```
Error Trace:	/home/runner/work/cerbos/cerbos/internal/verify/verify_test.go:67
        	Error:      	Should be empty, but was   (*policyv1.TestResults)(Inverse(protocmp.Transform, protocmp.Message{
        	            	  	"@type": s"cerbos.policy.v1.TestResults",
        	            	  	"suites": []protocmp.Message(Inverse(cmpopts.SortSlices, []protocmp.Message{
        	            	  		{
        	            	  			"@type": s"cerbos.policy.v1.TestResults.Suite",
        	            	  			"error": (
        	            	  				"""
        	            	  				failed to load test suite:
        	            	- 				20:24 tests[0].expected[0].actions["view:public"]: must be one of [EFFECT_ALLOW, EFFECT_DENY]
        	            	  				21:20 tests[0].expected[0].actions["approve"]: must be one of [EFFECT_ALLOW, EFFECT_DENY]
        	            	+ 				20:24 tests[0].expected[0].actions["view:public"]: must be one of [EFFECT_ALLOW, EFFECT_DENY]
        	            	  				"""
        	            	  			),
        	            	  			"file":    string("suite_test.yaml"),
        	            	  			"name":    string("Unknown"),
        	            	  			"summary": protocmp.Message{"@type": s"cerbos.policy.v1.TestResults.Summary", "overall_result": s"RESULT_ERRORED"},
        	            	  		},
        	            	  		{"@type": s"cerbos.policy.v1.TestResults.Suite", "description": string("Tests for verifying something"), "error": string(`Failed to load the test suite: invalid test "John and his leave `...), "file": string("another_suite_test.yaml"), ...},
        	            	  	})),
        	            	  	"summary": protocmp.Message{"@type": s"cerbos.policy.v1.TestResults.Summary", "overall_result": s"RESULT_ERRORED"},
        	            	  }))
        	Test:       	TestVerify/case_014
```
</details>
