### PR TITLE
Expose parser

### DIFF
--- a/private/parser/parser.go
+++ b/private/parser/parser.go
@@ -1,0 +1,11 @@
+// Copyright 2021-2026 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package parser
+
+import "github.com/cerbos/cerbos/internal/parser"
+
+func Unmarshal[T any, M parser.ProtoMessage[T]](contents []byte) ([]M, error) {
+	message, _, err := parser.UnmarshalBytes[T, M](contents)
+	return message, err
+}


### PR DESCRIPTION
This PR allows Hub to use the same parsing and validation as the PDP when validating files being added to stores (currently it's using the old `util.ReadJSONOrYAML` approach for tests and fixtures).