### PR TITLE
fix: reduce tautologies and contradictions in query planner filters

### DIFF
--- a/.changelog/20260820_0523.txt
+++ b/.changelog/20260820_0523.txt
@@ -1,0 +1,3 @@
+type:fix
+Reduce tautologies and contradictions in query planner filters
+The query planner can emit filters that contain mutually exclusive equality predicates, such as requiring a resource attribute to be two different values at once. Those tautologies and contradictions are now reduced during filter normalisation.

--- a/internal/ruletable/planner/ast.go
+++ b/internal/ruletable/planner/ast.go
@@ -710,6 +710,12 @@ func normaliseFilterExprOpExpr(expr *enginev1.PlanResourcesFilter_Expression_Ope
 		operands = append(operands, normalOp)
 	}
 
+	if logicalOperator == And || logicalOperator == Or {
+		if simplified := simplifyLogicalExpr(logicalOperator, operands); simplified != nil {
+			return simplified
+		}
+	}
+
 	// AND or OR of a single value is the value itself
 	//nolint:nestif
 	if logicalOperator != "" {

--- a/internal/ruletable/planner/merge.go
+++ b/internal/ruletable/planner/merge.go
@@ -44,5 +44,8 @@ func MergeWithAnd(filters []*enginev1.PlanResourcesFilter) (*enginev1.PlanResour
 		response.Condition = &exprOp{Node: mkExprOpExpr(And, operands...)}
 		response.Kind = enginev1.PlanResourcesFilter_KIND_CONDITIONAL
 	}
+	if response.Kind == enginev1.PlanResourcesFilter_KIND_CONDITIONAL {
+		response = normaliseFilter(response)
+	}
 	return response, FilterToString(response), nil
 }

