### PR TITLE
Add capability to scan protobuf-encoded rule table

### DIFF
--- a/internal/ruletable/wire.go
+++ b/internal/ruletable/wire.go
@@ -6,6 +6,7 @@
 package ruletable
 
 import (
+	"fmt"
 	"slices"
 
 	"google.golang.org/protobuf/encoding/protowire"
@@ -29,4 +30,54 @@ func AppendRuleRowRecord(buf []byte, row *runtimev1.RuleTable_RuleRow) ([]byte, 
 		return nil, err
 	}
 	return buf, nil
+}
+
+// ScanRuleTable walks the top-level records of a protobuf-encoded
+// runtimev1.RuleTable without unmarshalling it and invokes the callbacks.
+// onRow is a callback function invoked for each entry of the `rules` field.
+// Its arguments:
+// n - 0-based ordinal of the entry,
+// record - the full record bytes (tag, length and payload),
+// payload - payload itself.
+// onOther is a callback function invoked for each (top) field other than `rules`.
+// Its argument:
+// record - the full record bytes (tag, length and payload).
+func ScanRuleTable(data []byte, onRow func(n int, record, payload []byte) error, onOther func(record []byte) error) error {
+	n := 0
+	for len(data) > 0 {
+		num, typ, tagLen := protowire.ConsumeTag(data)
+		if tagLen < 0 {
+			return fmt.Errorf("malformed rule table: %w", protowire.ParseError(tagLen))
+		}
+
+		if num == ruleTableRulesField {
+			if typ != protowire.BytesType {
+				return fmt.Errorf("malformed rule table: rules record %d has wire type %d, want %d", n, typ, protowire.BytesType)
+			}
+
+			payload, valLen := protowire.ConsumeBytes(data[tagLen:])
+			if valLen < 0 {
+				return fmt.Errorf("malformed rule table: rules record %d: %w", n, protowire.ParseError(valLen))
+			}
+
+			if err := onRow(n, data[:tagLen+valLen], payload); err != nil {
+				return err
+			}
+			n++
+			data = data[tagLen+valLen:]
+			continue
+		}
+
+		valLen := protowire.ConsumeFieldValue(num, typ, data[tagLen:])
+		if valLen < 0 {
+			return fmt.Errorf("malformed rule table: field %d: %w", num, protowire.ParseError(valLen))
+		}
+
+		if err := onOther(data[:tagLen+valLen]); err != nil {
+			return err
+		}
+		data = data[tagLen+valLen:]
+	}
+
+	return nil
 }

