### PR TITLE
Enable constant folding in CEL expressions

### DIFF
--- a/.changelog/20260805_1548.txt
+++ b/.changelog/20260805_1548.txt
@@ -1,0 +1,3 @@
+type:enhancement
+Constant folding for policy expressions
+Adds a new optimization step where policy conditions are simplified by evaluating them with known values at compile time. In some cases, this can dramatically reduce the time taken to evaluate policy rules. This change also includes extra validation to catch invalid time and regex definitions at compile time.

--- a/internal/compile/conditions.go
+++ b/internal/compile/conditions.go
@@ -63,7 +63,7 @@ func compileMatch(modCtx *moduleCtx, path string, match *policyv1.Match, markRef
 func compileCELExpr(modCtx *moduleCtx, path, expr string, markReferencedConstantsAndVariablesAsUsed bool) *runtimev1.Expr {
 	result := &runtimev1.Expr{Original: expr}
 
-	celAST, issues := conditions.StdEnv.Compile(expr)
+	celAST, issues := conditions.Compile(expr)
 	if issues != nil && issues.Err() != nil {
 		errList := make([]string, len(issues.Errors()))
 		for i, ce := range issues.Errors() {

--- a/internal/conditions/cel.go
+++ b/internal/conditions/cel.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/google/cel-go/cel"
+	celast "github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/ext"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
@@ -54,17 +55,22 @@ var (
 	}
 
 	variablesType *exprpb.Type
+
+	unoptimizableFunctions = map[string]struct{}{
+		nowFn:       {},
+		timeSinceFn: {},
+	}
 )
 
 func init() {
 	var err error
 
 	StdEnv, err = cel.NewEnv(
-		ext.TwoVarComprehensions(),
 		cel.CrossTypeNumericComparisons(true),
+		cel.ASTValidators(cel.ValidateDurationLiterals(), cel.ValidateRegexLiterals(), cel.ValidateTimestampLiterals()),
+		cel.OptionalTypes(),
 		cel.Types(&enginev1.Request{}, &enginev1.Request_Principal{}, &enginev1.Request_Resource{}, &enginev1.Runtime{}),
 		cel.VariableDecls(StdEnvDecls...),
-		cel.OptionalTypes(),
 		ext.Bindings(),
 		ext.Encoders(),
 		ext.Lists(),
@@ -73,6 +79,7 @@ func init() {
 		ext.Regex(),
 		ext.Sets(),
 		ext.Strings(),
+		ext.TwoVarComprehensions(),
 		CerbosCELLib(),
 		types.Registry(),
 	)
@@ -97,7 +104,7 @@ func init() {
 }
 
 func compileConstant(value string) (*exprpb.CheckedExpr, error) {
-	ast, iss := StdEnv.Compile(value)
+	ast, iss := Compile(value)
 	if iss.Err() != nil {
 		return nil, fmt.Errorf("failed to compile constant %q: %w", value, iss.Err())
 	}
@@ -161,4 +168,59 @@ func ExpandAbbrev(s string) string {
 	}
 
 	return expanded
+}
+
+func Compile(expr string) (*cel.Ast, *cel.Issues) {
+	ast, iss := StdEnv.Compile(expr)
+	if iss != nil && iss.Err() != nil {
+		return nil, iss
+	}
+
+	return Optimize(StdEnv, ast, nil), iss
+}
+
+func Optimize(env *cel.Env, ast *cel.Ast, knownValues cel.Activation) *cel.Ast {
+	if !canOptimize(ast) {
+		return ast
+	}
+
+	var foldOpts []cel.ConstantFoldingOption
+	if knownValues != nil {
+		foldOpts = []cel.ConstantFoldingOption{cel.FoldKnownValues(knownValues)}
+	}
+
+	folder, err := cel.NewConstantFoldingOptimizer(foldOpts...)
+	if err != nil {
+		return ast
+	}
+
+	optimizer, err := cel.NewStaticOptimizer(folder)
+	if err != nil {
+		return ast
+	}
+
+	optimizedAST, issues := optimizer.Optimize(env, ast)
+	if err := issues.Err(); err != nil {
+		return ast
+	}
+
+	return optimizedAST
+}
+
+func canOptimize(ast *cel.Ast) bool {
+	if ast == nil {
+		return false
+	}
+
+	root := celast.NavigateAST(ast.NativeRep())
+	matches := celast.MatchDescendants(root, func(e celast.NavigableExpr) bool {
+		if e.Kind() != celast.CallKind {
+			return false
+		}
+
+		_, exists := unoptimizableFunctions[e.AsCall().FunctionName()]
+		return exists
+	})
+
+	return len(matches) == 0
 }

--- a/internal/conditions/cerbos_lib_benchmarks_test.go
+++ b/internal/conditions/cerbos_lib_benchmarks_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021-2026 Zenauth Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-package conditions
+package conditions_test
 
 import (
 	"fmt"
@@ -13,58 +13,60 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/ext"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cerbos/cerbos/internal/conditions"
 )
 
-const (
-	cerbosFuncIntersect = "hasIntersection"
-	extFuncIntersect    = "sets.intersects"
-)
+func BenchmarkSetOps(b *testing.B) {
+	functionsList := []string{
+		"hasIntersection",
+		"sets.intersects",
+		"isSubset",
+		"sets.contains",
+	}
 
-func BenchmarkExtIntersect5(b *testing.B) {
-	benchmarkFunc(b, extFuncIntersect, 5)
-}
+	for _, functionName := range functionsList {
+		for _, count := range []int{1, 5, 50, 100} {
+			expr := generateExpr(functionName, count)
+			b.Run(fmt.Sprintf("%s_%d", functionName, count), func(b *testing.B) {
+				env, err := cel.NewEnv(
+					cel.ExtendedValidations(),
+					conditions.CerbosCELLib(),
+					ext.Sets(),
+				)
+				require.NoError(b, err)
+				ast, issues := env.Compile(expr)
+				require.NoError(b, issues.Err())
 
-func BenchmarkIntersect5(b *testing.B) {
-	benchmarkFunc(b, cerbosFuncIntersect, 5)
-}
+				prg, err := env.Program(ast, cel.EvalOptions(cel.OptOptimize), cel.CustomDecorator(conditions.CacheFriendlyTimeDecorator()))
+				require.NoError(b, err)
 
-func BenchmarkExtIntersect50(b *testing.B) {
-	benchmarkFunc(b, extFuncIntersect, 50)
-}
+				b.ResetTimer()
+				b.ReportAllocs()
+				for b.Loop() {
+					result, _, err := prg.Eval(cel.NoVars())
+					require.NoError(b, err)
+					resultBool := result.Value().(bool)
+					require.Equal(b, true, resultBool)
+				}
+			})
 
-func BenchmarkIntersect50(b *testing.B) {
-	benchmarkFunc(b, cerbosFuncIntersect, 50)
-}
+			b.Run(fmt.Sprintf("%s_%d_folded", functionName, count), func(b *testing.B) {
+				ast, issues := conditions.Compile(expr)
+				require.NoError(b, issues.Err())
 
-const (
-	cerbosFuncIsSubset = "isSubset"
-	extFuncIsSubset    = "sets.contains"
-)
+				prg, err := conditions.StdEnv.Program(ast, cel.EvalOptions(cel.OptOptimize), cel.CustomDecorator(conditions.CacheFriendlyTimeDecorator()))
+				require.NoError(b, err)
 
-func BenchmarkExtIsSubset5(b *testing.B) {
-	benchmarkFunc(b, extFuncIsSubset, 5)
-}
-
-func BenchmarkIsSubset5(b *testing.B) {
-	benchmarkFunc(b, cerbosFuncIsSubset, 5)
-}
-
-func BenchmarkExtIsSubset50(b *testing.B) {
-	benchmarkFunc(b, extFuncIsSubset, 50)
-}
-
-func BenchmarkIsSubset50(b *testing.B) {
-	benchmarkFunc(b, cerbosFuncIsSubset, 50)
-}
-
-func benchmarkFunc(b *testing.B, function string, size int) {
-	b.Helper()
-	expr := generateExpr(function, size)
-	prg := prepareProgram(b, expr)
-
-	for b.Loop() {
-		_, _, err := prg.Eval(cel.NoVars())
-		require.NoError(b, err)
+				b.ResetTimer()
+				b.ReportAllocs()
+				for b.Loop() {
+					result, _, err := prg.Eval(cel.NoVars())
+					require.NoError(b, err)
+					require.Equal(b, true, result.Value())
+				}
+			})
+		}
 	}
 }
 
@@ -79,20 +81,4 @@ func generateExpr(function string, size int) string {
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
 	rnd.Shuffle(len(rhs), func(i, j int) { rhs[i], rhs[j] = rhs[j], rhs[i] })
 	return fmt.Sprintf("%s([%s], [%s])", function, strings.Join(lhs, ","), strings.Join(rhs, ","))
-}
-
-func prepareProgram(tb testing.TB, expr string) cel.Program {
-	tb.Helper()
-	is := require.New(tb)
-	env, err := cel.NewEnv(
-		CerbosCELLib(),
-		ext.Sets(),
-	)
-	is.NoError(err)
-	ast, issues := env.Compile(expr)
-	is.NoError(issues.Err())
-
-	prg, err := env.Program(ast, cel.EvalOptions(cel.OptOptimize), cel.CustomDecorator(newTimeDecorator(time.Now)))
-	is.NoError(err)
-	return prg
 }

--- a/internal/ruletable/index/index.go
+++ b/internal/ruletable/index/index.go
@@ -1045,7 +1045,7 @@ func getCelProgramsFromExpressions(vars []*runtimev1.Variable) ([]*CelProgram, e
 	progs := make([]*CelProgram, len(vars))
 
 	for i, v := range vars {
-		ast, iss := conditions.StdEnv.Compile(v.Expr.Original)
+		ast, iss := conditions.Compile(v.Expr.Original)
 		if iss != nil && iss.Err() != nil {
 			return nil, iss.Err()
 		}

--- a/internal/ruletable/index/index_test.go
+++ b/internal/ruletable/index/index_test.go
@@ -65,7 +65,7 @@ func TestParamsIndex(t *testing.T) {
 	t.Run("interns equivalent params", func(t *testing.T) {
 		impl := index.New()
 
-		ast, iss := conditions.StdEnv.Compile("1 + 1")
+		ast, iss := conditions.Compile("1 + 1")
 		require.Nil(t, iss)
 		checkedExpr, err := cel.AstToCheckedExpr(ast)
 		require.NoError(t, err)

--- a/internal/ruletable/planner/planner.go
+++ b/internal/ruletable/planner/planner.go
@@ -759,7 +759,7 @@ func (c *ExprCache) getOrCompile(e *runtimev1.Expr) (*exprpb.Expr, error) {
 }
 
 func compileToExpr(src string) (*exprpb.Expr, error) {
-	ast, iss := conditions.StdEnv.Compile(src)
+	ast, iss := conditions.Compile(src)
 	if iss != nil && iss.Err() != nil {
 		return nil, fmt.Errorf("failed to compile %q: %w", src, iss.Err())
 	}

--- a/internal/ruletable/planner/planner_test.go
+++ b/internal/ruletable/planner/planner_test.go
@@ -50,7 +50,7 @@ func Test_evaluateCondition(t *testing.T) {
 	}
 
 	compile := func(expr string, request *enginev1.Request) args {
-		ast, iss := conditions.StdEnv.Compile(expr)
+		ast, iss := conditions.Compile(expr)
 		require.Nil(t, iss, "Error is %s", iss.Err())
 		checkedExpr, err := cel.AstToCheckedExpr(ast)
 		require.NoError(t, err)

--- a/internal/ruletable/ruletable.go
+++ b/internal/ruletable/ruletable.go
@@ -559,7 +559,7 @@ func (c *ProgramCache) GetOrCreate(expr *runtimev1.Expr) (cel.Program, error) {
 }
 
 func compileFromSource(src string) (cel.Program, error) {
-	ast, iss := conditions.StdEnv.Compile(src)
+	ast, iss := conditions.Compile(src)
 	if iss != nil && iss.Err() != nil {
 		return nil, iss.Err()
 	}

--- a/internal/test/testdata/compile/multiple_imports.yaml.golden
+++ b/internal/test/testdata/compile/multiple_imports.yaml.golden
@@ -37,23 +37,23 @@
                       "checked": {
                         "referenceMap": {
                           "1": {
-                            "name": "request"
-                          },
-                          "5": {
                             "overloadId": [
                               "equals"
                             ]
                           },
-                          "6": {
+                          "5": {
+                            "name": "request"
+                          },
+                          "9": {
                             "name": "request"
                           }
                         },
                         "typeMap": {
                           "1": {
-                            "messageType": "cerbos.engine.v1.Request"
+                            "primitive": "BOOL"
                           },
                           "2": {
-                            "messageType": "cerbos.engine.v1.Request.Resource"
+                            "dyn": {}
                           },
                           "3": {
                             "mapType": {
@@ -66,18 +66,15 @@
                             }
                           },
                           "4": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request.Resource"
                           },
                           "5": {
-                            "primitive": "BOOL"
-                          },
-                          "6": {
                             "messageType": "cerbos.engine.v1.Request"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          "6": {
+                            "dyn": {}
                           },
-                          "8": {
+                          "7": {
                             "mapType": {
                               "keyType": {
                                 "primitive": "STRING"
@@ -87,8 +84,11 @@
                               }
                             }
                           },
+                          "8": {
+                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          },
                           "9": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request"
                           }
                         },
                         "sourceInfo": {
@@ -97,33 +97,33 @@
                             68
                           ],
                           "positions": {
-                            "1": 0,
-                            "2": 7,
+                            "1": 32,
+                            "2": 21,
                             "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                            "4": 7,
+                            "5": 0,
+                            "6": 57,
+                            "7": 52,
+                            "8": 42,
+                            "9": 35
                           }
                         },
                         "expr": {
-                          "id": "5",
+                          "id": "1",
                           "callExpr": {
                             "function": "_==_",
                             "args": [
                               {
-                                "id": "4",
+                                "id": "2",
                                 "selectExpr": {
                                   "operand": {
                                     "id": "3",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "2",
+                                        "id": "4",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "1",
+                                            "id": "5",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -138,16 +138,16 @@
                                 }
                               },
                               {
-                                "id": "9",
+                                "id": "6",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "8",
+                                    "id": "7",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "7",
+                                        "id": "8",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "6",
+                                            "id": "9",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -173,23 +173,23 @@
                       "checked": {
                         "referenceMap": {
                           "1": {
-                            "name": "request"
-                          },
-                          "5": {
                             "overloadId": [
                               "equals"
                             ]
                           },
-                          "6": {
+                          "5": {
+                            "name": "request"
+                          },
+                          "9": {
                             "name": "request"
                           }
                         },
                         "typeMap": {
                           "1": {
-                            "messageType": "cerbos.engine.v1.Request"
+                            "primitive": "BOOL"
                           },
                           "2": {
-                            "messageType": "cerbos.engine.v1.Request.Resource"
+                            "dyn": {}
                           },
                           "3": {
                             "mapType": {
@@ -202,18 +202,15 @@
                             }
                           },
                           "4": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request.Resource"
                           },
                           "5": {
-                            "primitive": "BOOL"
-                          },
-                          "6": {
                             "messageType": "cerbos.engine.v1.Request"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          "6": {
+                            "dyn": {}
                           },
-                          "8": {
+                          "7": {
                             "mapType": {
                               "keyType": {
                                 "primitive": "STRING"
@@ -223,8 +220,11 @@
                               }
                             }
                           },
+                          "8": {
+                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          },
                           "9": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request"
                           }
                         },
                         "sourceInfo": {
@@ -233,33 +233,33 @@
                             78
                           ],
                           "positions": {
-                            "1": 0,
-                            "2": 7,
+                            "1": 32,
+                            "2": 21,
                             "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                            "4": 7,
+                            "5": 0,
+                            "6": 57,
+                            "7": 52,
+                            "8": 42,
+                            "9": 35
                           }
                         },
                         "expr": {
-                          "id": "5",
+                          "id": "1",
                           "callExpr": {
                             "function": "_==_",
                             "args": [
                               {
-                                "id": "4",
+                                "id": "2",
                                 "selectExpr": {
                                   "operand": {
                                     "id": "3",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "2",
+                                        "id": "4",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "1",
+                                            "id": "5",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -274,16 +274,16 @@
                                 }
                               },
                               {
-                                "id": "9",
+                                "id": "6",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "8",
+                                    "id": "7",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "7",
+                                        "id": "8",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "6",
+                                            "id": "9",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -319,22 +319,25 @@
                 "checked": {
                   "referenceMap": {
                     "1": {
-                      "name": "R"
-                    },
-                    "4": {
                       "overloadId": [
                         "equals"
                       ]
                     },
-                    "5": {
+                    "4": {
+                      "name": "R"
+                    },
+                    "6": {
                       "name": "P"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.engine.v1.Request.Resource"
+                      "primitive": "BOOL"
                     },
                     "2": {
+                      "dyn": {}
+                    },
+                    "3": {
                       "mapType": {
                         "keyType": {
                           "primitive": "STRING"
@@ -344,17 +347,14 @@
                         }
                       }
                     },
-                    "3": {
-                      "dyn": {}
-                    },
                     "4": {
-                      "primitive": "BOOL"
+                      "messageType": "cerbos.engine.v1.Request.Resource"
                     },
                     "5": {
-                      "messageType": "cerbos.engine.v1.Request.Principal"
+                      "primitive": "STRING"
                     },
                     "6": {
-                      "primitive": "STRING"
+                      "messageType": "cerbos.engine.v1.Request.Principal"
                     }
                   },
                   "sourceInfo": {
@@ -363,27 +363,27 @@
                       21
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 1,
-                      "3": 6,
-                      "4": 13,
-                      "5": 16,
-                      "6": 17
+                      "1": 13,
+                      "2": 6,
+                      "3": 1,
+                      "4": 0,
+                      "5": 17,
+                      "6": 16
                     }
                   },
                   "expr": {
-                    "id": "4",
+                    "id": "1",
                     "callExpr": {
                       "function": "_==_",
                       "args": [
                         {
-                          "id": "3",
+                          "id": "2",
                           "selectExpr": {
                             "operand": {
-                              "id": "2",
+                              "id": "3",
                               "selectExpr": {
                                 "operand": {
-                                  "id": "1",
+                                  "id": "4",
                                   "identExpr": {
                                     "name": "R"
                                   }
@@ -395,10 +395,10 @@
                           }
                         },
                         {
-                          "id": "6",
+                          "id": "5",
                           "selectExpr": {
                             "operand": {
-                              "id": "5",
+                              "id": "6",
                               "identExpr": {
                                 "name": "P"
                               }
@@ -471,20 +471,20 @@
                 "checked": {
                   "referenceMap": {
                     "1": {
-                      "name": "request"
-                    },
-                    "5": {
                       "overloadId": [
                         "equals"
                       ]
+                    },
+                    "5": {
+                      "name": "request"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.engine.v1.Request"
+                      "primitive": "BOOL"
                     },
                     "2": {
-                      "messageType": "cerbos.engine.v1.Request.Resource"
+                      "dyn": {}
                     },
                     "3": {
                       "mapType": {
@@ -497,10 +497,10 @@
                       }
                     },
                     "4": {
-                      "dyn": {}
+                      "messageType": "cerbos.engine.v1.Request.Resource"
                     },
                     "5": {
-                      "primitive": "BOOL"
+                      "messageType": "cerbos.engine.v1.Request"
                     },
                     "6": {
                       "primitive": "STRING"
@@ -512,30 +512,30 @@
                       51
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 7,
+                      "1": 29,
+                      "2": 21,
                       "3": 16,
-                      "4": 21,
-                      "5": 29,
+                      "4": 7,
+                      "5": 0,
                       "6": 32
                     }
                   },
                   "expr": {
-                    "id": "5",
+                    "id": "1",
                     "callExpr": {
                       "function": "_==_",
                       "args": [
                         {
-                          "id": "4",
+                          "id": "2",
                           "selectExpr": {
                             "operand": {
                               "id": "3",
                               "selectExpr": {
                                 "operand": {
-                                  "id": "2",
+                                  "id": "4",
                                   "selectExpr": {
                                     "operand": {
-                                      "id": "1",
+                                      "id": "5",
                                       "identExpr": {
                                         "name": "request"
                                       }

--- a/internal/test/testdata/compile/principal_policy.yaml.golden
+++ b/internal/test/testdata/compile/principal_policy.yaml.golden
@@ -27,20 +27,20 @@
                     "checked": {
                       "referenceMap": {
                         "1": {
-                          "name": "request"
-                        },
-                        "5": {
                           "overloadId": [
                             "equals"
                           ]
+                        },
+                        "5": {
+                          "name": "request"
                         }
                       },
                       "typeMap": {
                         "1": {
-                          "messageType": "cerbos.engine.v1.Request"
+                          "primitive": "BOOL"
                         },
                         "2": {
-                          "messageType": "cerbos.engine.v1.Request.Resource"
+                          "dyn": {}
                         },
                         "3": {
                           "mapType": {
@@ -53,10 +53,10 @@
                           }
                         },
                         "4": {
-                          "dyn": {}
+                          "messageType": "cerbos.engine.v1.Request.Resource"
                         },
                         "5": {
-                          "primitive": "BOOL"
+                          "messageType": "cerbos.engine.v1.Request"
                         },
                         "6": {
                           "primitive": "BOOL"
@@ -68,30 +68,30 @@
                           41
                         ],
                         "positions": {
-                          "1": 0,
-                          "2": 7,
+                          "1": 33,
+                          "2": 21,
                           "3": 16,
-                          "4": 21,
-                          "5": 33,
+                          "4": 7,
+                          "5": 0,
                           "6": 36
                         }
                       },
                       "expr": {
-                        "id": "5",
+                        "id": "1",
                         "callExpr": {
                           "function": "_==_",
                           "args": [
                             {
-                              "id": "4",
+                              "id": "2",
                               "selectExpr": {
                                 "operand": {
                                   "id": "3",
                                   "selectExpr": {
                                     "operand": {
-                                      "id": "2",
+                                      "id": "4",
                                       "selectExpr": {
                                         "operand": {
-                                          "id": "1",
+                                          "id": "5",
                                           "identExpr": {
                                             "name": "request"
                                           }
@@ -124,18 +124,18 @@
                       "original": "\"donald_duck_dev_record_override:%s\".format([request.resource.attr.dev_record == true])",
                       "checked": {
                         "referenceMap": {
-                          "2": {
+                          "1": {
                             "overloadId": [
                               "string_format"
                             ]
                           },
                           "4": {
-                            "name": "request"
-                          },
-                          "8": {
                             "overloadId": [
                               "equals"
                             ]
+                          },
+                          "8": {
+                            "name": "request"
                           }
                         },
                         "typeMap": {
@@ -153,10 +153,10 @@
                             }
                           },
                           "4": {
-                            "messageType": "cerbos.engine.v1.Request"
+                            "primitive": "BOOL"
                           },
                           "5": {
-                            "messageType": "cerbos.engine.v1.Request.Resource"
+                            "dyn": {}
                           },
                           "6": {
                             "mapType": {
@@ -169,10 +169,10 @@
                             }
                           },
                           "7": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request.Resource"
                           },
                           "8": {
-                            "primitive": "BOOL"
+                            "messageType": "cerbos.engine.v1.Request"
                           },
                           "9": {
                             "primitive": "BOOL"
@@ -184,22 +184,22 @@
                             88
                           ],
                           "positions": {
-                            "1": 0,
-                            "2": 43,
+                            "1": 43,
+                            "2": 0,
                             "3": 44,
-                            "4": 45,
-                            "5": 52,
+                            "4": 78,
+                            "5": 66,
                             "6": 61,
-                            "7": 66,
-                            "8": 78,
+                            "7": 52,
+                            "8": 45,
                             "9": 81
                           }
                         },
                         "expr": {
-                          "id": "2",
+                          "id": "1",
                           "callExpr": {
                             "target": {
-                              "id": "1",
+                              "id": "2",
                               "constExpr": {
                                 "stringValue": "donald_duck_dev_record_override:%s"
                               }
@@ -211,21 +211,21 @@
                                 "listExpr": {
                                   "elements": [
                                     {
-                                      "id": "8",
+                                      "id": "4",
                                       "callExpr": {
                                         "function": "_==_",
                                         "args": [
                                           {
-                                            "id": "7",
+                                            "id": "5",
                                             "selectExpr": {
                                               "operand": {
                                                 "id": "6",
                                                 "selectExpr": {
                                                   "operand": {
-                                                    "id": "5",
+                                                    "id": "7",
                                                     "selectExpr": {
                                                       "operand": {
-                                                        "id": "4",
+                                                        "id": "8",
                                                         "identExpr": {
                                                           "name": "request"
                                                         }

--- a/internal/test/testdata/compile/role_policy.yaml.golden
+++ b/internal/test/testdata/compile/role_policy.yaml.golden
@@ -39,16 +39,16 @@
                 "original": "variables.is_public_report",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "variables"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -57,15 +57,15 @@
                       27
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 9
+                      "1": 9,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "variables"
                         }
@@ -83,12 +83,12 @@
                   "original": "\"expenses_report_allowed:%s\".format([request.principal.id])",
                   "checked": {
                     "referenceMap": {
-                      "2": {
+                      "1": {
                         "overloadId": [
                           "string_format"
                         ]
                       },
-                      "4": {
+                      "6": {
                         "name": "request"
                       }
                     },
@@ -107,13 +107,13 @@
                         }
                       },
                       "4": {
-                        "messageType": "cerbos.engine.v1.Request"
+                        "primitive": "STRING"
                       },
                       "5": {
                         "messageType": "cerbos.engine.v1.Request.Principal"
                       },
                       "6": {
-                        "primitive": "STRING"
+                        "messageType": "cerbos.engine.v1.Request"
                       }
                     },
                     "sourceInfo": {
@@ -122,19 +122,19 @@
                         60
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 35,
+                        "1": 35,
+                        "2": 0,
                         "3": 36,
-                        "4": 37,
+                        "4": 54,
                         "5": 44,
-                        "6": 54
+                        "6": 37
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "callExpr": {
                         "target": {
-                          "id": "1",
+                          "id": "2",
                           "constExpr": {
                             "stringValue": "expenses_report_allowed:%s"
                           }
@@ -146,13 +146,13 @@
                             "listExpr": {
                               "elements": [
                                 {
-                                  "id": "6",
+                                  "id": "4",
                                   "selectExpr": {
                                     "operand": {
                                       "id": "5",
                                       "selectExpr": {
                                         "operand": {
-                                          "id": "4",
+                                          "id": "6",
                                           "identExpr": {
                                             "name": "request"
                                           }
@@ -175,12 +175,12 @@
                   "original": "\"expenses_report_blocked:%s\".format([request.principal.id])",
                   "checked": {
                     "referenceMap": {
-                      "2": {
+                      "1": {
                         "overloadId": [
                           "string_format"
                         ]
                       },
-                      "4": {
+                      "6": {
                         "name": "request"
                       }
                     },
@@ -199,13 +199,13 @@
                         }
                       },
                       "4": {
-                        "messageType": "cerbos.engine.v1.Request"
+                        "primitive": "STRING"
                       },
                       "5": {
                         "messageType": "cerbos.engine.v1.Request.Principal"
                       },
                       "6": {
-                        "primitive": "STRING"
+                        "messageType": "cerbos.engine.v1.Request"
                       }
                     },
                     "sourceInfo": {
@@ -214,19 +214,19 @@
                         60
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 35,
+                        "1": 35,
+                        "2": 0,
                         "3": 36,
-                        "4": 37,
+                        "4": 54,
                         "5": 44,
-                        "6": 54
+                        "6": 37
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "callExpr": {
                         "target": {
-                          "id": "1",
+                          "id": "2",
                           "constExpr": {
                             "stringValue": "expenses_report_blocked:%s"
                           }
@@ -238,13 +238,13 @@
                             "listExpr": {
                               "elements": [
                                 {
-                                  "id": "6",
+                                  "id": "4",
                                   "selectExpr": {
                                     "operand": {
                                       "id": "5",
                                       "selectExpr": {
                                         "operand": {
-                                          "id": "4",
+                                          "id": "6",
                                           "identExpr": {
                                             "name": "request"
                                           }
@@ -277,23 +277,23 @@
           "checked": {
             "referenceMap": {
               "1": {
-                "name": "request"
-              },
-              "5": {
                 "overloadId": [
                   "equals"
                 ]
               },
-              "6": {
+              "5": {
+                "name": "request"
+              },
+              "7": {
                 "name": "constants"
               }
             },
             "typeMap": {
               "1": {
-                "messageType": "cerbos.engine.v1.Request"
+                "primitive": "BOOL"
               },
               "2": {
-                "messageType": "cerbos.engine.v1.Request.Resource"
+                "dyn": {}
               },
               "3": {
                 "mapType": {
@@ -306,16 +306,16 @@
                 }
               },
               "4": {
-                "dyn": {}
+                "messageType": "cerbos.engine.v1.Request.Resource"
               },
               "5": {
-                "primitive": "BOOL"
+                "messageType": "cerbos.engine.v1.Request"
               },
               "6": {
-                "messageType": "cerbos.Variables"
+                "dyn": {}
               },
               "7": {
-                "dyn": {}
+                "messageType": "cerbos.Variables"
               }
             },
             "sourceInfo": {
@@ -324,31 +324,31 @@
                 49
               ],
               "positions": {
-                "1": 0,
-                "2": 7,
+                "1": 29,
+                "2": 21,
                 "3": 16,
-                "4": 21,
-                "5": 29,
-                "6": 32,
-                "7": 41
+                "4": 7,
+                "5": 0,
+                "6": 41,
+                "7": 32
               }
             },
             "expr": {
-              "id": "5",
+              "id": "1",
               "callExpr": {
                 "function": "_==_",
                 "args": [
                   {
-                    "id": "4",
+                    "id": "2",
                     "selectExpr": {
                       "operand": {
                         "id": "3",
                         "selectExpr": {
                           "operand": {
-                            "id": "2",
+                            "id": "4",
                             "selectExpr": {
                               "operand": {
-                                "id": "1",
+                                "id": "5",
                                 "identExpr": {
                                   "name": "request"
                                 }
@@ -363,10 +363,10 @@
                     }
                   },
                   {
-                    "id": "7",
+                    "id": "6",
                     "selectExpr": {
                       "operand": {
-                        "id": "6",
+                        "id": "7",
                         "identExpr": {
                           "name": "constants"
                         }

--- a/internal/test/testdata/compile/scoped_principal_policy_set.yaml.golden
+++ b/internal/test/testdata/compile/scoped_principal_policy_set.yaml.golden
@@ -73,20 +73,20 @@
                     "checked": {
                       "referenceMap": {
                         "1": {
-                          "name": "request"
-                        },
-                        "5": {
                           "overloadId": [
                             "equals"
                           ]
+                        },
+                        "5": {
+                          "name": "request"
                         }
                       },
                       "typeMap": {
                         "1": {
-                          "messageType": "cerbos.engine.v1.Request"
+                          "primitive": "BOOL"
                         },
                         "2": {
-                          "messageType": "cerbos.engine.v1.Request.Resource"
+                          "dyn": {}
                         },
                         "3": {
                           "mapType": {
@@ -99,10 +99,10 @@
                           }
                         },
                         "4": {
-                          "dyn": {}
+                          "messageType": "cerbos.engine.v1.Request.Resource"
                         },
                         "5": {
-                          "primitive": "BOOL"
+                          "messageType": "cerbos.engine.v1.Request"
                         },
                         "6": {
                           "primitive": "BOOL"
@@ -114,30 +114,30 @@
                           41
                         ],
                         "positions": {
-                          "1": 0,
-                          "2": 7,
+                          "1": 33,
+                          "2": 21,
                           "3": 16,
-                          "4": 21,
-                          "5": 33,
+                          "4": 7,
+                          "5": 0,
                           "6": 36
                         }
                       },
                       "expr": {
-                        "id": "5",
+                        "id": "1",
                         "callExpr": {
                           "function": "_==_",
                           "args": [
                             {
-                              "id": "4",
+                              "id": "2",
                               "selectExpr": {
                                 "operand": {
                                   "id": "3",
                                   "selectExpr": {
                                     "operand": {
-                                      "id": "2",
+                                      "id": "4",
                                       "selectExpr": {
                                         "operand": {
-                                          "id": "1",
+                                          "id": "5",
                                           "identExpr": {
                                             "name": "request"
                                           }

--- a/internal/test/testdata/compile/scoped_resource_policy_set.yaml.golden
+++ b/internal/test/testdata/compile/scoped_resource_policy_set.yaml.golden
@@ -46,23 +46,23 @@
                       "checked": {
                         "referenceMap": {
                           "1": {
-                            "name": "request"
-                          },
-                          "5": {
                             "overloadId": [
                               "equals"
                             ]
                           },
-                          "6": {
+                          "5": {
+                            "name": "request"
+                          },
+                          "9": {
                             "name": "request"
                           }
                         },
                         "typeMap": {
                           "1": {
-                            "messageType": "cerbos.engine.v1.Request"
+                            "primitive": "BOOL"
                           },
                           "2": {
-                            "messageType": "cerbos.engine.v1.Request.Resource"
+                            "dyn": {}
                           },
                           "3": {
                             "mapType": {
@@ -75,18 +75,15 @@
                             }
                           },
                           "4": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request.Resource"
                           },
                           "5": {
-                            "primitive": "BOOL"
-                          },
-                          "6": {
                             "messageType": "cerbos.engine.v1.Request"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          "6": {
+                            "dyn": {}
                           },
-                          "8": {
+                          "7": {
                             "mapType": {
                               "keyType": {
                                 "primitive": "STRING"
@@ -96,8 +93,11 @@
                               }
                             }
                           },
+                          "8": {
+                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          },
                           "9": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request"
                           }
                         },
                         "sourceInfo": {
@@ -106,33 +106,33 @@
                             68
                           ],
                           "positions": {
-                            "1": 0,
-                            "2": 7,
+                            "1": 32,
+                            "2": 21,
                             "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                            "4": 7,
+                            "5": 0,
+                            "6": 57,
+                            "7": 52,
+                            "8": 42,
+                            "9": 35
                           }
                         },
                         "expr": {
-                          "id": "5",
+                          "id": "1",
                           "callExpr": {
                             "function": "_==_",
                             "args": [
                               {
-                                "id": "4",
+                                "id": "2",
                                 "selectExpr": {
                                   "operand": {
                                     "id": "3",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "2",
+                                        "id": "4",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "1",
+                                            "id": "5",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -147,16 +147,16 @@
                                 }
                               },
                               {
-                                "id": "9",
+                                "id": "6",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "8",
+                                    "id": "7",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "7",
+                                        "id": "8",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "6",
+                                            "id": "9",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -182,23 +182,23 @@
                       "checked": {
                         "referenceMap": {
                           "1": {
-                            "name": "request"
-                          },
-                          "5": {
                             "overloadId": [
                               "equals"
                             ]
                           },
-                          "6": {
+                          "5": {
+                            "name": "request"
+                          },
+                          "9": {
                             "name": "request"
                           }
                         },
                         "typeMap": {
                           "1": {
-                            "messageType": "cerbos.engine.v1.Request"
+                            "primitive": "BOOL"
                           },
                           "2": {
-                            "messageType": "cerbos.engine.v1.Request.Resource"
+                            "dyn": {}
                           },
                           "3": {
                             "mapType": {
@@ -211,18 +211,15 @@
                             }
                           },
                           "4": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request.Resource"
                           },
                           "5": {
-                            "primitive": "BOOL"
-                          },
-                          "6": {
                             "messageType": "cerbos.engine.v1.Request"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          "6": {
+                            "dyn": {}
                           },
-                          "8": {
+                          "7": {
                             "mapType": {
                               "keyType": {
                                 "primitive": "STRING"
@@ -232,8 +229,11 @@
                               }
                             }
                           },
+                          "8": {
+                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          },
                           "9": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request"
                           }
                         },
                         "sourceInfo": {
@@ -242,33 +242,33 @@
                             78
                           ],
                           "positions": {
-                            "1": 0,
-                            "2": 7,
+                            "1": 32,
+                            "2": 21,
                             "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                            "4": 7,
+                            "5": 0,
+                            "6": 57,
+                            "7": 52,
+                            "8": 42,
+                            "9": 35
                           }
                         },
                         "expr": {
-                          "id": "5",
+                          "id": "1",
                           "callExpr": {
                             "function": "_==_",
                             "args": [
                               {
-                                "id": "4",
+                                "id": "2",
                                 "selectExpr": {
                                   "operand": {
                                     "id": "3",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "2",
+                                        "id": "4",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "1",
+                                            "id": "5",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -283,16 +283,16 @@
                                 }
                               },
                               {
-                                "id": "9",
+                                "id": "6",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "8",
+                                    "id": "7",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "7",
+                                        "id": "8",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "6",
+                                            "id": "9",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -336,20 +336,20 @@
                 "checked": {
                   "referenceMap": {
                     "1": {
-                      "name": "request"
-                    },
-                    "5": {
                       "overloadId": [
                         "equals"
                       ]
+                    },
+                    "5": {
+                      "name": "request"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.engine.v1.Request"
+                      "primitive": "BOOL"
                     },
                     "2": {
-                      "messageType": "cerbos.engine.v1.Request.Resource"
+                      "dyn": {}
                     },
                     "3": {
                       "mapType": {
@@ -362,10 +362,10 @@
                       }
                     },
                     "4": {
-                      "dyn": {}
+                      "messageType": "cerbos.engine.v1.Request.Resource"
                     },
                     "5": {
-                      "primitive": "BOOL"
+                      "messageType": "cerbos.engine.v1.Request"
                     },
                     "6": {
                       "primitive": "STRING"
@@ -377,30 +377,30 @@
                       51
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 7,
+                      "1": 29,
+                      "2": 21,
                       "3": 16,
-                      "4": 21,
-                      "5": 29,
+                      "4": 7,
+                      "5": 0,
                       "6": 32
                     }
                   },
                   "expr": {
-                    "id": "5",
+                    "id": "1",
                     "callExpr": {
                       "function": "_==_",
                       "args": [
                         {
-                          "id": "4",
+                          "id": "2",
                           "selectExpr": {
                             "operand": {
                               "id": "3",
                               "selectExpr": {
                                 "operand": {
-                                  "id": "2",
+                                  "id": "4",
                                   "selectExpr": {
                                     "operand": {
-                                      "id": "1",
+                                      "id": "5",
                                       "identExpr": {
                                         "name": "request"
                                       }
@@ -472,23 +472,23 @@
                       "checked": {
                         "referenceMap": {
                           "1": {
-                            "name": "request"
-                          },
-                          "5": {
                             "overloadId": [
                               "equals"
                             ]
                           },
-                          "6": {
+                          "5": {
+                            "name": "request"
+                          },
+                          "9": {
                             "name": "request"
                           }
                         },
                         "typeMap": {
                           "1": {
-                            "messageType": "cerbos.engine.v1.Request"
+                            "primitive": "BOOL"
                           },
                           "2": {
-                            "messageType": "cerbos.engine.v1.Request.Resource"
+                            "dyn": {}
                           },
                           "3": {
                             "mapType": {
@@ -501,18 +501,15 @@
                             }
                           },
                           "4": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request.Resource"
                           },
                           "5": {
-                            "primitive": "BOOL"
-                          },
-                          "6": {
                             "messageType": "cerbos.engine.v1.Request"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          "6": {
+                            "dyn": {}
                           },
-                          "8": {
+                          "7": {
                             "mapType": {
                               "keyType": {
                                 "primitive": "STRING"
@@ -522,8 +519,11 @@
                               }
                             }
                           },
+                          "8": {
+                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          },
                           "9": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request"
                           }
                         },
                         "sourceInfo": {
@@ -532,33 +532,33 @@
                             68
                           ],
                           "positions": {
-                            "1": 0,
-                            "2": 7,
+                            "1": 32,
+                            "2": 21,
                             "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                            "4": 7,
+                            "5": 0,
+                            "6": 57,
+                            "7": 52,
+                            "8": 42,
+                            "9": 35
                           }
                         },
                         "expr": {
-                          "id": "5",
+                          "id": "1",
                           "callExpr": {
                             "function": "_==_",
                             "args": [
                               {
-                                "id": "4",
+                                "id": "2",
                                 "selectExpr": {
                                   "operand": {
                                     "id": "3",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "2",
+                                        "id": "4",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "1",
+                                            "id": "5",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -573,16 +573,16 @@
                                 }
                               },
                               {
-                                "id": "9",
+                                "id": "6",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "8",
+                                    "id": "7",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "7",
+                                        "id": "8",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "6",
+                                            "id": "9",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -608,23 +608,23 @@
                       "checked": {
                         "referenceMap": {
                           "1": {
-                            "name": "request"
-                          },
-                          "5": {
                             "overloadId": [
                               "equals"
                             ]
                           },
-                          "6": {
+                          "5": {
+                            "name": "request"
+                          },
+                          "9": {
                             "name": "request"
                           }
                         },
                         "typeMap": {
                           "1": {
-                            "messageType": "cerbos.engine.v1.Request"
+                            "primitive": "BOOL"
                           },
                           "2": {
-                            "messageType": "cerbos.engine.v1.Request.Resource"
+                            "dyn": {}
                           },
                           "3": {
                             "mapType": {
@@ -637,18 +637,15 @@
                             }
                           },
                           "4": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request.Resource"
                           },
                           "5": {
-                            "primitive": "BOOL"
-                          },
-                          "6": {
                             "messageType": "cerbos.engine.v1.Request"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          "6": {
+                            "dyn": {}
                           },
-                          "8": {
+                          "7": {
                             "mapType": {
                               "keyType": {
                                 "primitive": "STRING"
@@ -658,8 +655,11 @@
                               }
                             }
                           },
+                          "8": {
+                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          },
                           "9": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request"
                           }
                         },
                         "sourceInfo": {
@@ -668,33 +668,33 @@
                             78
                           ],
                           "positions": {
-                            "1": 0,
-                            "2": 7,
+                            "1": 32,
+                            "2": 21,
                             "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                            "4": 7,
+                            "5": 0,
+                            "6": 57,
+                            "7": 52,
+                            "8": 42,
+                            "9": 35
                           }
                         },
                         "expr": {
-                          "id": "5",
+                          "id": "1",
                           "callExpr": {
                             "function": "_==_",
                             "args": [
                               {
-                                "id": "4",
+                                "id": "2",
                                 "selectExpr": {
                                   "operand": {
                                     "id": "3",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "2",
+                                        "id": "4",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "1",
+                                            "id": "5",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -709,16 +709,16 @@
                                 }
                               },
                               {
-                                "id": "9",
+                                "id": "6",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "8",
+                                    "id": "7",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "7",
+                                        "id": "8",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "6",
+                                            "id": "9",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -754,22 +754,25 @@
                 "checked": {
                   "referenceMap": {
                     "1": {
-                      "name": "R"
-                    },
-                    "4": {
                       "overloadId": [
                         "equals"
                       ]
                     },
-                    "5": {
+                    "4": {
+                      "name": "R"
+                    },
+                    "6": {
                       "name": "P"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.engine.v1.Request.Resource"
+                      "primitive": "BOOL"
                     },
                     "2": {
+                      "dyn": {}
+                    },
+                    "3": {
                       "mapType": {
                         "keyType": {
                           "primitive": "STRING"
@@ -779,17 +782,14 @@
                         }
                       }
                     },
-                    "3": {
-                      "dyn": {}
-                    },
                     "4": {
-                      "primitive": "BOOL"
+                      "messageType": "cerbos.engine.v1.Request.Resource"
                     },
                     "5": {
-                      "messageType": "cerbos.engine.v1.Request.Principal"
+                      "primitive": "STRING"
                     },
                     "6": {
-                      "primitive": "STRING"
+                      "messageType": "cerbos.engine.v1.Request.Principal"
                     }
                   },
                   "sourceInfo": {
@@ -798,27 +798,27 @@
                       21
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 1,
-                      "3": 6,
-                      "4": 13,
-                      "5": 16,
-                      "6": 17
+                      "1": 13,
+                      "2": 6,
+                      "3": 1,
+                      "4": 0,
+                      "5": 17,
+                      "6": 16
                     }
                   },
                   "expr": {
-                    "id": "4",
+                    "id": "1",
                     "callExpr": {
                       "function": "_==_",
                       "args": [
                         {
-                          "id": "3",
+                          "id": "2",
                           "selectExpr": {
                             "operand": {
-                              "id": "2",
+                              "id": "3",
                               "selectExpr": {
                                 "operand": {
-                                  "id": "1",
+                                  "id": "4",
                                   "identExpr": {
                                     "name": "R"
                                   }
@@ -830,10 +830,10 @@
                           }
                         },
                         {
-                          "id": "6",
+                          "id": "5",
                           "selectExpr": {
                             "operand": {
-                              "id": "5",
+                              "id": "6",
                               "identExpr": {
                                 "name": "P"
                               }
@@ -896,20 +896,20 @@
                 "checked": {
                   "referenceMap": {
                     "1": {
-                      "name": "request"
-                    },
-                    "5": {
                       "overloadId": [
                         "equals"
                       ]
+                    },
+                    "5": {
+                      "name": "request"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.engine.v1.Request"
+                      "primitive": "BOOL"
                     },
                     "2": {
-                      "messageType": "cerbos.engine.v1.Request.Resource"
+                      "dyn": {}
                     },
                     "3": {
                       "mapType": {
@@ -922,10 +922,10 @@
                       }
                     },
                     "4": {
-                      "dyn": {}
+                      "messageType": "cerbos.engine.v1.Request.Resource"
                     },
                     "5": {
-                      "primitive": "BOOL"
+                      "messageType": "cerbos.engine.v1.Request"
                     },
                     "6": {
                       "primitive": "STRING"
@@ -937,30 +937,30 @@
                       51
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 7,
+                      "1": 29,
+                      "2": 21,
                       "3": 16,
-                      "4": 21,
-                      "5": 29,
+                      "4": 7,
+                      "5": 0,
                       "6": 32
                     }
                   },
                   "expr": {
-                    "id": "5",
+                    "id": "1",
                     "callExpr": {
                       "function": "_==_",
                       "args": [
                         {
-                          "id": "4",
+                          "id": "2",
                           "selectExpr": {
                             "operand": {
                               "id": "3",
                               "selectExpr": {
                                 "operand": {
-                                  "id": "2",
+                                  "id": "4",
                                   "selectExpr": {
                                     "operand": {
-                                      "id": "1",
+                                      "id": "5",
                                       "identExpr": {
                                         "name": "request"
                                       }

--- a/internal/test/testdata/compile/simple_valid_policy_set.yaml.golden
+++ b/internal/test/testdata/compile/simple_valid_policy_set.yaml.golden
@@ -37,23 +37,23 @@
                       "checked": {
                         "referenceMap": {
                           "1": {
-                            "name": "request"
-                          },
-                          "5": {
                             "overloadId": [
                               "equals"
                             ]
                           },
-                          "6": {
+                          "5": {
+                            "name": "request"
+                          },
+                          "9": {
                             "name": "request"
                           }
                         },
                         "typeMap": {
                           "1": {
-                            "messageType": "cerbos.engine.v1.Request"
+                            "primitive": "BOOL"
                           },
                           "2": {
-                            "messageType": "cerbos.engine.v1.Request.Resource"
+                            "dyn": {}
                           },
                           "3": {
                             "mapType": {
@@ -66,18 +66,15 @@
                             }
                           },
                           "4": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request.Resource"
                           },
                           "5": {
-                            "primitive": "BOOL"
-                          },
-                          "6": {
                             "messageType": "cerbos.engine.v1.Request"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          "6": {
+                            "dyn": {}
                           },
-                          "8": {
+                          "7": {
                             "mapType": {
                               "keyType": {
                                 "primitive": "STRING"
@@ -87,8 +84,11 @@
                               }
                             }
                           },
+                          "8": {
+                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          },
                           "9": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request"
                           }
                         },
                         "sourceInfo": {
@@ -97,33 +97,33 @@
                             68
                           ],
                           "positions": {
-                            "1": 0,
-                            "2": 7,
+                            "1": 32,
+                            "2": 21,
                             "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                            "4": 7,
+                            "5": 0,
+                            "6": 57,
+                            "7": 52,
+                            "8": 42,
+                            "9": 35
                           }
                         },
                         "expr": {
-                          "id": "5",
+                          "id": "1",
                           "callExpr": {
                             "function": "_==_",
                             "args": [
                               {
-                                "id": "4",
+                                "id": "2",
                                 "selectExpr": {
                                   "operand": {
                                     "id": "3",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "2",
+                                        "id": "4",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "1",
+                                            "id": "5",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -138,16 +138,16 @@
                                 }
                               },
                               {
-                                "id": "9",
+                                "id": "6",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "8",
+                                    "id": "7",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "7",
+                                        "id": "8",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "6",
+                                            "id": "9",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -173,23 +173,23 @@
                       "checked": {
                         "referenceMap": {
                           "1": {
-                            "name": "request"
-                          },
-                          "5": {
                             "overloadId": [
                               "equals"
                             ]
                           },
-                          "6": {
+                          "5": {
+                            "name": "request"
+                          },
+                          "9": {
                             "name": "request"
                           }
                         },
                         "typeMap": {
                           "1": {
-                            "messageType": "cerbos.engine.v1.Request"
+                            "primitive": "BOOL"
                           },
                           "2": {
-                            "messageType": "cerbos.engine.v1.Request.Resource"
+                            "dyn": {}
                           },
                           "3": {
                             "mapType": {
@@ -202,18 +202,15 @@
                             }
                           },
                           "4": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request.Resource"
                           },
                           "5": {
-                            "primitive": "BOOL"
-                          },
-                          "6": {
                             "messageType": "cerbos.engine.v1.Request"
                           },
-                          "7": {
-                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          "6": {
+                            "dyn": {}
                           },
-                          "8": {
+                          "7": {
                             "mapType": {
                               "keyType": {
                                 "primitive": "STRING"
@@ -223,8 +220,11 @@
                               }
                             }
                           },
+                          "8": {
+                            "messageType": "cerbos.engine.v1.Request.Principal"
+                          },
                           "9": {
-                            "dyn": {}
+                            "messageType": "cerbos.engine.v1.Request"
                           }
                         },
                         "sourceInfo": {
@@ -233,33 +233,33 @@
                             78
                           ],
                           "positions": {
-                            "1": 0,
-                            "2": 7,
+                            "1": 32,
+                            "2": 21,
                             "3": 16,
-                            "4": 21,
-                            "5": 32,
-                            "6": 35,
-                            "7": 42,
-                            "8": 52,
-                            "9": 57
+                            "4": 7,
+                            "5": 0,
+                            "6": 57,
+                            "7": 52,
+                            "8": 42,
+                            "9": 35
                           }
                         },
                         "expr": {
-                          "id": "5",
+                          "id": "1",
                           "callExpr": {
                             "function": "_==_",
                             "args": [
                               {
-                                "id": "4",
+                                "id": "2",
                                 "selectExpr": {
                                   "operand": {
                                     "id": "3",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "2",
+                                        "id": "4",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "1",
+                                            "id": "5",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -274,16 +274,16 @@
                                 }
                               },
                               {
-                                "id": "9",
+                                "id": "6",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "8",
+                                    "id": "7",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "7",
+                                        "id": "8",
                                         "selectExpr": {
                                           "operand": {
-                                            "id": "6",
+                                            "id": "9",
                                             "identExpr": {
                                               "name": "request"
                                             }
@@ -319,22 +319,25 @@
                 "checked": {
                   "referenceMap": {
                     "1": {
-                      "name": "R"
-                    },
-                    "4": {
                       "overloadId": [
                         "equals"
                       ]
                     },
-                    "5": {
+                    "4": {
+                      "name": "R"
+                    },
+                    "6": {
                       "name": "P"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.engine.v1.Request.Resource"
+                      "primitive": "BOOL"
                     },
                     "2": {
+                      "dyn": {}
+                    },
+                    "3": {
                       "mapType": {
                         "keyType": {
                           "primitive": "STRING"
@@ -344,17 +347,14 @@
                         }
                       }
                     },
-                    "3": {
-                      "dyn": {}
-                    },
                     "4": {
-                      "primitive": "BOOL"
+                      "messageType": "cerbos.engine.v1.Request.Resource"
                     },
                     "5": {
-                      "messageType": "cerbos.engine.v1.Request.Principal"
+                      "primitive": "STRING"
                     },
                     "6": {
-                      "primitive": "STRING"
+                      "messageType": "cerbos.engine.v1.Request.Principal"
                     }
                   },
                   "sourceInfo": {
@@ -363,27 +363,27 @@
                       21
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 1,
-                      "3": 6,
-                      "4": 13,
-                      "5": 16,
-                      "6": 17
+                      "1": 13,
+                      "2": 6,
+                      "3": 1,
+                      "4": 0,
+                      "5": 17,
+                      "6": 16
                     }
                   },
                   "expr": {
-                    "id": "4",
+                    "id": "1",
                     "callExpr": {
                       "function": "_==_",
                       "args": [
                         {
-                          "id": "3",
+                          "id": "2",
                           "selectExpr": {
                             "operand": {
-                              "id": "2",
+                              "id": "3",
                               "selectExpr": {
                                 "operand": {
-                                  "id": "1",
+                                  "id": "4",
                                   "identExpr": {
                                     "name": "R"
                                   }
@@ -395,10 +395,10 @@
                           }
                         },
                         {
-                          "id": "6",
+                          "id": "5",
                           "selectExpr": {
                             "operand": {
-                              "id": "5",
+                              "id": "6",
                               "identExpr": {
                                 "name": "P"
                               }
@@ -431,12 +431,12 @@
                   "original": "\"wildcard:%s\".format([request.principal.id])",
                   "checked": {
                     "referenceMap": {
-                      "2": {
+                      "1": {
                         "overloadId": [
                           "string_format"
                         ]
                       },
-                      "4": {
+                      "6": {
                         "name": "request"
                       }
                     },
@@ -455,13 +455,13 @@
                         }
                       },
                       "4": {
-                        "messageType": "cerbos.engine.v1.Request"
+                        "primitive": "STRING"
                       },
                       "5": {
                         "messageType": "cerbos.engine.v1.Request.Principal"
                       },
                       "6": {
-                        "primitive": "STRING"
+                        "messageType": "cerbos.engine.v1.Request"
                       }
                     },
                     "sourceInfo": {
@@ -470,19 +470,19 @@
                         45
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 20,
+                        "1": 20,
+                        "2": 0,
                         "3": 21,
-                        "4": 22,
+                        "4": 39,
                         "5": 29,
-                        "6": 39
+                        "6": 22
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "callExpr": {
                         "target": {
-                          "id": "1",
+                          "id": "2",
                           "constExpr": {
                             "stringValue": "wildcard:%s"
                           }
@@ -494,13 +494,13 @@
                             "listExpr": {
                               "elements": [
                                 {
-                                  "id": "6",
+                                  "id": "4",
                                   "selectExpr": {
                                     "operand": {
                                       "id": "5",
                                       "selectExpr": {
                                         "operand": {
-                                          "id": "4",
+                                          "id": "6",
                                           "identExpr": {
                                             "name": "request"
                                           }
@@ -523,12 +523,12 @@
                   "original": "\"condition_not_met:wildcard:%s\".format([request.principal.id])",
                   "checked": {
                     "referenceMap": {
-                      "2": {
+                      "1": {
                         "overloadId": [
                           "string_format"
                         ]
                       },
-                      "4": {
+                      "6": {
                         "name": "request"
                       }
                     },
@@ -547,13 +547,13 @@
                         }
                       },
                       "4": {
-                        "messageType": "cerbos.engine.v1.Request"
+                        "primitive": "STRING"
                       },
                       "5": {
                         "messageType": "cerbos.engine.v1.Request.Principal"
                       },
                       "6": {
-                        "primitive": "STRING"
+                        "messageType": "cerbos.engine.v1.Request"
                       }
                     },
                     "sourceInfo": {
@@ -562,19 +562,19 @@
                         63
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 38,
+                        "1": 38,
+                        "2": 0,
                         "3": 39,
-                        "4": 40,
+                        "4": 57,
                         "5": 47,
-                        "6": 57
+                        "6": 40
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "callExpr": {
                         "target": {
-                          "id": "1",
+                          "id": "2",
                           "constExpr": {
                             "stringValue": "condition_not_met:wildcard:%s"
                           }
@@ -586,13 +586,13 @@
                             "listExpr": {
                               "elements": [
                                 {
-                                  "id": "6",
+                                  "id": "4",
                                   "selectExpr": {
                                     "operand": {
                                       "id": "5",
                                       "selectExpr": {
                                         "operand": {
-                                          "id": "4",
+                                          "id": "6",
                                           "identExpr": {
                                             "name": "request"
                                           }
@@ -629,12 +629,12 @@
                   "original": "\"create:%s\".format([request.principal.id])",
                   "checked": {
                     "referenceMap": {
-                      "2": {
+                      "1": {
                         "overloadId": [
                           "string_format"
                         ]
                       },
-                      "4": {
+                      "6": {
                         "name": "request"
                       }
                     },
@@ -653,13 +653,13 @@
                         }
                       },
                       "4": {
-                        "messageType": "cerbos.engine.v1.Request"
+                        "primitive": "STRING"
                       },
                       "5": {
                         "messageType": "cerbos.engine.v1.Request.Principal"
                       },
                       "6": {
-                        "primitive": "STRING"
+                        "messageType": "cerbos.engine.v1.Request"
                       }
                     },
                     "sourceInfo": {
@@ -668,19 +668,19 @@
                         43
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 18,
+                        "1": 18,
+                        "2": 0,
                         "3": 19,
-                        "4": 20,
+                        "4": 37,
                         "5": 27,
-                        "6": 37
+                        "6": 20
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "callExpr": {
                         "target": {
-                          "id": "1",
+                          "id": "2",
                           "constExpr": {
                             "stringValue": "create:%s"
                           }
@@ -692,13 +692,13 @@
                             "listExpr": {
                               "elements": [
                                 {
-                                  "id": "6",
+                                  "id": "4",
                                   "selectExpr": {
                                     "operand": {
                                       "id": "5",
                                       "selectExpr": {
                                         "operand": {
-                                          "id": "4",
+                                          "id": "6",
                                           "identExpr": {
                                             "name": "request"
                                           }
@@ -784,20 +784,20 @@
                 "checked": {
                   "referenceMap": {
                     "1": {
-                      "name": "request"
-                    },
-                    "5": {
                       "overloadId": [
                         "equals"
                       ]
+                    },
+                    "5": {
+                      "name": "request"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.engine.v1.Request"
+                      "primitive": "BOOL"
                     },
                     "2": {
-                      "messageType": "cerbos.engine.v1.Request.Resource"
+                      "dyn": {}
                     },
                     "3": {
                       "mapType": {
@@ -810,10 +810,10 @@
                       }
                     },
                     "4": {
-                      "dyn": {}
+                      "messageType": "cerbos.engine.v1.Request.Resource"
                     },
                     "5": {
-                      "primitive": "BOOL"
+                      "messageType": "cerbos.engine.v1.Request"
                     },
                     "6": {
                       "primitive": "STRING"
@@ -826,30 +826,30 @@
                       62
                     ],
                     "positions": {
-                      "1": 11,
-                      "2": 18,
+                      "1": 40,
+                      "2": 32,
                       "3": 27,
-                      "4": 32,
-                      "5": 40,
+                      "4": 18,
+                      "5": 11,
                       "6": 43
                     }
                   },
                   "expr": {
-                    "id": "5",
+                    "id": "1",
                     "callExpr": {
                       "function": "_==_",
                       "args": [
                         {
-                          "id": "4",
+                          "id": "2",
                           "selectExpr": {
                             "operand": {
                               "id": "3",
                               "selectExpr": {
                                 "operand": {
-                                  "id": "2",
+                                  "id": "4",
                                   "selectExpr": {
                                     "operand": {
-                                      "id": "1",
+                                      "id": "5",
                                       "identExpr": {
                                         "name": "request"
                                       }
@@ -882,18 +882,18 @@
                   "original": "\"pending_approval:%s\".format([request.resource.attr.status == \"PENDING_APPROVAL\"])",
                   "checked": {
                     "referenceMap": {
-                      "2": {
+                      "1": {
                         "overloadId": [
                           "string_format"
                         ]
                       },
                       "4": {
-                        "name": "request"
-                      },
-                      "8": {
                         "overloadId": [
                           "equals"
                         ]
+                      },
+                      "8": {
+                        "name": "request"
                       }
                     },
                     "typeMap": {
@@ -911,10 +911,10 @@
                         }
                       },
                       "4": {
-                        "messageType": "cerbos.engine.v1.Request"
+                        "primitive": "BOOL"
                       },
                       "5": {
-                        "messageType": "cerbos.engine.v1.Request.Resource"
+                        "dyn": {}
                       },
                       "6": {
                         "mapType": {
@@ -927,10 +927,10 @@
                         }
                       },
                       "7": {
-                        "dyn": {}
+                        "messageType": "cerbos.engine.v1.Request.Resource"
                       },
                       "8": {
-                        "primitive": "BOOL"
+                        "messageType": "cerbos.engine.v1.Request"
                       },
                       "9": {
                         "primitive": "STRING"
@@ -942,22 +942,22 @@
                         83
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 28,
+                        "1": 28,
+                        "2": 0,
                         "3": 29,
-                        "4": 30,
-                        "5": 37,
+                        "4": 59,
+                        "5": 51,
                         "6": 46,
-                        "7": 51,
-                        "8": 59,
+                        "7": 37,
+                        "8": 30,
                         "9": 62
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "callExpr": {
                         "target": {
-                          "id": "1",
+                          "id": "2",
                           "constExpr": {
                             "stringValue": "pending_approval:%s"
                           }
@@ -969,21 +969,21 @@
                             "listExpr": {
                               "elements": [
                                 {
-                                  "id": "8",
+                                  "id": "4",
                                   "callExpr": {
                                     "function": "_==_",
                                     "args": [
                                       {
-                                        "id": "7",
+                                        "id": "5",
                                         "selectExpr": {
                                           "operand": {
                                             "id": "6",
                                             "selectExpr": {
                                               "operand": {
-                                                "id": "5",
+                                                "id": "7",
                                                 "selectExpr": {
                                                   "operand": {
-                                                    "id": "4",
+                                                    "id": "8",
                                                     "identExpr": {
                                                       "name": "request"
                                                     }

--- a/internal/test/testdata/compile/variables_principal_policy.yaml.golden
+++ b/internal/test/testdata/compile/variables_principal_policy.yaml.golden
@@ -26,16 +26,16 @@
             "original": "constants.a",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "constants"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -44,15 +44,15 @@
                   12
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 9
+                  "1": 9,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "constants"
                     }
@@ -67,9 +67,6 @@
             "checked": {
               "referenceMap": {
                 "1": {
-                  "name": "V"
-                },
-                "3": {
                   "overloadId": [
                     "add_bytes",
                     "add_double",
@@ -82,25 +79,28 @@
                     "add_uint64"
                   ]
                 },
-                "4": {
+                "3": {
+                  "name": "V"
+                },
+                "5": {
                   "name": "V"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
                   "dyn": {}
                 },
                 "3": {
-                  "dyn": {}
-                },
-                "4": {
                   "messageType": "cerbos.Variables"
                 },
-                "5": {
+                "4": {
                   "dyn": {}
+                },
+                "5": {
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -109,15 +109,15 @@
                   10
                 ],
                 "positions": {
-                  "1": 0,
+                  "1": 4,
                   "2": 1,
-                  "3": 4,
-                  "4": 6,
-                  "5": 7
+                  "3": 0,
+                  "4": 7,
+                  "5": 6
                 }
               },
               "expr": {
-                "id": "3",
+                "id": "1",
                 "callExpr": {
                   "function": "_+_",
                   "args": [
@@ -125,7 +125,7 @@
                       "id": "2",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "3",
                           "identExpr": {
                             "name": "V"
                           }
@@ -134,10 +134,10 @@
                       }
                     },
                     {
-                      "id": "5",
+                      "id": "4",
                       "selectExpr": {
                         "operand": {
-                          "id": "4",
+                          "id": "5",
                           "identExpr": {
                             "name": "V"
                           }
@@ -154,16 +154,16 @@
             "original": "C.b",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "C"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -172,15 +172,15 @@
                   4
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 1
+                  "1": 1,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "C"
                     }
@@ -194,16 +194,16 @@
             "original": "constants.j",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "constants"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -212,15 +212,15 @@
                   12
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 9
+                  "1": 9,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "constants"
                     }
@@ -243,9 +243,11 @@
                     "checked": {
                       "referenceMap": {
                         "1": {
-                          "name": "V"
+                          "overloadId": [
+                            "logical_and"
+                          ]
                         },
-                        "3": {
+                        "2": {
                           "overloadId": [
                             "less_bool",
                             "less_int64",
@@ -269,7 +271,7 @@
                         "6": {
                           "name": "V"
                         },
-                        "8": {
+                        "7": {
                           "overloadId": [
                             "greater_bool",
                             "greater_int64",
@@ -288,23 +290,21 @@
                           ]
                         },
                         "9": {
-                          "name": "C"
+                          "name": "V"
                         },
                         "11": {
-                          "overloadId": [
-                            "logical_and"
-                          ]
+                          "name": "C"
                         }
                       },
                       "typeMap": {
                         "1": {
-                          "messageType": "cerbos.Variables"
+                          "primitive": "BOOL"
                         },
                         "2": {
-                          "dyn": {}
+                          "primitive": "BOOL"
                         },
                         "3": {
-                          "primitive": "BOOL"
+                          "dyn": {}
                         },
                         "4": {
                           "messageType": "cerbos.Variables"
@@ -316,10 +316,10 @@
                           "messageType": "cerbos.Variables"
                         },
                         "7": {
-                          "dyn": {}
+                          "primitive": "BOOL"
                         },
                         "8": {
-                          "primitive": "BOOL"
+                          "dyn": {}
                         },
                         "9": {
                           "messageType": "cerbos.Variables"
@@ -328,7 +328,7 @@
                           "dyn": {}
                         },
                         "11": {
-                          "primitive": "BOOL"
+                          "messageType": "cerbos.Variables"
                         }
                       },
                       "sourceInfo": {
@@ -337,34 +337,34 @@
                           25
                         ],
                         "positions": {
-                          "1": 0,
-                          "2": 1,
-                          "3": 5,
-                          "4": 7,
+                          "1": 11,
+                          "2": 5,
+                          "3": 1,
+                          "4": 0,
                           "5": 8,
-                          "6": 14,
-                          "7": 15,
-                          "8": 19,
-                          "9": 21,
+                          "6": 7,
+                          "7": 19,
+                          "8": 15,
+                          "9": 14,
                           "10": 22,
-                          "11": 11
+                          "11": 21
                         }
                       },
                       "expr": {
-                        "id": "11",
+                        "id": "1",
                         "callExpr": {
                           "function": "_&&_",
                           "args": [
                             {
-                              "id": "3",
+                              "id": "2",
                               "callExpr": {
                                 "function": "_<_",
                                 "args": [
                                   {
-                                    "id": "2",
+                                    "id": "3",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "1",
+                                        "id": "4",
                                         "identExpr": {
                                           "name": "V"
                                         }
@@ -376,7 +376,7 @@
                                     "id": "5",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "4",
+                                        "id": "6",
                                         "identExpr": {
                                           "name": "V"
                                         }
@@ -388,15 +388,15 @@
                               }
                             },
                             {
-                              "id": "8",
+                              "id": "7",
                               "callExpr": {
                                 "function": "_>_",
                                 "args": [
                                   {
-                                    "id": "7",
+                                    "id": "8",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "6",
+                                        "id": "9",
                                         "identExpr": {
                                           "name": "V"
                                         }
@@ -408,7 +408,7 @@
                                     "id": "10",
                                     "selectExpr": {
                                       "operand": {
-                                        "id": "9",
+                                        "id": "11",
                                         "identExpr": {
                                           "name": "C"
                                         }
@@ -437,16 +437,16 @@
               "original": "constants.a",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "constants"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -455,15 +455,15 @@
                     12
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 9
+                    "1": 9,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "constants"
                       }
@@ -480,16 +480,16 @@
               "original": "C.b",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "C"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -498,15 +498,15 @@
                     4
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 1
+                    "1": 1,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "C"
                       }
@@ -524,9 +524,6 @@
               "checked": {
                 "referenceMap": {
                   "1": {
-                    "name": "V"
-                  },
-                  "3": {
                     "overloadId": [
                       "add_bytes",
                       "add_double",
@@ -539,25 +536,28 @@
                       "add_uint64"
                     ]
                   },
-                  "4": {
+                  "3": {
+                    "name": "V"
+                  },
+                  "5": {
                     "name": "V"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
                     "dyn": {}
                   },
                   "3": {
-                    "dyn": {}
-                  },
-                  "4": {
                     "messageType": "cerbos.Variables"
                   },
-                  "5": {
+                  "4": {
                     "dyn": {}
+                  },
+                  "5": {
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -566,15 +566,15 @@
                     10
                   ],
                   "positions": {
-                    "1": 0,
+                    "1": 4,
                     "2": 1,
-                    "3": 4,
-                    "4": 6,
-                    "5": 7
+                    "3": 0,
+                    "4": 7,
+                    "5": 6
                   }
                 },
                 "expr": {
-                  "id": "3",
+                  "id": "1",
                   "callExpr": {
                     "function": "_+_",
                     "args": [
@@ -582,7 +582,7 @@
                         "id": "2",
                         "selectExpr": {
                           "operand": {
-                            "id": "1",
+                            "id": "3",
                             "identExpr": {
                               "name": "V"
                             }
@@ -591,10 +591,10 @@
                         }
                       },
                       {
-                        "id": "5",
+                        "id": "4",
                         "selectExpr": {
                           "operand": {
-                            "id": "4",
+                            "id": "5",
                             "identExpr": {
                               "name": "V"
                             }
@@ -614,16 +614,16 @@
               "original": "constants.j",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "constants"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -632,15 +632,15 @@
                     12
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 9
+                    "1": 9,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "constants"
                       }
@@ -666,16 +666,16 @@
             "original": "constants.a",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "constants"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -684,15 +684,15 @@
                   12
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 9
+                  "1": 9,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "constants"
                     }
@@ -707,9 +707,6 @@
             "checked": {
               "referenceMap": {
                 "1": {
-                  "name": "V"
-                },
-                "3": {
                   "overloadId": [
                     "add_bytes",
                     "add_double",
@@ -722,25 +719,28 @@
                     "add_uint64"
                   ]
                 },
-                "4": {
+                "3": {
+                  "name": "V"
+                },
+                "5": {
                   "name": "V"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
                   "dyn": {}
                 },
                 "3": {
-                  "dyn": {}
-                },
-                "4": {
                   "messageType": "cerbos.Variables"
                 },
-                "5": {
+                "4": {
                   "dyn": {}
+                },
+                "5": {
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -749,15 +749,15 @@
                   10
                 ],
                 "positions": {
-                  "1": 0,
+                  "1": 4,
                   "2": 1,
-                  "3": 4,
-                  "4": 6,
-                  "5": 7
+                  "3": 0,
+                  "4": 7,
+                  "5": 6
                 }
               },
               "expr": {
-                "id": "3",
+                "id": "1",
                 "callExpr": {
                   "function": "_+_",
                   "args": [
@@ -765,7 +765,7 @@
                       "id": "2",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "3",
                           "identExpr": {
                             "name": "V"
                           }
@@ -774,10 +774,10 @@
                       }
                     },
                     {
-                      "id": "5",
+                      "id": "4",
                       "selectExpr": {
                         "operand": {
-                          "id": "4",
+                          "id": "5",
                           "identExpr": {
                             "name": "V"
                           }
@@ -795,9 +795,6 @@
             "checked": {
               "referenceMap": {
                 "1": {
-                  "name": "variables"
-                },
-                "3": {
                   "overloadId": [
                     "add_bytes",
                     "add_double",
@@ -810,25 +807,28 @@
                     "add_uint64"
                   ]
                 },
-                "4": {
+                "3": {
+                  "name": "variables"
+                },
+                "5": {
                   "name": "variables"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
                   "dyn": {}
                 },
                 "3": {
-                  "dyn": {}
-                },
-                "4": {
                   "messageType": "cerbos.Variables"
                 },
-                "5": {
+                "4": {
                   "dyn": {}
+                },
+                "5": {
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -837,15 +837,15 @@
                   27
                 ],
                 "positions": {
-                  "1": 0,
+                  "1": 13,
                   "2": 9,
-                  "3": 13,
-                  "4": 15,
-                  "5": 24
+                  "3": 0,
+                  "4": 24,
+                  "5": 15
                 }
               },
               "expr": {
-                "id": "3",
+                "id": "1",
                 "callExpr": {
                   "function": "_+_",
                   "args": [
@@ -853,7 +853,7 @@
                       "id": "2",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "3",
                           "identExpr": {
                             "name": "variables"
                           }
@@ -862,10 +862,10 @@
                       }
                     },
                     {
-                      "id": "5",
+                      "id": "4",
                       "selectExpr": {
                         "operand": {
-                          "id": "4",
+                          "id": "5",
                           "identExpr": {
                             "name": "variables"
                           }
@@ -883,9 +883,6 @@
             "checked": {
               "referenceMap": {
                 "1": {
-                  "name": "variables"
-                },
-                "3": {
                   "overloadId": [
                     "add_bytes",
                     "add_double",
@@ -898,25 +895,28 @@
                     "add_uint64"
                   ]
                 },
-                "4": {
+                "3": {
+                  "name": "variables"
+                },
+                "5": {
                   "name": "variables"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
                   "dyn": {}
                 },
                 "3": {
-                  "dyn": {}
-                },
-                "4": {
                   "messageType": "cerbos.Variables"
                 },
-                "5": {
+                "4": {
                   "dyn": {}
+                },
+                "5": {
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -925,15 +925,15 @@
                   28
                 ],
                 "positions": {
-                  "1": 0,
+                  "1": 14,
                   "2": 9,
-                  "3": 14,
-                  "4": 16,
-                  "5": 25
+                  "3": 0,
+                  "4": 25,
+                  "5": 16
                 }
               },
               "expr": {
-                "id": "3",
+                "id": "1",
                 "callExpr": {
                   "function": "_+_",
                   "args": [
@@ -941,7 +941,7 @@
                       "id": "2",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "3",
                           "identExpr": {
                             "name": "variables"
                           }
@@ -950,10 +950,10 @@
                       }
                     },
                     {
-                      "id": "5",
+                      "id": "4",
                       "selectExpr": {
                         "operand": {
-                          "id": "4",
+                          "id": "5",
                           "identExpr": {
                             "name": "variables"
                           }
@@ -970,16 +970,16 @@
             "original": "C.b",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "C"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -988,15 +988,15 @@
                   4
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 1
+                  "1": 1,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "C"
                     }
@@ -1010,16 +1010,16 @@
             "original": "constants.c",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "constants"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -1028,15 +1028,15 @@
                   12
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 9
+                  "1": 9,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "constants"
                     }
@@ -1050,16 +1050,16 @@
             "original": "constants.e",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "constants"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -1068,15 +1068,15 @@
                   12
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 9
+                  "1": 9,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "constants"
                     }
@@ -1090,16 +1090,16 @@
             "original": "C.f",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "C"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -1108,15 +1108,15 @@
                   4
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 1
+                  "1": 1,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "C"
                     }
@@ -1130,16 +1130,16 @@
             "original": "C.h",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "C"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -1148,15 +1148,15 @@
                   4
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 1
+                  "1": 1,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "C"
                     }
@@ -1179,9 +1179,6 @@
                     "checked": {
                       "referenceMap": {
                         "1": {
-                          "name": "V"
-                        },
-                        "3": {
                           "overloadId": [
                             "greater_bool",
                             "greater_int64",
@@ -1199,25 +1196,28 @@
                             "greater_duration"
                           ]
                         },
-                        "4": {
+                        "3": {
+                          "name": "V"
+                        },
+                        "5": {
                           "name": "C"
                         }
                       },
                       "typeMap": {
                         "1": {
-                          "messageType": "cerbos.Variables"
+                          "primitive": "BOOL"
                         },
                         "2": {
                           "dyn": {}
                         },
                         "3": {
-                          "primitive": "BOOL"
-                        },
-                        "4": {
                           "messageType": "cerbos.Variables"
                         },
-                        "5": {
+                        "4": {
                           "dyn": {}
+                        },
+                        "5": {
+                          "messageType": "cerbos.Variables"
                         }
                       },
                       "sourceInfo": {
@@ -1226,15 +1226,15 @@
                           13
                         ],
                         "positions": {
-                          "1": 0,
+                          "1": 7,
                           "2": 1,
-                          "3": 7,
-                          "4": 9,
-                          "5": 10
+                          "3": 0,
+                          "4": 10,
+                          "5": 9
                         }
                       },
                       "expr": {
-                        "id": "3",
+                        "id": "1",
                         "callExpr": {
                           "function": "_>_",
                           "args": [
@@ -1242,7 +1242,7 @@
                               "id": "2",
                               "selectExpr": {
                                 "operand": {
-                                  "id": "1",
+                                  "id": "3",
                                   "identExpr": {
                                     "name": "V"
                                   }
@@ -1251,10 +1251,10 @@
                               }
                             },
                             {
-                              "id": "5",
+                              "id": "4",
                               "selectExpr": {
                                 "operand": {
-                                  "id": "4",
+                                  "id": "5",
                                   "identExpr": {
                                     "name": "C"
                                   }
@@ -1275,16 +1275,16 @@
                       "original": "variables.f",
                       "checked": {
                         "referenceMap": {
-                          "1": {
+                          "2": {
                             "name": "variables"
                           }
                         },
                         "typeMap": {
                           "1": {
-                            "messageType": "cerbos.Variables"
+                            "dyn": {}
                           },
                           "2": {
-                            "dyn": {}
+                            "messageType": "cerbos.Variables"
                           }
                         },
                         "sourceInfo": {
@@ -1293,15 +1293,15 @@
                             12
                           ],
                           "positions": {
-                            "1": 0,
-                            "2": 9
+                            "1": 9,
+                            "2": 0
                           }
                         },
                         "expr": {
-                          "id": "2",
+                          "id": "1",
                           "selectExpr": {
                             "operand": {
-                              "id": "1",
+                              "id": "2",
                               "identExpr": {
                                 "name": "variables"
                               }
@@ -1327,9 +1327,6 @@
                     "checked": {
                       "referenceMap": {
                         "1": {
-                          "name": "variables"
-                        },
-                        "3": {
                           "overloadId": [
                             "greater_bool",
                             "greater_int64",
@@ -1347,25 +1344,28 @@
                             "greater_duration"
                           ]
                         },
-                        "4": {
+                        "3": {
+                          "name": "variables"
+                        },
+                        "5": {
                           "name": "constants"
                         }
                       },
                       "typeMap": {
                         "1": {
-                          "messageType": "cerbos.Variables"
+                          "primitive": "BOOL"
                         },
                         "2": {
                           "dyn": {}
                         },
                         "3": {
-                          "primitive": "BOOL"
-                        },
-                        "4": {
                           "messageType": "cerbos.Variables"
                         },
-                        "5": {
+                        "4": {
                           "dyn": {}
+                        },
+                        "5": {
+                          "messageType": "cerbos.Variables"
                         }
                       },
                       "sourceInfo": {
@@ -1374,15 +1374,15 @@
                           26
                         ],
                         "positions": {
-                          "1": 0,
+                          "1": 12,
                           "2": 9,
-                          "3": 12,
-                          "4": 14,
-                          "5": 23
+                          "3": 0,
+                          "4": 23,
+                          "5": 14
                         }
                       },
                       "expr": {
-                        "id": "3",
+                        "id": "1",
                         "callExpr": {
                           "function": "_>_",
                           "args": [
@@ -1390,7 +1390,7 @@
                               "id": "2",
                               "selectExpr": {
                                 "operand": {
-                                  "id": "1",
+                                  "id": "3",
                                   "identExpr": {
                                     "name": "variables"
                                   }
@@ -1399,10 +1399,10 @@
                               }
                             },
                             {
-                              "id": "5",
+                              "id": "4",
                               "selectExpr": {
                                 "operand": {
-                                  "id": "4",
+                                  "id": "5",
                                   "identExpr": {
                                     "name": "constants"
                                   }
@@ -1428,16 +1428,16 @@
               "original": "constants.a",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "constants"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -1446,15 +1446,15 @@
                     12
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 9
+                    "1": 9,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "constants"
                       }
@@ -1471,16 +1471,16 @@
               "original": "C.b",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "C"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -1489,15 +1489,15 @@
                     4
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 1
+                    "1": 1,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "C"
                       }
@@ -1515,9 +1515,6 @@
               "checked": {
                 "referenceMap": {
                   "1": {
-                    "name": "V"
-                  },
-                  "3": {
                     "overloadId": [
                       "add_bytes",
                       "add_double",
@@ -1530,25 +1527,28 @@
                       "add_uint64"
                     ]
                   },
-                  "4": {
+                  "3": {
+                    "name": "V"
+                  },
+                  "5": {
                     "name": "V"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
                     "dyn": {}
                   },
                   "3": {
-                    "dyn": {}
-                  },
-                  "4": {
                     "messageType": "cerbos.Variables"
                   },
-                  "5": {
+                  "4": {
                     "dyn": {}
+                  },
+                  "5": {
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -1557,15 +1557,15 @@
                     10
                   ],
                   "positions": {
-                    "1": 0,
+                    "1": 4,
                     "2": 1,
-                    "3": 4,
-                    "4": 6,
-                    "5": 7
+                    "3": 0,
+                    "4": 7,
+                    "5": 6
                   }
                 },
                 "expr": {
-                  "id": "3",
+                  "id": "1",
                   "callExpr": {
                     "function": "_+_",
                     "args": [
@@ -1573,7 +1573,7 @@
                         "id": "2",
                         "selectExpr": {
                           "operand": {
-                            "id": "1",
+                            "id": "3",
                             "identExpr": {
                               "name": "V"
                             }
@@ -1582,10 +1582,10 @@
                         }
                       },
                       {
-                        "id": "5",
+                        "id": "4",
                         "selectExpr": {
                           "operand": {
-                            "id": "4",
+                            "id": "5",
                             "identExpr": {
                               "name": "V"
                             }
@@ -1605,16 +1605,16 @@
               "original": "constants.c",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "constants"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -1623,15 +1623,15 @@
                     12
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 9
+                    "1": 9,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "constants"
                       }
@@ -1649,9 +1649,6 @@
               "checked": {
                 "referenceMap": {
                   "1": {
-                    "name": "variables"
-                  },
-                  "3": {
                     "overloadId": [
                       "add_bytes",
                       "add_double",
@@ -1664,25 +1661,28 @@
                       "add_uint64"
                     ]
                   },
-                  "4": {
+                  "3": {
+                    "name": "variables"
+                  },
+                  "5": {
                     "name": "variables"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
                     "dyn": {}
                   },
                   "3": {
-                    "dyn": {}
-                  },
-                  "4": {
                     "messageType": "cerbos.Variables"
                   },
-                  "5": {
+                  "4": {
                     "dyn": {}
+                  },
+                  "5": {
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -1691,15 +1691,15 @@
                     27
                   ],
                   "positions": {
-                    "1": 0,
+                    "1": 13,
                     "2": 9,
-                    "3": 13,
-                    "4": 15,
-                    "5": 24
+                    "3": 0,
+                    "4": 24,
+                    "5": 15
                   }
                 },
                 "expr": {
-                  "id": "3",
+                  "id": "1",
                   "callExpr": {
                     "function": "_+_",
                     "args": [
@@ -1707,7 +1707,7 @@
                         "id": "2",
                         "selectExpr": {
                           "operand": {
-                            "id": "1",
+                            "id": "3",
                             "identExpr": {
                               "name": "variables"
                             }
@@ -1716,10 +1716,10 @@
                         }
                       },
                       {
-                        "id": "5",
+                        "id": "4",
                         "selectExpr": {
                           "operand": {
-                            "id": "4",
+                            "id": "5",
                             "identExpr": {
                               "name": "variables"
                             }
@@ -1739,16 +1739,16 @@
               "original": "constants.e",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "constants"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -1757,15 +1757,15 @@
                     12
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 9
+                    "1": 9,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "constants"
                       }
@@ -1783,9 +1783,6 @@
               "checked": {
                 "referenceMap": {
                   "1": {
-                    "name": "variables"
-                  },
-                  "3": {
                     "overloadId": [
                       "add_bytes",
                       "add_double",
@@ -1798,25 +1795,28 @@
                       "add_uint64"
                     ]
                   },
-                  "4": {
+                  "3": {
+                    "name": "variables"
+                  },
+                  "5": {
                     "name": "variables"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
                     "dyn": {}
                   },
                   "3": {
-                    "dyn": {}
-                  },
-                  "4": {
                     "messageType": "cerbos.Variables"
                   },
-                  "5": {
+                  "4": {
                     "dyn": {}
+                  },
+                  "5": {
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -1825,15 +1825,15 @@
                     28
                   ],
                   "positions": {
-                    "1": 0,
+                    "1": 14,
                     "2": 9,
-                    "3": 14,
-                    "4": 16,
-                    "5": 25
+                    "3": 0,
+                    "4": 25,
+                    "5": 16
                   }
                 },
                 "expr": {
-                  "id": "3",
+                  "id": "1",
                   "callExpr": {
                     "function": "_+_",
                     "args": [
@@ -1841,7 +1841,7 @@
                         "id": "2",
                         "selectExpr": {
                           "operand": {
-                            "id": "1",
+                            "id": "3",
                             "identExpr": {
                               "name": "variables"
                             }
@@ -1850,10 +1850,10 @@
                         }
                       },
                       {
-                        "id": "5",
+                        "id": "4",
                         "selectExpr": {
                           "operand": {
-                            "id": "4",
+                            "id": "5",
                             "identExpr": {
                               "name": "variables"
                             }
@@ -1873,16 +1873,16 @@
               "original": "C.f",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "C"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -1891,15 +1891,15 @@
                     4
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 1
+                    "1": 1,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "C"
                       }
@@ -1916,16 +1916,16 @@
               "original": "C.h",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "C"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -1934,15 +1934,15 @@
                     4
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 1
+                    "1": 1,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "C"
                       }

--- a/internal/test/testdata/compile/variables_resource_policy.yaml.golden
+++ b/internal/test/testdata/compile/variables_resource_policy.yaml.golden
@@ -32,16 +32,16 @@
                 "original": "C.b",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "C"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -50,15 +50,15 @@
                       4
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 1
+                      "1": 1,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "C"
                         }
@@ -72,16 +72,16 @@
                 "original": "constants.c",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "constants"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -90,15 +90,15 @@
                       12
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 9
+                      "1": 9,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "constants"
                         }
@@ -112,16 +112,16 @@
                 "original": "C.f",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "C"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -130,15 +130,15 @@
                       4
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 1
+                      "1": 1,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "C"
                         }
@@ -152,16 +152,16 @@
                 "original": "constants.h",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "constants"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -170,15 +170,15 @@
                       12
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 9
+                      "1": 9,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "constants"
                         }
@@ -193,9 +193,6 @@
                 "checked": {
                   "referenceMap": {
                     "1": {
-                      "name": "V"
-                    },
-                    "3": {
                       "overloadId": [
                         "add_bytes",
                         "add_double",
@@ -208,25 +205,28 @@
                         "add_uint64"
                       ]
                     },
-                    "4": {
+                    "3": {
+                      "name": "V"
+                    },
+                    "5": {
                       "name": "V"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
                       "dyn": {}
                     },
                     "3": {
-                      "dyn": {}
-                    },
-                    "4": {
                       "messageType": "cerbos.Variables"
                     },
-                    "5": {
+                    "4": {
                       "dyn": {}
+                    },
+                    "5": {
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -235,15 +235,15 @@
                       10
                     ],
                     "positions": {
-                      "1": 0,
+                      "1": 4,
                       "2": 1,
-                      "3": 4,
-                      "4": 6,
-                      "5": 7
+                      "3": 0,
+                      "4": 7,
+                      "5": 6
                     }
                   },
                   "expr": {
-                    "id": "3",
+                    "id": "1",
                     "callExpr": {
                       "function": "_+_",
                       "args": [
@@ -251,7 +251,7 @@
                           "id": "2",
                           "selectExpr": {
                             "operand": {
-                              "id": "1",
+                              "id": "3",
                               "identExpr": {
                                 "name": "V"
                               }
@@ -260,10 +260,10 @@
                           }
                         },
                         {
-                          "id": "5",
+                          "id": "4",
                           "selectExpr": {
                             "operand": {
-                              "id": "4",
+                              "id": "5",
                               "identExpr": {
                                 "name": "V"
                               }
@@ -280,16 +280,16 @@
                 "original": "C.i",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "C"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -298,15 +298,15 @@
                       4
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 1
+                      "1": 1,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "C"
                         }
@@ -326,9 +326,6 @@
                       "checked": {
                         "referenceMap": {
                           "1": {
-                            "name": "V"
-                          },
-                          "3": {
                             "overloadId": [
                               "greater_bool",
                               "greater_int64",
@@ -346,25 +343,28 @@
                               "greater_duration"
                             ]
                           },
-                          "4": {
+                          "3": {
+                            "name": "V"
+                          },
+                          "5": {
                             "name": "V"
                           }
                         },
                         "typeMap": {
                           "1": {
-                            "messageType": "cerbos.Variables"
+                            "primitive": "BOOL"
                           },
                           "2": {
                             "dyn": {}
                           },
                           "3": {
-                            "primitive": "BOOL"
-                          },
-                          "4": {
                             "messageType": "cerbos.Variables"
                           },
-                          "5": {
+                          "4": {
                             "dyn": {}
+                          },
+                          "5": {
+                            "messageType": "cerbos.Variables"
                           }
                         },
                         "sourceInfo": {
@@ -373,15 +373,15 @@
                             10
                           ],
                           "positions": {
-                            "1": 0,
+                            "1": 4,
                             "2": 1,
-                            "3": 4,
-                            "4": 6,
-                            "5": 7
+                            "3": 0,
+                            "4": 7,
+                            "5": 6
                           }
                         },
                         "expr": {
-                          "id": "3",
+                          "id": "1",
                           "callExpr": {
                             "function": "_>_",
                             "args": [
@@ -389,7 +389,7 @@
                                 "id": "2",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "1",
+                                    "id": "3",
                                     "identExpr": {
                                       "name": "V"
                                     }
@@ -398,10 +398,10 @@
                                 }
                               },
                               {
-                                "id": "5",
+                                "id": "4",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "4",
+                                    "id": "5",
                                     "identExpr": {
                                       "name": "V"
                                     }
@@ -421,9 +421,6 @@
                       "checked": {
                         "referenceMap": {
                           "1": {
-                            "name": "variables"
-                          },
-                          "3": {
                             "overloadId": [
                               "greater_bool",
                               "greater_int64",
@@ -441,25 +438,28 @@
                               "greater_duration"
                             ]
                           },
-                          "4": {
+                          "3": {
+                            "name": "variables"
+                          },
+                          "5": {
                             "name": "variables"
                           }
                         },
                         "typeMap": {
                           "1": {
-                            "messageType": "cerbos.Variables"
+                            "primitive": "BOOL"
                           },
                           "2": {
                             "dyn": {}
                           },
                           "3": {
-                            "primitive": "BOOL"
-                          },
-                          "4": {
                             "messageType": "cerbos.Variables"
                           },
-                          "5": {
+                          "4": {
                             "dyn": {}
+                          },
+                          "5": {
+                            "messageType": "cerbos.Variables"
                           }
                         },
                         "sourceInfo": {
@@ -468,15 +468,15 @@
                             27
                           ],
                           "positions": {
-                            "1": 0,
+                            "1": 12,
                             "2": 9,
-                            "3": 12,
-                            "4": 14,
-                            "5": 23
+                            "3": 0,
+                            "4": 23,
+                            "5": 14
                           }
                         },
                         "expr": {
-                          "id": "3",
+                          "id": "1",
                           "callExpr": {
                             "function": "_>_",
                             "args": [
@@ -484,7 +484,7 @@
                                 "id": "2",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "1",
+                                    "id": "3",
                                     "identExpr": {
                                       "name": "variables"
                                     }
@@ -493,10 +493,10 @@
                                 }
                               },
                               {
-                                "id": "5",
+                                "id": "4",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "4",
+                                    "id": "5",
                                     "identExpr": {
                                       "name": "variables"
                                     }
@@ -520,16 +520,16 @@
                   "original": "C.b",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "C"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -538,15 +538,15 @@
                         4
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 1
+                        "1": 1,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "C"
                           }
@@ -563,16 +563,16 @@
                   "original": "constants.c",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "constants"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -581,15 +581,15 @@
                         12
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 9
+                        "1": 9,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "constants"
                           }
@@ -606,16 +606,16 @@
                   "original": "C.f",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "C"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -624,15 +624,15 @@
                         4
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 1
+                        "1": 1,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "C"
                           }
@@ -649,16 +649,16 @@
                   "original": "constants.h",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "constants"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -667,15 +667,15 @@
                         12
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 9
+                        "1": 9,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "constants"
                           }
@@ -692,16 +692,16 @@
                   "original": "C.i",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "C"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -710,15 +710,15 @@
                         4
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 1
+                        "1": 1,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "C"
                           }
@@ -736,9 +736,6 @@
                   "checked": {
                     "referenceMap": {
                       "1": {
-                        "name": "V"
-                      },
-                      "3": {
                         "overloadId": [
                           "add_bytes",
                           "add_double",
@@ -751,25 +748,28 @@
                           "add_uint64"
                         ]
                       },
-                      "4": {
+                      "3": {
+                        "name": "V"
+                      },
+                      "5": {
                         "name": "V"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
                         "dyn": {}
                       },
                       "3": {
-                        "dyn": {}
-                      },
-                      "4": {
                         "messageType": "cerbos.Variables"
                       },
-                      "5": {
+                      "4": {
                         "dyn": {}
+                      },
+                      "5": {
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -778,15 +778,15 @@
                         10
                       ],
                       "positions": {
-                        "1": 0,
+                        "1": 4,
                         "2": 1,
-                        "3": 4,
-                        "4": 6,
-                        "5": 7
+                        "3": 0,
+                        "4": 7,
+                        "5": 6
                       }
                     },
                     "expr": {
-                      "id": "3",
+                      "id": "1",
                       "callExpr": {
                         "function": "_+_",
                         "args": [
@@ -794,7 +794,7 @@
                             "id": "2",
                             "selectExpr": {
                               "operand": {
-                                "id": "1",
+                                "id": "3",
                                 "identExpr": {
                                   "name": "V"
                                 }
@@ -803,10 +803,10 @@
                             }
                           },
                           {
-                            "id": "5",
+                            "id": "4",
                             "selectExpr": {
                               "operand": {
-                                "id": "4",
+                                "id": "5",
                                 "identExpr": {
                                   "name": "V"
                                 }
@@ -836,16 +836,16 @@
             "original": "constants.a",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "constants"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -854,15 +854,15 @@
                   12
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 9
+                  "1": 9,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "constants"
                     }
@@ -877,9 +877,6 @@
             "checked": {
               "referenceMap": {
                 "1": {
-                  "name": "V"
-                },
-                "3": {
                   "overloadId": [
                     "add_bytes",
                     "add_double",
@@ -892,25 +889,28 @@
                     "add_uint64"
                   ]
                 },
-                "4": {
+                "3": {
+                  "name": "V"
+                },
+                "5": {
                   "name": "V"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
                   "dyn": {}
                 },
                 "3": {
-                  "dyn": {}
-                },
-                "4": {
                   "messageType": "cerbos.Variables"
                 },
-                "5": {
+                "4": {
                   "dyn": {}
+                },
+                "5": {
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -919,15 +919,15 @@
                   10
                 ],
                 "positions": {
-                  "1": 0,
+                  "1": 4,
                   "2": 1,
-                  "3": 4,
-                  "4": 6,
-                  "5": 7
+                  "3": 0,
+                  "4": 7,
+                  "5": 6
                 }
               },
               "expr": {
-                "id": "3",
+                "id": "1",
                 "callExpr": {
                   "function": "_+_",
                   "args": [
@@ -935,7 +935,7 @@
                       "id": "2",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "3",
                           "identExpr": {
                             "name": "V"
                           }
@@ -944,10 +944,10 @@
                       }
                     },
                     {
-                      "id": "5",
+                      "id": "4",
                       "selectExpr": {
                         "operand": {
-                          "id": "4",
+                          "id": "5",
                           "identExpr": {
                             "name": "V"
                           }
@@ -964,16 +964,16 @@
             "original": "C.b",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "C"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -982,15 +982,15 @@
                   4
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 1
+                  "1": 1,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "C"
                     }
@@ -1004,16 +1004,16 @@
             "original": "constants.n",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "constants"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -1022,15 +1022,15 @@
                   12
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 9
+                  "1": 9,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "constants"
                     }
@@ -1056,9 +1056,6 @@
                 "checked": {
                   "referenceMap": {
                     "1": {
-                      "name": "variables"
-                    },
-                    "3": {
                       "overloadId": [
                         "greater_bool",
                         "greater_int64",
@@ -1076,25 +1073,28 @@
                         "greater_duration"
                       ]
                     },
-                    "4": {
+                    "3": {
+                      "name": "variables"
+                    },
+                    "5": {
                       "name": "variables"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "primitive": "BOOL"
                     },
                     "2": {
                       "dyn": {}
                     },
                     "3": {
-                      "primitive": "BOOL"
-                    },
-                    "4": {
                       "messageType": "cerbos.Variables"
                     },
-                    "5": {
+                    "4": {
                       "dyn": {}
+                    },
+                    "5": {
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -1103,15 +1103,15 @@
                       27
                     ],
                     "positions": {
-                      "1": 0,
+                      "1": 12,
                       "2": 9,
-                      "3": 12,
-                      "4": 14,
-                      "5": 23
+                      "3": 0,
+                      "4": 23,
+                      "5": 14
                     }
                   },
                   "expr": {
-                    "id": "3",
+                    "id": "1",
                     "callExpr": {
                       "function": "_>_",
                       "args": [
@@ -1119,7 +1119,7 @@
                           "id": "2",
                           "selectExpr": {
                             "operand": {
-                              "id": "1",
+                              "id": "3",
                               "identExpr": {
                                 "name": "variables"
                               }
@@ -1128,10 +1128,10 @@
                           }
                         },
                         {
-                          "id": "5",
+                          "id": "4",
                           "selectExpr": {
                             "operand": {
-                              "id": "4",
+                              "id": "5",
                               "identExpr": {
                                 "name": "variables"
                               }
@@ -1155,16 +1155,16 @@
               "original": "constants.a",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "constants"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -1173,15 +1173,15 @@
                     12
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 9
+                    "1": 9,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "constants"
                       }
@@ -1198,16 +1198,16 @@
               "original": "C.b",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "C"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -1216,15 +1216,15 @@
                     4
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 1
+                    "1": 1,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "C"
                       }
@@ -1242,9 +1242,6 @@
               "checked": {
                 "referenceMap": {
                   "1": {
-                    "name": "V"
-                  },
-                  "3": {
                     "overloadId": [
                       "add_bytes",
                       "add_double",
@@ -1257,25 +1254,28 @@
                       "add_uint64"
                     ]
                   },
-                  "4": {
+                  "3": {
+                    "name": "V"
+                  },
+                  "5": {
                     "name": "V"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
                     "dyn": {}
                   },
                   "3": {
-                    "dyn": {}
-                  },
-                  "4": {
                     "messageType": "cerbos.Variables"
                   },
-                  "5": {
+                  "4": {
                     "dyn": {}
+                  },
+                  "5": {
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -1284,15 +1284,15 @@
                     10
                   ],
                   "positions": {
-                    "1": 0,
+                    "1": 4,
                     "2": 1,
-                    "3": 4,
-                    "4": 6,
-                    "5": 7
+                    "3": 0,
+                    "4": 7,
+                    "5": 6
                   }
                 },
                 "expr": {
-                  "id": "3",
+                  "id": "1",
                   "callExpr": {
                     "function": "_+_",
                     "args": [
@@ -1300,7 +1300,7 @@
                         "id": "2",
                         "selectExpr": {
                           "operand": {
-                            "id": "1",
+                            "id": "3",
                             "identExpr": {
                               "name": "V"
                             }
@@ -1309,10 +1309,10 @@
                         }
                       },
                       {
-                        "id": "5",
+                        "id": "4",
                         "selectExpr": {
                           "operand": {
-                            "id": "4",
+                            "id": "5",
                             "identExpr": {
                               "name": "V"
                             }
@@ -1332,16 +1332,16 @@
               "original": "constants.n",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "constants"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -1350,15 +1350,15 @@
                     12
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 9
+                    "1": 9,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "constants"
                       }
@@ -1389,16 +1389,16 @@
                 "original": "constants.a",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "constants"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -1407,15 +1407,15 @@
                       12
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 9
+                      "1": 9,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "constants"
                         }
@@ -1430,9 +1430,6 @@
                 "checked": {
                   "referenceMap": {
                     "1": {
-                      "name": "V"
-                    },
-                    "3": {
                       "overloadId": [
                         "add_bytes",
                         "add_double",
@@ -1445,25 +1442,28 @@
                         "add_uint64"
                       ]
                     },
-                    "4": {
+                    "3": {
+                      "name": "V"
+                    },
+                    "5": {
                       "name": "V"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
                       "dyn": {}
                     },
                     "3": {
-                      "dyn": {}
-                    },
-                    "4": {
                       "messageType": "cerbos.Variables"
                     },
-                    "5": {
+                    "4": {
                       "dyn": {}
+                    },
+                    "5": {
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -1472,15 +1472,15 @@
                       10
                     ],
                     "positions": {
-                      "1": 0,
+                      "1": 4,
                       "2": 1,
-                      "3": 4,
-                      "4": 6,
-                      "5": 7
+                      "3": 0,
+                      "4": 7,
+                      "5": 6
                     }
                   },
                   "expr": {
-                    "id": "3",
+                    "id": "1",
                     "callExpr": {
                       "function": "_+_",
                       "args": [
@@ -1488,7 +1488,7 @@
                           "id": "2",
                           "selectExpr": {
                             "operand": {
-                              "id": "1",
+                              "id": "3",
                               "identExpr": {
                                 "name": "V"
                               }
@@ -1497,10 +1497,10 @@
                           }
                         },
                         {
-                          "id": "5",
+                          "id": "4",
                           "selectExpr": {
                             "operand": {
-                              "id": "4",
+                              "id": "5",
                               "identExpr": {
                                 "name": "V"
                               }
@@ -1518,9 +1518,6 @@
                 "checked": {
                   "referenceMap": {
                     "1": {
-                      "name": "variables"
-                    },
-                    "3": {
                       "overloadId": [
                         "add_bytes",
                         "add_double",
@@ -1533,25 +1530,28 @@
                         "add_uint64"
                       ]
                     },
-                    "4": {
+                    "3": {
+                      "name": "variables"
+                    },
+                    "5": {
                       "name": "variables"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
                       "dyn": {}
                     },
                     "3": {
-                      "dyn": {}
-                    },
-                    "4": {
                       "messageType": "cerbos.Variables"
                     },
-                    "5": {
+                    "4": {
                       "dyn": {}
+                    },
+                    "5": {
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -1560,15 +1560,15 @@
                       27
                     ],
                     "positions": {
-                      "1": 0,
+                      "1": 13,
                       "2": 9,
-                      "3": 13,
-                      "4": 15,
-                      "5": 24
+                      "3": 0,
+                      "4": 24,
+                      "5": 15
                     }
                   },
                   "expr": {
-                    "id": "3",
+                    "id": "1",
                     "callExpr": {
                       "function": "_+_",
                       "args": [
@@ -1576,7 +1576,7 @@
                           "id": "2",
                           "selectExpr": {
                             "operand": {
-                              "id": "1",
+                              "id": "3",
                               "identExpr": {
                                 "name": "variables"
                               }
@@ -1585,10 +1585,10 @@
                           }
                         },
                         {
-                          "id": "5",
+                          "id": "4",
                           "selectExpr": {
                             "operand": {
-                              "id": "4",
+                              "id": "5",
                               "identExpr": {
                                 "name": "variables"
                               }
@@ -1605,16 +1605,16 @@
                 "original": "C.b",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "C"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -1623,15 +1623,15 @@
                       4
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 1
+                      "1": 1,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "C"
                         }
@@ -1645,16 +1645,16 @@
                 "original": "constants.c",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "constants"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -1663,15 +1663,15 @@
                       12
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 9
+                      "1": 9,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "constants"
                         }
@@ -1685,16 +1685,16 @@
                 "original": "constants.e",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "constants"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -1703,15 +1703,15 @@
                       12
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 9
+                      "1": 9,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "constants"
                         }
@@ -1725,16 +1725,16 @@
                 "original": "C.g",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "C"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -1743,15 +1743,15 @@
                       4
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 1
+                      "1": 1,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "C"
                         }
@@ -1765,16 +1765,16 @@
                 "original": "constants.h",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "constants"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -1783,15 +1783,15 @@
                       12
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 9
+                      "1": 9,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "constants"
                         }
@@ -1811,25 +1811,25 @@
                       "checked": {
                         "referenceMap": {
                           "1": {
-                            "name": "V"
-                          },
-                          "3": {
                             "overloadId": [
                               "greater_int64",
                               "greater_uint64_int64",
                               "greater_double_int64"
                             ]
+                          },
+                          "3": {
+                            "name": "V"
                           }
                         },
                         "typeMap": {
                           "1": {
-                            "messageType": "cerbos.Variables"
+                            "primitive": "BOOL"
                           },
                           "2": {
                             "dyn": {}
                           },
                           "3": {
-                            "primitive": "BOOL"
+                            "messageType": "cerbos.Variables"
                           },
                           "4": {
                             "primitive": "INT64"
@@ -1841,14 +1841,14 @@
                             10
                           ],
                           "positions": {
-                            "1": 0,
+                            "1": 6,
                             "2": 1,
-                            "3": 6,
+                            "3": 0,
                             "4": 8
                           }
                         },
                         "expr": {
-                          "id": "3",
+                          "id": "1",
                           "callExpr": {
                             "function": "_>_",
                             "args": [
@@ -1856,7 +1856,7 @@
                                 "id": "2",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "1",
+                                    "id": "3",
                                     "identExpr": {
                                       "name": "V"
                                     }
@@ -1885,9 +1885,6 @@
                             "checked": {
                               "referenceMap": {
                                 "1": {
-                                  "name": "variables"
-                                },
-                                "3": {
                                   "overloadId": [
                                     "less_bool",
                                     "less_int64",
@@ -1905,25 +1902,28 @@
                                     "less_duration"
                                   ]
                                 },
-                                "4": {
+                                "3": {
+                                  "name": "variables"
+                                },
+                                "5": {
                                   "name": "variables"
                                 }
                               },
                               "typeMap": {
                                 "1": {
-                                  "messageType": "cerbos.Variables"
+                                  "primitive": "BOOL"
                                 },
                                 "2": {
                                   "dyn": {}
                                 },
                                 "3": {
-                                  "primitive": "BOOL"
-                                },
-                                "4": {
                                   "messageType": "cerbos.Variables"
                                 },
-                                "5": {
+                                "4": {
                                   "dyn": {}
+                                },
+                                "5": {
+                                  "messageType": "cerbos.Variables"
                                 }
                               },
                               "sourceInfo": {
@@ -1932,15 +1932,15 @@
                                   26
                                 ],
                                 "positions": {
-                                  "1": 0,
+                                  "1": 12,
                                   "2": 9,
-                                  "3": 12,
-                                  "4": 14,
-                                  "5": 23
+                                  "3": 0,
+                                  "4": 23,
+                                  "5": 14
                                 }
                               },
                               "expr": {
-                                "id": "3",
+                                "id": "1",
                                 "callExpr": {
                                   "function": "_<_",
                                   "args": [
@@ -1948,7 +1948,7 @@
                                       "id": "2",
                                       "selectExpr": {
                                         "operand": {
-                                          "id": "1",
+                                          "id": "3",
                                           "identExpr": {
                                             "name": "variables"
                                           }
@@ -1957,10 +1957,10 @@
                                       }
                                     },
                                     {
-                                      "id": "5",
+                                      "id": "4",
                                       "selectExpr": {
                                         "operand": {
-                                          "id": "4",
+                                          "id": "5",
                                           "identExpr": {
                                             "name": "variables"
                                           }
@@ -1980,9 +1980,6 @@
                             "checked": {
                               "referenceMap": {
                                 "1": {
-                                  "name": "V"
-                                },
-                                "3": {
                                   "overloadId": [
                                     "greater_bool",
                                     "greater_int64",
@@ -2000,25 +1997,28 @@
                                     "greater_duration"
                                   ]
                                 },
-                                "4": {
+                                "3": {
+                                  "name": "V"
+                                },
+                                "5": {
                                   "name": "C"
                                 }
                               },
                               "typeMap": {
                                 "1": {
-                                  "messageType": "cerbos.Variables"
+                                  "primitive": "BOOL"
                                 },
                                 "2": {
                                   "dyn": {}
                                 },
                                 "3": {
-                                  "primitive": "BOOL"
-                                },
-                                "4": {
                                   "messageType": "cerbos.Variables"
                                 },
-                                "5": {
+                                "4": {
                                   "dyn": {}
+                                },
+                                "5": {
+                                  "messageType": "cerbos.Variables"
                                 }
                               },
                               "sourceInfo": {
@@ -2027,15 +2027,15 @@
                                   10
                                 ],
                                 "positions": {
-                                  "1": 0,
+                                  "1": 4,
                                   "2": 1,
-                                  "3": 4,
-                                  "4": 6,
-                                  "5": 7
+                                  "3": 0,
+                                  "4": 7,
+                                  "5": 6
                                 }
                               },
                               "expr": {
-                                "id": "3",
+                                "id": "1",
                                 "callExpr": {
                                   "function": "_>_",
                                   "args": [
@@ -2043,7 +2043,7 @@
                                       "id": "2",
                                       "selectExpr": {
                                         "operand": {
-                                          "id": "1",
+                                          "id": "3",
                                           "identExpr": {
                                             "name": "V"
                                           }
@@ -2052,10 +2052,10 @@
                                       }
                                     },
                                     {
-                                      "id": "5",
+                                      "id": "4",
                                       "selectExpr": {
                                         "operand": {
-                                          "id": "4",
+                                          "id": "5",
                                           "identExpr": {
                                             "name": "C"
                                           }
@@ -2082,16 +2082,16 @@
                   "original": "constants.a",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "constants"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -2100,15 +2100,15 @@
                         12
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 9
+                        "1": 9,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "constants"
                           }
@@ -2125,16 +2125,16 @@
                   "original": "C.b",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "C"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -2143,15 +2143,15 @@
                         4
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 1
+                        "1": 1,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "C"
                           }
@@ -2169,9 +2169,6 @@
                   "checked": {
                     "referenceMap": {
                       "1": {
-                        "name": "V"
-                      },
-                      "3": {
                         "overloadId": [
                           "add_bytes",
                           "add_double",
@@ -2184,25 +2181,28 @@
                           "add_uint64"
                         ]
                       },
-                      "4": {
+                      "3": {
+                        "name": "V"
+                      },
+                      "5": {
                         "name": "V"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
                         "dyn": {}
                       },
                       "3": {
-                        "dyn": {}
-                      },
-                      "4": {
                         "messageType": "cerbos.Variables"
                       },
-                      "5": {
+                      "4": {
                         "dyn": {}
+                      },
+                      "5": {
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -2211,15 +2211,15 @@
                         10
                       ],
                       "positions": {
-                        "1": 0,
+                        "1": 4,
                         "2": 1,
-                        "3": 4,
-                        "4": 6,
-                        "5": 7
+                        "3": 0,
+                        "4": 7,
+                        "5": 6
                       }
                     },
                     "expr": {
-                      "id": "3",
+                      "id": "1",
                       "callExpr": {
                         "function": "_+_",
                         "args": [
@@ -2227,7 +2227,7 @@
                             "id": "2",
                             "selectExpr": {
                               "operand": {
-                                "id": "1",
+                                "id": "3",
                                 "identExpr": {
                                   "name": "V"
                                 }
@@ -2236,10 +2236,10 @@
                             }
                           },
                           {
-                            "id": "5",
+                            "id": "4",
                             "selectExpr": {
                               "operand": {
-                                "id": "4",
+                                "id": "5",
                                 "identExpr": {
                                   "name": "V"
                                 }
@@ -2259,16 +2259,16 @@
                   "original": "constants.c",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "constants"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -2277,15 +2277,15 @@
                         12
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 9
+                        "1": 9,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "constants"
                           }
@@ -2302,16 +2302,16 @@
                   "original": "constants.e",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "constants"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -2320,15 +2320,15 @@
                         12
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 9
+                        "1": 9,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "constants"
                           }
@@ -2345,16 +2345,16 @@
                   "original": "C.g",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "C"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -2363,15 +2363,15 @@
                         4
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 1
+                        "1": 1,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "C"
                           }
@@ -2389,9 +2389,6 @@
                   "checked": {
                     "referenceMap": {
                       "1": {
-                        "name": "variables"
-                      },
-                      "3": {
                         "overloadId": [
                           "add_bytes",
                           "add_double",
@@ -2404,25 +2401,28 @@
                           "add_uint64"
                         ]
                       },
-                      "4": {
+                      "3": {
+                        "name": "variables"
+                      },
+                      "5": {
                         "name": "variables"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
                         "dyn": {}
                       },
                       "3": {
-                        "dyn": {}
-                      },
-                      "4": {
                         "messageType": "cerbos.Variables"
                       },
-                      "5": {
+                      "4": {
                         "dyn": {}
+                      },
+                      "5": {
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -2431,15 +2431,15 @@
                         27
                       ],
                       "positions": {
-                        "1": 0,
+                        "1": 13,
                         "2": 9,
-                        "3": 13,
-                        "4": 15,
-                        "5": 24
+                        "3": 0,
+                        "4": 24,
+                        "5": 15
                       }
                     },
                     "expr": {
-                      "id": "3",
+                      "id": "1",
                       "callExpr": {
                         "function": "_+_",
                         "args": [
@@ -2447,7 +2447,7 @@
                             "id": "2",
                             "selectExpr": {
                               "operand": {
-                                "id": "1",
+                                "id": "3",
                                 "identExpr": {
                                   "name": "variables"
                                 }
@@ -2456,10 +2456,10 @@
                             }
                           },
                           {
-                            "id": "5",
+                            "id": "4",
                             "selectExpr": {
                               "operand": {
-                                "id": "4",
+                                "id": "5",
                                 "identExpr": {
                                   "name": "variables"
                                 }
@@ -2479,16 +2479,16 @@
                   "original": "constants.h",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "constants"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -2497,15 +2497,15 @@
                         12
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 9
+                        "1": 9,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "constants"
                           }
@@ -2538,16 +2538,16 @@
                 "original": "C.b",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "C"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -2556,15 +2556,15 @@
                       4
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 1
+                      "1": 1,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "C"
                         }
@@ -2578,16 +2578,16 @@
                 "original": "constants.c",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "constants"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -2596,15 +2596,15 @@
                       12
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 9
+                      "1": 9,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "constants"
                         }
@@ -2618,16 +2618,16 @@
                 "original": "C.f",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "C"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -2636,15 +2636,15 @@
                       4
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 1
+                      "1": 1,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "C"
                         }
@@ -2658,16 +2658,16 @@
                 "original": "constants.h",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "constants"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -2676,15 +2676,15 @@
                       12
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 9
+                      "1": 9,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "constants"
                         }
@@ -2699,9 +2699,6 @@
                 "checked": {
                   "referenceMap": {
                     "1": {
-                      "name": "V"
-                    },
-                    "3": {
                       "overloadId": [
                         "add_bytes",
                         "add_double",
@@ -2714,25 +2711,28 @@
                         "add_uint64"
                       ]
                     },
-                    "4": {
+                    "3": {
+                      "name": "V"
+                    },
+                    "5": {
                       "name": "V"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
                       "dyn": {}
                     },
                     "3": {
-                      "dyn": {}
-                    },
-                    "4": {
                       "messageType": "cerbos.Variables"
                     },
-                    "5": {
+                    "4": {
                       "dyn": {}
+                    },
+                    "5": {
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -2741,15 +2741,15 @@
                       10
                     ],
                     "positions": {
-                      "1": 0,
+                      "1": 4,
                       "2": 1,
-                      "3": 4,
-                      "4": 6,
-                      "5": 7
+                      "3": 0,
+                      "4": 7,
+                      "5": 6
                     }
                   },
                   "expr": {
-                    "id": "3",
+                    "id": "1",
                     "callExpr": {
                       "function": "_+_",
                       "args": [
@@ -2757,7 +2757,7 @@
                           "id": "2",
                           "selectExpr": {
                             "operand": {
-                              "id": "1",
+                              "id": "3",
                               "identExpr": {
                                 "name": "V"
                               }
@@ -2766,10 +2766,10 @@
                           }
                         },
                         {
-                          "id": "5",
+                          "id": "4",
                           "selectExpr": {
                             "operand": {
-                              "id": "4",
+                              "id": "5",
                               "identExpr": {
                                 "name": "V"
                               }
@@ -2786,16 +2786,16 @@
                 "original": "C.i",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "C"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -2804,15 +2804,15 @@
                       4
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 1
+                      "1": 1,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "C"
                         }
@@ -2832,9 +2832,6 @@
                       "checked": {
                         "referenceMap": {
                           "1": {
-                            "name": "V"
-                          },
-                          "3": {
                             "overloadId": [
                               "greater_bool",
                               "greater_int64",
@@ -2852,25 +2849,28 @@
                               "greater_duration"
                             ]
                           },
-                          "4": {
+                          "3": {
+                            "name": "V"
+                          },
+                          "5": {
                             "name": "V"
                           }
                         },
                         "typeMap": {
                           "1": {
-                            "messageType": "cerbos.Variables"
+                            "primitive": "BOOL"
                           },
                           "2": {
                             "dyn": {}
                           },
                           "3": {
-                            "primitive": "BOOL"
-                          },
-                          "4": {
                             "messageType": "cerbos.Variables"
                           },
-                          "5": {
+                          "4": {
                             "dyn": {}
+                          },
+                          "5": {
+                            "messageType": "cerbos.Variables"
                           }
                         },
                         "sourceInfo": {
@@ -2879,15 +2879,15 @@
                             10
                           ],
                           "positions": {
-                            "1": 0,
+                            "1": 4,
                             "2": 1,
-                            "3": 4,
-                            "4": 6,
-                            "5": 7
+                            "3": 0,
+                            "4": 7,
+                            "5": 6
                           }
                         },
                         "expr": {
-                          "id": "3",
+                          "id": "1",
                           "callExpr": {
                             "function": "_>_",
                             "args": [
@@ -2895,7 +2895,7 @@
                                 "id": "2",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "1",
+                                    "id": "3",
                                     "identExpr": {
                                       "name": "V"
                                     }
@@ -2904,10 +2904,10 @@
                                 }
                               },
                               {
-                                "id": "5",
+                                "id": "4",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "4",
+                                    "id": "5",
                                     "identExpr": {
                                       "name": "V"
                                     }
@@ -2927,9 +2927,6 @@
                       "checked": {
                         "referenceMap": {
                           "1": {
-                            "name": "variables"
-                          },
-                          "3": {
                             "overloadId": [
                               "greater_bool",
                               "greater_int64",
@@ -2947,25 +2944,28 @@
                               "greater_duration"
                             ]
                           },
-                          "4": {
+                          "3": {
+                            "name": "variables"
+                          },
+                          "5": {
                             "name": "variables"
                           }
                         },
                         "typeMap": {
                           "1": {
-                            "messageType": "cerbos.Variables"
+                            "primitive": "BOOL"
                           },
                           "2": {
                             "dyn": {}
                           },
                           "3": {
-                            "primitive": "BOOL"
-                          },
-                          "4": {
                             "messageType": "cerbos.Variables"
                           },
-                          "5": {
+                          "4": {
                             "dyn": {}
+                          },
+                          "5": {
+                            "messageType": "cerbos.Variables"
                           }
                         },
                         "sourceInfo": {
@@ -2974,15 +2974,15 @@
                             27
                           ],
                           "positions": {
-                            "1": 0,
+                            "1": 12,
                             "2": 9,
-                            "3": 12,
-                            "4": 14,
-                            "5": 23
+                            "3": 0,
+                            "4": 23,
+                            "5": 14
                           }
                         },
                         "expr": {
-                          "id": "3",
+                          "id": "1",
                           "callExpr": {
                             "function": "_>_",
                             "args": [
@@ -2990,7 +2990,7 @@
                                 "id": "2",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "1",
+                                    "id": "3",
                                     "identExpr": {
                                       "name": "variables"
                                     }
@@ -2999,10 +2999,10 @@
                                 }
                               },
                               {
-                                "id": "5",
+                                "id": "4",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "4",
+                                    "id": "5",
                                     "identExpr": {
                                       "name": "variables"
                                     }
@@ -3026,16 +3026,16 @@
                   "original": "C.b",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "C"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -3044,15 +3044,15 @@
                         4
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 1
+                        "1": 1,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "C"
                           }
@@ -3069,16 +3069,16 @@
                   "original": "constants.c",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "constants"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -3087,15 +3087,15 @@
                         12
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 9
+                        "1": 9,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "constants"
                           }
@@ -3112,16 +3112,16 @@
                   "original": "C.f",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "C"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -3130,15 +3130,15 @@
                         4
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 1
+                        "1": 1,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "C"
                           }
@@ -3155,16 +3155,16 @@
                   "original": "constants.h",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "constants"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -3173,15 +3173,15 @@
                         12
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 9
+                        "1": 9,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "constants"
                           }
@@ -3198,16 +3198,16 @@
                   "original": "C.i",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "C"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -3216,15 +3216,15 @@
                         4
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 1
+                        "1": 1,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "C"
                           }
@@ -3242,9 +3242,6 @@
                   "checked": {
                     "referenceMap": {
                       "1": {
-                        "name": "V"
-                      },
-                      "3": {
                         "overloadId": [
                           "add_bytes",
                           "add_double",
@@ -3257,25 +3254,28 @@
                           "add_uint64"
                         ]
                       },
-                      "4": {
+                      "3": {
+                        "name": "V"
+                      },
+                      "5": {
                         "name": "V"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
                         "dyn": {}
                       },
                       "3": {
-                        "dyn": {}
-                      },
-                      "4": {
                         "messageType": "cerbos.Variables"
                       },
-                      "5": {
+                      "4": {
                         "dyn": {}
+                      },
+                      "5": {
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -3284,15 +3284,15 @@
                         10
                       ],
                       "positions": {
-                        "1": 0,
+                        "1": 4,
                         "2": 1,
-                        "3": 4,
-                        "4": 6,
-                        "5": 7
+                        "3": 0,
+                        "4": 7,
+                        "5": 6
                       }
                     },
                     "expr": {
-                      "id": "3",
+                      "id": "1",
                       "callExpr": {
                         "function": "_+_",
                         "args": [
@@ -3300,7 +3300,7 @@
                             "id": "2",
                             "selectExpr": {
                               "operand": {
-                                "id": "1",
+                                "id": "3",
                                 "identExpr": {
                                   "name": "V"
                                 }
@@ -3309,10 +3309,10 @@
                             }
                           },
                           {
-                            "id": "5",
+                            "id": "4",
                             "selectExpr": {
                               "operand": {
-                                "id": "4",
+                                "id": "5",
                                 "identExpr": {
                                   "name": "V"
                                 }
@@ -3346,16 +3346,16 @@
                 "original": "constants.a",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "constants"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -3364,15 +3364,15 @@
                       12
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 9
+                      "1": 9,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "constants"
                         }
@@ -3386,16 +3386,16 @@
                 "original": "C.d",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "C"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -3404,15 +3404,15 @@
                       4
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 1
+                      "1": 1,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "C"
                         }
@@ -3426,16 +3426,16 @@
                 "original": "constants.e",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "constants"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -3444,15 +3444,15 @@
                       12
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 9
+                      "1": 9,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "constants"
                         }
@@ -3466,16 +3466,16 @@
                 "original": "constants.j",
                 "checked": {
                   "referenceMap": {
-                    "1": {
+                    "2": {
                       "name": "constants"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "2": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -3484,15 +3484,15 @@
                       12
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 9
+                      "1": 9,
+                      "2": 0
                     }
                   },
                   "expr": {
-                    "id": "2",
+                    "id": "1",
                     "selectExpr": {
                       "operand": {
-                        "id": "1",
+                        "id": "2",
                         "identExpr": {
                           "name": "constants"
                         }
@@ -3509,7 +3509,22 @@
                 "checked": {
                   "referenceMap": {
                     "1": {
-                      "name": "V"
+                      "overloadId": [
+                        "equals"
+                      ]
+                    },
+                    "2": {
+                      "overloadId": [
+                        "add_bytes",
+                        "add_double",
+                        "add_duration_duration",
+                        "add_duration_timestamp",
+                        "add_timestamp_duration",
+                        "add_int64",
+                        "add_list",
+                        "add_string",
+                        "add_uint64"
+                      ]
                     },
                     "3": {
                       "overloadId": [
@@ -3524,37 +3539,22 @@
                         "add_uint64"
                       ]
                     },
-                    "4": {
+                    "5": {
                       "name": "V"
-                    },
-                    "6": {
-                      "overloadId": [
-                        "add_bytes",
-                        "add_double",
-                        "add_duration_duration",
-                        "add_duration_timestamp",
-                        "add_timestamp_duration",
-                        "add_int64",
-                        "add_list",
-                        "add_string",
-                        "add_uint64"
-                      ]
                     },
                     "7": {
                       "name": "V"
                     },
                     "9": {
-                      "overloadId": [
-                        "equals"
-                      ]
+                      "name": "V"
                     },
-                    "10": {
+                    "11": {
                       "name": "V"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "primitive": "BOOL"
                     },
                     "2": {
                       "dyn": {}
@@ -3563,10 +3563,10 @@
                       "dyn": {}
                     },
                     "4": {
-                      "messageType": "cerbos.Variables"
+                      "dyn": {}
                     },
                     "5": {
-                      "dyn": {}
+                      "messageType": "cerbos.Variables"
                     },
                     "6": {
                       "dyn": {}
@@ -3578,13 +3578,13 @@
                       "dyn": {}
                     },
                     "9": {
-                      "primitive": "BOOL"
-                    },
-                    "10": {
                       "messageType": "cerbos.Variables"
                     },
-                    "11": {
+                    "10": {
                       "dyn": {}
+                    },
+                    "11": {
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -3593,26 +3593,26 @@
                       23
                     ],
                     "positions": {
-                      "1": 0,
-                      "2": 1,
+                      "1": 16,
+                      "2": 10,
                       "3": 4,
-                      "4": 6,
-                      "5": 7,
-                      "6": 10,
-                      "7": 12,
+                      "4": 1,
+                      "5": 0,
+                      "6": 7,
+                      "7": 6,
                       "8": 13,
-                      "9": 16,
-                      "10": 19,
-                      "11": 20
+                      "9": 12,
+                      "10": 20,
+                      "11": 19
                     }
                   },
                   "expr": {
-                    "id": "9",
+                    "id": "1",
                     "callExpr": {
                       "function": "_==_",
                       "args": [
                         {
-                          "id": "6",
+                          "id": "2",
                           "callExpr": {
                             "function": "_+_",
                             "args": [
@@ -3622,10 +3622,10 @@
                                   "function": "_+_",
                                   "args": [
                                     {
-                                      "id": "2",
+                                      "id": "4",
                                       "selectExpr": {
                                         "operand": {
-                                          "id": "1",
+                                          "id": "5",
                                           "identExpr": {
                                             "name": "V"
                                           }
@@ -3634,10 +3634,10 @@
                                       }
                                     },
                                     {
-                                      "id": "5",
+                                      "id": "6",
                                       "selectExpr": {
                                         "operand": {
-                                          "id": "4",
+                                          "id": "7",
                                           "identExpr": {
                                             "name": "V"
                                           }
@@ -3652,7 +3652,7 @@
                                 "id": "8",
                                 "selectExpr": {
                                   "operand": {
-                                    "id": "7",
+                                    "id": "9",
                                     "identExpr": {
                                       "name": "V"
                                     }
@@ -3664,10 +3664,10 @@
                           }
                         },
                         {
-                          "id": "11",
+                          "id": "10",
                           "selectExpr": {
                             "operand": {
-                              "id": "10",
+                              "id": "11",
                               "identExpr": {
                                 "name": "V"
                               }
@@ -3688,16 +3688,16 @@
                   "original": "constants.a",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "constants"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -3706,15 +3706,15 @@
                         12
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 9
+                        "1": 9,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "constants"
                           }
@@ -3731,16 +3731,16 @@
                   "original": "C.d",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "C"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -3749,15 +3749,15 @@
                         4
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 1
+                        "1": 1,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "C"
                           }
@@ -3774,16 +3774,16 @@
                   "original": "constants.e",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "constants"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -3792,15 +3792,15 @@
                         12
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 9
+                        "1": 9,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "constants"
                           }
@@ -3817,16 +3817,16 @@
                   "original": "constants.j",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "constants"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -3835,15 +3835,15 @@
                         12
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 9
+                        "1": 9,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "constants"
                           }
@@ -3869,16 +3869,16 @@
             "original": "constants.a",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "constants"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -3887,15 +3887,15 @@
                   12
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 9
+                  "1": 9,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "constants"
                     }
@@ -3910,9 +3910,6 @@
             "checked": {
               "referenceMap": {
                 "1": {
-                  "name": "V"
-                },
-                "3": {
                   "overloadId": [
                     "add_bytes",
                     "add_double",
@@ -3925,25 +3922,28 @@
                     "add_uint64"
                   ]
                 },
-                "4": {
+                "3": {
+                  "name": "V"
+                },
+                "5": {
                   "name": "V"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
                   "dyn": {}
                 },
                 "3": {
-                  "dyn": {}
-                },
-                "4": {
                   "messageType": "cerbos.Variables"
                 },
-                "5": {
+                "4": {
                   "dyn": {}
+                },
+                "5": {
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -3952,15 +3952,15 @@
                   10
                 ],
                 "positions": {
-                  "1": 0,
+                  "1": 4,
                   "2": 1,
-                  "3": 4,
-                  "4": 6,
-                  "5": 7
+                  "3": 0,
+                  "4": 7,
+                  "5": 6
                 }
               },
               "expr": {
-                "id": "3",
+                "id": "1",
                 "callExpr": {
                   "function": "_+_",
                   "args": [
@@ -3968,7 +3968,7 @@
                       "id": "2",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "3",
                           "identExpr": {
                             "name": "V"
                           }
@@ -3977,10 +3977,10 @@
                       }
                     },
                     {
-                      "id": "5",
+                      "id": "4",
                       "selectExpr": {
                         "operand": {
-                          "id": "4",
+                          "id": "5",
                           "identExpr": {
                             "name": "V"
                           }
@@ -3998,9 +3998,6 @@
             "checked": {
               "referenceMap": {
                 "1": {
-                  "name": "variables"
-                },
-                "3": {
                   "overloadId": [
                     "add_bytes",
                     "add_double",
@@ -4013,25 +4010,28 @@
                     "add_uint64"
                   ]
                 },
-                "4": {
+                "3": {
+                  "name": "variables"
+                },
+                "5": {
                   "name": "variables"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
                   "dyn": {}
                 },
                 "3": {
-                  "dyn": {}
-                },
-                "4": {
                   "messageType": "cerbos.Variables"
                 },
-                "5": {
+                "4": {
                   "dyn": {}
+                },
+                "5": {
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -4040,15 +4040,15 @@
                   27
                 ],
                 "positions": {
-                  "1": 0,
+                  "1": 13,
                   "2": 9,
-                  "3": 13,
-                  "4": 15,
-                  "5": 24
+                  "3": 0,
+                  "4": 24,
+                  "5": 15
                 }
               },
               "expr": {
-                "id": "3",
+                "id": "1",
                 "callExpr": {
                   "function": "_+_",
                   "args": [
@@ -4056,7 +4056,7 @@
                       "id": "2",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "3",
                           "identExpr": {
                             "name": "variables"
                           }
@@ -4065,10 +4065,10 @@
                       }
                     },
                     {
-                      "id": "5",
+                      "id": "4",
                       "selectExpr": {
                         "operand": {
-                          "id": "4",
+                          "id": "5",
                           "identExpr": {
                             "name": "variables"
                           }
@@ -4086,9 +4086,6 @@
             "checked": {
               "referenceMap": {
                 "1": {
-                  "name": "variables"
-                },
-                "3": {
                   "overloadId": [
                     "add_bytes",
                     "add_double",
@@ -4101,25 +4098,28 @@
                     "add_uint64"
                   ]
                 },
-                "4": {
+                "3": {
+                  "name": "variables"
+                },
+                "5": {
                   "name": "variables"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
                   "dyn": {}
                 },
                 "3": {
-                  "dyn": {}
-                },
-                "4": {
                   "messageType": "cerbos.Variables"
                 },
-                "5": {
+                "4": {
                   "dyn": {}
+                },
+                "5": {
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -4128,15 +4128,15 @@
                   28
                 ],
                 "positions": {
-                  "1": 0,
+                  "1": 14,
                   "2": 9,
-                  "3": 14,
-                  "4": 16,
-                  "5": 25
+                  "3": 0,
+                  "4": 25,
+                  "5": 16
                 }
               },
               "expr": {
-                "id": "3",
+                "id": "1",
                 "callExpr": {
                   "function": "_+_",
                   "args": [
@@ -4144,7 +4144,7 @@
                       "id": "2",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "3",
                           "identExpr": {
                             "name": "variables"
                           }
@@ -4153,10 +4153,10 @@
                       }
                     },
                     {
-                      "id": "5",
+                      "id": "4",
                       "selectExpr": {
                         "operand": {
-                          "id": "4",
+                          "id": "5",
                           "identExpr": {
                             "name": "variables"
                           }
@@ -4173,16 +4173,16 @@
             "original": "C.b",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "C"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -4191,15 +4191,15 @@
                   4
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 1
+                  "1": 1,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "C"
                     }
@@ -4213,16 +4213,16 @@
             "original": "constants.c",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "constants"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -4231,15 +4231,15 @@
                   12
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 9
+                  "1": 9,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "constants"
                     }
@@ -4253,16 +4253,16 @@
             "original": "constants.l",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "constants"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -4271,15 +4271,15 @@
                   12
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 9
+                  "1": 9,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "constants"
                     }
@@ -4293,16 +4293,16 @@
             "original": "C.m",
             "checked": {
               "referenceMap": {
-                "1": {
+                "2": {
                   "name": "C"
                 }
               },
               "typeMap": {
                 "1": {
-                  "messageType": "cerbos.Variables"
+                  "dyn": {}
                 },
                 "2": {
-                  "dyn": {}
+                  "messageType": "cerbos.Variables"
                 }
               },
               "sourceInfo": {
@@ -4311,15 +4311,15 @@
                   4
                 ],
                 "positions": {
-                  "1": 0,
-                  "2": 1
+                  "1": 1,
+                  "2": 0
                 }
               },
               "expr": {
-                "id": "2",
+                "id": "1",
                 "selectExpr": {
                   "operand": {
-                    "id": "1",
+                    "id": "2",
                     "identExpr": {
                       "name": "C"
                     }
@@ -4345,9 +4345,6 @@
                 "checked": {
                   "referenceMap": {
                     "1": {
-                      "name": "variables"
-                    },
-                    "3": {
                       "overloadId": [
                         "greater_bool",
                         "greater_int64",
@@ -4365,25 +4362,28 @@
                         "greater_duration"
                       ]
                     },
-                    "4": {
+                    "3": {
+                      "name": "variables"
+                    },
+                    "5": {
                       "name": "constants"
                     }
                   },
                   "typeMap": {
                     "1": {
-                      "messageType": "cerbos.Variables"
+                      "primitive": "BOOL"
                     },
                     "2": {
                       "dyn": {}
                     },
                     "3": {
-                      "primitive": "BOOL"
-                    },
-                    "4": {
                       "messageType": "cerbos.Variables"
                     },
-                    "5": {
+                    "4": {
                       "dyn": {}
+                    },
+                    "5": {
+                      "messageType": "cerbos.Variables"
                     }
                   },
                   "sourceInfo": {
@@ -4392,15 +4392,15 @@
                       26
                     ],
                     "positions": {
-                      "1": 0,
+                      "1": 12,
                       "2": 9,
-                      "3": 12,
-                      "4": 14,
-                      "5": 23
+                      "3": 0,
+                      "4": 23,
+                      "5": 14
                     }
                   },
                   "expr": {
-                    "id": "3",
+                    "id": "1",
                     "callExpr": {
                       "function": "_>_",
                       "args": [
@@ -4408,7 +4408,7 @@
                           "id": "2",
                           "selectExpr": {
                             "operand": {
-                              "id": "1",
+                              "id": "3",
                               "identExpr": {
                                 "name": "variables"
                               }
@@ -4417,10 +4417,10 @@
                           }
                         },
                         {
-                          "id": "5",
+                          "id": "4",
                           "selectExpr": {
                             "operand": {
-                              "id": "4",
+                              "id": "5",
                               "identExpr": {
                                 "name": "constants"
                               }
@@ -4441,16 +4441,16 @@
                   "original": "V.abcl",
                   "checked": {
                     "referenceMap": {
-                      "1": {
+                      "2": {
                         "name": "V"
                       }
                     },
                     "typeMap": {
                       "1": {
-                        "messageType": "cerbos.Variables"
+                        "dyn": {}
                       },
                       "2": {
-                        "dyn": {}
+                        "messageType": "cerbos.Variables"
                       }
                     },
                     "sourceInfo": {
@@ -4459,15 +4459,15 @@
                         7
                       ],
                       "positions": {
-                        "1": 0,
-                        "2": 1
+                        "1": 1,
+                        "2": 0
                       }
                     },
                     "expr": {
-                      "id": "2",
+                      "id": "1",
                       "selectExpr": {
                         "operand": {
-                          "id": "1",
+                          "id": "2",
                           "identExpr": {
                             "name": "V"
                           }
@@ -4500,16 +4500,16 @@
               "original": "constants.a",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "constants"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -4518,15 +4518,15 @@
                     12
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 9
+                    "1": 9,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "constants"
                       }
@@ -4543,16 +4543,16 @@
               "original": "C.b",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "C"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -4561,15 +4561,15 @@
                     4
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 1
+                    "1": 1,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "C"
                       }
@@ -4587,9 +4587,6 @@
               "checked": {
                 "referenceMap": {
                   "1": {
-                    "name": "V"
-                  },
-                  "3": {
                     "overloadId": [
                       "add_bytes",
                       "add_double",
@@ -4602,25 +4599,28 @@
                       "add_uint64"
                     ]
                   },
-                  "4": {
+                  "3": {
+                    "name": "V"
+                  },
+                  "5": {
                     "name": "V"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
                     "dyn": {}
                   },
                   "3": {
-                    "dyn": {}
-                  },
-                  "4": {
                     "messageType": "cerbos.Variables"
                   },
-                  "5": {
+                  "4": {
                     "dyn": {}
+                  },
+                  "5": {
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -4629,15 +4629,15 @@
                     10
                   ],
                   "positions": {
-                    "1": 0,
+                    "1": 4,
                     "2": 1,
-                    "3": 4,
-                    "4": 6,
-                    "5": 7
+                    "3": 0,
+                    "4": 7,
+                    "5": 6
                   }
                 },
                 "expr": {
-                  "id": "3",
+                  "id": "1",
                   "callExpr": {
                     "function": "_+_",
                     "args": [
@@ -4645,7 +4645,7 @@
                         "id": "2",
                         "selectExpr": {
                           "operand": {
-                            "id": "1",
+                            "id": "3",
                             "identExpr": {
                               "name": "V"
                             }
@@ -4654,10 +4654,10 @@
                         }
                       },
                       {
-                        "id": "5",
+                        "id": "4",
                         "selectExpr": {
                           "operand": {
-                            "id": "4",
+                            "id": "5",
                             "identExpr": {
                               "name": "V"
                             }
@@ -4677,16 +4677,16 @@
               "original": "constants.c",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "constants"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -4695,15 +4695,15 @@
                     12
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 9
+                    "1": 9,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "constants"
                       }
@@ -4721,9 +4721,6 @@
               "checked": {
                 "referenceMap": {
                   "1": {
-                    "name": "variables"
-                  },
-                  "3": {
                     "overloadId": [
                       "add_bytes",
                       "add_double",
@@ -4736,25 +4733,28 @@
                       "add_uint64"
                     ]
                   },
-                  "4": {
+                  "3": {
+                    "name": "variables"
+                  },
+                  "5": {
                     "name": "variables"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
                     "dyn": {}
                   },
                   "3": {
-                    "dyn": {}
-                  },
-                  "4": {
                     "messageType": "cerbos.Variables"
                   },
-                  "5": {
+                  "4": {
                     "dyn": {}
+                  },
+                  "5": {
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -4763,15 +4763,15 @@
                     27
                   ],
                   "positions": {
-                    "1": 0,
+                    "1": 13,
                     "2": 9,
-                    "3": 13,
-                    "4": 15,
-                    "5": 24
+                    "3": 0,
+                    "4": 24,
+                    "5": 15
                   }
                 },
                 "expr": {
-                  "id": "3",
+                  "id": "1",
                   "callExpr": {
                     "function": "_+_",
                     "args": [
@@ -4779,7 +4779,7 @@
                         "id": "2",
                         "selectExpr": {
                           "operand": {
-                            "id": "1",
+                            "id": "3",
                             "identExpr": {
                               "name": "variables"
                             }
@@ -4788,10 +4788,10 @@
                         }
                       },
                       {
-                        "id": "5",
+                        "id": "4",
                         "selectExpr": {
                           "operand": {
-                            "id": "4",
+                            "id": "5",
                             "identExpr": {
                               "name": "variables"
                             }
@@ -4811,16 +4811,16 @@
               "original": "constants.l",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "constants"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -4829,15 +4829,15 @@
                     12
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 9
+                    "1": 9,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "constants"
                       }
@@ -4855,9 +4855,6 @@
               "checked": {
                 "referenceMap": {
                   "1": {
-                    "name": "variables"
-                  },
-                  "3": {
                     "overloadId": [
                       "add_bytes",
                       "add_double",
@@ -4870,25 +4867,28 @@
                       "add_uint64"
                     ]
                   },
-                  "4": {
+                  "3": {
+                    "name": "variables"
+                  },
+                  "5": {
                     "name": "variables"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
                     "dyn": {}
                   },
                   "3": {
-                    "dyn": {}
-                  },
-                  "4": {
                     "messageType": "cerbos.Variables"
                   },
-                  "5": {
+                  "4": {
                     "dyn": {}
+                  },
+                  "5": {
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -4897,15 +4897,15 @@
                     28
                   ],
                   "positions": {
-                    "1": 0,
+                    "1": 14,
                     "2": 9,
-                    "3": 14,
-                    "4": 16,
-                    "5": 25
+                    "3": 0,
+                    "4": 25,
+                    "5": 16
                   }
                 },
                 "expr": {
-                  "id": "3",
+                  "id": "1",
                   "callExpr": {
                     "function": "_+_",
                     "args": [
@@ -4913,7 +4913,7 @@
                         "id": "2",
                         "selectExpr": {
                           "operand": {
-                            "id": "1",
+                            "id": "3",
                             "identExpr": {
                               "name": "variables"
                             }
@@ -4922,10 +4922,10 @@
                         }
                       },
                       {
-                        "id": "5",
+                        "id": "4",
                         "selectExpr": {
                           "operand": {
-                            "id": "4",
+                            "id": "5",
                             "identExpr": {
                               "name": "variables"
                             }
@@ -4945,16 +4945,16 @@
               "original": "C.m",
               "checked": {
                 "referenceMap": {
-                  "1": {
+                  "2": {
                     "name": "C"
                   }
                 },
                 "typeMap": {
                   "1": {
-                    "messageType": "cerbos.Variables"
+                    "dyn": {}
                   },
                   "2": {
-                    "dyn": {}
+                    "messageType": "cerbos.Variables"
                   }
                 },
                 "sourceInfo": {
@@ -4963,15 +4963,15 @@
                     4
                   ],
                   "positions": {
-                    "1": 0,
-                    "2": 1
+                    "1": 1,
+                    "2": 0
                   }
                 },
                 "expr": {
-                  "id": "2",
+                  "id": "1",
                   "selectExpr": {
                     "operand": {
-                      "id": "1",
+                      "id": "2",
                       "identExpr": {
                         "name": "C"
                       }


### PR DESCRIPTION
Configures constant-folding optimizations for CEL expressions. It
simplifies the AST by evaluating known values into constant values. E.g.
`1+1` becomes `2`.

The `now` and `timeSince` functions don't play nice with the optimizer
because it doesn't apply the decorator we have for time functions.
So, `now() == now()` evaluates to `false` because `now()` is called
twice during the optimization pass and it returns a different value each
time. Unfortunately, there's no way to configure the optimizer to use
the decorator we have. The other way to mark a function as unfoldable is
by setting the `LateFunctionBinding()` option during the function
declaration. However, there doesn't seem to be a consistent way to
define the late binding and I couldn't get it to work correctly.

Also enables extra AST validation for durations, timestamps, and
regexes. It should help detect more invalid expressions at compile time
rather than at run time.

The improvement from constant folding is quite dramatic at times. For
example, the `set.contains` benchmark for two sets of 100 items takes
~53735ns without the optimization and ~393ns with the optimization.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
