### PR TITLE
fix(conditions): prevent slice bounds out of range panic in crosspath.Dir

### DIFF
--- a/internal/conditions/crosspath/crosspath.go
+++ b/internal/conditions/crosspath/crosspath.go
@@ -112,20 +112,23 @@ func Dir(path string) (string, error) {
 			return Decode(encoded), nil
 		}
 
-		idx := strings.LastIndex(encoded.value, "/")
-		encoded.value = encoded.value[:idx]
+		if idx := strings.LastIndex(encoded.value, "/"); idx != -1 {
+			encoded.value = encoded.value[:idx]
+		}
 		return Decode(encoded), nil
 	case encoded.kind == KindDrive:
 		if encoded.root {
 			return Decode(encoded) + `\`, nil
 		}
 
-		idx := strings.LastIndex(encoded.value, "/")
-		encoded.value = encoded.value[:idx]
+		if idx := strings.LastIndex(encoded.value, "/"); idx != -1 {
+			encoded.value = encoded.value[:idx]
+		}
 		return Decode(encoded), nil
 	case encoded.kind == KindUnknown && encoded.win32:
-		idx := strings.LastIndex(encoded.value, "/")
-		encoded.value = encoded.value[:idx]
+		if idx := strings.LastIndex(encoded.value, "/"); idx != -1 {
+			encoded.value = encoded.value[:idx]
+		}
 		return Decode(encoded), nil
 	default:
 		encoded.value = filepath.Dir(encoded.value)

--- a/internal/conditions/crosspath/crosspath_test.go
+++ b/internal/conditions/crosspath/crosspath_test.go
@@ -119,6 +119,7 @@ func TestDir(t *testing.T) {
 		{path: `\\host\share\path\\to\file.txt`, want: `\\host\share\path\to`},
 		{path: `\\host\share\\file.txt`, want: `\\host\share`},
 		{path: `C:\path\\to\file.txt`, want: `C:\path\to`},
+		{path: "file.txt", want: "."},
 	}
 
 	for idx, testCase := range testCases {


### PR DESCRIPTION
In internal/conditions/crosspath/crosspath.go, Dir() computes strings.LastIndex(encoded.value, '/') and slices encoded.value[:idx]. When encoded.value does not contain a forward slash, strings.LastIndex returns -1. Slicing [: -1] caused a runtime panic: slice bounds out of range [:-1]. This PR adds an explicit check if idx != -1 before slicing encoded.value[:idx] across UNC, drive, and Win32 path branches in crosspath.Dir.