### PR TITLE
Iterable stores

### DIFF
--- a/internal/compile/manager.go
+++ b/internal/compile/manager.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 
 	"go.uber.org/zap"
 
@@ -90,41 +91,59 @@ func (c *Manager) GetAll(ctx context.Context) ([]*runtimev1.RunnablePolicySet, e
 	return rpsSet, nil
 }
 
-// GetAllStreaming compiles compilation units one at a time and yields each compiled
-// policy set.
-func (c *Manager) GetAllStreaming(ctx context.Context, yield func(*runtimev1.RunnablePolicySet) error) error {
-	compileAndYield := func(cu *policy.CompilationUnit) error {
-		rps, err := c.compile(cu)
+func (c *Manager) Iter(ctx context.Context) iter.Seq2[*runtimev1.RunnablePolicySet, error] {
+	return func(yield func(*runtimev1.RunnablePolicySet, error) bool) {
+		if iterable, ok := c.store.(storage.IterableSourceStore); ok {
+			for unit, err := range iterable.Iter(ctx) {
+				if err != nil {
+					yield(nil, fmt.Errorf("failed to get compilation units: %w", err))
+					return
+				}
+
+				rps, err := c.compile(unit)
+				if err != nil {
+					err = PolicyCompilationErr{underlying: err}
+				}
+
+				if !yield(rps, err) {
+					return
+				}
+			}
+
+			return
+		}
+
+		units, err := c.store.GetAll(ctx)
 		if err != nil {
-			return PolicyCompilationErr{underlying: err}
+			yield(nil, fmt.Errorf("failed to get compilation units: %w", err))
+			return
 		}
 
-		if rps == nil {
-			return nil
+		for i, unit := range units {
+			rps, err := c.compile(unit)
+			if err != nil {
+				err = PolicyCompilationErr{underlying: err}
+			}
+
+			if !yield(rps, err) {
+				return
+			}
+
+			// Drop it as soon as it is compiled.
+			units[i] = nil
 		}
-
-		return yield(rps)
 	}
+}
 
-	if ss, ok := c.store.(storage.StreamingSourceStore); ok {
-		return ss.GetAllStreaming(ctx, compileAndYield)
-	}
-
-	cus, err := c.store.GetAll(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get compilation units: %w", err)
-	}
-
-	for i, cu := range cus {
-		if err := compileAndYield(cu); err != nil {
-			return err
+func (c *Manager) CompileAll(ctx context.Context) error {
+	errs := newErrorSet()
+	for _, err := range c.Iter(ctx) {
+		if err != nil {
+			errs.Add(err)
 		}
-
-		// Drop it as soon as it is compiled.
-		cus[i] = nil
 	}
 
-	return nil
+	return errs.ErrOrNil()
 }
 
 func (c *Manager) GetAllMatching(ctx context.Context, modIDs []namer.ModuleID) ([]*runtimev1.RunnablePolicySet, error) {

--- a/internal/engine/policyloader/policy_loader.go
+++ b/internal/engine/policyloader/policy_loader.go
@@ -5,6 +5,7 @@ package policyloader
 
 import (
 	"context"
+	"iter"
 
 	auditv1 "github.com/cerbos/cerbos/api/genpb/cerbos/audit/v1"
 	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
@@ -18,8 +19,8 @@ type PolicyLoader interface {
 	Source() *auditv1.PolicySource
 }
 
-// StreamingPolicyLoader is an optional interface for loaders that can yield compiled
+// IterablePolicyLoader is an optional interface for loaders that can yield compiled
 // policy sets one at a time.
-type StreamingPolicyLoader interface {
-	GetAllStreaming(ctx context.Context, yield func(*runtimev1.RunnablePolicySet) error) error
+type IterablePolicyLoader interface {
+	Iter(ctx context.Context) iter.Seq2[*runtimev1.RunnablePolicySet, error]
 }

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -603,8 +603,8 @@ func paceBuildGC() (restore func()) {
 func NewRuleTableFromLoader(ctx context.Context, policyLoader policyloader.PolicyLoader) (*RuleTable, error) {
 	defer paceBuildGC()()
 
-	if spl, ok := policyLoader.(policyloader.StreamingPolicyLoader); ok {
-		return newRuleTableFromStreamingLoader(ctx, spl)
+	if spl, ok := policyLoader.(policyloader.IterablePolicyLoader); ok {
+		return newRuleTableFromIterableLoader(ctx, spl)
 	}
 
 	protoRT := NewProtoRuletable()
@@ -616,7 +616,7 @@ func NewRuleTableFromLoader(ctx context.Context, policyLoader policyloader.Polic
 	return NewRuleTable(protoRT)
 }
 
-func newRuleTableFromStreamingLoader(ctx context.Context, spl policyloader.StreamingPolicyLoader) (*RuleTable, error) {
+func newRuleTableFromIterableLoader(ctx context.Context, spl policyloader.IterablePolicyLoader) (*RuleTable, error) {
 	rt := &RuleTable{
 		RuleTable:     NewProtoRuletable(),
 		idx:           index.New(),
@@ -625,8 +625,14 @@ func newRuleTableFromStreamingLoader(ctx context.Context, spl policyloader.Strea
 	}
 	rt.initBuildState()
 
-	if err := spl.GetAllStreaming(ctx, rt.ingestPolicy); err != nil {
-		return nil, fmt.Errorf("failed to load policies: %w", err)
+	for rps, err := range spl.Iter(ctx) {
+		if err != nil {
+			return nil, fmt.Errorf("failed to load policies due to compilation failure: %w", err)
+		}
+
+		if err := rt.ingestPolicy(rps); err != nil {
+			return nil, fmt.Errorf("failed to load policies: %w", err)
+		}
 	}
 
 	rt.finalizeBuild()

--- a/internal/storage/blob/store.go
+++ b/internal/storage/blob/store.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"iter"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -517,8 +518,8 @@ func (s *Store) GetAll(ctx context.Context) ([]*policy.CompilationUnit, error) {
 	return s.idx.GetAll(ctx)
 }
 
-func (s *Store) GetAllStreaming(ctx context.Context, fn func(*policy.CompilationUnit) error) error {
-	return index.StreamAll(ctx, s.idx, fn)
+func (s *Store) Iter(ctx context.Context) iter.Seq2[*policy.CompilationUnit, error] {
+	return s.idx.Iter(ctx)
 }
 
 func (s *Store) GetAllMatching(_ context.Context, modIDs []namer.ModuleID) ([]*policy.CompilationUnit, error) {

--- a/internal/storage/db/internal/db.go
+++ b/internal/storage/db/internal/db.go
@@ -13,9 +13,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -38,6 +40,7 @@ import (
 )
 
 const (
+	batchSize   = 32
 	driverName  = "db"
 	tableLogKey = "table"
 )
@@ -49,6 +52,7 @@ type DBStorage interface {
 	storage.Instrumented
 	storage.Reloadable
 	storage.Verifiable
+	storage.IterableSourceStore
 	AddOrUpdate(ctx context.Context, policies ...policy.Wrapper) error
 	GetFirstMatch(ctx context.Context, candidates []namer.ModuleID) (*policy.CompilationUnit, error)
 	GetAll(ctx context.Context) ([]*policy.CompilationUnit, error)
@@ -384,6 +388,35 @@ func (s *dbStorage) GetAll(ctx context.Context) ([]*policy.CompilationUnit, erro
 	}
 
 	return res, nil
+}
+
+func (s *dbStorage) Iter(ctx context.Context) iter.Seq2[*policy.CompilationUnit, error] {
+	return func(yield func(*policy.CompilationUnit, error) bool) {
+		policyKeys, err := s.ListPolicyIDs(ctx, storage.ListPolicyIDsParams{})
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		for batch := range slices.Chunk(policyKeys, batchSize) {
+			modIDs := make([]namer.ModuleID, len(batch))
+			for i, k := range batch {
+				modIDs[i] = namer.GenModuleIDFromFQN(namer.FQNFromPolicyKey(k))
+			}
+
+			cus, err := s.GetCompilationUnits(ctx, modIDs...)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			for _, cu := range cus {
+				if !yield(cu, nil) {
+					return
+				}
+			}
+		}
+	}
 }
 
 func (s *dbStorage) GetAllMatching(ctx context.Context, modIDs []namer.ModuleID) ([]*policy.CompilationUnit, error) {

--- a/internal/storage/db/internal/tests.go
+++ b/internal/storage/db/internal/tests.go
@@ -129,6 +129,17 @@ func TestSuite(store DBStorage) func(*testing.T) {
 			t.Run("update_partial", addPolicies([]policy.Wrapper{rp, dr}, wantPartialEvents))
 		})
 
+		t.Run("iter", func(t *testing.T) {
+			count := 0
+			for cu, err := range store.Iter(t.Context()) {
+				require.NoError(t, err)
+				require.NotNil(t, cu)
+				count++
+			}
+
+			require.Equal(t, len(policyList), count)
+		})
+
 		t.Run("add_id_collision", func(t *testing.T) {
 			require.ErrorIs(t, store.AddOrUpdate(ctx, rpDupe2), storage.ErrPolicyIDCollision, "rpDupe2 not detected")
 			require.ErrorIs(t, store.AddOrUpdate(ctx, ppDupe2), storage.ErrPolicyIDCollision, "ppDupe2 not detected")
@@ -489,7 +500,8 @@ func TestSuite(store DBStorage) func(*testing.T) {
 					require.NoError(t, store.AddOrUpdate(t.Context(), e, d, r1, r2), "setup failed for transient test case")
 
 					t.Run("case_1", func(t *testing.T) {
-						_, err = store.Delete(ctx,
+						_, err = store.Delete(
+							ctx,
 							namer.PolicyKeyFromFQN(e.FQN),
 							namer.PolicyKeyFromFQN(d.FQN),
 							namer.PolicyKeyFromFQN(r1.FQN),
@@ -512,7 +524,8 @@ func TestSuite(store DBStorage) func(*testing.T) {
 					})
 
 					t.Run("case_2", func(t *testing.T) {
-						_, err = store.Delete(ctx,
+						_, err = store.Delete(
+							ctx,
 							namer.PolicyKeyFromFQN(e.FQN),
 							namer.PolicyKeyFromFQN(r1.FQN),
 							namer.PolicyKeyFromFQN(r2.FQN),
@@ -531,14 +544,16 @@ func TestSuite(store DBStorage) func(*testing.T) {
 					})
 
 					t.Run("case_3", func(t *testing.T) {
-						_, err = store.Delete(ctx,
+						_, err = store.Delete(
+							ctx,
 							namer.PolicyKeyFromFQN(d.FQN),
 							namer.PolicyKeyFromFQN(r1.FQN),
 							namer.PolicyKeyFromFQN(r2.FQN),
 						)
 						require.NoError(t, err)
 
-						_, err = store.Delete(ctx,
+						_, err = store.Delete(
+							ctx,
 							namer.PolicyKeyFromFQN(e.FQN),
 						)
 						require.NoError(t, err)

--- a/internal/storage/disk/disk.go
+++ b/internal/storage/disk/disk.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"iter"
 	"path/filepath"
 	"time"
 
@@ -125,8 +126,8 @@ func (s *Store) GetAll(ctx context.Context) ([]*policy.CompilationUnit, error) {
 	return s.idx.GetAll(ctx)
 }
 
-func (s *Store) GetAllStreaming(ctx context.Context, fn func(*policy.CompilationUnit) error) error {
-	return index.StreamAll(ctx, s.idx, fn)
+func (s *Store) Iter(ctx context.Context) iter.Seq2[*policy.CompilationUnit, error] {
+	return s.idx.Iter(ctx)
 }
 
 func (s *Store) GetAllMatching(_ context.Context, modIDs []namer.ModuleID) ([]*policy.CompilationUnit, error) {

--- a/internal/storage/git/store.go
+++ b/internal/storage/git/store.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"os"
 	"strings"
 	"sync"
@@ -172,8 +173,8 @@ func (s *Store) GetAll(ctx context.Context) ([]*policy.CompilationUnit, error) {
 	return s.idx.GetAll(ctx)
 }
 
-func (s *Store) GetAllStreaming(ctx context.Context, fn func(*policy.CompilationUnit) error) error {
-	return index.StreamAll(ctx, s.idx, fn)
+func (s *Store) Iter(ctx context.Context) iter.Seq2[*policy.CompilationUnit, error] {
+	return s.idx.Iter(ctx)
 }
 
 func (s *Store) GetAllMatching(_ context.Context, modIDs []namer.ModuleID) ([]*policy.CompilationUnit, error) {

--- a/internal/storage/index/index.go
+++ b/internal/storage/index/index.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"iter"
 	"sort"
 	"sync"
 
@@ -58,6 +59,7 @@ type Index interface {
 	GetFiles() []string
 	GetAllCompilationUnits(context.Context) <-chan *policy.CompilationUnit
 	GetAllCompilationUnitsWithCount(context.Context) (int, <-chan *policy.CompilationUnit)
+	Iter(context.Context) iter.Seq2[*policy.CompilationUnit, error]
 	Clear() error
 	InspectPolicies(context.Context, ...string) (map[string]*responsev1.InspectPoliciesResponse_Result, error)
 	ListPolicyIDs(context.Context, ...string) ([]string, error)
@@ -396,30 +398,6 @@ func (idx *index) GetAllCompilationUnits(ctx context.Context) <-chan *policy.Com
 	return ch
 }
 
-// StreamAll lazily loads each compilation unit from the index and passes it to fn, holding
-// only one unit resident at a time.
-func StreamAll(ctx context.Context, idx Index, fn func(*policy.CompilationUnit) error) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	n, ch := idx.GetAllCompilationUnitsWithCount(ctx)
-	var count int
-	for cu := range ch {
-		if err := fn(cu); err != nil {
-			return err
-		}
-		count++
-	}
-
-	if count < n {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (idx *index) GetAllCompilationUnitsWithCount(ctx context.Context) (int, <-chan *policy.CompilationUnit) {
 	idx.mu.RLock()
 	toCompile := make([]namer.ModuleID, 0, len(idx.executables))
@@ -458,6 +436,20 @@ func (idx *index) GetAllCompilationUnitsWithCount(ctx context.Context) (int, <-c
 	}()
 
 	return len(toCompile), outChan
+}
+
+func (idx *index) Iter(ctx context.Context) iter.Seq2[*policy.CompilationUnit, error] {
+	return func(yield func(*policy.CompilationUnit, error) bool) {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		ch := idx.GetAllCompilationUnits(ctx)
+		for unit := range ch {
+			if !yield(unit, nil) {
+				return
+			}
+		}
+	}
 }
 
 func (idx *index) Clear() error {

--- a/internal/storage/index/index_test.go
+++ b/internal/storage/index/index_test.go
@@ -238,3 +238,17 @@ func TestIndexGetDependents(t *testing.T) {
 		namer.ResourcePolicyModuleID("import_derived_roles_that_import_variables", "default", ""),
 	}, dependents[modID])
 }
+
+func TestIndexIter(t *testing.T) {
+	idx, err := index.Build(t.Context(), os.DirFS(test.PathToDir(t, "store")))
+	require.NoError(t, err)
+
+	count := 0
+	for cu, err := range idx.Iter(t.Context()) {
+		require.NoError(t, err)
+		require.NotNil(t, cu)
+		count++
+	}
+
+	require.Greater(t, count, 5)
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"sync"
 
 	auditv1 "github.com/cerbos/cerbos/api/genpb/cerbos/audit/v1"
@@ -155,10 +156,10 @@ type SourceStore interface {
 	LoadPolicy(context.Context, ...string) ([]*policy.Wrapper, error)
 }
 
-// StreamingSourceStore is an optional interface for source stores that can yield their
+// IterableSourceStore is an optional interface for source stores that can yield their
 // compilation units one at a time instead of materialising them all into a slice.
-type StreamingSourceStore interface {
-	GetAllStreaming(ctx context.Context, fn func(*policy.CompilationUnit) error) error
+type IterableSourceStore interface {
+	Iter(ctx context.Context) iter.Seq2[*policy.CompilationUnit, error]
 }
 
 // BinaryStore is implemented by stores that have pre-compiled policies in binary format.

--- a/internal/test/mocks/Index.go
+++ b/internal/test/mocks/Index.go
@@ -10,6 +10,7 @@ package mocks
 import (
 	"context"
 	"io"
+	"iter"
 
 	"github.com/cerbos/cerbos/api/genpb/cerbos/response/v1"
 	"github.com/cerbos/cerbos/internal/namer"
@@ -816,6 +817,59 @@ func (_c *Index_InspectPolicies_Call) Return(stringToInspectPoliciesResponse_Res
 }
 
 func (_c *Index_InspectPolicies_Call) RunAndReturn(run func(context1 context.Context, strings ...string) (map[string]*responsev1.InspectPoliciesResponse_Result, error)) *Index_InspectPolicies_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Iter provides a mock function for the type Index
+func (_mock *Index) Iter(context1 context.Context) iter.Seq2[*policy.CompilationUnit, error] {
+	ret := _mock.Called(context1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Iter")
+	}
+
+	var r0 iter.Seq2[*policy.CompilationUnit, error]
+	if returnFunc, ok := ret.Get(0).(func(context.Context) iter.Seq2[*policy.CompilationUnit, error]); ok {
+		r0 = returnFunc(context1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(iter.Seq2[*policy.CompilationUnit, error])
+		}
+	}
+	return r0
+}
+
+// Index_Iter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Iter'
+type Index_Iter_Call struct {
+	*mock.Call
+}
+
+// Iter is a helper method to define mock.On call
+//   - context1 context.Context
+func (_e *Index_Expecter) Iter(context1 any) *Index_Iter_Call {
+	return &Index_Iter_Call{Call: _e.mock.On("Iter", context1)}
+}
+
+func (_c *Index_Iter_Call) Run(run func(context1 context.Context)) *Index_Iter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Index_Iter_Call) Return(seq2 iter.Seq2[*policy.CompilationUnit, error]) *Index_Iter_Call {
+	_c.Call.Return(seq2)
+	return _c
+}
+
+func (_c *Index_Iter_Call) RunAndReturn(run func(context1 context.Context) iter.Seq2[*policy.CompilationUnit, error]) *Index_Iter_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Builds on #3245 and converts the method signatures to Go iterators so
that we can use idiomatic Go when iterating over the store contents.
Includes support iterating over database stores with batched reads to
balance between memory use and database load.

Also adds `CompileAll` method to `CompileManager` to help with #3251

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
