### PR TITLE
Handle YAML block scalar syntax in test fixture attributes

### DIFF
--- a/.changelog/20260728_1534.txt
+++ b/.changelog/20260728_1534.txt
@@ -1,0 +1,3 @@
+type:fix
+Handle YAML block scalar syntax in test fixture attributes
+A regression introduced in Cerbos v0.54.0 meant test suites would fail to load if they referenced test fixtures that used YAML block scalar syntax (multiline strings denoted by `|` or `>`) in their attributes.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1039,6 +1039,10 @@ func (u *unmarshaler[T]) unmarshalValue(uctx *unmarshalCtx, n ast.Node, out *str
 		out.Kind = &structpb.Value_StringValue{StringValue: t.Value}
 		return nil
 
+	case *ast.LiteralNode:
+		out.Kind = &structpb.Value_StringValue{StringValue: t.Value.Value}
+		return nil
+
 	case *ast.BoolNode:
 		out.Kind = &structpb.Value_BoolValue{BoolValue: t.Value}
 		return nil

--- a/internal/test/testdata/verify/cases/case_001.yaml.input
+++ b/internal/test/testdata/verify/cases/case_001.yaml.input
@@ -40,8 +40,10 @@ resources:
       department: marketing
       geography: GB
       id: XX125
-      owner: john
-      team: design
+      owner: >
+        john
+      team: |-
+        design
   pending_leave_request:
     kind: leave_request
     policyVersion: '20210210'


### PR DESCRIPTION
https://github.com/cerbos/cerbos/pull/3232 introduced a regression; the parser didn't handle unmarshalling an `*ast.LiteralNode` (a YAML block scalar denoted by `|` or `>`) into a `*structpb.Value`, meaning that test fixtures with block scalars in their attributes failed to load.