--- a/internal/ruletable/planner/simplify.go
+++ b/internal/ruletable/planner/simplify.go
@@ -1,0 +1,180 @@
+// Copyright 2021-2026 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package planner
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
+)
+
+// simplifyLogicalExpr reduces tautologies and contradictions among equality
+// predicates. A non-nil return replaces the current AND/OR node.
+func simplifyLogicalExpr(operator string, operands []*enginev1.PlanResourcesFilter_Expression_Operand) *enginev1.PlanResourcesFilter_Expression_Operand {
+	switch operator {
+	case And:
+		if hasAndContradiction(operands) {
+			return falseExprOpValue
+		}
+	case Or:
+		if hasOrTautology(operands) {
+			return trueExprOpValue
+		}
+	}
+
+	return nil
+}
+
+func hasAndContradiction(operands []*enginev1.PlanResourcesFilter_Expression_Operand) bool {
+	flat := flattenLogical(And, operands)
+	eqs := map[string]*structpb.Value{}
+	var neqs []varConst
+
+	for _, op := range flat {
+		if v, val, ok := asVarConst(op, Equals); ok {
+			if prev, exists := eqs[v]; exists && !proto.Equal(prev, val) {
+				return true
+			}
+			eqs[v] = val
+			continue
+		}
+		if v, val, ok := asVarConst(op, NotEquals); ok {
+			neqs = append(neqs, varConst{variable: v, value: val})
+		}
+	}
+
+	for _, ne := range neqs {
+		if prev, exists := eqs[ne.variable]; exists && proto.Equal(prev, ne.value) {
+			return true
+		}
+	}
+
+	for _, op := range flat {
+		child := asNotOperand(op)
+		if child == nil {
+			continue
+		}
+		if containsOperand(flat, op, child) {
+			return true
+		}
+		if v, val, ok := asVarConst(child, Equals); ok {
+			if prev, exists := eqs[v]; exists && proto.Equal(prev, val) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func hasOrTautology(operands []*enginev1.PlanResourcesFilter_Expression_Operand) bool {
+	flat := flattenLogical(Or, operands)
+	var eqs []varConst
+	var neqs []varConst
+
+	for _, op := range flat {
+		if v, val, ok := asVarConst(op, Equals); ok {
+			eqs = append(eqs, varConst{variable: v, value: val})
+			continue
+		}
+		if v, val, ok := asVarConst(op, NotEquals); ok {
+			neqs = append(neqs, varConst{variable: v, value: val})
+		}
+	}
+
+	for _, eq := range eqs {
+		for _, ne := range neqs {
+			if eq.variable == ne.variable && proto.Equal(eq.value, ne.value) {
+				return true
+			}
+		}
+	}
+
+	for _, op := range flat {
+		child := asNotOperand(op)
+		if child == nil {
+			continue
+		}
+		if containsOperand(flat, op, child) {
+			return true
+		}
+		if v, val, ok := asVarConst(child, Equals); ok {
+			for _, eq := range eqs {
+				if eq.variable == v && proto.Equal(eq.value, val) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+type varConst struct {
+	value    *structpb.Value
+	variable string
+}
+
+func flattenLogical(operator string, operands []*enginev1.PlanResourcesFilter_Expression_Operand) []*enginev1.PlanResourcesFilter_Expression_Operand {
+	out := make([]*enginev1.PlanResourcesFilter_Expression_Operand, 0, len(operands))
+	for _, op := range operands {
+		if expr := op.GetExpression(); expr != nil && expr.Operator == operator {
+			out = append(out, flattenLogical(operator, expr.Operands)...)
+			continue
+		}
+		out = append(out, op)
+	}
+	return out
+}
+
+func asNotOperand(op *enginev1.PlanResourcesFilter_Expression_Operand) *enginev1.PlanResourcesFilter_Expression_Operand {
+	expr := op.GetExpression()
+	if expr == nil || expr.Operator != Not || len(expr.Operands) != 1 {
+		return nil
+	}
+	return expr.Operands[0]
+}
+
+func asVarConst(op *enginev1.PlanResourcesFilter_Expression_Operand, operator string) (string, *structpb.Value, bool) {
+	expr := op.GetExpression()
+	if expr == nil || expr.Operator != operator || len(expr.Operands) != 2 {
+		return "", nil, false
+	}
+
+	a, b := expr.Operands[0], expr.Operands[1]
+	if v := a.GetVariable(); v != "" && b.GetValue() != nil {
+		return v, b.GetValue(), true
+	}
+	if v := b.GetVariable(); v != "" && a.GetValue() != nil {
+		return v, a.GetValue(), true
+	}
+	return "", nil, false
+}
+
+func containsOperand(ops []*enginev1.PlanResourcesFilter_Expression_Operand, skip, want *enginev1.PlanResourcesFilter_Expression_Operand) bool {
+	for _, op := range ops {
+		if op == skip {
+			continue
+		}
+		if proto.Equal(op, want) {
+			return true
+		}
+		if equivalentVarConst(op, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func equivalentVarConst(a, b *enginev1.PlanResourcesFilter_Expression_Operand) bool {
+	for _, operator := range []string{Equals, NotEquals} {
+		v1, val1, ok1 := asVarConst(a, operator)
+		v2, val2, ok2 := asVarConst(b, operator)
+		if ok1 && ok2 && v1 == v2 && proto.Equal(val1, val2) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ruletable/planner/simplify_test.go
+++ b/internal/ruletable/planner/simplify_test.go
@@ -1,0 +1,179 @@
+// Copyright 2021-2026 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build tests
+
+package planner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
+)
+
+func TestSimplifyTautologiesAndContradictions(t *testing.T) {
+	t.Parallel()
+
+	dept := "request.resource.attr.department"
+
+	tests := []struct {
+		name       string
+		input      *enginev1.PlanResourcesFilter
+		wantKind   enginev1.PlanResourcesFilter_Kind
+		wantString string
+	}{
+		{
+			name: "not of mutually exclusive equalities is a tautology",
+			// (and (not (and (eq dept "secret") (eq dept "it"))) (eq dept "it"))
+			// inner AND is a contradiction, so NOT of it is always true.
+			input: conditionalFilter(andOp(
+				notOp(andOp(
+					eqOp(dept, "secret"),
+					eqOp(dept, "it"),
+				)),
+				eqOp(dept, "it"),
+			)),
+			wantKind:   enginev1.PlanResourcesFilter_KIND_CONDITIONAL,
+			wantString: `(eq request.resource.attr.department "it")`,
+		},
+		{
+			name: "equality and its negation is a contradiction",
+			// (and (not (eq dept "secret")) (eq dept "secret"))
+			input: conditionalFilter(andOp(
+				notOp(eqOp(dept, "secret")),
+				eqOp(dept, "secret"),
+			)),
+			wantKind:   enginev1.PlanResourcesFilter_KIND_ALWAYS_DENIED,
+			wantString: "(false)",
+		},
+		{
+			name: "mutually exclusive equalities in AND is a contradiction",
+			input: conditionalFilter(andOp(
+				eqOp(dept, "secret"),
+				eqOp(dept, "it"),
+			)),
+			wantKind:   enginev1.PlanResourcesFilter_KIND_ALWAYS_DENIED,
+			wantString: "(false)",
+		},
+		{
+			name: "NOT of mutually exclusive equalities is ALWAYS_ALLOWED",
+			input: conditionalFilter(notOp(andOp(
+				eqOp(dept, "secret"),
+				eqOp(dept, "it"),
+			))),
+			wantKind:   enginev1.PlanResourcesFilter_KIND_ALWAYS_ALLOWED,
+			wantString: "(true)",
+		},
+		{
+			name: "P or not P is a tautology",
+			input: conditionalFilter(orOp(
+				eqOp(dept, "secret"),
+				notOp(eqOp(dept, "secret")),
+			)),
+			wantKind:   enginev1.PlanResourcesFilter_KIND_ALWAYS_ALLOWED,
+			wantString: "(true)",
+		},
+		{
+			name: "eq and ne on the same value is a contradiction",
+			input: conditionalFilter(andOp(
+				eqOp(dept, "secret"),
+				neOp(dept, "secret"),
+			)),
+			wantKind:   enginev1.PlanResourcesFilter_KIND_ALWAYS_DENIED,
+			wantString: "(false)",
+		},
+		{
+			name: "equalities on different variables are unchanged",
+			input: conditionalFilter(andOp(
+				eqOp(dept, "it"),
+				eqOp("request.resource.attr.owner", "user1"),
+			)),
+			wantKind:   enginev1.PlanResourcesFilter_KIND_CONDITIONAL,
+			wantString: `(and (eq request.resource.attr.department "it") (eq request.resource.attr.owner "user1"))`,
+		},
+		{
+			name: "reversed eq operand order still detects contradiction",
+			input: conditionalFilter(andOp(
+				eqOp(dept, "secret"),
+				eqValueVar("it", dept),
+			)),
+			wantKind:   enginev1.PlanResourcesFilter_KIND_ALWAYS_DENIED,
+			wantString: "(false)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := normaliseFilter(tt.input)
+			require.Equal(t, tt.wantKind, got.Kind)
+			require.Equal(t, tt.wantString, FilterToString(got))
+		})
+	}
+}
+
+func TestMergeWithAndSimplifiesContradiction(t *testing.T) {
+	t.Parallel()
+
+	dept := "request.resource.attr.department"
+	left := normaliseFilter(conditionalFilter(notOp(eqOp(dept, "secret"))))
+	right := normaliseFilter(conditionalFilter(eqOp(dept, "secret")))
+
+	got, gotStr, err := MergeWithAnd([]*enginev1.PlanResourcesFilter{left, right})
+	require.NoError(t, err)
+	require.Equal(t, enginev1.PlanResourcesFilter_KIND_ALWAYS_DENIED, got.Kind)
+	require.Equal(t, "(false)", gotStr)
+}
+
+func conditionalFilter(cond *enginev1.PlanResourcesFilter_Expression_Operand) *enginev1.PlanResourcesFilter {
+	return &enginev1.PlanResourcesFilter{
+		Kind:      enginev1.PlanResourcesFilter_KIND_CONDITIONAL,
+		Condition: cond,
+	}
+}
+
+func eqOp(variable, value string) *enginev1.PlanResourcesFilter_Expression_Operand {
+	return exprNode(Equals, varOp(variable), valueOp(value))
+}
+
+func eqValueVar(value, variable string) *enginev1.PlanResourcesFilter_Expression_Operand {
+	return exprNode(Equals, valueOp(value), varOp(variable))
+}
+
+func neOp(variable, value string) *enginev1.PlanResourcesFilter_Expression_Operand {
+	return exprNode(NotEquals, varOp(variable), valueOp(value))
+}
+
+func andOp(ops ...*enginev1.PlanResourcesFilter_Expression_Operand) *enginev1.PlanResourcesFilter_Expression_Operand {
+	return exprNode(And, ops...)
+}
+
+func orOp(ops ...*enginev1.PlanResourcesFilter_Expression_Operand) *enginev1.PlanResourcesFilter_Expression_Operand {
+	return exprNode(Or, ops...)
+}
+
+func notOp(op *enginev1.PlanResourcesFilter_Expression_Operand) *enginev1.PlanResourcesFilter_Expression_Operand {
+	return exprNode(Not, op)
+}
+
+func exprNode(op string, operands ...*enginev1.PlanResourcesFilter_Expression_Operand) *enginev1.PlanResourcesFilter_Expression_Operand {
+	return &enginev1.PlanResourcesFilter_Expression_Operand{
+		Node: mkExprOpExpr(op, operands...),
+	}
+}
+
+func varOp(name string) *enginev1.PlanResourcesFilter_Expression_Operand {
+	return &enginev1.PlanResourcesFilter_Expression_Operand{
+		Node: &enginev1.PlanResourcesFilter_Expression_Operand_Variable{Variable: name},
+	}
+}
+
+func valueOp(s string) *enginev1.PlanResourcesFilter_Expression_Operand {
+	return &enginev1.PlanResourcesFilter_Expression_Operand{
+		Node: &enginev1.PlanResourcesFilter_Expression_Operand_Value{Value: structpb.NewStringValue(s)},
+	}
+}

--- a/internal/test/testdata/query_planner/suite/harry.yaml
+++ b/internal/test/testdata/query_planner/suite/harry.yaml
@@ -251,23 +251,6 @@ tests:
     action: multi-role-test-conditional-allow-deny
     want:
       filter:
-        kind: KIND_CONDITIONAL
-        condition:
-          expression:
-            operator: and
-            operands:
-              - expression:
-                  operator: eq
-                  operands:
-                    - variable: request.resource.attr.owner
-                    - value: harry
-              - expression:
-                  operator: not
-                  operands:
-                    - expression:
-                        operator: eq
-                        operands:
-                          - variable: request.resource.attr.owner
-                          - value: harry
+        kind: KIND_ALWAYS_DENIED
       matchedScopes:
         multi-role-test-conditional-allow-deny: ""


### PR DESCRIPTION
The query planner could emit obvious tautologies and contradictions, e.g.

`(and (not (and (eq request.resource.attr.department \"secret\") (eq request.resource.attr.department \"it\"))) (eq request.resource.attr.department \"it\"))`

which should reduce to `(eq request.resource.attr.department \"it\")`.

After the existing true/false folding, AND/OR nodes now drop mutually exclusive equalities, `P` with `not P`, and matching `eq`/`ne`. Combined action filters go through the same pass.

Fixes #3040