### PR TITLE
 Auto-configure GOMEMLIMIT from the cgroup memory limit

### DIFF
--- a/.changelog/20260702_0713.txt
+++ b/.changelog/20260702_0713.txt
@@ -1,0 +1,3 @@
+type:enhancement
+Automatically configure GOMEMLIMIT from the cgroup memory limit
+When the PDP runs under a cgroup memory limit and GOMEMLIMIT is not set explicitly, it now derives GOMEMLIMIT from the cgroup cap.

--- a/.changelog/20260702_0714.txt
+++ b/.changelog/20260702_0714.txt
@@ -1,0 +1,3 @@
+type:enhancement
+Expose Go runtime GC-CPU and GOMEMLIMIT metrics
+The metrics endpoint now exports the Go runtime CPU-class metrics (`go_cpu_classes_*`, including GC CPU time) and the effective memory limit (`go_gc_gomemlimit_bytes`).

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.26.4
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1
 	buf.build/go/protovalidate v1.2.0
+	github.com/KimMachineGun/automemlimit v0.7.5
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/adrg/xdg v0.5.3
 	github.com/alecthomas/chroma/v2 v2.27.0
@@ -233,6 +234,7 @@ require (
 	github.com/olekukonko/ll v0.1.6 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.55.0/go.mod h1:vB2GH9GAYYJTO3mEn8oYwzEdhlayZIdQz6zdzgUIRvA=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 h1:0s6TxfCu2KHkkZPnBfsQ2y5qia0jl3MMrmBhu3nCOYk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
+github.com/KimMachineGun/automemlimit v0.7.5 h1:RkbaC0MwhjL1ZuBKunGDjE/ggwAX43DwZrJqVwyveTk=
+github.com/KimMachineGun/automemlimit v0.7.5/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
 github.com/MarvinJWendt/testza v0.1.0/go.mod h1:7AxNvlfeHP7Z/hDQ5JtE3OKYT3XFUeLCDE2DQninSqs=
 github.com/MarvinJWendt/testza v0.2.1/go.mod h1:God7bhG8n6uQxwdScay+gjm9/LnO4D3kkcZX4hv9Rp8=
 github.com/MarvinJWendt/testza v0.2.8/go.mod h1:nwIcjmr0Zz+Rcwfh3/4UhBp7ePKVhuBExvZqnKYWlII=
@@ -508,6 +510,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/ory/dockertest/v4 v4.0.0 h1:i19aFsO/VXE0VrMk4ifnKW4G/KIJ93PCjLOslxXoPME=
 github.com/ory/dockertest/v4 v4.0.0/go.mod h1:b5Ofu8VIxWNhXFvQcLu17pRNQdoUBKtXBW74G4Ygzx8=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/peterh/liner v1.2.2 h1:aJ4AOodmL+JxOZZEL2u9iJf8omNRpqHc/EbrK+3mAXw=
 github.com/peterh/liner v1.2.2/go.mod h1:xFwJyiKIXJZUKItq5dGHZSTBRAuG/CpeNpWLyiNRNwI=

--- a/hack/loadtest/gcp/env.sh
+++ b/hack/loadtest/gcp/env.sh
@@ -187,6 +187,7 @@ PDP_FLOOR_METRICS=(
   go_memstats_heap_inuse_bytes
   go_memstats_sys_bytes
   go_memstats_heap_released_bytes
+  go_gc_gomemlimit_bytes
 )
 
 # Print an mpstat CPU-utilization summary (avg/max %used from the "all" rows).

--- a/hack/loadtest/gcp/reports/loadtest-classic.md
+++ b/hack/loadtest/gcp/reports/loadtest-classic.md
@@ -11,7 +11,7 @@
 - Under sustained load at ~85% of capacity, p99 grows from 11.6 ms at 800 policies to 40.8 ms at 40K.
 - RSS peak is 133 MiB at 800 policies, 224 MiB at 8K, and 748 MiB at 40K, growing sub-linearly with policy count.
 - GC CPU stays around 8-9% across the range, with no sustained stalls or throughput gaps.
-- To provision for max RPS, run `GOGC=100` and set a cgroup MemoryMax of 192 MiB at 800 policies, 360 MiB at 8K, or 1.3 GiB at 40K, with a `GOMEMLIMIT` backstop below the cap.
+- To provision for max RPS, run `GOGC=100` and set a cgroup MemoryMax of 192 MiB at 800 policies, 360 MiB at 8K, or 1.3 GiB at 40K, with `GOMEMLIMIT` at 110 MiB, 250 MiB, or 1.0 GiB respectively.
 - The multitenant policy set measures within ~6% of classic at the same policy count (memory, provisioning, and the backstop curve match; throughput is a few percent lower), so these numbers apply to either.
 
 ## Performance (default config, `GOGC=100`)
@@ -67,7 +67,7 @@ Fewer connections is slightly faster: one connection gives the lowest latency an
 2. Under sustained load at about 85% of capacity, p99 rises gradually from 11.6 ms at 800 policies to 40.8 ms at 40K.
 3. RSS peak ranges from 133 MiB at 800 policies to 748 MiB at 40K and grows sub-linearly with policy count.
 4. GC CPU stays around 8-9% across the range, with no sustained stalls or throughput gaps.
-5. For max RPS, run `GOGC=100` and provision a cgroup MemoryMax of 192 MiB at 800 policies, 360 MiB at 8K, or 1.3 GiB at 40K, with a `GOMEMLIMIT` backstop sized just below the cap. Treat these as starting points and tune them on your own policy set and hardware.
+5. For max RPS, run `GOGC=100` and provision a cgroup MemoryMax of 192 MiB at 800 policies, 360 MiB at 8K, or 1.3 GiB at 40K, with `GOMEMLIMIT` set to 110 MiB, 250 MiB, or 1.0 GiB respectively (about 1.5x the loaded runtime heap, well below the cap). Treat these as starting points and tune them on your own policy set and hardware.
 
 ## Source Data
 

--- a/hack/loadtest/gcp/sweep.sh
+++ b/hack/loadtest/gcp/sweep.sh
@@ -73,8 +73,10 @@ mkdir -p "$LOCAL_RESULTS"
 run_arm() {
   local label="$1" gogc="$2" memlimit="$3" cgroup="${4:-}"
   local armdir="${LOCAL_RESULTS}/${label}"
-  local memlimit_h
-  if [[ -n "$memlimit" ]]; then
+  local memlimit_h="unset" # empty => the PDP decides (auto-configure under a cgroup, else off)
+  if [[ "$memlimit" == "off" ]]; then
+    memlimit_h="off"
+  elif [[ -n "$memlimit" ]]; then
     memlimit_h=$(humanise "$memlimit")
   fi
   if [[ -n "$cgroup" ]]; then
@@ -82,7 +84,7 @@ run_arm() {
   fi
 
   mkdir -p "$armdir"
-  log "=== arm ${label}: GOGC=${gogc:-default} GOMEMLIMIT=${memlimit_h:-off} cgroup=${cgroup:-none} ==="
+  log "=== arm ${label}: GOGC=${gogc:-default} GOMEMLIMIT=${memlimit_h} cgroup=${cgroup:-none} ==="
   { echo "label=${label}"; echo "gogc=${gogc}"; echo "memlimit=${memlimit}"; echo "cgroup=${cgroup}"; } > "${armdir}/arm.meta"
 
   if ! GOGC="$gogc" GOMEMLIMIT="$memlimit" CGROUP_LIMIT="$cgroup" restart_cerbos; then
@@ -151,11 +153,11 @@ else
   log "skipping auto-GOMEMLIMIT validation: no GOGC=100 Edge-1 loaded peak (include 100 in GOGC_ARMS)"
 fi
 
-# --- Hard-OOM demo: cgroup just above the build high-water, NO GOMEMLIMIT, GOGC=100.
+# --- Hard-OOM demo: cgroup just above the build high-water, GOMEMLIMIT explicitly off, GOGC=100.
 #     Demonstrates why the soft GOMEMLIMIT backstop is needed. ---
 
 _oom_box=$(awk -v h="${BUILD_HWM:-0}" 'BEGIN{printf "%d", h*1.05}')
-run_arm "oom_demo_nolimit" "100" "" "$_oom_box"
+run_arm "oom_demo_nolimit" "100" "off" "$_oom_box"
 
 # --- Emit the result tables from the per-arm JSON (jq on ghz output) ---
 emit_tables() {

--- a/hack/loadtest/gcp/sweep.sh
+++ b/hack/loadtest/gcp/sweep.sh
@@ -136,19 +136,19 @@ for mult in "${MEMLIMIT_MULTS[@]}"; do
   run_arm "edge2_m${mult}" "off" "$gml" "$box"
 done
 
-# --- Validation: the recommended max-RPS config (GOGC=100 + lean GOMEMLIMIT backstop).
-#     GOMEMLIMIT = VALID_H * (loaded RSS peak - O), with the loaded peak taken from the GOGC=100
-#     Edge-1 arm and the precise O from Step 0; cgroup = GOMEMLIMIT + O + safety. Confirms the
-#     recommended provisioning reproduces the uncapped Edge-1 GOGC=100 numbers, i.e. the lean cap
-#     does NOT bind. ---
+# --- Validation: the recommended max-RPS config, exercising the PDP's auto-GOMEMLIMIT feature.
+#     Provision the recommended cgroup box (sized for GOMEMLIMIT = VALID_H * (loaded RSS peak - O),
+#     the loaded peak from the GOGC=100 Edge-1 arm and O from Step 0), then leave GOMEMLIMIT unset
+#     so the PDP derives it in-process from the cgroup cap. Confirms the auto-configured limit
+#     reproduces the uncapped Edge-1 GOGC=100 numbers, i.e. the cap does NOT bind. ---
 
 _valid_peak=$(cat "${LOCAL_RESULTS}/edge1_gogc100/vmhwm_bytes.txt" 2>/dev/null || echo 0)
 if [[ "${_valid_peak:-0}" -gt 0 ]]; then
   _valid_gml=$(awk -v p="$_valid_peak" -v o="${OFFSET:-0}" -v h="$VALID_H" 'BEGIN{g=(p-o)*h; printf "%d", (g>0?g:0)}')
   _valid_box=$(cgroup_for "$_valid_gml")
-  run_arm "valid_recommended" "100" "$_valid_gml" "$_valid_box"
+  run_arm "valid_auto" "100" "" "$_valid_box"
 else
-  log "skipping recommended-config validation: no GOGC=100 Edge-1 loaded peak (include 100 in GOGC_ARMS)"
+  log "skipping auto-GOMEMLIMIT validation: no GOGC=100 Edge-1 loaded peak (include 100 in GOGC_ARMS)"
 fi
 
 # --- Hard-OOM demo: cgroup just above the build high-water, NO GOMEMLIMIT, GOGC=100.
@@ -164,7 +164,7 @@ emit_tables() {
     printf '# Provisioning sweep - %s policies%s\n\n' "$NUM_POLICIES" "$([[ "$POLICY_SET" != classic ]] && printf -- ' (%s)' "$POLICY_SET")"
     printf 'Floor (cold, no load): R (Sys-HeapReleased) = %s; settled RSS = %s; off-runtime offset O = %s; build high-water = %s.\n' \
       "$(humanise "$R")" "$(humanise "${_rss:-0}")" "$(humanise "${OFFSET}")" "$(humanise "${BUILD_HWM}")"
-    printf 'Edge 2: soft GOMEMLIMIT = mult x R. Validation: GOMEMLIMIT = %s x (loaded RSS peak - O), the recommended max-RPS backstop. Both pair a hard cgroup MemoryMax = GOMEMLIMIT + O + safety (safety = %s x GOMEMLIMIT; RSS-correct; soft bites before the kernel OOM-kills).\n' "${VALID_H}" "${SAFETY_FRAC}"
+    printf 'Edge 2: soft GOMEMLIMIT = mult x R. Validation: provision the recommended cgroup box (= %s x (loaded RSS peak - O) + O + safety) and let the PDP auto-configure GOMEMLIMIT from the cap; the reported GOMEMLIMIT is the value the PDP chose. safety = %s x GOMEMLIMIT.\n' "${VALID_H}" "${SAFETY_FRAC}"
     printf 'stalls/gaps: 1s windows on the sustained run flagged as stall (>10%% of reqs above p95) / gap (<75%% of mean throughput) by analyse_latency.sh; clustering tracks GC pressure.\n\n'
 
     printf '## Edge 1 - sizing (no limit)\n\n'
@@ -183,7 +183,11 @@ emit_tables() {
 
     printf '\n## Validation\n\n'
     printf '| Arm | cgroup | RSS peak | GC CPU%% | Max RPS | Sust RPS | p99@sust (ms) | stalls/gaps | outcome |\n|---|--:|--:|--:|--:|--:|--:|--:|---|\n'
-    [[ -n "${_valid_box:-}" ]] && _row "valid_recommended" "GOGC=100, GOMEMLIMIT=$(humanise "$_valid_gml") (${VALID_H}(peak RSS-O))" "$_valid_box"
+    if [[ -n "${_valid_box:-}" ]]; then
+      local auto_gml
+      auto_gml=$(awk '/^go_gc_gomemlimit_bytes/{printf "%d", $2; exit}' "${LOCAL_RESULTS}/valid_auto/post_metrics.txt" 2>/dev/null)
+      _row "valid_auto" "GOGC=100, GOMEMLIMIT=$(humanise "${auto_gml:-0}") (auto)" "$_valid_box"
+    fi
     _row "oom_demo_nolimit" "GOGC=100, no GOMEMLIMIT" "$_oom_box"
   } > "$out"
   log "Summary table: ${out}"

--- a/hack/loadtest/gcp/sweep.sh
+++ b/hack/loadtest/gcp/sweep.sh
@@ -61,7 +61,7 @@ DURATION_SECS=${DURATION_SECS:-120}
 ITERATIONS=${ITERATIONS:-1000000}
 
 # classic stays unsuffixed (sweep-N) for back-compat; other sets get sweep-N-<set>.
-LOCAL_RESULTS="${SCRIPT_DIR}/../results/gcp/sweep-${NUM_POLICIES}$([[ "$POLICY_SET" != classic ]] && printf -- '-%s' "$POLICY_SET")"
+LOCAL_RESULTS="${SCRIPT_DIR}/../results/gcp/sweep-${NUM_POLICIES}$([[ "$POLICY_SET" != "classic" ]] && printf -- '-%s' "$POLICY_SET" || printf -- '')"
 rm -rf "$LOCAL_RESULTS"
 mkdir -p "$LOCAL_RESULTS"
 

--- a/internal/observability/metrics/handler_test.go
+++ b/internal/observability/metrics/handler_test.go
@@ -23,6 +23,7 @@ func TestNewHandlerExposesRuntimeMetrics(t *testing.T) {
 	for _, want := range []string{
 		"go_cpu_classes_gc_total_cpu_seconds_total",
 		"go_cpu_classes_total_cpu_seconds_total",
+		"go_gc_gomemlimit_bytes",
 		"go_memstats_heap_released_bytes",
 		"go_memstats_sys_bytes",
 		"go_gc_duration_seconds",

--- a/internal/observability/metrics/metrics.go
+++ b/internal/observability/metrics/metrics.go
@@ -201,16 +201,18 @@ func NewHandler() (http.Handler, error) {
 		return nil, fmt.Errorf("failed to start runtime metrics collector: %w", err)
 	}
 
-	// Replace the default Go collector with the one exporting /cpu/classes/*.
+	// Replace the default Go collector with one that also exports /cpu/classes/* (GC CPU cost)
+	// and /gc/gomemlimit:bytes (the effective GOMEMLIMIT, including the auto-configured value).
 	prometheus.Unregister(collectors.NewGoCollector())
-	cpuClassesCollector := collectors.NewGoCollector(
+	goCollector := collectors.NewGoCollector(
 		collectors.WithGoCollectorRuntimeMetrics(
 			collectors.GoRuntimeMetricsRule{Matcher: regexp.MustCompile(`^/cpu/classes/.*`)},
+			collectors.GoRuntimeMetricsRule{Matcher: regexp.MustCompile(`^/gc/gomemlimit:bytes$`)},
 		),
 	)
-	prometheus.Unregister(cpuClassesCollector)
-	if err := prometheus.Register(cpuClassesCollector); err != nil {
-		return nil, fmt.Errorf("failed to register Go collector with CPU metrics: %w", err)
+	prometheus.Unregister(goCollector)
+	if err := prometheus.Register(goCollector); err != nil {
+		return nil, fmt.Errorf("failed to register Go collector with CPU and memory-limit metrics: %w", err)
 	}
 
 	return promhttp.Handler(), nil

--- a/internal/server/memlimit.go
+++ b/internal/server/memlimit.go
@@ -1,0 +1,126 @@
+// Copyright 2021-2026 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"math"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"runtime/metrics"
+	"strconv"
+	"strings"
+
+	"github.com/KimMachineGun/automemlimit/memlimit"
+
+	"github.com/cerbos/cerbos/internal/observability/logging"
+)
+
+// memLimitSafetyFraction is the headroom expressed as a fraction of the
+// soft limit: the hard cap equals GOMEMLIMIT + offset + safety, where safety
+// = memLimitSafetyFraction * GOMEMLIMIT. Inverting for a known cap gives
+// GOMEMLIMIT = (cap - offset) / (1 + memLimitSafetyFraction). This mirrors
+// sweep.sh's SAFETY_FRAC, so the auto-configured limit matches the operating
+// point the sweep load-test validated.
+const memLimitSafetyFraction = 0.2
+
+// fallbackOffsetBytes is the off-runtime offset used when it cannot be measured (R >= RSS): the
+// empirically observed footprint (binary text/data, file maps), so GOMEMLIMIT is not set too high.
+const fallbackOffsetBytes uint64 = 60 << 20 // 60 MiB
+
+// configureMemoryLimit derives GOMEMLIMIT from the cgroup memory cap so users do not have to
+// compute it themselves. It must be called once after the rule table build has settled, so the
+// off-runtime offset (binary, stacks, maps) is measured against the cold heap floor.
+//
+// If GOMEMLIMIT is set explicitly the runtime value is left untouched; if that value cannot
+// engage before the kernel OOM-kills, a warning is logged. With no cgroup cap, nothing is set.
+func configureMemoryLimit() {
+	log := logging.NewLogger("memlimit")
+
+	capBytes, err := memlimit.FromCgroup()
+	hasCap := err == nil && capBytes > 0 && capBytes < math.MaxInt64
+	if !hasCap {
+		return // no cgroup cap to derive from or warn against; leave GOMEMLIMIT as-is
+	}
+
+	runtime.GC()
+	debug.FreeOSMemory()
+
+	rss, ok := residentBytes()
+	if !ok {
+		log.Warnw("RSS unreadable; leaving GOMEMLIMIT unchanged", "cgroup_cap_bytes", capBytes)
+		return
+	}
+
+	settledR := runtimeManagedBytes()
+	// Normally RSS > R and the offset is RSS - R. When R >= RSS,
+	// fall back to the observed floor rather than a near-zero offset.
+	offset := fallbackOffsetBytes
+	if rss > settledR {
+		offset = rss - settledR
+	}
+
+	if gomemlimit := os.Getenv("GOMEMLIMIT"); gomemlimit != "" {
+		cur := debug.SetMemoryLimit(-1)
+		switch {
+		case gomemlimit == "off":
+			log.Warnw("GOMEMLIMIT is off", "cgroup_cap_bytes", capBytes)
+		case uint64(cur)+offset >= capBytes: // offset is small, so the sum never overflows
+			log.Warnw("GOMEMLIMIT is set too high to engage before the kernel OOM-kills",
+				"gomemlimit_bytes", cur, "cgroup_cap_bytes", capBytes)
+		}
+		return
+	}
+
+	limit := computeMemLimit(capBytes, offset)
+	if limit <= 0 || uint64(limit) <= settledR {
+		log.Warnw("cgroup memory cap is too small for a GOMEMLIMIT backstop above the settled floor; leaving GOMEMLIMIT unset",
+			"cgroup_cap_bytes", capBytes, "offset_bytes", offset, "floor_bytes", settledR)
+		return
+	}
+
+	debug.SetMemoryLimit(limit)
+	log.Infow("Auto-configured GOMEMLIMIT from the cgroup memory cap", "gomemlimit_bytes", limit, "cgroup_cap_bytes", capBytes,
+		"offset_bytes", offset, "safety_fraction", memLimitSafetyFraction)
+}
+
+func computeMemLimit(capBytes, offset uint64) int64 {
+	if capBytes <= offset {
+		return 0
+	}
+	return int64(math.Round(float64(capBytes-offset) / (1 + memLimitSafetyFraction)))
+}
+
+// runtimeManagedBytes is R = Sys - HeapReleased: the runtime-managed memory GOMEMLIMIT accounts
+// for (it excludes the binary and other off-runtime memory).
+func runtimeManagedBytes() uint64 {
+	samples := []metrics.Sample{
+		{Name: "/memory/classes/total:bytes"},
+		{Name: "/memory/classes/heap/released:bytes"},
+	}
+	metrics.Read(samples)
+	total, released := samples[0].Value.Uint64(), samples[1].Value.Uint64()
+	if released > total {
+		return 0
+	}
+	return total - released
+}
+
+// residentBytes reads the process resident set size from /proc/self/statm (Linux). The bool is
+// false when it cannot be read.
+func residentBytes() (uint64, bool) {
+	data, err := os.ReadFile("/proc/self/statm")
+	if err != nil {
+		return 0, false
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) < 2 { //nolint:mnd
+		return 0, false
+	}
+	pages, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return pages * uint64(os.Getpagesize()), true
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -107,6 +107,8 @@ func Start(ctx context.Context) error {
 		return err
 	}
 
+	configureMemoryLimit()
+
 	s := NewServer(conf)
 
 	telemetry.Start(ctx, core.Store)


### PR DESCRIPTION
When the PDP runs under a `cgroup` memory limit and `GOMEMLIMIT` is not set explicitly, it now derives `GOMEMLIMIT` from the `cgroup` cap once the policy index is built.

