### PR TITLE
fix: validate policy scope chains on update

### DIFF
--- a/.changelog/20260815_1314.txt
+++ b/.changelog/20260815_1314.txt
@@ -1,0 +1,2 @@
+type:fix
+Reject Admin API policy writes that would leave a broken scope chain

--- a/internal/storage/db/internal/db.go
+++ b/internal/storage/db/internal/db.go
@@ -321,6 +321,10 @@ func (s *dbStorage) AddOrUpdate(ctx context.Context, policies ...policy.Wrapper)
 			events = append(events, storage.Event{Kind: storage.EventAddOrUpdatePolicy, PolicyID: p.ID})
 		}
 
+		if err := s.validateScopeChains(ctx, tx, policies); err != nil {
+			return err
+		}
+
 		// build a deduplicated union of dependents across the whole batch and
 		// exclude policies updated in this batch.
 		depEvent := storage.Event{Kind: storage.EventAddOrUpdatePolicy}
@@ -347,6 +351,57 @@ func (s *dbStorage) AddOrUpdate(ctx context.Context, policies ...policy.Wrapper)
 
 	s.subs.NotifySubscribers(events...)
 	return nil
+}
+
+func (s *dbStorage) validateScopeChains(ctx context.Context, tx *goqu.TxDatabase, policies []policy.Wrapper) error {
+	requiredAncestors := make(map[namer.ModuleID]string)
+	for _, p := range policies {
+		for id, fqn := range policy.RequiredAncestors(p.Policy) {
+			requiredAncestors[id] = namer.PolicyKeyFromFQN(fqn)
+		}
+	}
+
+	if len(requiredAncestors) == 0 {
+		return nil
+	}
+
+	ancestorIDs := make([]namer.ModuleID, 0, len(requiredAncestors))
+	for id := range requiredAncestors {
+		ancestorIDs = append(ancestorIDs, id)
+	}
+
+	var existingAncestorIDs []namer.ModuleID
+	if err := tx.
+		From(PolicyTbl).
+		Select(goqu.C(PolicyTblIDCol)).
+		Where(
+			goqu.C(PolicyTblIDCol).In(ancestorIDs),
+			goqu.C(PolicyTblDisabledCol).Neq(goqu.V(true)),
+		).
+		Executor().
+		ScanValsContext(ctx, &existingAncestorIDs); err != nil {
+		return fmt.Errorf("failed to validate policy scope chains: %w", err)
+	}
+
+	for _, id := range existingAncestorIDs {
+		delete(requiredAncestors, id)
+	}
+
+	if len(requiredAncestors) == 0 {
+		return nil
+	}
+
+	missingAncestors := make([]string, 0, len(requiredAncestors))
+	for _, policyKey := range requiredAncestors {
+		missingAncestors = append(missingAncestors, policyKey)
+	}
+	slices.Sort(missingAncestors)
+
+	return storage.NewInvalidPolicyError(
+		errors.New("scope chain is incomplete"),
+		"missing ancestor policies: %s",
+		strings.Join(missingAncestors, ", "),
+	)
 }
 
 func (s *dbStorage) GetFirstMatch(ctx context.Context, candidates []namer.ModuleID) (*policy.CompilationUnit, error) {

--- a/internal/storage/db/internal/tests.go
+++ b/internal/storage/db/internal/tests.go
@@ -127,6 +127,19 @@ func TestSuite(store DBStorage) func(*testing.T) {
 				{Kind: storage.EventAddOrUpdatePolicy, Dependents: []namer.ModuleID{rpAcme.ID, rpAcmeHR.ID, rpAcmeHRUK.ID}},
 			}
 			t.Run("update_partial", addPolicies([]policy.Wrapper{rp, dr}, wantPartialEvents))
+
+			t.Run("rejects_broken_scope_chain", func(t *testing.T) {
+				orphan := withScope(test.GenResourcePolicy(test.Suffix("_orphan")), "acme.hr")
+
+				err := store.AddOrUpdate(ctx, orphan)
+				require.Error(t, err)
+				require.ErrorContains(t, err, "missing ancestor policies")
+				require.ErrorContains(t, err, "orphan")
+
+				have, err := store.GetCompilationUnits(ctx, orphan.ID)
+				require.NoError(t, err)
+				require.Empty(t, have)
+			})
 		})
 
 		t.Run("iter", func(t *testing.T) {

--- a/internal/test/testdata/server/admin/add_or_update_policy/invalid_case_02.yaml
+++ b/internal/test/testdata/server/admin/add_or_update_policy/invalid_case_02.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=../../../.jsonschema/ServerTestCase.schema.json
+---
+description: "Policy with a broken scope chain"
+wantError: true
+wantStatus:
+  httpStatusCode: 400
+  grpcStatusCode: 3
+adminAddOrUpdatePolicy:
+  input: {
+    "policies": [
+      {
+        "apiVersion": "api.cerbos.dev/v1",
+        "resourcePolicy": {
+          "version": "default",
+          "scope": "acme.hr",
+          "resource": "orphan_resource",
+          "rules": [
+            {
+              "actions": ["read"],
+              "effect": "EFFECT_ALLOW",
+              "roles": ["user"]
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Closes #1591.

## What changed

- validate the required scope ancestors after all policies in an Admin API batch have been written inside the transaction
- reject missing or disabled ancestors with `InvalidArgument` and roll back the whole batch
- keep valid out-of-order full-chain batches working
- add storage rollback and Admin API gRPC/HTTP regression coverage

## Root cause

`AddOrUpdate` recorded ancestor references but never checked that the referenced policies existed and were enabled. A leaf policy could therefore be accepted even though the resulting stored scope chain was incomplete.

## Validation

- red before: the SQLite regression expected an error but `AddOrUpdate` returned `nil`
- `go test -tags=tests ./internal/storage/db/sqlite3 -count=1`
- `go test -tags=tests ./internal/storage/db/internal ./internal/storage/db/sqlite3 ./internal/svc -count=1`
- targeted SQLite regression with `-race`
- `go vet -tags=tests ./internal/storage/db/internal ./internal/storage/db/sqlite3 ./internal/svc`
- `go build ./...`
- direct Admin service check returned gRPC `codes.InvalidArgument`
- Admin server fixture template parse passed

The full socket-based Admin gRPC/HTTP suite was not run locally because the isolated test sandbox prohibits loopback binding; the submitted fixture covers both transports in CI.

## AI assistance disclosure

This PR was written with OpenAI Codex assistance. I reviewed the implementation and tests, reproduced the failure before the fix, and ran the validation listed above.
