### PR TITLE
Enable incremental rule table marshalling

### DIFF
--- a/internal/ruletable/index/core.go
+++ b/internal/ruletable/index/core.go
@@ -168,4 +168,21 @@ type RowParams struct {
 	CelPrograms []*CelProgram
 	Variables   []*runtimev1.Variable
 	Key         uint64
+	refcount    int
+}
+
+func (p *RowParams) addRef() {
+	if p != nil {
+		p.refcount++
+	}
+}
+
+func (p *RowParams) removeRef(m map[uint64]*RowParams) {
+	if p == nil {
+		return
+	}
+	p.refcount--
+	if p.refcount <= 0 {
+		delete(m, p.Key)
+	}
 }

--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -807,9 +807,11 @@ func (m *Index) DeletePolicy(fqn string) error {
 		m.bi.removeBinding(b)
 
 		if len(b.Core.origins) == 0 {
-			delete(m.bi.coresBySum, b.Core.sum)
-			b.Core.Params.removeRef(m.paramsCache)
-			b.Core.DerivedRoleParams.removeRef(m.drParamsCache)
+			if _, ok := m.bi.coresBySum[b.Core.sum]; ok {
+				delete(m.bi.coresBySum, b.Core.sum)
+				b.Core.Params.removeRef(m.paramsCache)
+				b.Core.DerivedRoleParams.removeRef(m.drParamsCache)
+			}
 		}
 	}
 