--- a/private/ruletable/compile/compile_test.go
+++ b/private/ruletable/compile/compile_test.go
@@ -103,13 +103,6 @@ func TestScanRuleTable(t *testing.T) {
 	conventional, err := rt.MarshalVT()
 	require.NoError(t, err)
 
-	var streamed, buf []byte
-	for _, row := range rt.Rules {
-		buf, err = ruletablecompile.AppendRuleRowRecord(buf[:0], row)
-		require.NoError(t, err)
-		streamed = append(streamed, buf...)
-	}
-
 	rows := rt.Rules
 	rt.Rules = nil
 	remainderBytes, err := rt.MarshalVT()
@@ -117,6 +110,13 @@ func TestScanRuleTable(t *testing.T) {
 	remainder := &runtimev1.RuleTable{}
 	require.NoError(t, remainder.UnmarshalVT(remainderBytes))
 	rt.Rules = rows
+
+	var streamed, buf []byte
+	for _, row := range rt.Rules {
+		buf, err = ruletablecompile.AppendRuleRowRecord(buf[:0], row)
+		require.NoError(t, err)
+		streamed = append(streamed, buf...)
+	}
 
 	streamed = append(streamed, remainderBytes...)
 	for name, data := range map[string][]byte{"conventional": conventional, "streamed": streamed} {

--- a/private/ruletable/compile/compile_test.go
+++ b/private/ruletable/compile/compile_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cerbos/cerbos/internal/test"
 	"github.com/cerbos/cerbos/internal/util"
 	"github.com/cerbos/cerbos/private/compile"
+	privateruletable "github.com/cerbos/cerbos/private/ruletable"
 	ruletablecompile "github.com/cerbos/cerbos/private/ruletable/compile"
 )
 
@@ -90,6 +91,67 @@ func TestCompileStream(t *testing.T) {
 	sortRules(want)
 	sortRules(have)
 	require.Empty(t, gocmp.Diff(want, have, protocmp.Transform()))
+}
+
+// TestScanRuleTable proves that ScanRuleTable is the inverse of marshalling.
+func TestScanRuleTable(t *testing.T) {
+	rt, err := ruletablecompile.Compile(t.Context(), os.DirFS(test.PathToDir(t, "store")))
+	require.NoError(t, err)
+	require.NotEmpty(t, rt.GetRules())
+	rt.Manifest = &runtimev1.RuleTable_Manifest{BundleId: "SCANCHECK0000000"}
+
+	conventional, err := rt.MarshalVT()
+	require.NoError(t, err)
+
+	var streamed, buf []byte
+	for _, row := range rt.Rules {
+		buf, err = ruletablecompile.AppendRuleRowRecord(buf[:0], row)
+		require.NoError(t, err)
+		streamed = append(streamed, buf...)
+	}
+
+	rows := rt.Rules
+	rt.Rules = nil
+	remainderBytes, err := rt.MarshalVT()
+	require.NoError(t, err)
+	remainder := &runtimev1.RuleTable{}
+	require.NoError(t, remainder.UnmarshalVT(remainderBytes))
+	rt.Rules = rows
+
+	streamed = append(streamed, remainderBytes...)
+	for name, data := range map[string][]byte{"conventional": conventional, "streamed": streamed} {
+		t.Run(name, func(t *testing.T) {
+			var data1, remainderBytes1 []byte
+			var rows1 []*runtimev1.RuleTable_RuleRow
+			require.NoError(t, privateruletable.ScanRuleTable(data,
+				func(n int, record, payload []byte) error {
+					require.Equal(t, len(rows1), n, "ordinals must be sequential")
+					row := &runtimev1.RuleTable_RuleRow{}
+					require.NoError(t, row.UnmarshalVT(payload))
+					rows1 = append(rows1, row)
+					data1 = append(data1, record...)
+					return nil
+				},
+				func(record []byte) error {
+					remainderBytes1 = append(remainderBytes1, record...)
+					data1 = append(data1, record...)
+					return nil
+				}))
+
+			require.Len(t, rows1, len(rows))
+			for n := range len(rows) {
+				require.Empty(t, gocmp.Diff(rows[n], rows1[n], protocmp.Transform()), "row %d mismatch", n)
+			}
+
+			remainder1 := &runtimev1.RuleTable{}
+			require.NoError(t, remainder1.UnmarshalVT(remainderBytes1))
+			require.Empty(t, gocmp.Diff(remainder, remainder1, protocmp.Transform()), "remainder mismatch")
+
+			rt1 := &runtimev1.RuleTable{}
+			require.NoError(t, rt1.UnmarshalVT(data1))
+			require.Empty(t, gocmp.Diff(rt, rt1, protocmp.Transform()), "reassembled table mismatch")
+		})
+	}
 }
 
 // TestStreamedWireCompatibility proves that a rule table can be serialized incrementally.

--- a/private/ruletable/index.go
+++ b/private/ruletable/index.go
@@ -6,6 +6,7 @@
 package ruletable
 
 import (
+	internalruletable "github.com/cerbos/cerbos/internal/ruletable"
 	"github.com/cerbos/cerbos/internal/ruletable/index"
 )
 
@@ -21,3 +22,17 @@ var (
 	New       = index.New
 	Unmarshal = index.Unmarshal
 )
+
+// ScanRuleTable walks the top-level records of a protobuf-encoded
+// runtimev1.RuleTable without unmarshalling it and invokes the callbacks.
+// onRow is a callback function invoked for each entry of the `rules` field.
+// Its arguments:
+// n - 0-based ordinal of the entry,
+// record - the full record bytes (tag, length and payload),
+// payload - payload itself.
+// onOther is a callback function invoked for each (top) field other than `rules`.
+// Its argument:
+// record - the full record bytes (tag, length and payload).
+func ScanRuleTable(data []byte, onRow func(n int, record, payload []byte) error, onOther func(record []byte) error) error {
+	return internalruletable.ScanRuleTable(data, onRow, onOther)
+}


### PR DESCRIPTION
This PR adds the `ScanRuleTable` function to walk top-level fields of the protobuf-serialised rule table and allows filtering its rows without deserialising it.