### PR TITLE
Measure audit log activity and backend buffer sizes

### DIFF
--- a/internal/audit/hub/hub.go
+++ b/internal/audit/hub/hub.go
@@ -14,6 +14,7 @@ import (
 
 	badgerv4 "github.com/dgraph-io/badger/v4"
 	"github.com/sourcegraph/conc/pool"
+	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -66,7 +67,27 @@ func init() {
 			}
 		}
 
-		return NewLog(conf, decisionFilter, syncer, logger, pipeLog)
+		newl, err := NewLog(conf, decisionFilter, syncer, logger, pipeLog)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := metrics.Meter().RegisterCallback(func(_ context.Context, o metric.Observer) error {
+			rows := int64(0)
+			for _, tbl := range newl.Db.Tables() {
+				rows += int64(tbl.KeyCount)
+			}
+
+			o.ObserveInt64(metrics.AuditBackendBufferEntries(), rows, metric.WithAttributes(
+				metrics.AuditBackendKey.String(Backend),
+			))
+
+			return nil
+		}, metrics.AuditBackendBufferEntries()); err != nil {
+			return nil, err
+		}
+
+		return newl, nil
 	})
 }
 

--- a/internal/audit/kafka/publisher.go
+++ b/internal/audit/kafka/publisher.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/plugin/kzap"
+	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -60,8 +61,22 @@ func init() {
 		if err := confW.GetSection(conf); err != nil {
 			return nil, fmt.Errorf("failed to read kafka audit log configuration: %w", err)
 		}
+		newp, err := NewPublisher(ctx, conf, decisionFilter)
+		if err != nil {
+			return nil, err
+		}
 
-		return NewPublisher(ctx, conf, decisionFilter)
+		if _, err := metrics.Meter().RegisterCallback(func(_ context.Context, o metric.Observer) error {
+			o.ObserveInt64(metrics.AuditBackendBufferEntries(), newp.measureBacklog(), metric.WithAttributes(
+				metrics.AuditBackendKey.String(Backend),
+			))
+
+			return nil
+		}, metrics.AuditBackendBufferEntries()); err != nil {
+			return nil, err
+		}
+
+		return newp, nil
 	})
 }
 
@@ -74,6 +89,7 @@ type Client interface {
 
 type Publisher struct {
 	Client         Client
+	measureBacklog func() int64
 	decisionFilter audit.DecisionLogEntryFilter
 	marshaller     recordMarshaller
 	sync           bool
@@ -135,6 +151,7 @@ func NewPublisher(ctx context.Context, conf *Conf, decisionFilter audit.Decision
 		marshaller:     newMarshaller(conf.Encoding),
 		sync:           conf.ProduceSync,
 		closeTimeout:   conf.CloseTimeout,
+		measureBacklog: client.BufferedProduceRecords,
 	}, nil
 }
 

--- a/internal/audit/local/badgerdb.go
+++ b/internal/audit/local/badgerdb.go
@@ -13,11 +13,13 @@ import (
 	"time"
 
 	badgerv4 "github.com/dgraph-io/badger/v4"
+	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/cerbos/cerbos/internal/audit"
 	"github.com/cerbos/cerbos/internal/config"
+	"github.com/cerbos/cerbos/internal/observability/metrics"
 )
 
 const (
@@ -46,7 +48,23 @@ func init() {
 			return nil, fmt.Errorf("failed to read local audit log configuration: %w", err)
 		}
 
-		return NewLog(conf, decisionFilter)
+		newl, err := NewLog(conf, decisionFilter)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := metrics.Meter().RegisterCallback(func(_ context.Context, o metric.Observer) error {
+			count := int64(len(newl.buffer)) // it is GoRoutine safe to read len for measurement
+			o.ObserveInt64(metrics.AuditBackendBufferEntries(), count, metric.WithAttributes(
+				metrics.AuditBackendKey.String(Backend),
+			))
+
+			return nil
+		}, metrics.AuditBackendBufferEntries()); err != nil {
+			return nil, err
+		}
+
+		return newl, nil
 	})
 }
 

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -171,7 +171,11 @@ func (lw *logWrapper) WriteAccessLogEntry(ctx context.Context, entry AccessLogEn
 		if err := lw.backend.WriteAccessLogEntry(ctx, entry); err != nil {
 			metrics.Inc(ctx, metrics.AuditErrorCount(), metrics.KindKey(KindAccess))
 			logging.FromContext(ctx).Warn("Failed to write access log entry", zap.Error(err))
+
+			return
 		}
+
+		metrics.Inc(ctx, metrics.AuditLogCount(), metrics.KindKey(KindAccess))
 	})
 
 	return nil
@@ -188,7 +192,11 @@ func (lw *logWrapper) WriteDecisionLogEntry(ctx context.Context, entry DecisionL
 		if err := lw.backend.WriteDecisionLogEntry(ctx, entry); err != nil {
 			metrics.Inc(ctx, metrics.AuditErrorCount(), metrics.KindKey(KindDecision))
 			logging.FromContext(ctx).Warn("Failed to write decision log entry", zap.Error(err))
+
+			return
 		}
+
+		metrics.Inc(ctx, metrics.AuditLogCount(), metrics.KindKey(KindDecision))
 	})
 
 	return nil

--- a/internal/observability/metrics/metrics.go
+++ b/internal/observability/metrics/metrics.go
@@ -45,6 +45,13 @@ var Meter = sync.OnceValue(func() metric.Meter {
 })
 
 var (
+	AuditLogCount = once(func() (metric.Int64Counter, error) {
+		return Meter().Int64Counter(
+			"cerbos_dev_audit_log_count",
+			metric.WithDescription("Number of audit log entries accepted by the backend"),
+		)
+	})
+
 	AuditErrorCount = once(func() (metric.Int64Counter, error) {
 		return Meter().Int64Counter(
 			"cerbos_dev_audit_error_count",

--- a/internal/observability/metrics/metrics.go
+++ b/internal/observability/metrics/metrics.go
@@ -52,6 +52,14 @@ var (
 		)
 	})
 
+	AuditBackendKey           = attribute.Key("backend")
+	AuditBackendBufferEntries = once(func() (metric.Int64ObservableGauge, error) {
+		return Meter().Int64ObservableGauge(
+			"cerbos_dev_audit_log_backend_buffer_entries",
+			metric.WithDescription("Number of audit log entires buffered by the backend"),
+		)
+	})
+
 	AuditErrorCount = once(func() (metric.Int64Counter, error) {
 		return Meter().Int64Counter(
 			"cerbos_dev_audit_error_count",


### PR DESCRIPTION
This PR adds additional metrics for audit log acctivity by the client (beyond the existing error counts). It also adds measure of the number of entries being queued by the active backend.