### PR TITLE
Fix zizmor issues

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,0 +1,30 @@
+name: Lint GitHub Actions
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/actions/**
+      - .github/workflows/*
+
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  lint-actions:
+    name: Lint GitHub Actions
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Lint GitHub Actions
+        uses: cerbos/actions/lint-actions@0d9b5e1ccb075eb3b6817a6f1718b9c189498c0a # main

--- a/.github/workflows/aws.yaml
+++ b/.github/workflows/aws.yaml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Free disk space
-        uses: ./.github/actions/free-disk-space
+        uses: $/.github/actions/free-disk-space
 
       - name: Set up QEMU
         id: qemu
@@ -45,7 +45,7 @@ jobs:
           registries: ${{ vars.AWS_CONTAINER_REGISTRY_ID }}
 
       - name: Install Go and cache dependencies
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
         with:
           cross_compiling: true
           write_build_cache: true

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -45,11 +45,11 @@ jobs:
           persist-credentials: false
 
       - name: Free disk space
-        uses: ./.github/actions/free-disk-space
+        uses: $/.github/actions/free-disk-space
 
       - name: Install Go and cache dependencies
         id: setup
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
         with:
           write_deps_cache: true
           write_build_cache: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,10 +24,10 @@ jobs:
           persist-credentials: false
 
       - name: Generate docs
-        uses: ./.github/actions/antora-docs
+        uses: $/.github/actions/antora-docs
 
       - name: Publish to Netlify
-        uses: ./.github/actions/publish-docs
+        uses: $/.github/actions/publish-docs
         with:
           auth_token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           site_id: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,10 +24,10 @@ jobs:
           persist-credentials: false
 
       - name: Free disk space
-        uses: ./.github/actions/free-disk-space
+        uses: $/.github/actions/free-disk-space
 
       - name: Install Go and restore cached dependencies
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
 
       - name: Install tools
         uses: cerbos/actions/install-tools@0d9b5e1ccb075eb3b6817a6f1718b9c189498c0a # main

--- a/.github/workflows/perf-regression.yaml
+++ b/.github/workflows/perf-regression.yaml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
 
       - name: Set up Cerbos (dev)
         run: |

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -40,7 +40,7 @@ jobs:
               - '**/*.proto'
 
   cache:
-    uses: ./.github/workflows/cache.yaml
+    uses: $/.github/workflows/cache.yaml
     permissions:
       pull-requests: read
 
@@ -58,10 +58,10 @@ jobs:
           persist-credentials: false
 
       - name: Free disk space
-        uses: ./.github/actions/free-disk-space
+        uses: $/.github/actions/free-disk-space
 
       - name: Install Go and restore cached dependencies
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
 
       - name: Install tools
         uses: cerbos/actions/install-tools@0d9b5e1ccb075eb3b6817a6f1718b9c189498c0a # main
@@ -119,10 +119,10 @@ jobs:
           persist-credentials: false
 
       - name: Free disk space
-        uses: ./.github/actions/free-disk-space
+        uses: $/.github/actions/free-disk-space
 
       - name: Install Go and restore cached dependencies
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
 
       - name: Install just
         uses: cerbos/actions/install-tools@0d9b5e1ccb075eb3b6817a6f1718b9c189498c0a # main
@@ -231,7 +231,7 @@ jobs:
           persist-credentials: false
 
       - name: Generate docs
-        uses: ./.github/actions/antora-docs
+        uses: $/.github/actions/antora-docs
         id: docs
 
   golangci:
@@ -342,10 +342,10 @@ jobs:
           persist-credentials: false
 
       - name: Free disk space
-        uses: ./.github/actions/free-disk-space
+        uses: $/.github/actions/free-disk-space
 
       - name: Install Go and cache dependencies
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
         with:
           cross_compiling: true
 

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -14,7 +14,6 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      actions: ${{ steps.filter.outputs.actions }}
       code: ${{ steps.filter.outputs.code }}
       docs: ${{ steps.filter.outputs.docs }}
       npm: ${{ steps.filter.outputs.npm }}
@@ -24,8 +23,6 @@ jobs:
         id: filter
         with:
           filters: |
-            actions:
-              - '.github/**'
             code:
               - '!(.node-version|{docs,npm}/**)'
             docs:
@@ -433,19 +430,3 @@ jobs:
         run: test "${NEEDS_TEST_NPM_RESULT}" = "success"
         env:
           NEEDS_TEST_NPM_RESULT: ${{ needs.test-npm.result }}
-
-  lint-actions:
-    name: Lint GitHub Actions
-    runs-on: ubuntu-latest
-    needs: changes
-    if: ${{ needs.changes.outputs.actions == 'true' }}
-    permissions:
-      security-events: write
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Lint GitHub Actions
-        uses: cerbos/actions/lint-actions@0d9b5e1ccb075eb3b6817a6f1718b9c189498c0a # main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,10 +22,10 @@ jobs:
           persist-credentials: false
 
       - name: Free disk space
-        uses: ./.github/actions/free-disk-space
+        uses: $/.github/actions/free-disk-space
 
       - name: Install Go and restore cached dependencies
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
         with:
           cross_compiling: true
 
@@ -158,10 +158,10 @@ jobs:
           persist-credentials: false
 
       - name: Generate docs
-        uses: ./.github/actions/antora-docs
+        uses: $/.github/actions/antora-docs
 
       - name: Publish to Netlify
-        uses: ./.github/actions/publish-docs
+        uses: $/.github/actions/publish-docs
         with:
           auth_token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           site_id: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - v*
+permissions: {}
 jobs:
   releaseBinaries:
     name: Release Binaries

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -23,10 +23,10 @@ jobs:
           persist-credentials: false
 
       - name: Free disk space
-        uses: ./.github/actions/free-disk-space
+        uses: $/.github/actions/free-disk-space
 
       - name: Install Go and cache dependencies
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
         with:
           cross_compiling: true
           write_build_cache: true
@@ -74,7 +74,7 @@ jobs:
           persist-credentials: false
 
       - name: Free disk space
-        uses: ./.github/actions/free-disk-space
+        uses: $/.github/actions/free-disk-space
 
       - name: Set up QEMU
         id: qemu
@@ -113,7 +113,7 @@ jobs:
           registries: ${{ vars.AWS_CONTAINER_REGISTRY_ID }}
 
       - name: Install Go and cache dependencies
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
         with:
           cross_compiling: true
           write_build_cache: true

--- a/.github/workflows/test-lambda-publish.yaml
+++ b/.github/workflows/test-lambda-publish.yaml
@@ -34,10 +34,10 @@ jobs:
           persist-credentials: false
 
       - name: Free disk space
-        uses: ./.github/actions/free-disk-space
+        uses: $/.github/actions/free-disk-space
 
       - name: Install Go and restore cached dependencies
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
         with:
           cross_compiling: true
 

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -17,10 +17,10 @@ jobs:
           persist-credentials: false
 
       - name: Free disk space
-        uses: ./.github/actions/free-disk-space
+        uses: $/.github/actions/free-disk-space
 
       - name: Install Go and restore cached dependencies
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
 
       - name: Install just
         uses: cerbos/actions/install-tools@0d9b5e1ccb075eb3b6817a6f1718b9c189498c0a # main


### PR DESCRIPTION
This PR fixes issues reported by the latest version of zizmor.

It also fixes a longer-standing issue with overly-broad permissions in the release workflow, and moves action linting to a workflow that also runs on pushes to `main` so that issues get reported in GitHub Advanced Security in future.