### PR TITLE
fix(run): Propagate command start errors in `cerbos run` 

### DIFF
--- a/cmd/cerbos/run/run.go
+++ b/cmd/cerbos/run/run.go
@@ -128,10 +128,10 @@ func (c *Cmd) Run(k *kong.Kong) error {
 		return err
 	case status := <-statusChan:
 		if status.Error != nil {
-			log.Errorw("Command execution error", "command", c.Command, "error", err)
+			log.Errorw("Command execution error", "command", c.Command, "error", status.Error)
 			cleanup()
 
-			return err
+			return status.Error
 		}
 
 		if status.Complete {

--- a/cmd/cerbos/run/run_test.go
+++ b/cmd/cerbos/run/run_test.go
@@ -1,0 +1,66 @@
+// Copyright 2021-2026 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunPropagatesCommandStartError(t *testing.T) {
+	httpPort, grpcPort := allocateFreePorts(t)
+
+	dir := t.TempDir()
+	policiesDir := filepath.Join(dir, "policies")
+	require.NoError(t, os.MkdirAll(policiesDir, 0o755))
+
+	confPath := filepath.Join(dir, ".cerbos.yaml")
+	conf := fmt.Sprintf(`
+server:
+  httpListenAddr: "127.0.0.1:%d"
+  grpcListenAddr: "127.0.0.1:%d"
+storage:
+  driver: "disk"
+  disk:
+    directory: %q
+`, httpPort, grpcPort, policiesDir)
+	require.NoError(t, os.WriteFile(confPath, []byte(conf), 0o600))
+
+	k, err := kong.New(&struct{}{}, kong.Writers(&bytes.Buffer{}, &bytes.Buffer{}))
+	require.NoError(t, err)
+
+	const cmdName = "cerbos-test-nonexistent-command"
+	cmd := &Cmd{
+		Config:  confPath,
+		Command: []string{"--", cmdName},
+		Timeout: 30 * time.Second,
+	}
+
+	err = cmd.Run(k)
+	require.Error(t, err)
+	require.ErrorContains(t, err, cmdName)
+}
+
+func allocateFreePorts(t *testing.T) (httpPort, grpcPort int) {
+	t.Helper()
+
+	var lc net.ListenConfig
+	ports := make([]int, 2)
+	for i := range ports {
+		l, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		ports[i] = l.Addr().(*net.TCPAddr).Port
+		require.NoError(t, l.Close())
+	}
+
+	return ports[0], ports[1]
+}


### PR DESCRIPTION
#### Description
 
When the command launched by `cerbos run` fails to start — e.g. because the executable does not exist in `PATH` — the error-handling branch logged and returned the outer `err` variable instead of `status.Error`. That variable is always `nil` at that point (it is only set by the successful `startPDP` call), so the failure was logged as `error: null` and `cerbos run` returned `nil`, exiting with status 0. This made it look like the command ran successfully, which is especially misleading in CI.
 
The fix logs and returns `status.Error`, which `go-cmd` populates when the process cannot be started, so the underlying error is surfaced and the exit code is non-zero.
 
Changes:
- `cmd/cerbos/run/run.go`: use `status.Error` in the log call and as the returned error.
- `cmd/cerbos/run/run_test.go`: new `TestRunPropagatesCommandStartError` that boots an in-process PDP on ephemeral ports and asserts the error propagates when a non-existent command is launched.
- Changelog entry added via the `fix` type.
 
Testing:
- Verified the new test fails against the pre-fix code (`Error: An error is expected but got nil.`) and passes with the fix.
- `go test ./cmd/cerbos/run/`, `go vet ./cmd/cerbos/run/`, `golangci-lint run --config=.golangci.yaml ./cmd/cerbos/run/...` all pass.