--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -54,9 +54,11 @@ type CelProgram struct {
 type Option func(*Index)
 
 type Index struct {
-	bi          *bitmapIndex
-	parentRoles map[string]map[string][]string
-	handles     UniqueHandles // handles to canonical strings
+	bi            *bitmapIndex
+	parentRoles   map[string]map[string][]string
+	handles       UniqueHandles // handles to canonical strings
+	paramsCache   map[uint64]*RowParams
+	drParamsCache map[uint64]*RowParams
 }
 
 func New(opts ...Option) *Index {
@@ -83,98 +85,109 @@ func (m *Index) IndexRules(rules []*runtimev1.RuleTable_RuleRow) error {
 		m.bi.evalKeys = slices.Grow(m.bi.evalKeys, newBindings)
 	}
 
-	paramsCache := make(map[uint64]*RowParams)
-	drParamsCache := make(map[uint64]*RowParams)
-
 	for _, rule := range rules {
-		var params, drParams *RowParams
-
-		switch rule.PolicyKind { //nolint:exhaustive
-		case policyv1.Kind_KIND_RESOURCE:
-			p, err := getOrGenerateParams(paramsCache, rule.Params)
-			if err != nil {
-				return err
-			}
-			params = p
-			if rule.OriginDerivedRole != "" {
-				drp, err := getOrGenerateParams(drParamsCache, rule.DerivedRoleParams)
-				if err != nil {
-					return err
-				}
-				drParams = drp
-			}
-		case policyv1.Kind_KIND_PRINCIPAL:
-			p, err := getOrGenerateParams(paramsCache, rule.Params)
-			if err != nil {
-				return err
-			}
-			params = p
+		if err := m.IndexRule(rule); err != nil {
+			return err
 		}
-
-		// hashpb does not include field tags, so Condition=X/DerivedRoleCondition=nil
-		// hashes identically to Condition=nil/DerivedRoleCondition=X when X is the
-		// same Condition content. Feed a discriminator byte into the hasher to break
-		// the collision.
-		// TODO(saml): addressing upstream in protoc-gen-go-hashpb, remove this when that lands.
-		hasher := xxhash.New()
-		rule.HashPB(hasher, nonFunctionalChecksumFields)
-		var condDisc byte
-		if rule.Condition != nil {
-			condDisc |= 1
-		}
-		if rule.DerivedRoleCondition != nil {
-			condDisc |= 2
-		}
-		_, _ = hasher.Write([]byte{condDisc})
-		funcSum := hasher.Sum64()
-
-		core, ok := m.bi.coresBySum[funcSum]
-		if !ok {
-			core = &FunctionalCore{
-				Effect:               rule.Effect,
-				Condition:            rule.Condition,
-				DerivedRoleCondition: rule.DerivedRoleCondition,
-				EmitOutput:           rule.EmitOutput,
-				ScopePermissions:     rule.ScopePermissions,
-				FromRolePolicy:       rule.FromRolePolicy,
-				PolicyKind:           rule.PolicyKind,
-				Params:               params,
-				DerivedRoleParams:    drParams,
-				origins:              make(map[string]struct{}),
-				sum:                  funcSum,
-			}
-			m.bi.coresBySum[funcSum] = core
-		}
-		core.origins[rule.OriginFqn] = struct{}{}
-
-		var action unique.Handle[string]
-		var allowActions map[unique.Handle[string]]struct{}
-		switch v := rule.ActionSet.(type) {
-		case *runtimev1.RuleTable_RuleRow_AllowActions_:
-			allowActions = make(map[unique.Handle[string]]struct{}, len(v.AllowActions.GetActions()))
-			for a := range v.AllowActions.GetActions() {
-				allowActions[mkStringHandle(a)] = struct{}{}
-			}
-		case *runtimev1.RuleTable_RuleRow_Action:
-			action = mkStringHandle(v.Action)
-		}
-
-		b := &BindingHandle{
-			Scope:             mkStringHandle(rule.Scope),
-			Version:           mkStringHandle(rule.Version),
-			Resource:          mkStringHandle(rule.Resource),
-			Role:              mkStringHandle(rule.Role),
-			Action:            action,
-			Principal:         mkStringHandle(rule.Principal),
-			OriginFqn:         mkStringHandle(rule.OriginFqn),
-			OriginDerivedRole: mkStringHandle(rule.OriginDerivedRole),
-			Name:              mkStringHandle(rule.Name),
-			AllowActions:      allowActions,
-			Core:              core,
-		}
-
-		m.bi.addBinding(b, makeEvaluationKeyTuple(rule.EvaluationKeyTuple, rule.EvaluationKey))
 	}
+
+	return nil
+}
+
+// IndexRule indexes a single rule row.
+func (m *Index) IndexRule(rule *runtimev1.RuleTable_RuleRow) error {
+	if m.paramsCache == nil {
+		m.paramsCache = make(map[uint64]*RowParams)
+		m.drParamsCache = make(map[uint64]*RowParams)
+	}
+
+	var params, drParams *RowParams
+
+	switch rule.PolicyKind { //nolint:exhaustive
+	case policyv1.Kind_KIND_RESOURCE:
+		p, err := getOrGenerateParams(m.paramsCache, rule.Params)
+		if err != nil {
+			return err
+		}
+		params = p
+		if rule.OriginDerivedRole != "" {
+			drp, err := getOrGenerateParams(m.drParamsCache, rule.DerivedRoleParams)
+			if err != nil {
+				return err
+			}
+			drParams = drp
+		}
+	case policyv1.Kind_KIND_PRINCIPAL:
+		p, err := getOrGenerateParams(m.paramsCache, rule.Params)
+		if err != nil {
+			return err
+		}
+		params = p
+	}
+
+	// hashpb does not include field tags, so Condition=X/DerivedRoleCondition=nil
+	// hashes identically to Condition=nil/DerivedRoleCondition=X when X is the
+	// same Condition content. Feed a discriminator byte into the hasher to break
+	// the collision.
+	// TODO(saml): addressing upstream in protoc-gen-go-hashpb, remove this when that lands.
+	hasher := xxhash.New()
+	rule.HashPB(hasher, nonFunctionalChecksumFields)
+	var condDisc byte
+	if rule.Condition != nil {
+		condDisc |= 1
+	}
+	if rule.DerivedRoleCondition != nil {
+		condDisc |= 2
+	}
+	_, _ = hasher.Write([]byte{condDisc})
+	funcSum := hasher.Sum64()
+
+	core, ok := m.bi.coresBySum[funcSum]
+	if !ok {
+		core = &FunctionalCore{
+			Effect:               rule.Effect,
+			Condition:            rule.Condition,
+			DerivedRoleCondition: rule.DerivedRoleCondition,
+			EmitOutput:           rule.EmitOutput,
+			ScopePermissions:     rule.ScopePermissions,
+			FromRolePolicy:       rule.FromRolePolicy,
+			PolicyKind:           rule.PolicyKind,
+			Params:               params,
+			DerivedRoleParams:    drParams,
+			origins:              make(map[string]struct{}),
+			sum:                  funcSum,
+		}
+		m.bi.coresBySum[funcSum] = core
+	}
+	core.origins[rule.OriginFqn] = struct{}{}
+
+	var action unique.Handle[string]
+	var allowActions map[unique.Handle[string]]struct{}
+	switch v := rule.ActionSet.(type) {
+	case *runtimev1.RuleTable_RuleRow_AllowActions_:
+		allowActions = make(map[unique.Handle[string]]struct{}, len(v.AllowActions.GetActions()))
+		for a := range v.AllowActions.GetActions() {
+			allowActions[mkStringHandle(a)] = struct{}{}
+		}
+	case *runtimev1.RuleTable_RuleRow_Action:
+		action = mkStringHandle(v.Action)
+	}
+
+	b := &BindingHandle{
+		Scope:             mkStringHandle(rule.Scope),
+		Version:           mkStringHandle(rule.Version),
+		Resource:          mkStringHandle(rule.Resource),
+		Role:              mkStringHandle(rule.Role),
+		Action:            action,
+		Principal:         mkStringHandle(rule.Principal),
+		OriginFqn:         mkStringHandle(rule.OriginFqn),
+		OriginDerivedRole: mkStringHandle(rule.OriginDerivedRole),
+		Name:              mkStringHandle(rule.Name),
+		AllowActions:      allowActions,
+		Core:              core,
+	}
+
+	m.bi.addBinding(b, makeEvaluationKeyTuple(rule.EvaluationKeyTuple, rule.EvaluationKey))
 
 	return nil
 }

--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -158,6 +158,8 @@ func (m *Index) IndexRule(rule *runtimev1.RuleTable_RuleRow) error {
 			sum:                  funcSum,
 		}
 		m.bi.coresBySum[funcSum] = core
+		params.addRef()
+		drParams.addRef()
 	}
 	core.origins[rule.OriginFqn] = struct{}{}
 
@@ -806,6 +808,8 @@ func (m *Index) DeletePolicy(fqn string) error {
 
 		if len(b.Core.origins) == 0 {
 			delete(m.bi.coresBySum, b.Core.sum)
+			b.Core.Params.removeRef(m.paramsCache)
+			b.Core.DerivedRoleParams.removeRef(m.drParamsCache)
 		}
 	}
 

--- a/internal/ruletable/index/params_cache_test.go
+++ b/internal/ruletable/index/params_cache_test.go
@@ -6,11 +6,12 @@ package index
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	effectv1 "github.com/cerbos/cerbos/api/genpb/cerbos/effect/v1"
 	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
 	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
 	"github.com/cerbos/cerbos/internal/namer"
-	"github.com/stretchr/testify/require"
 )
 
 func mkParamsRow(fqn string, fn ...func(*runtimev1.RuleTable_RuleRow)) *runtimev1.RuleTable_RuleRow {
@@ -42,12 +43,16 @@ func TestParamsCacheEviction(t *testing.T) {
 	t.Run("entry evicted when the last core referencing it is deleted", func(t *testing.T) {
 		impl := New()
 
-		// same params content, different conditions: two cores sharing one cache entry.
 		require.NoError(t, impl.IndexRule(mkParamsRow(fqnA)))
+		require.NoError(t, impl.IndexRule(mkParamsRow(fqnA, func(r *runtimev1.RuleTable_RuleRow) {
+			r.Role = "editor"
+		})))
+		// same params content, different conditions: two cores sharing one cache entry.
 		require.NoError(t, impl.IndexRule(mkParamsRow(fqnB, func(r *runtimev1.RuleTable_RuleRow) {
 			r.Condition = &runtimev1.Condition{Op: &runtimev1.Condition_Expr{Expr: &runtimev1.Expr{Original: "true"}}}
 		})))
 
+		require.Len(t, impl.bi.bindings, 3)
 		require.Len(t, impl.paramsCache, 1)
 		require.Len(t, impl.bi.coresBySum, 2)
 

--- a/internal/ruletable/index/params_cache_test.go
+++ b/internal/ruletable/index/params_cache_test.go
@@ -1,0 +1,102 @@
+// Copyright 2021-2026 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package index
+
+import (
+	"testing"
+
+	effectv1 "github.com/cerbos/cerbos/api/genpb/cerbos/effect/v1"
+	policyv1 "github.com/cerbos/cerbos/api/genpb/cerbos/policy/v1"
+	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
+	"github.com/cerbos/cerbos/internal/namer"
+	"github.com/stretchr/testify/require"
+)
+
+func mkParamsRow(fqn string, fn ...func(*runtimev1.RuleTable_RuleRow)) *runtimev1.RuleTable_RuleRow {
+	r := &runtimev1.RuleTable_RuleRow{
+		OriginFqn:  fqn,
+		PolicyKind: policyv1.Kind_KIND_RESOURCE,
+		Resource:   "document",
+		Role:       "viewer",
+		ActionSet:  &runtimev1.RuleTable_RuleRow_Action{Action: "view"},
+		Effect:     effectv1.Effect_EFFECT_ALLOW,
+		Version:    "default",
+		Params: &runtimev1.RuleTable_RuleRow_Params{
+			OrderedVariables: []*runtimev1.Variable{{
+				Name: "v",
+				Expr: &runtimev1.Expr{Original: "1 + 1"},
+			}},
+		},
+	}
+	for _, m := range fn {
+		m(r)
+	}
+	return r
+}
+
+func TestParamsCacheEviction(t *testing.T) {
+	fqnA := namer.ResourcePolicyFQN("document", "default", "")
+	fqnB := namer.ResourcePolicyFQN("document", "default", "acme")
+
+	t.Run("entry evicted when the last core referencing it is deleted", func(t *testing.T) {
+		impl := New()
+
+		// same params content, different conditions: two cores sharing one cache entry.
+		require.NoError(t, impl.IndexRule(mkParamsRow(fqnA)))
+		require.NoError(t, impl.IndexRule(mkParamsRow(fqnB, func(r *runtimev1.RuleTable_RuleRow) {
+			r.Condition = &runtimev1.Condition{Op: &runtimev1.Condition_Expr{Expr: &runtimev1.Expr{Original: "true"}}}
+		})))
+
+		require.Len(t, impl.paramsCache, 1)
+		require.Len(t, impl.bi.coresBySum, 2)
+
+		require.NoError(t, impl.DeletePolicy(fqnA))
+		require.Len(t, impl.paramsCache, 1, "entry still referenced by fqnB's core must survive")
+
+		require.NoError(t, impl.DeletePolicy(fqnB))
+		require.Empty(t, impl.paramsCache, "entry must be evicted with its last core")
+		require.Empty(t, impl.bi.coresBySum)
+
+		// re-indexing equivalent content recompiles and repopulates the cache.
+		require.NoError(t, impl.IndexRule(mkParamsRow(fqnA)))
+		require.Len(t, impl.paramsCache, 1)
+	})
+
+	t.Run("no decrement while a shared core still has origins", func(t *testing.T) {
+		impl := New()
+
+		// functionally identical rows: one core with two origins.
+		require.NoError(t, impl.IndexRule(mkParamsRow(fqnA)))
+		require.NoError(t, impl.IndexRule(mkParamsRow(fqnB)))
+		require.Len(t, impl.bi.coresBySum, 1)
+		require.Len(t, impl.paramsCache, 1)
+
+		require.NoError(t, impl.DeletePolicy(fqnA))
+		require.Len(t, impl.paramsCache, 1, "core still has an origin; entry must survive")
+
+		require.NoError(t, impl.DeletePolicy(fqnB))
+		require.Empty(t, impl.paramsCache)
+	})
+
+	t.Run("derived-role params evicted alongside rule params", func(t *testing.T) {
+		impl := New()
+
+		withDR := func(r *runtimev1.RuleTable_RuleRow) {
+			r.OriginDerivedRole = "owner"
+			r.DerivedRoleParams = &runtimev1.RuleTable_RuleRow_Params{
+				OrderedVariables: []*runtimev1.Variable{{
+					Name: "d",
+					Expr: &runtimev1.Expr{Original: "2 + 2"},
+				}},
+			}
+		}
+		require.NoError(t, impl.IndexRule(mkParamsRow(fqnA, withDR)))
+		require.Len(t, impl.paramsCache, 1)
+		require.Len(t, impl.drParamsCache, 1)
+
+		require.NoError(t, impl.DeletePolicy(fqnA))
+		require.Empty(t, impl.paramsCache)
+		require.Empty(t, impl.drParamsCache)
+	})
+}

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -84,6 +84,15 @@ func LoadPolicies(ctx context.Context, rt *runtimev1.RuleTable, pl policyloader.
 // LoadPoliciesIter is the streaming equivalent of LoadPolicies: it consumes compiled
 // policy sets one at a time.
 func LoadPoliciesIter(rt *runtimev1.RuleTable, policySets iter.Seq2[*runtimev1.RunnablePolicySet, error]) error {
+	return LoadPoliciesIterFunc(rt, policySets, func(row *runtimev1.RuleTable_RuleRow) error {
+		rt.Rules = append(rt.Rules, row)
+		return nil
+	})
+}
+
+// LoadPoliciesIterFunc is like LoadPoliciesIter, but each rule row is passed to onRow
+// instead of being appended to rt.Rules.
+func LoadPoliciesIterFunc(rt *runtimev1.RuleTable, policySets iter.Seq2[*runtimev1.RunnablePolicySet, error], onRow func(*runtimev1.RuleTable_RuleRow) error) error {
 	for rps, err := range policySets {
 		if err != nil {
 			return fmt.Errorf("failed to get compiled policy set: %w", err)
@@ -93,8 +102,11 @@ func LoadPoliciesIter(rt *runtimev1.RuleTable, policySets iter.Seq2[*runtimev1.R
 			continue
 		}
 
-		rows := AddPolicy(rt, rps)
-		rt.Rules = append(rt.Rules, rows...)
+		for _, row := range AddPolicy(rt, rps) {
+			if err := onRow(row); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/internal/ruletable/wire.go
+++ b/internal/ruletable/wire.go
@@ -11,7 +11,7 @@ import (
 	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
 )
 
-var ruleTableRulesField = protowire.Number((&runtimev1.RuleTable{}).ProtoReflect().Descriptor().Fields().ByName("rules").Number())
+var ruleTableRulesField = new(runtimev1.RuleTable).ProtoReflect().Descriptor().Fields().ByName("rules").Number()
 
 // AppendRuleRowRecord replicates protobuf marshalling of a single
 // runtimev1.RuleTable_RuleRow as it is done by the (*RuleTable).MarshalToVT

--- a/internal/ruletable/wire.go
+++ b/internal/ruletable/wire.go
@@ -1,0 +1,30 @@
+// Copyright 2021-2026 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package ruletable
+
+import (
+	"slices"
+
+	"google.golang.org/protobuf/encoding/protowire"
+
+	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
+)
+
+var ruleTableRulesField = protowire.Number((&runtimev1.RuleTable{}).ProtoReflect().Descriptor().Fields().ByName("rules").Number())
+
+// AppendRuleRowRecord replicates protobuf marshalling of a single
+// runtimev1.RuleTable_RuleRow as it is done by the (*RuleTable).MarshalToVT
+// method. It can be used to marshall rows separately from the rest of the
+// RuleTable.
+func AppendRuleRowRecord(buf []byte, row *runtimev1.RuleTable_RuleRow) ([]byte, error) {
+	buf = protowire.AppendTag(buf, ruleTableRulesField, protowire.BytesType)
+	size := row.SizeVT()
+	buf = protowire.AppendVarint(buf, uint64(size))
+	offset := len(buf)
+	buf = slices.Grow(buf, size)[: offset+size : offset+size]
+	if _, err := row.MarshalToVT(buf[offset:]); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}

--- a/private/ruletable/compile/compile.go
+++ b/private/ruletable/compile/compile.go
@@ -16,6 +16,23 @@ import (
 )
 
 func Compile(ctx context.Context, fsys fs.FS, attrs ...compile.SourceAttribute) (*runtimev1.RuleTable, error) {
+	var rows []*runtimev1.RuleTable_RuleRow
+	rt, err := CompileStream(ctx, fsys, func(row *runtimev1.RuleTable_RuleRow) error {
+		rows = append(rows, row)
+		return nil
+	}, attrs...)
+	if err != nil {
+		return nil, err
+	}
+
+	rt.Rules = rows
+	return rt, nil
+}
+
+// CompileStream compiles the policies in fsys into rule table rows, passing each row to
+// onRow as it is produced instead of accumulating them. The returned rule table has all other field (schemas,
+// metadata, derived roles, scope maps) initialised.
+func CompileStream(ctx context.Context, fsys fs.FS, onRow func(*runtimev1.RuleTable_RuleRow) error, attrs ...compile.SourceAttribute) (*runtimev1.RuleTable, error) {
 	idx, err := compile.BuildIndex(ctx, fsys, attrs...)
 	if err != nil {
 		return nil, err
@@ -30,7 +47,7 @@ func Compile(ctx context.Context, fsys fs.FS, attrs ...compile.SourceAttribute) 
 
 	rt := ruletable.NewProtoRuletable()
 
-	if err := ruletable.LoadPoliciesIter(rt, mgr.Iter(ctx)); err != nil {
+	if err := ruletable.LoadPoliciesIterFunc(rt, mgr.Iter(ctx), onRow); err != nil {
 		return nil, fmt.Errorf("failed to load policies: %w", err)
 	}
 
@@ -39,4 +56,12 @@ func Compile(ctx context.Context, fsys fs.FS, attrs ...compile.SourceAttribute) 
 	}
 
 	return rt, nil
+}
+
+// AppendRuleRowRecord replicates protobuf marshalling of a single
+// runtimev1.RuleTable_RuleRow as it is done by the (*RuleTable).MarshalToVT
+// method. It can be used to marshall rows separately from the rest of the
+// RuleTable.
+func AppendRuleRowRecord(buf []byte, row *runtimev1.RuleTable_RuleRow) ([]byte, error) {
+	return ruletable.AppendRuleRowRecord(buf, row)
 }

--- a/private/ruletable/compile/compile_test.go
+++ b/private/ruletable/compile/compile_test.go
@@ -11,6 +11,8 @@ import (
 
 	gocmp "github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	runtimev1 "github.com/cerbos/cerbos/api/genpb/cerbos/runtime/v1"
@@ -52,4 +54,50 @@ func sortRules(rt *runtimev1.RuleTable) {
 	slices.SortFunc(rt.Rules, func(a, b *runtimev1.RuleTable_RuleRow) int {
 		return cmp.Compare(util.HashPB(a, nil), util.HashPB(b, nil))
 	})
+}
+// TestStreamedWireCompatibility proves that a rule table serialized incrementally.
+func TestStreamedWireCompatibility(t *testing.T) {
+	const rulesFieldNumber = 1 // runtimev1.RuleTable.rules
+
+	rt, err := ruletablecompile.Compile(t.Context(), os.DirFS(test.PathToDir(t, "store")))
+	require.NoError(t, err)
+	require.NotEmpty(t, rt.GetRules())
+	rt.Manifest = &runtimev1.RuleTable_Manifest{BundleId: "WIRECHECK0000000"}
+
+	conventional, err := rt.MarshalVT()
+	require.NoError(t, err)
+
+	var rowRecords []byte
+	for _, row := range rt.Rules {
+		rowBytes, err := row.MarshalVT()
+		require.NoError(t, err)
+		rowRecords = protowire.AppendTag(rowRecords, rulesFieldNumber, protowire.BytesType)
+		rowRecords = protowire.AppendVarint(rowRecords, uint64(len(rowBytes)))
+		rowRecords = append(rowRecords, rowBytes...)
+	}
+
+	rows := rt.Rules
+	rt.Rules = nil
+	remainder, err := rt.MarshalVT()
+	require.NoError(t, err)
+	rt.Rules = rows
+
+	control := &runtimev1.RuleTable{}
+	require.NoError(t, control.UnmarshalVT(conventional))
+
+	streamed := map[string][]byte{
+		"rowsFirst":      append(slices.Clone(rowRecords), remainder...),
+		"remainderFirst": append(slices.Clone(remainder), rowRecords...),
+	}
+	for name, data := range streamed {
+		t.Run(name, func(t *testing.T) {
+			vt := &runtimev1.RuleTable{}
+			require.NoError(t, vt.UnmarshalVT(data))
+			require.Empty(t, gocmp.Diff(control, vt, protocmp.Transform()), "UnmarshalVT mismatch")
+
+			std := &runtimev1.RuleTable{}
+			require.NoError(t, proto.Unmarshal(data, std))
+			require.Empty(t, gocmp.Diff(control, std, protocmp.Transform()), "proto.Unmarshal mismatch")
+		})
+	}
 }

--- a/private/ruletable/compile/compile_test.go
+++ b/private/ruletable/compile/compile_test.go
@@ -55,6 +55,43 @@ func sortRules(rt *runtimev1.RuleTable) {
 		return cmp.Compare(util.HashPB(a, nil), util.HashPB(b, nil))
 	})
 }
+
+func TestCompileStream(t *testing.T) {
+	fsys := os.DirFS(test.PathToDir(t, "store"))
+	ctx := t.Context()
+
+	want, err := ruletablecompile.Compile(ctx, fsys)
+	require.NoError(t, err)
+	require.NotEmpty(t, want.GetRules())
+
+	var streamed, buf []byte
+	rowCount := 0
+	remainder, err := ruletablecompile.CompileStream(ctx, fsys, func(row *runtimev1.RuleTable_RuleRow) error {
+		var err error
+		buf, err = ruletablecompile.AppendRuleRowRecord(buf[:0], row)
+		if err != nil {
+			return err
+		}
+		streamed = append(streamed, buf...)
+		rowCount++
+		return nil
+	})
+	require.NoError(t, err)
+	require.Empty(t, remainder.GetRules(), "remainder must not accumulate rows")
+	require.Equal(t, len(want.GetRules()), rowCount)
+
+	remainderBytes, err := remainder.MarshalVT()
+	require.NoError(t, err)
+	streamed = append(streamed, remainderBytes...)
+
+	have := &runtimev1.RuleTable{}
+	require.NoError(t, have.UnmarshalVT(streamed))
+
+	sortRules(want)
+	sortRules(have)
+	require.Empty(t, gocmp.Diff(want, have, protocmp.Transform()))
+}
+
 // TestStreamedWireCompatibility proves that a rule table serialized incrementally.
 func TestStreamedWireCompatibility(t *testing.T) {
 	const rulesFieldNumber = 1 // runtimev1.RuleTable.rules

--- a/private/ruletable/compile/compile_test.go
+++ b/private/ruletable/compile/compile_test.go
@@ -64,7 +64,7 @@ func TestCompileStream(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, want.GetRules())
 
-	var streamed, buf []byte
+	var streamed, buf []byte //nolint:prealloc
 	rowCount := 0
 	remainder, err := ruletablecompile.CompileStream(ctx, fsys, func(row *runtimev1.RuleTable_RuleRow) error {
 		var err error

--- a/private/ruletable/compile/compile_test.go
+++ b/private/ruletable/compile/compile_test.go
@@ -92,7 +92,7 @@ func TestCompileStream(t *testing.T) {
 	require.Empty(t, gocmp.Diff(want, have, protocmp.Transform()))
 }
 
-// TestStreamedWireCompatibility proves that a rule table serialized incrementally.
+// TestStreamedWireCompatibility proves that a rule table can be serialized incrementally.
 func TestStreamedWireCompatibility(t *testing.T) {
 	const rulesFieldNumber = 1 // runtimev1.RuleTable.rules
 


### PR DESCRIPTION
This PR enabled incremental table marshalling (see `TestStreamedWireCompatibility`) for memory efficiency.

Currently to create a rule table bundle the entire rule table needs to be build, then it is marshalled into a buffer. For a brief moment both the rule table and its serialised form are being held in memory. 

This changes enables streaming compilation with the `CompileStream` function, when each rule isn't appended to the rule table, but processed by a callback function.