### PR TITLE
Set log level to error for CI performance regression test

### DIFF
--- a/hack/loadtest/ci/run-test.sh
+++ b/hack/loadtest/ci/run-test.sh
@@ -56,7 +56,7 @@ echo "Starting Cerbos..."
 cerbos server \
   --config="${SCRIPT_DIR}/cerbos.yaml" \
   --set="storage.disk.directory=${WORK_DIR}/policies" \
-  --log-level=warn &
+  --log-level=error &
 CERBOS_PID=$!
 trap "kill $CERBOS_PID 2>/dev/null || true" EXIT
 


### PR DESCRIPTION
Too many warning messages in the log cause the job failure.