### PR TITLE
Better error message when disk directory doesn't exist

### DIFF
--- a/internal/storage/disk/conf.go
+++ b/internal/storage/disk/conf.go
@@ -6,6 +6,9 @@
 package disk
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/cerbos/cerbos/internal/config"
 	"github.com/cerbos/cerbos/internal/storage"
 )
@@ -25,6 +28,14 @@ type Conf struct {
 
 func (conf *Conf) Key() string {
 	return confKey
+}
+
+func (conf *Conf) Validate() error {
+	if _, err := os.Stat(conf.Directory); err != nil {
+		return fmt.Errorf("failed to stat policy directory: %w", err)
+	}
+
+	return nil
 }
 
 func GetConf() (*Conf, error) {


### PR DESCRIPTION
When `disk.directory` does not exist, the generated error message is not very helpful (`failed to create store: failed to stat .: stat .: no such file or directory`).

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
